### PR TITLE
HMS fix: only copy the ADL adapter info for GPU devices

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -12704,21 +12704,14 @@ int main (int argc, char **argv)
 
       // copy hm_adapter info to data.hm_device[]
 
-      uint hm_adapter_cur = hm_adapter_index;
-
-      if ((device_type & CL_DEVICE_TYPE_GPU) == 0)
-      {
-        // assign a CPU adapter (i.e. not initialized hm_adapter_all[] entry)
-
-        hm_adapter_cur = devices_all_cnt - 1;
-      }
-
-      memcpy (&data.hm_device[device_id], &hm_adapter_all[hm_adapter_cur], sizeof (hm_attrs_t));
-
       if (device_type & CL_DEVICE_TYPE_GPU)
       {
+        memcpy (&data.hm_device[device_id], &hm_adapter_all[hm_adapter_index], sizeof (hm_attrs_t));
+
         hm_adapter_index++;
       }
+      // this would be the CPU case (but it should be zeroed out already):
+      // else memset (&data.hm_device[device_id], 0, sizeof (hm_attrs_t));
 
       devices_cnt++;
     }


### PR DESCRIPTION
... for CPU devices we should leave it AS-IS (zeroed out).

We only need the ADL info for GPU devices, if we encounter a non-GPU devices (e.g. CPU) we leave the current data.hm_device[] struct with all-zero-values (i.e. fan support turned off etc).
This prevents that we get errors about not working fan reading etc.
