### PR TITLE
Makefile: remove kernels/ directory when running make clean

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -124,6 +124,7 @@ clean:
 	$(RM) -f obj/*.o lib/*.a ./*.bin ./*.exe ./*.app *.restore *.out *.pot *.dictstat *.log oclHashcat core
 	$(RM) -rf *.induct
 	$(RM) -rf *.outfiles
+	$(RM) -rf kernels
 
 linux32:        oclHashcat32.bin
 linux64:        oclHashcat64.bin


### PR DESCRIPTION
I would like to suggest that we remove the (pre-compiled) kernels/ directory whenever we run "make clean".
This way, we might solve/prevent some strange behaviour of old kernels that are still present on the file system (under [cwd]/kernels).
Thx 
