### PR TITLE
add skipped devices to the --benchmark output

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -12451,6 +12451,13 @@ int main (int argc, char **argv)
      * devices mask and properties
      */
 
+    uint quiet_sav = quiet;
+
+    if (benchmark)
+    {
+      quiet = 0;
+    }
+
     for (uint device_all_id = 0; device_all_id < devices_all_cnt; device_all_id++)
     {
       // skip the device, if the user did specify a list of GPUs to skip
@@ -12531,6 +12538,8 @@ int main (int argc, char **argv)
 
       devices_cnt++;
     }
+
+    quiet = quiet_sav;
 
     if (devices_cnt == 0)
     {


### PR DESCRIPTION
this fixes the changes from PR #126 , when we use --benchmark, skipped devices should be also within the output.
But if we do not use --benchmark the --quiet option should work unchanged (as #126 was trying to fix).
Thx
