### PR TITLE
set default iteration count for -m 2100 = DCC2 to 10240

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -95,6 +95,10 @@ Type.: Bug
 File.: Kernel
 Desc.: Fix a bug in the implementation of GOST R 34.11-94, zero length passwords were not cracked
 
+Type.: Bug
+File.: Host
+Desc.: Forced default iteration count for -m 2100 = DCC2 hashes to 10240
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -9868,7 +9868,14 @@ int dcc2_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt_t *salt = hash_buf->salt;
 
-  salt->salt_iter = atoi (iter_pos) - 1;
+  uint iter = atoi (iter_pos);
+
+  if (iter < 1)
+  {
+    iter = ROUNDS_DCC2;
+  }
+
+  salt->salt_iter = iter - 1;
 
   char *salt_pos = strchr (iter_pos, '#');
 


### PR DESCRIPTION
this pull request makes sure that the iteration count for -m 2100 = DCC2 hashes is always correctly set.
In some cases, user reported that DCC2 is very slow or they see 0 H/s. The problem was that the atoi () function for some hashes (without iteration count) returned 0 and therefore salt->salt_iter was not correct.
Hereby, I suggest to add an extra check to make sure that the value returned by atoi () is at least 1. If this is not true, we should set the value to the default iteration count (ROUNDS_DCC2).

Thx
