### PR TITLE
buffer overflow fix for -m 8900 = scrypt

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -14586,7 +14586,7 @@ int scrypt_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   // base64 decode
 
-  u8 tmp_buf[32];
+  u8 tmp_buf[33];
 
   memset (tmp_buf, 0, sizeof (tmp_buf));
 


### PR DESCRIPTION
There was a buffer overflow problem within the -m = 8900 = scrypt parse function that is related to https://github.com/hashcat/oclHashcat/pull/135 and https://github.com/hashcat/oclHashcat/issues/137, since the base64_encode () / base64_decode ()  does write more bytes than expected (yes, this should be fixed with #137), the buffer needs to be at least 33 bytes (similar to the case in #135).

The extra 1 byte shouldn't make much of a difference, even though I would prefer that we fix #137 asap.
