### PR TITLE
Do not create a kernel cache file if build failed (actually if size ended up as zero).

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -13547,7 +13547,7 @@ int main (int argc, char **argv)
 
         struct stat cst;
 
-        if (stat (cached_file, &cst) == -1)
+        if ((stat (cached_file, &cst) == -1) || cst.st_size == 0)
         {
           cached = 0;
         }

--- a/src/shared.c
+++ b/src/shared.c
@@ -8672,12 +8672,15 @@ void load_kernel (const char *kernel_file, int num_devices, size_t *kernel_lengt
 
 void writeProgramBin (char *dst, u8 *binary, size_t binary_size)
 {
-  FILE *fp = fopen (dst, "wb");
+  if (binary_size > 0)
+  {
+    FILE *fp = fopen (dst, "wb");
 
-  fwrite (binary, sizeof (u8), binary_size, fp);
+    fwrite (binary, sizeof (u8), binary_size, fp);
 
-  fflush (fp);
-  fclose (fp);
+    fflush (fp);
+    fclose (fp);
+  }
 }
 
 /**


### PR DESCRIPTION
Also disregard any existing cache files with size of zero. Should close #164.
