### PR TITLE
Drop dependencies on non-distributable ADL/NVML headers.

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -18,11 +18,9 @@ To compile **oclHashcat** the following third party libraries are required:
 The next thing to do is download all the third party libraries listed above and put these files into the *deps/tmp* directory.
 
 The following files are needed inside the *deps/tmp* directory:
-    
-    ADL_SDK9.zip
-    R352-developer.zip
-    gdk_linux_amd64_352_55_release.run
-    
+
+    R352-developer.zip  (only needed when cross-compiling for Windows)
+
 # Building oclHashcat
 First get a copy of the **oclHashcat** repository
 

--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -10,7 +10,240 @@
 
 #include <common.h>
 
-#include <adl_sdk.h>
+/**
+ * Declarations from adl_sdk.h and subheaders
+ */
+
+#define ADL_OK                                  0
+#define ADL_ERR                                 -1
+#define ADL_ERR_NOT_SUPPORTED                   -8
+
+#define ADL_MAX_PATH                            256
+
+#define ADL_DL_FANCTRL_SUPPORTS_PERCENT_READ    1
+#define ADL_DL_FANCTRL_SUPPORTS_PERCENT_WRITE   2
+#define ADL_DL_FANCTRL_SPEED_TYPE_PERCENT       1
+#define ADL_DL_FANCTRL_FLAG_USER_DEFINED_SPEED  1
+
+#define ADL_OD6_SETSTATE_PERFORMANCE            0x00000001
+#define ADL_OD6_GETSTATEINFO_CUSTOM_PERFORMANCE 0x00000004
+#define ADL_OD6_FANSPEED_TYPE_PERCENT           0x00000001
+
+typedef struct AdapterInfo
+{
+  int  iSize;
+  int  iAdapterIndex;
+  char strUDID[ADL_MAX_PATH];
+  int  iBusNumber;
+  int  iDeviceNumber;
+  int  iFunctionNumber;
+  int  iVendorID;
+  char strAdapterName[ADL_MAX_PATH];
+  char strDisplayName[ADL_MAX_PATH];
+  int  iPresent;
+
+#if defined (_WIN32) || defined (_WIN64)
+  int  iExist;
+  char strDriverPath[ADL_MAX_PATH];
+  char strDriverPathExt[ADL_MAX_PATH];
+  char strPNPString[ADL_MAX_PATH];
+  int  iOSDisplayIndex;
+#endif /* (_WIN32) || (_WIN64) */
+
+#if defined (__linux__)
+  int  iXScreenNum;
+  int  iDrvIndex;
+  char strXScreenConfigName[ADL_MAX_PATH];
+#endif /* (__linux__) */
+} AdapterInfo, *LPAdapterInfo;
+
+typedef struct ADLThermalControllerInfo
+{
+  int iSize;
+  int iThermalDomain;
+  int iDomainIndex;
+  int iFlags;
+} ADLThermalControllerInfo;
+
+typedef struct ADLTemperature
+{
+  int iSize;
+  int iTemperature;
+} ADLTemperature;
+
+typedef struct ADLFanSpeedInfo
+{
+  int iSize;
+  int iFlags;
+  int iMinPercent;
+  int iMaxPercent;
+  int iMinRPM;
+  int iMaxRPM;
+} ADLFanSpeedInfo;
+
+typedef struct ADLFanSpeedValue
+{
+  int iSize;
+  int iSpeedType;
+  int iFanSpeed;
+  int iFlags;
+} ADLFanSpeedValue;
+
+typedef struct ADLDisplayID
+{
+  int iDisplayLogicalIndex;
+  int iDisplayPhysicalIndex;
+  int iDisplayLogicalAdapterIndex;
+  int iDisplayPhysicalAdapterIndex;
+} ADLDisplayID, *LPADLDisplayID;
+
+typedef struct ADLDisplayInfo
+{
+  ADLDisplayID displayID;
+  int  iDisplayControllerIndex;
+  char strDisplayName[ADL_MAX_PATH];
+  char strDisplayManufacturerName[ADL_MAX_PATH];
+  int  iDisplayType;
+  int  iDisplayOutputType;
+  int  iDisplayConnector;
+  int  iDisplayInfoMask;
+  int  iDisplayInfoValue;
+} ADLDisplayInfo, *LPADLDisplayInfo;
+
+typedef struct ADLBiosInfo
+{
+  char strPartNumber[ADL_MAX_PATH];
+  char strVersion[ADL_MAX_PATH];
+  char strDate[ADL_MAX_PATH];
+} ADLBiosInfo, *LPADLBiosInfo;
+
+typedef struct ADLPMActivity
+{
+  int iSize;
+  int iEngineClock;
+  int iMemoryClock;
+  int iVddc;
+  int iActivityPercent;
+  int iCurrentPerformanceLevel;
+  int iCurrentBusSpeed;
+  int iCurrentBusLanes;
+  int iMaximumBusLanes;
+  int iReserved;
+} ADLPMActivity;
+
+typedef struct ADLODParameterRange
+{
+  int iMin;
+  int iMax;
+  int iStep;
+} ADLODParameterRange;
+
+typedef struct ADLODParameters
+{
+  int iSize;
+  int iNumberOfPerformanceLevels;
+  int iActivityReportingSupported;
+  int iDiscretePerformanceLevels;
+  int iReserved;
+  ADLODParameterRange sEngineClock;
+  ADLODParameterRange sMemoryClock;
+  ADLODParameterRange sVddc;
+} ADLODParameters;
+
+typedef struct ADLODPerformanceLevel
+{
+  int iEngineClock;
+  int iMemoryClock;
+  int iVddc;
+} ADLODPerformanceLevel;
+
+typedef struct ADLODPerformanceLevels
+{
+  int iSize;
+  int iReserved;
+  ADLODPerformanceLevel aLevels [1];
+} ADLODPerformanceLevels;
+
+typedef struct ADLOD6FanSpeedInfo
+{
+  int iSpeedType;
+  int iFanSpeedPercent;
+  int iFanSpeedRPM;
+  int iExtValue;
+  int iExtMask;
+} ADLOD6FanSpeedInfo;
+
+typedef struct ADLOD6FanSpeedValue
+{
+  int iSpeedType;
+  int iFanSpeed;
+  int iExtValue;
+  int iExtMask;
+} ADLOD6FanSpeedValue;
+
+typedef struct ADLOD6CurrentStatus
+{
+  int iEngineClock;
+  int iMemoryClock;
+  int iActivityPercent;
+  int iCurrentPerformanceLevel;
+  int iCurrentBusSpeed;
+  int iCurrentBusLanes;
+  int iMaximumBusLanes;
+  int iExtValue;
+  int iExtMask;
+} ADLOD6CurrentStatus;
+
+typedef struct ADLOD6ParameterRange
+{
+  int iMin;
+  int iMax;
+  int iStep;
+} ADLOD6ParameterRange;
+
+typedef struct ADLOD6Capabilities
+{
+  int iCapabilities;
+  int iSupportedStates;
+  int iNumberOfPerformanceLevels;
+  ADLOD6ParameterRange sEngineClockRange;
+  ADLOD6ParameterRange sMemoryClockRange;
+  int iExtValue;
+  int iExtMask;
+} ADLOD6Capabilities;
+
+typedef struct ADLOD6PerformanceLevel
+{
+  int iEngineClock;
+  int iMemoryClock;
+} ADLOD6PerformanceLevel;
+
+typedef struct ADLOD6StateInfo
+{
+  int iNumberOfPerformanceLevels;
+  int iExtValue;
+  int iExtMask;
+  ADLOD6PerformanceLevel aLevels [1];
+} ADLOD6StateInfo;
+
+typedef struct ADLOD6PowerControlInfo
+{
+  int iMinValue;
+  int iMaxValue;
+  int iStepValue;
+  int iExtValue;
+  int iExtMask;
+} ADLOD6PowerControlInfo;
+
+#if !(defined (_WIN32) || defined (_WIN64))
+#define __stdcall
+#endif
+
+typedef void* (__stdcall *ADL_MAIN_MALLOC_CALLBACK )( int );
+
+/*
+ * End of declarations from adl_sdk.h and subheaders
+ **/
 
 typedef int HM_ADAPTER_AMD;
 

--- a/include/ext_nvml.h
+++ b/include/ext_nvml.h
@@ -10,7 +10,48 @@
 
 #include <common.h>
 
-#include <nvml.h>
+/**
+ * Declarations from nvml.h
+ */
+
+typedef struct nvmlDevice_st* nvmlDevice_t;
+
+typedef struct nvmlPciInfo_st {
+  char busId[16];
+  unsigned int domain;
+  unsigned int bus;
+  unsigned int device;
+  unsigned int pciDeviceId;
+  unsigned int pciSubSystemId;
+} nvmlPciInfo_t;
+
+typedef struct nvmlUtilization_st {
+  unsigned int gpu;    // GPU kernel execution last second, percent
+  unsigned int memory; // GPU memory read/write last second, percent
+} nvmlUtilization_t;
+
+typedef enum nvmlTemperatureSensors_enum {
+  NVML_TEMPERATURE_GPU = 0     // Temperature sensor for the GPU die
+} nvmlTemperatureSensors_t;
+
+typedef enum nvmlReturn_enum {
+  NVML_SUCCESS = 0,                   // The operation was successful
+  NVML_ERROR_UNINITIALIZED = 1,       // NVML was not first initialized with nvmlInit()
+  NVML_ERROR_INVALID_ARGUMENT = 2,    // A supplied argument is invalid
+  NVML_ERROR_NOT_SUPPORTED = 3,       // The requested operation is not available on target device
+  NVML_ERROR_NO_PERMISSION = 4,       // The current user does not have permission for operation
+  NVML_ERROR_ALREADY_INITIALIZED = 5, // Deprecated: Multiple initializations are now allowed through ref counting
+  NVML_ERROR_NOT_FOUND = 6,           // A query to find an object was unsuccessful
+  NVML_ERROR_INSUFFICIENT_SIZE = 7,   // An input argument is not large enough
+  NVML_ERROR_INSUFFICIENT_POWER = 8,  // A device's external power cables are not properly attached
+  NVML_ERROR_DRIVER_NOT_LOADED = 9,   // NVIDIA driver is not loaded
+  NVML_ERROR_TIMEOUT = 10,            // User provided timeout passed
+  NVML_ERROR_UNKNOWN = 999            // An internal driver error occurred
+} nvmlReturn_t;
+
+/*
+ * End of declarations from nvml.h
+ **/
 
 typedef nvmlDevice_t HM_ADAPTER_NV;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,8 +45,6 @@ DOCUMENT_FOLDER          ?= $(PREFIX)/share/doc/$(PROG_NAME)
 ## Dependencies
 ##
 
-ADL                      := deps/adl-sdk
-GDK                      := deps/nvidia-gdk
 NVAPI                    := deps/R352-developer
 
 ##
@@ -65,25 +63,15 @@ NVML                     := $(GDK)/usr/include/nvidia/gdk
 ## Check dependencies
 ##
 
-FOUND_ADL                := 0
-FOUND_NVML               := 0
+WITH_ADL                 := 1
+WITH_NVML                := 1
 FOUND_NVAPI              := 0
-
-ifneq ($(wildcard $(ADL)/include/adl_sdk.h),)
-FOUND_ADL                := 1
-endif
-
-ifneq ($(wildcard $(NVML)/nvml.h),)
-FOUND_NVML               := 1
-endif
 
 ifneq ($(wildcard $(NVAPI)/nvapi.h),)
 FOUND_NVAPI              := 1
 endif
 
 ifeq ($(DEBUG),1)
-$(warning "## ADL is found ? $(FOUND_ADL)")
-$(warning "## NVML is found ? $(FOUND_NVML)")
 $(warning "## NVAPI is found ? $(FOUND_NVAPI)")
 endif
 
@@ -144,8 +132,8 @@ CFLAGS_NATIVE            += $(CFLAGS)
 
 LFLAGS_NATIVE            := -lpthread
 
-FOUND_ADL                := 0
-FOUND_NVML               := 0
+WITH_ADL                 := 0
+WITH_NVML                := 0
 endif
 
 ifeq ($(UNAME),Linux)
@@ -154,13 +142,13 @@ CFLAGS_NATIVE            += -s $(CFLAGS)
 
 LFLAGS_NATIVE            := -lpthread -ldl
 
-ifneq (,$(filter 1,$(FOUND_ADL) $(FOUND_NVML)))
+ifneq (,$(filter 1,$(WITH_ADL) $(WITH_NVML)))
 CFLAGS_NATIVE            += -DHAVE_HWMON
-ifeq ($(FOUND_ADL),1)
-CFLAGS_NATIVE            += -DHAVE_ADL -I$(ADL)/include/
+ifeq ($(WITH_ADL),1)
+CFLAGS_NATIVE            += -DHAVE_ADL
 endif
-ifeq ($(FOUND_NVML),1)
-CFLAGS_NATIVE            += -DHAVE_NVML -I$(NVML)/
+ifeq ($(WITH_NVML),1)
+CFLAGS_NATIVE            += -DHAVE_NVML
 endif
 endif
 
@@ -174,15 +162,15 @@ CFLAGS_CROSS_LINUX       := -D_POSIX -DLINUX
 CFLAGS_CROSS_LINUX       += -s $(CFLAGS)
 CFLAGS_CROSS_LINUX       += -I$(OPENCL_HEADERS_KHRONOS)/
 
-ifneq (,$(filter 1,$(FOUND_ADL) $(FOUND_NVML)))
+ifneq (,$(filter 1,$(WITH_ADL) $(WITH_NVML)))
 CFLAGS_CROSS_LINUX       += -DHAVE_HWMON
 
-ifeq ($(FOUND_ADL),1)
-CFLAGS_CROSS_LINUX       += -DHAVE_ADL -I$(ADL)/include/
+ifeq ($(WITH_ADL),1)
+CFLAGS_CROSS_LINUX       += -DHAVE_ADL
 endif
 
-ifeq ($(FOUND_NVML),1)
-CFLAGS_CROSS_LINUX       += -DHAVE_NVML -I$(NVML)/
+ifeq ($(WITH_NVML),1)
+CFLAGS_CROSS_LINUX       += -DHAVE_NVML
 endif
 endif
 
@@ -190,15 +178,15 @@ CFLAGS_CROSS_WIN         := -D_WIN   -DWIN -D__MSVCRT__ -D__USE_MINGW_ANSI_STDIO
 CFLAGS_CROSS_WIN         += -s $(filter-out -fsanitize=address,$(CFLAGS))
 CFLAGS_CROSS_WIN         += -I$(OPENCL_HEADERS_KHRONOS)/
 
-ifneq (,$(filter 1,$(FOUND_ADL) $(FOUND_NVAPI)))
+ifneq (,$(filter 1,$(WITH_ADL) $(FOUND_NVAPI)))
 CFLAGS_CROSS_WIN         += -DHAVE_HWMON
 
-ifeq ($(FOUND_ADL),1)
-CFLAGS_CROSS_WIN         += -DHAVE_ADL -I$(ADL)/include/
+ifeq ($(WITH_ADL),1)
+CFLAGS_CROSS_WIN         += -DHAVE_ADL
 endif
 
 ifeq ($(FOUND_NVAPI),1)
-CFLAGS_CROSS_WIN         += -DHAVE_NVAPI -I$(NVAPI)/
+CFLAGS_CROSS_WIN         += -DHAVE_NVAPI
 endif
 endif
 
@@ -214,12 +202,12 @@ LFLAGS_CROSS_WIN         := -lpsapi
 
 NATIVE_OBJS              := obj/ext_OpenCL.NATIVE.o obj/shared.NATIVE.o obj/rp_kernel_on_cpu.NATIVE.o
 
-ifneq (,$(filter 1,$(FOUND_ADL) $(FOUND_NVML)))
-ifeq ($(FOUND_ADL),1)
+ifneq (,$(filter 1,$(WITH_ADL) $(WITH_NVML)))
+ifeq ($(WITH_ADL),1)
 NATIVE_OBJS              += obj/ext_ADL.NATIVE.o
 endif
 
-ifeq ($(FOUND_NVML),1)
+ifeq ($(WITH_NVML),1)
 NATIVE_OBJS              += obj/ext_nvml.NATIVE.o
 endif
 endif
@@ -230,7 +218,7 @@ LINUX_64_OBJS            := obj/ext_OpenCL.LINUX.64.o obj/shared.LINUX.64.o obj/
 WIN_32_OBJS              := obj/ext_OpenCL.WIN.32.o obj/shared.WIN.32.o obj/rp_kernel_on_cpu.WIN.32.o
 WIN_64_OBJS              := obj/ext_OpenCL.WIN.64.o obj/shared.WIN.64.o obj/rp_kernel_on_cpu.WIN.64.o
 
-ifeq ($(FOUND_ADL),1)
+ifeq ($(WITH_ADL),1)
 LINUX_32_OBJS            += obj/ext_ADL.LINUX.32.o
 LINUX_64_OBJS            += obj/ext_ADL.LINUX.64.o
 
@@ -238,7 +226,7 @@ WIN_32_OBJS              += obj/ext_ADL.WIN.32.o
 WIN_64_OBJS              += obj/ext_ADL.WIN.64.o
 endif
 
-ifeq ($(FOUND_NVML),1)
+ifeq ($(WITH_NVML),1)
 LINUX_32_OBJS            += obj/ext_nvml.LINUX.32.o
 LINUX_64_OBJS            += obj/ext_nvml.LINUX.64.o
 endif

--- a/tools/deps.sh
+++ b/tools/deps.sh
@@ -5,7 +5,8 @@
 ## global vars
 DEPS="make gcc g++ gcc-multilib g++-multilib libc6-dev-i386 mingw-w64 build-essential unzip opencl-headers ocl-icd-libopencl1 dos2unix"
 DEPS_AMD_DEV="ocl-icd-opencl-dev"
-DOWNLOAD_DEPS="ADL_SDK9.zip R352-developer.zip gdk_linux_amd64_352_55_release.run"
+## Now suppressed: ADL_SDK9.zip gdk_linux_amd64_352_55_release.run
+DOWNLOAD_DEPS="R352-developer.zip"
 
 ## enter the deps directory
 cur_directory=$(dirname ${0})
@@ -17,7 +18,8 @@ cd ${deps_dir}
 
 ## cleanup the directories under the 'deps' folder
 rm -rf {adl-sdk*,nvidia-gdk,R352-developer} && \
-mkdir -p {tmp,adl-sdk,nvidia-gdk,R352-developer} && \
+#mkdir -p {tmp,adl-sdk,nvidia-gdk,R352-developer} && \
+mkdir -p {tmp,R352-developer} && \
 cd tmp/
 
 if [ $? -ne 0 ]; then
@@ -54,20 +56,20 @@ for pkg in ${DEPS}; do
 done
 
 ## extract ADL SDK
-unzip ADL_SDK9.zip -d ${deps_dir}/adl-sdk-9
-ret=$?
-
-if [[ ${ret} -ne 0 ]] && [[ ${ret} -ne 1 ]]; then
-  echo "! failed to extract ADL SDK"
-  exit 1
-fi
-
-rm -rf ${deps_dir}/adl-sdk && ln -s ${deps_dir}/adl-sdk-9 ${deps_dir}/adl-sdk
-
-if [ $? -ne 0 ]; then
-  echo "! failed to setup ADL SDK link"
-  exit 1
-fi
+#unzip ADL_SDK9.zip -d ${deps_dir}/adl-sdk-9
+#ret=$?
+#
+#if [[ ${ret} -ne 0 ]] && [[ ${ret} -ne 1 ]]; then
+#  echo "! failed to extract ADL SDK"
+#  exit 1
+#fi
+#
+#rm -rf ${deps_dir}/adl-sdk && ln -s ${deps_dir}/adl-sdk-9 ${deps_dir}/adl-sdk
+#
+#if [ $? -ne 0 ]; then
+#  echo "! failed to setup ADL SDK link"
+#  exit 1
+#fi
 
 ## extract NVAPI
 unzip R352-developer.zip -d ${deps_dir}
@@ -79,13 +81,13 @@ if [[ ${ret} -ne 0 ]] && [[ ${ret} -ne 1 ]]; then
 fi
 
 ## install NVIDIA GPU Deployment Kit
-chmod +x gdk_linux_amd64_352_55_release.run && \
-./gdk_linux_amd64_352_55_release.run --silent --installdir=${deps_dir}/nvidia-gdk
-
-if [ $? -ne 0 ]; then
-  echo "! failed to install NVIDIA GPU Deployment Kit"
-  exit 1
-fi
+#chmod +x gdk_linux_amd64_352_55_release.run && \
+#./gdk_linux_amd64_352_55_release.run --silent --installdir=${deps_dir}/nvidia-gdk
+#
+#if [ $? -ne 0 ]; then
+#  echo "! failed to install NVIDIA GPU Deployment Kit"
+#  exit 1
+#fi
 
 ## check if libOpenCL.so is available (and if not install DEPS_AMD_DEV)
 


### PR DESCRIPTION
The needed glue is copied into our respective local headers. Should close #120.

Please review the changes to Makefile and deps.sh, not sure they are good as-is. I left some stuff in there, but commented out, in case someone temporarily wants to use the real headers during devel.

Tested on Linux 64-bit and OSX. The statically linked NV stuff for Windows was left as-is.
