### PR TITLE
Updated gpu accel for -m 6211 and default runtime value to 8

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -189,7 +189,7 @@ extern hc_thread_mutex_t mux_display;
 #ifdef OSX
 #define KERNEL_ACCEL_5000    16
 #define KERNEL_ACCEL_6100    1
-#define KERNEL_ACCEL_6211    4
+#define KERNEL_ACCEL_6211    2
 #define KERNEL_ACCEL_6231    1
 #define KERNEL_ACCEL_6241    4
 #define KERNEL_ACCEL_8200    1

--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -6577,7 +6577,7 @@ int main (int argc, char **argv)
 
     if (runtime_chgd == 0)
     {
-      runtime =  4;
+      runtime =  8;
 
       if (benchmark_mode == 1) runtime = 17;
 


### PR DESCRIPTION
Found too high gpu accel for hash mode 6211 (got trap 6)
The runtime value update is a workaround for an issue in Apple OpenCL engine,
before ~6 seconds we can't understand if gpu loops and accel value are wrong or not.
