### PR TITLE
Handling clBuildProgram failure (show build log on errors)

### DIFF
--- a/src/ext_OpenCL.c
+++ b/src/ext_OpenCL.c
@@ -375,8 +375,33 @@ void hc_clBuildProgram (OCL_PTR *ocl, cl_program program, cl_uint num_devices, c
   {
     log_error ("ERROR: %s : %d : %s\n", "clBuildProgram()", CL_err, val2cstr_cl (CL_err));
 
-    // If we exit here we can't see the error message
-    // exit (-1);
+    char *buf = NULL;
+    size_t len = 0;
+
+    if (ocl->clGetProgramBuildInfo (program, *device_list, CL_PROGRAM_BUILD_LOG, 0, NULL, &len) != CL_SUCCESS)
+    {
+      log_error ("ERROR: %s : %d : %s\n", "clGetProgramBuildInfo()", CL_err, val2cstr_cl (CL_err));
+
+      exit (-1);
+    }
+
+    if (len > 0)
+    {
+      buf = (char *) mymalloc (len + 1);
+
+      if (ocl->clGetProgramBuildInfo (program, *device_list, CL_PROGRAM_BUILD_LOG, len, buf, NULL) != CL_SUCCESS)
+      {
+        log_error ("ERROR: %s : %d : %s\n", "clGetProgramBuildInfo()", CL_err, val2cstr_cl (CL_err));
+      }
+      else
+      {
+        log_error ("Build log:\n%s\n", buf);
+      }
+
+      myfree (buf);
+    }
+
+    exit (-1);
   }
 }
 
@@ -520,7 +545,7 @@ void hc_clGetProgramBuildInfo (OCL_PTR *ocl, cl_program program, cl_device_id de
   }
 }
 
-void hc_clGetProgramInfo (OCL_PTR *ocl, cl_program program, cl_program_info param_name, size_t param_value_size, void *param_value, size_t * param_value_size_ret)
+void hc_clGetProgramInfo (OCL_PTR *ocl, cl_program program, cl_program_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret)
 {
   cl_int CL_err = ocl->clGetProgramInfo (program, param_name, param_value_size, param_value, param_value_size_ret);
 


### PR DESCRIPTION
Without the patch

```
$ ./oclHashcat.app -b -m 6900 --force
oclHashcat v2.01 (g692a86e) starting in benchmark-mode...

Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, skipped
Device #2: Iris, 384/1536 MB allocatable, 1200Mhz, 40MCU



ERROR: clBuildProgram() : -11 : CL_BUILD_PROGRAM_FAILURE


Trace/BPT trap: 5

```

With the patch

```
$ ./oclHashcat.app -b -m 6900 --force
oclHashcat v2.01 (gebd2855) starting in benchmark-mode...

Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, skipped
Device #2: Iris, 384/1536 MB allocatable, 1200Mhz, 40MCU



ERROR: clBuildProgram() : -11 : CL_BUILD_PROGRAM_FAILURE




Build log:
<program source>:301:9: warning: 'round' macro redefined
#define round(k1,k2,tbl)                  \
        ^
/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4701:13: note: previous definition is here
    #define round(__x) __cl_round(__x)
            ^
<program source>:704:905: error: parameter may not be qualified with an address space
static void m06900m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 s_tables[4][256])
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ^
<program source>:880:905: error: parameter may not be qualified with an address space
static void m06900s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 s_tables[4][256])
```
