### PR TITLE
Proposal workaround for use __local vars in 6900 gpu code with osx

### DIFF
--- a/OpenCL/m06900_a0.cl
+++ b/OpenCL/m06900_a0.cl
@@ -1,5 +1,7 @@
 /**
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -292,7 +294,7 @@ __constant u32 c_tables[4][256] =
 
 #define BOX(i,n,S) (S)[(n)][(i)]
 
-#define round(k1,k2,tbl)                  \
+#define _round(k1,k2,tbl)                 \
 {                                         \
   u32 t;                                  \
   t = (k1) + r;                           \
@@ -313,22 +315,22 @@ __constant u32 c_tables[4][256] =
   u32 l;                  \
   r = h[i + 0];           \
   l = h[i + 1];           \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[7], k[6], t);  \
-  round (k[5], k[4], t);  \
-  round (k[3], k[2], t);  \
-  round (k[1], k[0], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[7], k[6], t);  \
+  _round (k[5], k[4], t);  \
+  _round (k[3], k[2], t);  \
+  _round (k[1], k[0], t);  \
   s[i + 0] = l;           \
   s[i + 1] = r;           \
 }

--- a/OpenCL/m06900_a1.cl
+++ b/OpenCL/m06900_a1.cl
@@ -1,5 +1,7 @@
 /**
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -290,7 +292,7 @@ __constant u32 c_tables[4][256] =
 
 #define BOX(i,n,S) (S)[(n)][(i)]
 
-#define round(k1,k2,tbl)                  \
+#define _round(k1,k2,tbl)                 \
 {                                         \
   u32 t;                                  \
   t = (k1) + r;                           \
@@ -311,22 +313,22 @@ __constant u32 c_tables[4][256] =
   u32 l;                  \
   r = h[i + 0];           \
   l = h[i + 1];           \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[7], k[6], t);  \
-  round (k[5], k[4], t);  \
-  round (k[3], k[2], t);  \
-  round (k[1], k[0], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[7], k[6], t);  \
+  _round (k[5], k[4], t);  \
+  _round (k[3], k[2], t);  \
+  _round (k[1], k[0], t);  \
   s[i + 0] = l;           \
   s[i + 1] = r;           \
 }

--- a/OpenCL/m06900_a3.cl
+++ b/OpenCL/m06900_a3.cl
@@ -1,5 +1,7 @@
 /**
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -298,7 +300,7 @@ __constant u32 c_tables[4][256] =
 #define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
 #endif
 
-#define round(k1,k2,tbl)                  \
+#define _round(k1,k2,tbl)                 \
 {                                         \
   u32x t;                                 \
   t = (k1) + r;                           \
@@ -319,22 +321,22 @@ __constant u32 c_tables[4][256] =
   u32x l;                 \
   r = h[i + 0];           \
   l = h[i + 1];           \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[0], k[1], t);  \
-  round (k[2], k[3], t);  \
-  round (k[4], k[5], t);  \
-  round (k[6], k[7], t);  \
-  round (k[7], k[6], t);  \
-  round (k[5], k[4], t);  \
-  round (k[3], k[2], t);  \
-  round (k[1], k[0], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[0], k[1], t);  \
+  _round (k[2], k[3], t);  \
+  _round (k[4], k[5], t);  \
+  _round (k[6], k[7], t);  \
+  _round (k[7], k[6], t);  \
+  _round (k[5], k[4], t);  \
+  _round (k[3], k[2], t);  \
+  _round (k[1], k[0], t);  \
   s[i + 0] = l;           \
   s[i + 1] = r;           \
 }
@@ -701,7 +703,7 @@ __constant u32 c_tables[4][256] =
   R (k, h, s, 6, t);      \
 }
 
-static void m06900m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 s_tables[4][256])
+static void m06900m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 (*s_tables)[256])
 {
   /**
    * modifier
@@ -877,7 +879,7 @@ static void m06900m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_le
   }
 }
 
-static void m06900s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 s_tables[4][256])
+static void m06900s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 (*s_tables)[256])
 {
   /**
    * modifier


### PR DESCRIPTION
With the patch in PR #174 I discover the error below

```
Build log:
In file included from <program source>:41:
[REMOVED]/./OpenCL/m06900_multi.cl:9:905: error: parameter may not be qualified with an address space
static void m06900m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 s_tables[4][256])
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ^
In file included from <program source>:42:
[REMOVED]/./OpenCL/m06900_single.cl:9:905: error: parameter may not be qualified with an address space
static void m06900s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset, __local u32 s_tables[4][256])
```

With osx we can't use **__local** vars in function definition but we can still use inside **__kernel** functions.
The idea is get rid of functions in case of platform detected is Apple by using some macro, else the code is the same without osx support, but no code repeat because I split something like all the functions and the shared code for all attacks in external files (_shared.h _multi.cl _single.cl).

I also rename the macro "round" to "_round" because

```
Build log:
<program source>:301:9: warning: 'round' macro redefined
#define round(k1,k2,tbl)                  \
        ^
/System/Library/Frameworks/OpenCL.framework/Versions/A/lib/clang/3.2/include/cl_kernel.h:4701:13: note: previous definition is here
    #define round(__x) __cl_round(__x)
```

The result is

```
$ ./tools/test.sh -o osx -m 6900 -t all -a all
[ test_1454012928 ] > Init test for hash type 6900.
[ test_1454012928 ] [ Type 6900, Attack 0, Mode single ] > OK : 0/31 not found, 0/31 not matched, 0/31 timeout
[ test_1454012928 ] [ Type 6900, Attack 0, Mode multi  ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1454012928 ] [ Type 6900, Attack 1, Mode single ] > OK : 0/30 not found, 0/30 not matched, 0/30 timeout
[ test_1454012928 ] [ Type 6900, Attack 1, Mode multi  ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1454012928 ] [ Type 6900, Attack 3, Mode single ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1454012928 ] [ Type 6900, Attack 3, Mode multi  ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1454012928 ] [ Type 6900, Attack 6, Mode single ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1454012928 ] [ Type 6900, Attack 6, Mode multi  ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1454012928 ] [ Type 6900, Attack 7, Mode single ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1454012928 ] [ Type 6900, Attack 7, Mode multi  ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
```

Let me know ;)
