### PR TITLE
Select bash from env (very useful on osx)

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##
 ## Authors.....: Gabriele Gristina <matrix@hashcat.net>


### PR DESCRIPTION
With OSX the default bash version is too old version (3.2.x with 10.11.2).
After update bash with brew and this patch is possible using last bash version
and we can solve this annoying error message:

```
./tools/test.sh: line 278: syntax error near unexpected token `>'
./tools/test.sh: line 278: `           echo "password not found, cmdline : ${CMD}" &>> ${OUTD}/logfull.txt'
```
