### PR TITLE
Acquire an exclusive lock before writing to any file.

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <search.h>
+#include <fcntl.h>
 
 #ifdef _POSIX
 #include <sys/time.h>
@@ -62,7 +63,6 @@ typedef void *HM_LIB;
 #include <tchar.h>
 #include <psapi.h>
 #include <io.h>
-#include <fcntl.h>
 
 typedef UINT8  uint8_t;
 typedef UINT16 uint16_t;

--- a/include/shared.h
+++ b/include/shared.h
@@ -1832,6 +1832,14 @@ char *logfile_generate_topid ();
 char *logfile_generate_subid ();
 void logfile_append (const char *fmt, ...);
 
+#if F_SETLKW
+void lock_file (FILE *fp);
+void unlock_file (FILE *fp);
+#else
+#define lock_file(dummy) {}
+#define unlock_file(dummy) {}
+#endif
+
 #ifdef _WIN
 void fsync (int fd);
 #endif

--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -2081,6 +2081,8 @@ static void check_hash (hc_device_param_t *device_param, const uint salt_pos, co
 
   if (pot_fp)
   {
+    lock_file (pot_fp);
+
     fprintf (pot_fp, "%s:", out_buf);
 
     format_plain (pot_fp, plain_ptr, plain_len, 1);
@@ -2088,6 +2090,8 @@ static void check_hash (hc_device_param_t *device_param, const uint salt_pos, co
     fputc ('\n', pot_fp);
 
     fflush (pot_fp);
+
+    unlock_file (pot_fp);
   }
 
   // outfile
@@ -2102,6 +2106,7 @@ static void check_hash (hc_device_param_t *device_param, const uint salt_pos, co
 
       out_fp = stdout;
     }
+    lock_file (out_fp);
   }
   else
   {
@@ -2141,6 +2146,8 @@ static void check_hash (hc_device_param_t *device_param, const uint salt_pos, co
 
     if ((fb_fp = fopen (loopback_file, "ab")) != NULL)
     {
+      lock_file (fb_fp);
+
       format_plain (fb_fp, plain_ptr, plain_len, 1);
 
       fputc ('\n', fb_fp);
@@ -16179,6 +16186,8 @@ int main (int argc, char **argv)
 
           if (dictstat_fp)
           {
+            lock_file (dictstat_fp);
+
             fwrite (dictstat_base, sizeof (dictstat_t), dictstat_nmemb, dictstat_fp);
 
             fclose (dictstat_fp);


### PR DESCRIPTION
Note that in some cases we never explicitly unlock a file because fclose will do it implicitly. Closes #172.

Locking code will be silently skipped for Windows builds.
