### PR TITLE
Fixed gcc warnings about missing field initializers

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -2630,7 +2630,9 @@ char *logfile_generate_subid ()
 #if F_SETLKW
 void lock_file (FILE *fp)
 {
-  struct flock lock = { 0 };
+  struct flock lock;
+
+  memset (&lock, 0, sizeof (struct flock));
 
   lock.l_type = F_WRLCK;
   while (fcntl(fileno(fp), F_SETLKW, &lock))
@@ -2646,7 +2648,9 @@ void lock_file (FILE *fp)
 
 void unlock_file (FILE *fp)
 {
-  struct flock lock = { 0 };
+  struct flock lock;
+
+  memset (&lock, 0, sizeof (struct flock));
 
   lock.l_type = F_UNLCK;
   fcntl(fileno(fp), F_SETLK, &lock);


### PR DESCRIPTION
I got these warnings with osx

```
src/shared.c:2633:27: warning: missing field 'l_len' initializer [-Wmissing-field-initializers]
  struct flock lock = { 0 };
                          ^
src/shared.c:2649:27: warning: missing field 'l_len' initializer [-Wmissing-field-initializers]
  struct flock lock = { 0 };
                          ^
2 warnings generated.
```
