### PR TITLE
Solved Apple OpenCL compiler errors

### DIFF
--- a/OpenCL/m03100_a0.cl
+++ b/OpenCL/m03100_a0.cl
@@ -1,5 +1,7 @@
 /**
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -358,7 +360,7 @@ __constant u32 c_skb[8][64] =
 
 #define BOX(i,n,S) (S)[(n)][(i)]
 
-static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], __local u32 s_SPtrans[8][64])
+static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], __local u32 (*s_SPtrans)[64])
 {
   u32 tt;
 
@@ -410,7 +412,7 @@ static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], 
   iv[1] = r;
 }
 
-static void _des_crypt_keysetup (u32 c, u32 d, u32 Kc[16], u32 Kd[16], __local u32 s_skb[8][64])
+static void _des_crypt_keysetup (u32 c, u32 d, u32 Kc[16], u32 Kd[16], __local u32 (*s_skb)[64])
 {
   u32 tt;
 

--- a/OpenCL/m03100_a1.cl
+++ b/OpenCL/m03100_a1.cl
@@ -1,5 +1,7 @@
 /**
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -356,7 +358,7 @@ __constant u32 c_skb[8][64] =
 
 #define BOX(i,n,S) (S)[(n)][(i)]
 
-static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], __local u32 s_SPtrans[8][64])
+static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], __local u32 (*s_SPtrans)[64])
 {
   u32 tt;
 
@@ -408,7 +410,7 @@ static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], 
   iv[1] = r;
 }
 
-static void _des_crypt_keysetup (u32 c, u32 d, u32 Kc[16], u32 Kd[16], __local u32 s_skb[8][64])
+static void _des_crypt_keysetup (u32 c, u32 d, u32 Kc[16], u32 Kd[16], __local u32 (*s_skb)[64])
 {
   u32 tt;
 

--- a/OpenCL/m03100_a3.cl
+++ b/OpenCL/m03100_a3.cl
@@ -1,5 +1,7 @@
 /** / s_skb
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -364,7 +366,7 @@ __constant u32 c_skb[8][64] =
 #define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
 #endif
 
-static void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 s_SPtrans[8][64])
+static void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
 {
   u32x tt;
 
@@ -416,7 +418,7 @@ static void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[1
   iv[1] = r;
 }
 
-static void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 s_skb[8][64])
+static void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 (*s_skb)[64])
 {
   u32x tt;
 
@@ -486,7 +488,7 @@ static void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __loc
   }
 }
 
-static void m03100m (__local u32 s_SPtrans[8][64], __local u32 s_skb[8][64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset)
+static void m03100m (__local u32 (*s_SPtrans)[64], __local u32 (*s_skb)[64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset)
 {
   /**
    * modifier
@@ -700,7 +702,7 @@ static void m03100m (__local u32 s_SPtrans[8][64], __local u32 s_skb[8][64], u32
   }
 }
 
-static void m03100s (__local u32 s_SPtrans[8][64], __local u32 s_skb[8][64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset)
+static void m03100s (__local u32 (*s_SPtrans)[64], __local u32 (*s_skb)[64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 bfs_cnt, const u32 digests_cnt, const u32 digests_offset)
 {
   /**
    * modifier


### PR DESCRIPTION
As already mentioned in PR #175 for m06900 mods,
I finally discovered the issues about **__local** and **__constant** usage as functions parameters.

Apple OpenCL compiler show error like

`error: parameter may not be qualified with an address space`

if as functions parameters has been used array of **__local** or **__constant** instead of pointer.
Example:

```
// not allowed
static void hello (u32 w0, __local u32 L[8][8], __constant u32 C[8])

// what i found is allowed, redeclared as pointers 
static void hello (u32 w0, __local u32 (*L)[8], __constant u32 *C)
```

Real example (part of m03100 patch):

```
-static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], __local u32 s_SPtrans[8][64])
+static void _des_crypt_encrypt (u32 iv[2], u32 data[2], u32 Kc[16], u32 Kd[16], __local u32 (*s_SPtrans)[64])

```

Below some test

```
$ make clean && make && ./tools/test.sh -o osx -m 3100 -t all -a all && ./oclHashcat.app -b -m 3100 --force
rm -f obj/*.o lib/*.a *.bin *.exe *.app *.restore *.out *.pot *.dictstat *.log oclHashcat core
rm -rf *.induct
rm -rf *.outfiles
rm -rf *.dSYM
rm -rf kernels
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -c -o obj/ext_OpenCL.NATIVE.o src/ext_OpenCL.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -c -o obj/shared.NATIVE.o src/shared.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -c -o obj/rp_kernel_on_cpu.NATIVE.o src/rp_kernel_on_cpu.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/    -o oclHashcat.app src/oclHashcat.c obj/ext_OpenCL.NATIVE.o obj/shared.NATIVE.o obj/rp_kernel_on_cpu.NATIVE.o -lpthread -DCOMPTIME=1454165191 -DVERSION_TAG=\"v2.01\" -DVERSION_SUM=\"g2c4ad77+\" -DINSTALL_FOLDER=\"/usr/local/bin\" -DSHARED_FOLDER=\"/usr/local/share/oclHashcat\" -DDOCUMENT_FOLDER=\"/usr/local/share/doc/oclHashcat\"
[ test_1454165199 ] > Init test for hash type 3100.
[ test_1454165199 ] [ Type 3100, Attack 0, Mode single ] > OK : 0/31 not found, 0/31 not matched, 0/31 timeout
[ test_1454165199 ] [ Type 3100, Attack 0, Mode multi  ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1454165199 ] [ Type 3100, Attack 1, Mode single ] > OK : 0/30 not found, 0/30 not matched, 0/30 timeout
[ test_1454165199 ] [ Type 3100, Attack 1, Mode multi  ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1454165199 ] [ Type 3100, Attack 3, Mode single ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1454165199 ] [ Type 3100, Attack 3, Mode multi  ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1454165199 ] [ Type 3100, Attack 6, Mode single ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1454165199 ] [ Type 3100, Attack 6, Mode multi  ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1454165199 ] [ Type 3100, Attack 7, Mode single ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1454165199 ] [ Type 3100, Attack 7, Mode multi  ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
oclHashcat v2.01 (g2c4ad77+) starting in benchmark-mode...

Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, skipped
Device #2: Iris, 384/1536 MB allocatable, 1200Mhz, 40MCU

Hashtype: Oracle H: Type (Oracle 7+)
Workload: 16 loops, 64 accel

Speed.Dev.#2.:  8280.6 kH/s

Started: Sat Jan 30 15:54:13 2016
Stopped: Sat Jan 30 15:54:34 2016
```

Applying these small changes most likely to the code should be compatible with all platforms, and not only Apple.

From [https://www.khronos.org/registry/cl/specs/opencl-1.0.48.pdf](url)

```
6.5.2 __local (or local)
The __local or local address space name is used to describe variables that need to be
allocated in local memory and are shared by all work-items of a work-group. This qualifier can
be used with arguments to functions (including __kernel functions) declared as pointers, or
with variables declared inside a __kernel function. 

6.5.3 __constant (or constant)
The __constant or constant address space name is used to describe variables allocated in
global memory and which are accessed inside a kernel(s) as read-only variables. These readonly
variables can be accessed by all (global) work-items of the kernel during its execution. This
qualifier can be used with arguments to functions (including __kernel functions) that are
declared as pointers, or with local variables inside a function declared as pointers, or with global
variables. Global variables declared in the program source with the __constant qualifier are
required to be initialized. 
```

If the team agree, next patch will be global, multiple changes on multiple .cl files
but very simple to understand after this explanation.
