### PR TITLE
cleanup unnecessary clGetProgramBuildInfo code

### DIFF
--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -130,7 +130,7 @@ void *hc_clEnqueueMapBuffer (OCL_PTR *ocl, cl_command_queue command_queue, cl_me
 void hc_clEnqueueUnmapMemObject (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem memobj, void *mapped_ptr, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event);
 void hc_clEnqueueFillBuffer (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem buffer, const void *pattern, size_t pattern_size, size_t offset, size_t size, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event);
 void hc_clGetKernelWorkGroupInfo (OCL_PTR *ocl, cl_kernel kernel, cl_device_id device, cl_kernel_work_group_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret);
-void hc_clGetProgramBuildInfo (OCL_PTR *ocl, cl_program program, cl_device_id device, cl_program_build_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret);
+cl_int hc_clGetProgramBuildInfo (OCL_PTR *ocl, cl_program program, cl_device_id device, cl_program_build_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret);
 void hc_clGetProgramInfo (OCL_PTR *ocl, cl_program program, cl_program_info param_name, size_t param_value_size, void *param_value, size_t * param_value_size_ret);
 void hc_clGetEventInfo (OCL_PTR *ocl, cl_event event, cl_event_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret);
 #endif

--- a/src/ext_OpenCL.c
+++ b/src/ext_OpenCL.c
@@ -378,24 +378,15 @@ void hc_clBuildProgram (OCL_PTR *ocl, cl_program program, cl_uint num_devices, c
     char *buf = NULL;
     size_t len = 0;
 
-    if (ocl->clGetProgramBuildInfo (program, *device_list, CL_PROGRAM_BUILD_LOG, 0, NULL, &len) != CL_SUCCESS)
-    {
-      log_error ("ERROR: %s : %d : %s\n", "clGetProgramBuildInfo()", CL_err, val2cstr_cl (CL_err));
+    cl_int err = hc_clGetProgramBuildInfo (ocl, program, *device_list, CL_PROGRAM_BUILD_LOG, 0, NULL, &len);
 
-      exit (-1);
-    }
-
-    if (len > 0)
+    if (err == CL_SUCCESS && len > 0)
     {
       buf = (char *) mymalloc (len + 1);
 
-      if (ocl->clGetProgramBuildInfo (program, *device_list, CL_PROGRAM_BUILD_LOG, len, buf, NULL) != CL_SUCCESS)
+      if (hc_clGetProgramBuildInfo (ocl, program, *device_list, CL_PROGRAM_BUILD_LOG, len, buf, NULL) == CL_SUCCESS)
       {
-        log_error ("ERROR: %s : %d : %s\n", "clGetProgramBuildInfo()", CL_err, val2cstr_cl (CL_err));
-      }
-      else
-      {
-        log_error ("Build log:\n%s\n", buf);
+        fprintf (stderr, "\n=== Build Log (start) ===\n%s\n=== Build Log (end) ===\n", buf);
       }
 
       myfree (buf);
@@ -533,7 +524,7 @@ void hc_clGetKernelWorkGroupInfo (OCL_PTR *ocl, cl_kernel kernel, cl_device_id d
   }
 }
 
-void hc_clGetProgramBuildInfo (OCL_PTR *ocl, cl_program program, cl_device_id device, cl_program_build_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret)
+cl_int hc_clGetProgramBuildInfo (OCL_PTR *ocl, cl_program program, cl_device_id device, cl_program_build_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret)
 {
   cl_int CL_err = ocl->clGetProgramBuildInfo (program, device, param_name, param_value_size, param_value, param_value_size_ret);
 
@@ -541,8 +532,10 @@ void hc_clGetProgramBuildInfo (OCL_PTR *ocl, cl_program program, cl_device_id de
   {
     log_error ("ERROR: %s : %d : %s\n", "clGetProgramBuildInfo()", CL_err, val2cstr_cl (CL_err));
 
-    exit (-1);
+    return (-1);
   }
+
+  return CL_err;
 }
 
 void hc_clGetProgramInfo (OCL_PTR *ocl, cl_program program, cl_program_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret)

--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -13646,23 +13646,6 @@ int main (int argc, char **argv)
         local_free (kernel_lengths);
         local_free (kernel_sources[0]);
         local_free (kernel_sources);
-
-        // this is mostly for debug
-
-        size_t ret_val_size = 0;
-
-        hc_clGetProgramBuildInfo (data.ocl, device_param->program, device_param->device, CL_PROGRAM_BUILD_LOG, 0, NULL, &ret_val_size);
-
-        if (ret_val_size > 2)
-        {
-          char *build_log = (char *) mymalloc (ret_val_size + 1);
-
-          hc_clGetProgramBuildInfo (data.ocl, device_param->program, device_param->device, CL_PROGRAM_BUILD_LOG, ret_val_size, build_log, NULL);
-
-          puts (build_log);
-
-          myfree (build_log);
-        }
       }
 
       /**
@@ -13749,23 +13732,6 @@ int main (int argc, char **argv)
         local_free (kernel_lengths);
         local_free (kernel_sources[0]);
         local_free (kernel_sources);
-
-        // this is mostly for debug
-
-        size_t ret_val_size = 0;
-
-        hc_clGetProgramBuildInfo (data.ocl, device_param->program_mp, device_param->device, CL_PROGRAM_BUILD_LOG, 0, NULL, &ret_val_size);
-
-        if (ret_val_size > 2)
-        {
-          char *build_log = (char *) mymalloc (ret_val_size + 1);
-
-          hc_clGetProgramBuildInfo (data.ocl, device_param->program_mp, device_param->device, CL_PROGRAM_BUILD_LOG, ret_val_size, build_log, NULL);
-
-          puts (build_log);
-
-          myfree (build_log);
-        }
       }
 
       /**
@@ -13856,23 +13822,6 @@ int main (int argc, char **argv)
         local_free (kernel_lengths);
         local_free (kernel_sources[0]);
         local_free (kernel_sources);
-
-        // this is mostly for debug
-
-        size_t ret_val_size = 0;
-
-        hc_clGetProgramBuildInfo (data.ocl, device_param->program_amp, device_param->device, CL_PROGRAM_BUILD_LOG, 0, NULL, &ret_val_size);
-
-        if (ret_val_size > 2)
-        {
-          char *build_log = (char *) mymalloc (ret_val_size + 1);
-
-          hc_clGetProgramBuildInfo (data.ocl, device_param->program_amp, device_param->device, CL_PROGRAM_BUILD_LOG, ret_val_size, build_log, NULL);
-
-          puts (build_log);
-
-          myfree (build_log);
-        }
       }
 
       /**


### PR DESCRIPTION
- oclHashcat.c
  Remove unnecessary call to clGetProgramBuildInfo
- ext_OpenCL.c / ext_OpenCL.h
  Rewrite hc_clGetProgramBuildInfo, without exit(-1)
  Update hc_clBuildProgram for use new code
