### PR TITLE
Fixed typo in help

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -492,7 +492,7 @@ const char *USAGE_BIG[] =
   "   ?l = abcdefghijklmnopqrstuvwxyz",
   "   ?u = ABCDEFGHIJKLMNOPQRSTUVWXYZ",
   "   ?d = 0123456789",
-  "   ?s =  !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+  "   ?s =  !\"#$%%&'()*+,-./:;<=>?@[\\]^_`{|}~",
   "   ?a = ?l?u?d?s",
   "   ?b = 0x00 - 0xff",
   "",


### PR DESCRIPTION
Found with DEBUG enabled :)

```
$ make clean && make DEBUG=1 && ./oclHashcat.app -h | grep hashcat
rm -f obj/*.o lib/*.a *.bin *.exe *.app *.restore *.out *.pot *.dictstat *.log oclHashcat core
rm -rf *.induct
rm -rf *.outfiles
rm -rf *.dSYM
rm -rf kernels
src/Makefile:21: "## Detected Operating System : Darwin"
src/Makefile:75: "## NVAPI is found ? 0"
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -DDEBUG -g -ggdb -fsanitize=address -fno-omit-frame-pointer -c -o obj/ext_OpenCL.NATIVE.o src/ext_OpenCL.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -DDEBUG -g -ggdb -fsanitize=address -fno-omit-frame-pointer -c -o obj/shared.NATIVE.o src/shared.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -DDEBUG -g -ggdb -fsanitize=address -fno-omit-frame-pointer -c -o obj/rp_kernel_on_cpu.NATIVE.o src/rp_kernel_on_cpu.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -DDEBUG -g -ggdb -fsanitize=address -fno-omit-frame-pointer    -o oclHashcat.app src/oclHashcat.c obj/ext_OpenCL.NATIVE.o obj/shared.NATIVE.o obj/rp_kernel_on_cpu.NATIVE.o -lpthread -DCOMPTIME=1454245023 -DVERSION_TAG=\"v2.01\" -DVERSION_SUM=\"g17d24e2\" -DINSTALL_FOLDER=\"/usr/local/bin\" -DSHARED_FOLDER=\"/usr/local/share/oclHashcat\" -DDOCUMENT_FOLDER=\"/usr/local/share/doc/oclHashcat\"
       --markov-hcstat=FILE          Specify hcstat file to use, default is hashcat.hcstat
==3916==WARNING: unexpected format specifier in printf interceptor: %&
```

"--help" output, from

```
   ?l = abcdefghijklmnopqrstuvwxyz
   ?u = ABCDEFGHIJKLMNOPQRSTUVWXYZ
   ?d = 0123456789
==3997==WARNING: unexpected format specifier in printf interceptor: %&
   ?s =  !"#$&'()*+,-./:;<=>?@[\]^_`{|}~
   ?a = ?l?u?d?s
   ?b = 0x00 - 0xff
```

to

```
   ?l = abcdefghijklmnopqrstuvwxyz
   ?u = ABCDEFGHIJKLMNOPQRSTUVWXYZ
   ?d = 0123456789
   ?s =  !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
   ?a = ?l?u?d?s
   ?b = 0x00 - 0xff

```
