### PR TITLE
Removed deprecated and unused ADL function (ADL_DisplayEnable_Set)

### DIFF
--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -359,7 +359,7 @@ int hc_ADL_Overdrive_PowerControlInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLO
 int hc_ADL_Overdrive_PowerControl_Get (ADL_PTR *adl, int iAdapterIndex, int *level);
 int hc_ADL_Overdrive_PowerControl_Set (ADL_PTR *adl, int iAdapterIndex, int level);
 int hc_ADL_Adapter_Active_Get (ADL_PTR *adl, int iAdapterIndex, int *lpStatus);
-int hc_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayIndexList, int iDisplayListSize, int bPersistOnly);
+//int hc_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayIndexList, int iDisplayListSize, int bPersistOnly);
 int hc_ADL_Overdrive_Caps (ADL_PTR *adl, int iAdapterIndex, int *od_supported, int *od_enabled, int *od_version);
 int hc_ADL_Overdrive_CurrentStatus_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6CurrentStatus *status);
 int hc_ADL_Overdrive_StateInfo_Get (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6MemClockState *state);

--- a/src/ext_ADL.c
+++ b/src/ext_ADL.c
@@ -52,7 +52,7 @@ int adl_init (ADL_PTR *adl)
   HC_LOAD_FUNC(adl, ADL_Overdrive6_PowerControl_Get, ADL_OVERDRIVE6_POWERCONTROL_GET, ADL, 0)
   HC_LOAD_FUNC(adl, ADL_Overdrive6_PowerControl_Set, ADL_OVERDRIVE6_POWERCONTROL_SET, ADL, 0)
   HC_LOAD_FUNC(adl, ADL_Adapter_Active_Get, ADL_ADAPTER_ACTIVE_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_DisplayEnable_Set, ADL_DISPLAYENABLE_SET, ADL, 0)
+  //HC_LOAD_FUNC(adl, ADL_DisplayEnable_Set, ADL_DISPLAYENABLE_SET, ADL, 0)
   HC_LOAD_FUNC(adl, ADL_Overdrive_Caps, ADL_OVERDRIVE_CAPS, ADL, 0)
   HC_LOAD_FUNC(adl, ADL_Overdrive6_PowerControl_Caps, ADL_OVERDRIVE6_POWERCONTROL_CAPS, ADL, 0)
   HC_LOAD_FUNC(adl, ADL_Overdrive6_Capabilities_Get, ADL_OVERDRIVE6_CAPABILITIES_GET, ADL, 0)
@@ -426,6 +426,7 @@ int hc_ADL_Adapter_Active_Get (ADL_PTR *adl, int iAdapterIndex, int *lpStatus)
   return (ADL_rc);
 }
 
+/*
 int hc_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayIndexList, int iDisplayListSize, int bPersistOnly)
 {
   if (!adl) return (-1);
@@ -439,6 +440,7 @@ int hc_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayInd
 
   return (ADL_rc);
 }
+*/
 
 int hc_ADL_Overdrive_Caps (ADL_PTR *adl, int iAdapterIndex, int *od_supported, int *od_enabled, int *od_version)
 {


### PR DESCRIPTION
WARNING: ADL_DisplayEnable_Set is missing from ADL shared library.
