### PR TITLE
HWMon mod

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -50,8 +50,8 @@
 typedef void *OCL_LIB;
 
 #ifdef HAVE_HWMON
-typedef void *HM_LIB;
-typedef void *ADL_LIB;
+typedef void *NV_LIB;
+typedef void *AMD_LIB;
 #ifdef OSX
 #define __stdcall
 #endif
@@ -80,12 +80,12 @@ typedef INT64  int64_t;
 typedef UINT32 uint;
 typedef UINT64 uint64_t;
 
-#ifdef HAVE_HWMON
-typedef HINSTANCE HM_LIB;
-typedef HINSTANCE ADL_LIB;
-#endif
-
 typedef HINSTANCE OCL_LIB;
+
+#ifdef HAVE_HWMON
+typedef HINSTANCE NV_LIB;
+typedef HINSTANCE AMD_LIB;
+#endif
 
 #define mkdir(name,mode) mkdir (name)
 

--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -293,7 +293,7 @@ typedef int (*ADL_OVERDRIVE6_TARGETTEMPERATUREDATA_GET) (int, int *, int *);
 
 typedef struct
 {
-  ADL_LIB lib;
+  AMD_LIB lib;
 
   ADL_MAIN_CONTROL_DESTROY ADL_Main_Control_Destroy;
   ADL_MAIN_CONTROL_CREATE ADL_Main_Control_Create;
@@ -328,45 +328,45 @@ typedef struct
   ADL_OVERDRIVE6_STATE_SET ADL_Overdrive6_State_Set;
   ADL_OVERDRIVE6_TARGETTEMPERATUREDATA_GET ADL_Overdrive6_TargetTemperatureData_Get;
 
-} hc_adl_lib_t;
+} hm_adl_lib_t;
 
-#define ADL_PTR hc_adl_lib_t
+#define ADL_PTR hm_adl_lib_t
 
 int adl_init (ADL_PTR *lib);
 void adl_close (ADL_PTR *lib);
 
-int hc_ADL_Main_Control_Destroy (ADL_PTR *adl);
-int hc_ADL_Main_Control_Create (ADL_PTR *adl, ADL_MAIN_MALLOC_CALLBACK callback, int iEnumConnectedAdapters);
-int hc_ADL_Adapter_NumberOfAdapters_Get (ADL_PTR *adl, int *lpNumAdapters);
-int hc_ADL_Adapter_AdapterInfo_Get (ADL_PTR *adl, LPAdapterInfo lpInfo, int iInputSize);
-int hc_ADL_Display_DisplayInfo_Get (ADL_PTR *adl, int iAdapterIndex, int *iNumDisplays, ADLDisplayInfo **lppInfo, int iForceDetect);
-int hc_ADL_Overdrive5_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLTemperature *lpTemperature);
-int hc_ADL_Overdrive6_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int *iTemperature);
-int hc_ADL_Overdrive_CurrentActivity_Get (ADL_PTR *adl, int iAdapterIndex, ADLPMActivity *lpActivity);
-int hc_ADL_Overdrive_ThermalDevices_Enum (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLThermalControllerInfo *lpThermalControllerInfo);
-int hc_ADL_Adapter_ID_Get (ADL_PTR *adl, int iAdapterIndex, int *lpAdapterID);
-int hc_ADL_Adapter_VideoBiosInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLBiosInfo *lpBiosInfo);
-int hc_ADL_Overdrive5_FanSpeedInfo_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedInfo *lpFanSpeedInfo);
-int hc_ADL_Overdrive5_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue);
-int hc_ADL_Overdrive6_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedInfo *lpFanSpeedInfo);
-int hc_ADL_Overdrive5_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue);
-int hc_ADL_Overdrive6_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedValue *lpFanSpeedValue);
-int hc_ADL_Overdrive5_FanSpeedToDefault_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex);
-int hc_ADL_Overdrive_ODParameters_Get (ADL_PTR *adl, int iAdapterIndex, ADLODParameters *lpOdParameters);
-int hc_ADL_Overdrive_ODPerformanceLevels_Get (ADL_PTR *adl, int iAdapterIndex, int iDefault, ADLODPerformanceLevels *lpOdPerformanceLevels);
-int hc_ADL_Overdrive_ODPerformanceLevels_Set (ADL_PTR *adl, int iAdapterIndex, ADLODPerformanceLevels *lpOdPerformanceLevels);
-int hc_ADL_Overdrive_PowerControlInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6PowerControlInfo *);
-int hc_ADL_Overdrive_PowerControl_Get (ADL_PTR *adl, int iAdapterIndex, int *level);
-int hc_ADL_Overdrive_PowerControl_Set (ADL_PTR *adl, int iAdapterIndex, int level);
-int hc_ADL_Adapter_Active_Get (ADL_PTR *adl, int iAdapterIndex, int *lpStatus);
-//int hc_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayIndexList, int iDisplayListSize, int bPersistOnly);
-int hc_ADL_Overdrive_Caps (ADL_PTR *adl, int iAdapterIndex, int *od_supported, int *od_enabled, int *od_version);
-int hc_ADL_Overdrive_CurrentStatus_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6CurrentStatus *status);
-int hc_ADL_Overdrive_StateInfo_Get (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6MemClockState *state);
-int hc_ADL_Overdrive_Capabilities_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6Capabilities *caps);
-int hc_ADL_Overdrive_State_Set (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6StateInfo *state);
-int hc_ADL_Overdrive6_PowerControl_Caps (ADL_PTR *adl, int iAdapterIndex, int *lpSupported);
-int hc_ADL_Overdrive6_TargetTemperatureData_Get (ADL_PTR *adl, int iAdapterIndex, int *cur_temp, int *default_temp);
+int hm_ADL_Main_Control_Destroy (ADL_PTR *adl);
+int hm_ADL_Main_Control_Create (ADL_PTR *adl, ADL_MAIN_MALLOC_CALLBACK callback, int iEnumConnectedAdapters);
+int hm_ADL_Adapter_NumberOfAdapters_Get (ADL_PTR *adl, int *lpNumAdapters);
+int hm_ADL_Adapter_AdapterInfo_Get (ADL_PTR *adl, LPAdapterInfo lpInfo, int iInputSize);
+int hm_ADL_Display_DisplayInfo_Get (ADL_PTR *adl, int iAdapterIndex, int *iNumDisplays, ADLDisplayInfo **lppInfo, int iForceDetect);
+int hm_ADL_Overdrive5_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLTemperature *lpTemperature);
+int hm_ADL_Overdrive6_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int *iTemperature);
+int hm_ADL_Overdrive_CurrentActivity_Get (ADL_PTR *adl, int iAdapterIndex, ADLPMActivity *lpActivity);
+int hm_ADL_Overdrive_ThermalDevices_Enum (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLThermalControllerInfo *lpThermalControllerInfo);
+int hm_ADL_Adapter_ID_Get (ADL_PTR *adl, int iAdapterIndex, int *lpAdapterID);
+int hm_ADL_Adapter_VideoBiosInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLBiosInfo *lpBiosInfo);
+int hm_ADL_Overdrive5_FanSpeedInfo_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedInfo *lpFanSpeedInfo);
+int hm_ADL_Overdrive5_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue);
+int hm_ADL_Overdrive6_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedInfo *lpFanSpeedInfo);
+int hm_ADL_Overdrive5_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue);
+int hm_ADL_Overdrive6_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedValue *lpFanSpeedValue);
+int hm_ADL_Overdrive5_FanSpeedToDefault_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex);
+int hm_ADL_Overdrive_ODParameters_Get (ADL_PTR *adl, int iAdapterIndex, ADLODParameters *lpOdParameters);
+int hm_ADL_Overdrive_ODPerformanceLevels_Get (ADL_PTR *adl, int iAdapterIndex, int iDefault, ADLODPerformanceLevels *lpOdPerformanceLevels);
+int hm_ADL_Overdrive_ODPerformanceLevels_Set (ADL_PTR *adl, int iAdapterIndex, ADLODPerformanceLevels *lpOdPerformanceLevels);
+int hm_ADL_Overdrive_PowerControlInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6PowerControlInfo *);
+int hm_ADL_Overdrive_PowerControl_Get (ADL_PTR *adl, int iAdapterIndex, int *level);
+int hm_ADL_Overdrive_PowerControl_Set (ADL_PTR *adl, int iAdapterIndex, int level);
+int hm_ADL_Adapter_Active_Get (ADL_PTR *adl, int iAdapterIndex, int *lpStatus);
+//int hm_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayIndexList, int iDisplayListSize, int bPersistOnly);
+int hm_ADL_Overdrive_Caps (ADL_PTR *adl, int iAdapterIndex, int *od_supported, int *od_enabled, int *od_version);
+int hm_ADL_Overdrive_CurrentStatus_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6CurrentStatus *status);
+int hm_ADL_Overdrive_StateInfo_Get (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6MemClockState *state);
+int hm_ADL_Overdrive_Capabilities_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6Capabilities *caps);
+int hm_ADL_Overdrive_State_Set (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6StateInfo *state);
+int hm_ADL_Overdrive6_PowerControl_Caps (ADL_PTR *adl, int iAdapterIndex, int *lpSupported);
+int hm_ADL_Overdrive6_TargetTemperatureData_Get (ADL_PTR *adl, int iAdapterIndex, int *cur_temp, int *default_temp);
 
 #endif // HAVE_HWMON && HAVE_ADL
 

--- a/include/ext_nvapi.h
+++ b/include/ext_nvapi.h
@@ -1,5 +1,7 @@
 /**
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -10,7 +12,308 @@
 
 #include <common.h>
 
+/*
+ * Declarations from nvapi.h and subheaders
+ **/
+
+#ifndef __success
+    #define __nvapi_success
+    #define __success(epxr)
+#endif
+
+#define NVAPI_INTERFACE extern __success(return == NVAPI_OK) NvAPI_Status __cdecl
+
+/*
+ * Definitions from nvapi_lite_common.h
+ */
+
+// 64-bit types for compilers that support them, plus some obsolete variants
+#if defined(__GNUC__) || defined(__arm) || defined(__IAR_SYSTEMS_ICC__) || defined(__ghs__) || defined(_WIN64)
+typedef unsigned long long NvU64; /* 0 to 18446744073709551615  */
+typedef long long          NvS64; /* -9223372036854775808 to 9223372036854775807  */
+#else
+typedef unsigned __int64   NvU64; /* 0 to 18446744073709551615  */
+typedef __int64            NvS64; /* -9223372036854775808 to 9223372036854775807  */
+#endif
+
+// mac os 32-bit still needs this
+#if (defined(macintosh) || defined(__APPLE__)) && !defined(__LP64__)
+typedef signed long        NvS32; /* -2147483648 to 2147483647  */
+#else
+typedef signed int         NvS32; /* -2147483648 to 2147483647 */
+#endif
+
+// mac os 32-bit still needs this
+#if ( (defined(macintosh) && defined(__LP64__) && (__NVAPI_RESERVED0__)) || \
+      (!defined(macintosh) && defined(__NVAPI_RESERVED0__)) )
+typedef unsigned int       NvU32; /* 0 to 4294967295                         */
+#else
+typedef unsigned long      NvU32; /* 0 to 4294967295                         */
+#endif
+
+typedef signed   short   NvS16;
+typedef unsigned short   NvU16;
+typedef unsigned char    NvU8;
+typedef signed   char    NvS8;
+
+#define NV_DECLARE_HANDLE(name) struct name##__ { int unused; }; typedef struct name##__ *name
+
+NV_DECLARE_HANDLE(NvPhysicalGpuHandle);            // A single physical GPU
+
+#define NVAPI_GENERIC_STRING_MAX    4096
+#define NVAPI_LONG_STRING_MAX       256
+#define NVAPI_SHORT_STRING_MAX      64
+
+typedef char NvAPI_String[NVAPI_GENERIC_STRING_MAX];
+typedef char NvAPI_LongString[NVAPI_LONG_STRING_MAX];
+typedef char NvAPI_ShortString[NVAPI_SHORT_STRING_MAX];
+
+#define MAKE_NVAPI_VERSION(typeName,ver) (NvU32)(sizeof(typeName) | ((ver)<<16))
+#define GET_NVAPI_VERSION(ver) (NvU32)((ver)>>16)
+#define GET_NVAPI_SIZE(ver) (NvU32)((ver) & 0xffff)
+
+#define NVAPI_MAX_PHYSICAL_GPUS             64
+
+typedef enum _NvAPI_Status
+{
+    NVAPI_OK                                    =  0,      // Success. Request is completed.
+    NVAPI_ERROR                                 = -1,      // Generic error
+    NVAPI_LIBRARY_NOT_FOUND                     = -2,      // NVAPI support library cannot be loaded.
+    NVAPI_NO_IMPLEMENTATION                     = -3,      // not implemented in current driver installation
+    NVAPI_API_NOT_INITIALIZED                   = -4,      // NvAPI_Initialize has not been called (successfully)
+    NVAPI_INVALID_ARGUMENT                      = -5,      // The argument/parameter value is not valid or NULL.
+    NVAPI_NVIDIA_DEVICE_NOT_FOUND               = -6,      // No NVIDIA display driver, or NVIDIA GPU driving a display, was found.
+    NVAPI_END_ENUMERATION                       = -7,      // No more items to enumerate
+    NVAPI_INVALID_HANDLE                        = -8,      // Invalid handle
+    NVAPI_INCOMPATIBLE_STRUCT_VERSION           = -9,      // An argument's structure version is not supported
+    NVAPI_HANDLE_INVALIDATED                    = -10,     // The handle is no longer valid (likely due to GPU or display re-configuration)
+    NVAPI_OPENGL_CONTEXT_NOT_CURRENT            = -11,     // No NVIDIA OpenGL context is current (but needs to be)
+    NVAPI_INVALID_POINTER                       = -14,     // An invalid pointer, usually NULL, was passed as a parameter
+    NVAPI_NO_GL_EXPERT                          = -12,     // OpenGL Expert is not supported by the current drivers
+    NVAPI_INSTRUMENTATION_DISABLED              = -13,     // OpenGL Expert is supported, but driver instrumentation is currently disabled
+    NVAPI_NO_GL_NSIGHT                          = -15,     // OpenGL does not support Nsight
+
+    NVAPI_EXPECTED_LOGICAL_GPU_HANDLE           = -100,    // Expected a logical GPU handle for one or more parameters
+    NVAPI_EXPECTED_PHYSICAL_GPU_HANDLE          = -101,    // Expected a physical GPU handle for one or more parameters
+    NVAPI_EXPECTED_DISPLAY_HANDLE               = -102,    // Expected an NV display handle for one or more parameters
+    NVAPI_INVALID_COMBINATION                   = -103,    // The combination of parameters is not valid.
+    NVAPI_NOT_SUPPORTED                         = -104,    // Requested feature is not supported in the selected GPU
+    NVAPI_PORTID_NOT_FOUND                      = -105,    // No port ID was found for the I2C transaction
+    NVAPI_EXPECTED_UNATTACHED_DISPLAY_HANDLE    = -106,    // Expected an unattached display handle as one of the input parameters.
+    NVAPI_INVALID_PERF_LEVEL                    = -107,    // Invalid perf level
+    NVAPI_DEVICE_BUSY                           = -108,    // Device is busy; request not fulfilled
+    NVAPI_NV_PERSIST_FILE_NOT_FOUND             = -109,    // NV persist file is not found
+    NVAPI_PERSIST_DATA_NOT_FOUND                = -110,    // NV persist data is not found
+    NVAPI_EXPECTED_TV_DISPLAY                   = -111,    // Expected a TV output display
+    NVAPI_EXPECTED_TV_DISPLAY_ON_DCONNECTOR     = -112,    // Expected a TV output on the D Connector - HDTV_EIAJ4120.
+    NVAPI_NO_ACTIVE_SLI_TOPOLOGY                = -113,    // SLI is not active on this device.
+    NVAPI_SLI_RENDERING_MODE_NOTALLOWED         = -114,    // Setup of SLI rendering mode is not possible right now.
+    NVAPI_EXPECTED_DIGITAL_FLAT_PANEL           = -115,    // Expected a digital flat panel.
+    NVAPI_ARGUMENT_EXCEED_MAX_SIZE              = -116,    // Argument exceeds the expected size.
+    NVAPI_DEVICE_SWITCHING_NOT_ALLOWED          = -117,    // Inhibit is ON due to one of the flags in NV_GPU_DISPLAY_CHANGE_INHIBIT or SLI active.
+    NVAPI_TESTING_CLOCKS_NOT_SUPPORTED          = -118,    // Testing of clocks is not supported.
+    NVAPI_UNKNOWN_UNDERSCAN_CONFIG              = -119,    // The specified underscan config is from an unknown source (e.g. INF)
+    NVAPI_TIMEOUT_RECONFIGURING_GPU_TOPO        = -120,    // Timeout while reconfiguring GPUs
+    NVAPI_DATA_NOT_FOUND                        = -121,    // Requested data was not found
+    NVAPI_EXPECTED_ANALOG_DISPLAY               = -122,    // Expected an analog display
+    NVAPI_NO_VIDLINK                            = -123,    // No SLI video bridge is present
+    NVAPI_REQUIRES_REBOOT                       = -124,    // NVAPI requires a reboot for the settings to take effect
+    NVAPI_INVALID_HYBRID_MODE                   = -125,    // The function is not supported with the current Hybrid mode.
+    NVAPI_MIXED_TARGET_TYPES                    = -126,    // The target types are not all the same
+    NVAPI_SYSWOW64_NOT_SUPPORTED                = -127,    // The function is not supported from 32-bit on a 64-bit system.
+    NVAPI_IMPLICIT_SET_GPU_TOPOLOGY_CHANGE_NOT_ALLOWED = -128,    // There is no implicit GPU topology active. Use NVAPI_SetHybridMode to change topology.
+    NVAPI_REQUEST_USER_TO_CLOSE_NON_MIGRATABLE_APPS = -129,      // Prompt the user to close all non-migratable applications.
+    NVAPI_OUT_OF_MEMORY                         = -130,    // Could not allocate sufficient memory to complete the call.
+    NVAPI_WAS_STILL_DRAWING                     = -131,    // The previous operation that is transferring information to or from this surface is incomplete.
+    NVAPI_FILE_NOT_FOUND                        = -132,    // The file was not found.
+    NVAPI_TOO_MANY_UNIQUE_STATE_OBJECTS         = -133,    // There are too many unique instances of a particular type of state object.
+    NVAPI_INVALID_CALL                          = -134,    // The method call is invalid. For example, a method's parameter may not be a valid pointer.
+    NVAPI_D3D10_1_LIBRARY_NOT_FOUND             = -135,    // d3d10_1.dll cannot be loaded.
+    NVAPI_FUNCTION_NOT_FOUND                    = -136,    // Couldn't find the function in the loaded DLL.
+    NVAPI_INVALID_USER_PRIVILEGE                = -137,    // Current User is not Admin.
+    NVAPI_EXPECTED_NON_PRIMARY_DISPLAY_HANDLE   = -138,    // The handle corresponds to GDIPrimary.
+    NVAPI_EXPECTED_COMPUTE_GPU_HANDLE           = -139,    // Setting Physx GPU requires that the GPU is compute-capable.
+    NVAPI_STEREO_NOT_INITIALIZED                = -140,    // The Stereo part of NVAPI failed to initialize completely. Check if the stereo driver is installed.
+    NVAPI_STEREO_REGISTRY_ACCESS_FAILED         = -141,    // Access to stereo-related registry keys or values has failed.
+    NVAPI_STEREO_REGISTRY_PROFILE_TYPE_NOT_SUPPORTED = -142, // The given registry profile type is not supported.
+    NVAPI_STEREO_REGISTRY_VALUE_NOT_SUPPORTED   = -143,    // The given registry value is not supported.
+    NVAPI_STEREO_NOT_ENABLED                    = -144,    // Stereo is not enabled and the function needed it to execute completely.
+    NVAPI_STEREO_NOT_TURNED_ON                  = -145,    // Stereo is not turned on and the function needed it to execute completely.
+    NVAPI_STEREO_INVALID_DEVICE_INTERFACE       = -146,    // Invalid device interface.
+    NVAPI_STEREO_PARAMETER_OUT_OF_RANGE         = -147,    // Separation percentage or JPEG image capture quality is out of [0-100] range.
+    NVAPI_STEREO_FRUSTUM_ADJUST_MODE_NOT_SUPPORTED = -148, // The given frustum adjust mode is not supported.
+    NVAPI_TOPO_NOT_POSSIBLE                     = -149,    // The mosaic topology is not possible given the current state of the hardware.
+    NVAPI_MODE_CHANGE_FAILED                    = -150,    // An attempt to do a display resolution mode change has failed.
+    NVAPI_D3D11_LIBRARY_NOT_FOUND               = -151,    // d3d11.dll/d3d11_beta.dll cannot be loaded.
+    NVAPI_INVALID_ADDRESS                       = -152,    // Address is outside of valid range.
+    NVAPI_STRING_TOO_SMALL                      = -153,    // The pre-allocated string is too small to hold the result.
+    NVAPI_MATCHING_DEVICE_NOT_FOUND             = -154,    // The input does not match any of the available devices.
+    NVAPI_DRIVER_RUNNING                        = -155,    // Driver is running.
+    NVAPI_DRIVER_NOTRUNNING                     = -156,    // Driver is not running.
+    NVAPI_ERROR_DRIVER_RELOAD_REQUIRED          = -157,    // A driver reload is required to apply these settings.
+    NVAPI_SET_NOT_ALLOWED                       = -158,    // Intended setting is not allowed.
+    NVAPI_ADVANCED_DISPLAY_TOPOLOGY_REQUIRED    = -159,    // Information can't be returned due to "advanced display topology".
+    NVAPI_SETTING_NOT_FOUND                     = -160,    // Setting is not found.
+    NVAPI_SETTING_SIZE_TOO_LARGE                = -161,    // Setting size is too large.
+    NVAPI_TOO_MANY_SETTINGS_IN_PROFILE          = -162,    // There are too many settings for a profile.
+    NVAPI_PROFILE_NOT_FOUND                     = -163,    // Profile is not found.
+    NVAPI_PROFILE_NAME_IN_USE                   = -164,    // Profile name is duplicated.
+    NVAPI_PROFILE_NAME_EMPTY                    = -165,    // Profile name is empty.
+    NVAPI_EXECUTABLE_NOT_FOUND                  = -166,    // Application not found in the Profile.
+    NVAPI_EXECUTABLE_ALREADY_IN_USE             = -167,    // Application already exists in the other profile.
+    NVAPI_DATATYPE_MISMATCH                     = -168,    // Data Type mismatch
+    NVAPI_PROFILE_REMOVED                       = -169,    // The profile passed as parameter has been removed and is no longer valid.
+    NVAPI_UNREGISTERED_RESOURCE                 = -170,    // An unregistered resource was passed as a parameter.
+    NVAPI_ID_OUT_OF_RANGE                       = -171,    // The DisplayId corresponds to a display which is not within the normal outputId range.
+    NVAPI_DISPLAYCONFIG_VALIDATION_FAILED       = -172,    // Display topology is not valid so the driver cannot do a mode set on this configuration.
+    NVAPI_DPMST_CHANGED                         = -173,    // Display Port Multi-Stream topology has been changed.
+    NVAPI_INSUFFICIENT_BUFFER                   = -174,    // Input buffer is insufficient to hold the contents.
+    NVAPI_ACCESS_DENIED                         = -175,    // No access to the caller.
+    NVAPI_MOSAIC_NOT_ACTIVE                     = -176,    // The requested action cannot be performed without Mosaic being enabled.
+    NVAPI_SHARE_RESOURCE_RELOCATED              = -177,    // The surface is relocated away from video memory.
+    NVAPI_REQUEST_USER_TO_DISABLE_DWM           = -178,    // The user should disable DWM before calling NvAPI.
+    NVAPI_D3D_DEVICE_LOST                       = -179,    // D3D device status is D3DERR_DEVICELOST or D3DERR_DEVICENOTRESET - the user has to reset the device.
+    NVAPI_INVALID_CONFIGURATION                 = -180,    // The requested action cannot be performed in the current state.
+    NVAPI_STEREO_HANDSHAKE_NOT_DONE             = -181,    // Call failed as stereo handshake not completed.
+    NVAPI_EXECUTABLE_PATH_IS_AMBIGUOUS          = -182,    // The path provided was too short to determine the correct NVDRS_APPLICATION
+    NVAPI_DEFAULT_STEREO_PROFILE_IS_NOT_DEFINED = -183,    // Default stereo profile is not currently defined
+    NVAPI_DEFAULT_STEREO_PROFILE_DOES_NOT_EXIST = -184,    // Default stereo profile does not exist
+    NVAPI_CLUSTER_ALREADY_EXISTS                = -185,    // A cluster is already defined with the given configuration.
+    NVAPI_DPMST_DISPLAY_ID_EXPECTED             = -186,    // The input display id is not that of a multi stream enabled connector or a display device in a multi stream topology
+    NVAPI_INVALID_DISPLAY_ID                    = -187,    // The input display id is not valid or the monitor associated to it does not support the current operation
+    NVAPI_STREAM_IS_OUT_OF_SYNC                 = -188,    // While playing secure audio stream, stream goes out of sync
+    NVAPI_INCOMPATIBLE_AUDIO_DRIVER             = -189,    // Older audio driver version than required
+    NVAPI_VALUE_ALREADY_SET                     = -190,    // Value already set, setting again not allowed.
+    NVAPI_TIMEOUT                               = -191,    // Requested operation timed out
+    NVAPI_GPU_WORKSTATION_FEATURE_INCOMPLETE    = -192,    // The requested workstation feature set has incomplete driver internal allocation resources
+    NVAPI_STEREO_INIT_ACTIVATION_NOT_DONE       = -193,    // Call failed because InitActivation was not called.
+    NVAPI_SYNC_NOT_ACTIVE                       = -194,    // The requested action cannot be performed without Sync being enabled.
+    NVAPI_SYNC_MASTER_NOT_FOUND                 = -195,    // The requested action cannot be performed without Sync Master being enabled.
+    NVAPI_INVALID_SYNC_TOPOLOGY                 = -196,    // Invalid displays passed in the NV_GSYNC_DISPLAY pointer.
+    NVAPI_ECID_SIGN_ALGO_UNSUPPORTED            = -197,    // The specified signing algorithm is not supported. Either an incorrect value was entered or the current installed driver/hardware does not support the input value.
+    NVAPI_ECID_KEY_VERIFICATION_FAILED          = -198,    // The encrypted public key verification has failed.
+    NVAPI_FIRMWARE_OUT_OF_DATE                  = -199,    // The device's firmware is out of date.
+    NVAPI_FIRMWARE_REVISION_NOT_SUPPORTED       = -200,    // The device's firmware is not supported.
+} NvAPI_Status;
+
+/*
+ * Declarations from from nvapi.h
+ */
+
+#define NVAPI_MAX_THERMAL_SENSORS_PER_GPU 3
+
+// Used in NV_GPU_THERMAL_SETTINGS
+typedef enum
+{
+    NVAPI_THERMAL_TARGET_NONE          = 0,
+    NVAPI_THERMAL_TARGET_GPU           = 1,     // GPU core temperature requires NvPhysicalGpuHandle
+    NVAPI_THERMAL_TARGET_MEMORY        = 2,     // GPU memory temperature requires NvPhysicalGpuHandle
+    NVAPI_THERMAL_TARGET_POWER_SUPPLY  = 4,     // GPU power supply temperature requires NvPhysicalGpuHandle
+    NVAPI_THERMAL_TARGET_BOARD         = 8,     // GPU board ambient temperature requires NvPhysicalGpuHandle
+    NVAPI_THERMAL_TARGET_VCD_BOARD     = 9,     // Visual Computing Device Board temperature requires NvVisualComputingDeviceHandle
+    NVAPI_THERMAL_TARGET_VCD_INLET     = 10,    // Visual Computing Device Inlet temperature requires NvVisualComputingDeviceHandle
+    NVAPI_THERMAL_TARGET_VCD_OUTLET    = 11,    // Visual Computing Device Outlet temperature requires NvVisualComputingDeviceHandle
+
+    NVAPI_THERMAL_TARGET_ALL           = 15,
+    NVAPI_THERMAL_TARGET_UNKNOWN       = -1,
+} NV_THERMAL_TARGET;
+
+// Used in NV_GPU_THERMAL_SETTINGS
+typedef enum
+{
+    NVAPI_THERMAL_CONTROLLER_NONE = 0,
+    NVAPI_THERMAL_CONTROLLER_GPU_INTERNAL,
+    NVAPI_THERMAL_CONTROLLER_ADM1032,
+    NVAPI_THERMAL_CONTROLLER_MAX6649,
+    NVAPI_THERMAL_CONTROLLER_MAX1617,
+    NVAPI_THERMAL_CONTROLLER_LM99,
+    NVAPI_THERMAL_CONTROLLER_LM89,
+    NVAPI_THERMAL_CONTROLLER_LM64,
+    NVAPI_THERMAL_CONTROLLER_ADT7473,
+    NVAPI_THERMAL_CONTROLLER_SBMAX6649,
+    NVAPI_THERMAL_CONTROLLER_VBIOSEVT,
+    NVAPI_THERMAL_CONTROLLER_OS,
+    NVAPI_THERMAL_CONTROLLER_UNKNOWN = -1,
+} NV_THERMAL_CONTROLLER;
+
+// Used in NvAPI_GPU_GetThermalSettings()
+typedef struct
+{
+    NvU32   version;                // structure version
+    NvU32   count;                  // number of associated thermal sensors
+    struct
+    {
+        NV_THERMAL_CONTROLLER       controller;        // internal, ADM1032, MAX6649...
+        NvU32                       defaultMinTemp;    // The min default temperature value of the thermal sensor in degree Celsius
+        NvU32                       defaultMaxTemp;    // The max default temperature value of the thermal sensor in degree Celsius
+        NvU32                       currentTemp;       // The current temperature value of the thermal sensor in degree Celsius
+        NV_THERMAL_TARGET           target;            // Thermal sensor targeted @ GPU, memory, chipset, powersupply, Visual Computing Device, etc.
+    } sensor[NVAPI_MAX_THERMAL_SENSORS_PER_GPU];
+
+} NV_GPU_THERMAL_SETTINGS_V1;
+
+typedef struct
+{
+    NvU32   version;                // structure version
+    NvU32   count;                  // number of associated thermal sensors
+    struct
+    {
+        NV_THERMAL_CONTROLLER       controller;         // internal, ADM1032, MAX6649...
+        NvS32                       defaultMinTemp;     // Minimum default temperature value of the thermal sensor in degree Celsius
+        NvS32                       defaultMaxTemp;     // Maximum default temperature value of the thermal sensor in degree Celsius
+        NvS32                       currentTemp;        // Current temperature value of the thermal sensor in degree Celsius
+        NV_THERMAL_TARGET           target;             // Thermal sensor targeted - GPU, memory, chipset, powersupply, Visual Computing Device, etc
+    } sensor[NVAPI_MAX_THERMAL_SENSORS_PER_GPU];
+
+} NV_GPU_THERMAL_SETTINGS_V2;
+
+typedef NV_GPU_THERMAL_SETTINGS_V2  NV_GPU_THERMAL_SETTINGS;
+
+// Macro for constructing the version field of NV_GPU_THERMAL_SETTINGS_V1
+#define NV_GPU_THERMAL_SETTINGS_VER_1   MAKE_NVAPI_VERSION(NV_GPU_THERMAL_SETTINGS_V1,1)
+
+// Macro for constructing the version field of NV_GPU_THERMAL_SETTINGS_V2
+#define NV_GPU_THERMAL_SETTINGS_VER_2   MAKE_NVAPI_VERSION(NV_GPU_THERMAL_SETTINGS_V2,2)
+
+// Macro for constructing the version field of NV_GPU_THERMAL_SETTINGS
+#define NV_GPU_THERMAL_SETTINGS_VER     NV_GPU_THERMAL_SETTINGS_VER_2
+
+#define NVAPI_MAX_GPU_UTILIZATIONS 8
+
+// Used in NvAPI_GPU_GetDynamicPstatesInfoEx().
+typedef struct
+{
+    NvU32       version;        // Structure version
+    NvU32       flags;          // bit 0 indicates if the dynamic Pstate is enabled or not
+    struct
+    {
+        NvU32   bIsPresent:1;   // Set if this utilization domain is present on this GPU
+        NvU32   percentage;     // Percentage of time where the domain is considered busy in the last 1 second interval
+    } utilization[NVAPI_MAX_GPU_UTILIZATIONS];
+} NV_GPU_DYNAMIC_PSTATES_INFO_EX;
+
+// Macro for constructing the version field of NV_GPU_DYNAMIC_PSTATES_INFO_EX
+#define NV_GPU_DYNAMIC_PSTATES_INFO_EX_VER MAKE_NVAPI_VERSION(NV_GPU_DYNAMIC_PSTATES_INFO_EX,1)
+
+NVAPI_INTERFACE NvAPI_Initialize();
+NVAPI_INTERFACE NvAPI_Unload();
+NVAPI_INTERFACE NvAPI_GetErrorMessage(NvAPI_Status nr,NvAPI_ShortString szDesc);
+NVAPI_INTERFACE NvAPI_EnumPhysicalGPUs(NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount);
+NVAPI_INTERFACE NvAPI_GPU_GetThermalSettings(NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings);
+NVAPI_INTERFACE NvAPI_GPU_GetTachReading(NvPhysicalGpuHandle hPhysicalGPU, NvU32 *pValue);
+NVAPI_INTERFACE NvAPI_GPU_GetDynamicPstatesInfoEx(NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DYNAMIC_PSTATES_INFO_EX *pDynamicPstatesInfoEx);
+
+#ifdef __nvapi_success
+    #undef __success
+    #undef __nvapi_success
+#endif
+
+/*
+ * End of declarations from nvapi.h and subheaders
+ **/
+
 // Just annotations (they do nothing special)
+
 #ifndef __success
 #define __success(x)
 #endif
@@ -54,15 +357,45 @@
 #define __out_ecount_full_opt(x)
 #endif
 
-#include <nvapi.h>
-
 typedef NvPhysicalGpuHandle HM_ADAPTER_NV;
 
-int hc_NvAPI_EnumPhysicalGPUs (NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount);
-int hc_NvAPI_GPU_GetThermalSettings (NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings);
-int hc_NvAPI_GPU_GetTachReading (NvPhysicalGpuHandle hPhysicalGPU, NvU32 *pValue);
-int hc_NvAPI_GPU_GetDynamicPstatesInfoEx (NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DYNAMIC_PSTATES_INFO_EX *pDynamicPstatesInfoEx);
+#include <shared.h>
+
+typedef NvAPI_Status (*NVAPI_INITIALIZE) (void);
+typedef NvAPI_Status (*NVAPI_UNLOAD) (void);
+typedef NvAPI_Status (*NVAPI_GETERRORMESSAGE) (NvAPI_Status, NvAPI_ShortString);
+typedef NvAPI_Status (*NVAPI_ENUMPHYSICALGPUS) (NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *);
+typedef NvAPI_Status (*NVAPI_GPU_GETTHERMALSETTINGS) (NvPhysicalGpuHandle, NvU32, NV_GPU_THERMAL_SETTINGS *);
+typedef NvAPI_Status (*NVAPI_GPU_GETTACHREADING) (NvPhysicalGpuHandle, NvU32 *);
+typedef NvAPI_Status (*NVAPI_GPU_GETDYNAMICPSTATESINFOEX) (NvPhysicalGpuHandle, NV_GPU_DYNAMIC_PSTATES_INFO_EX *);
+
+typedef struct
+{
+  NV_LIB lib;
+
+  NVAPI_INITIALIZE NvAPI_Initialize;
+  NVAPI_UNLOAD NvAPI_Unload;
+  NVAPI_GETERRORMESSAGE NvAPI_GetErrorMessage;
+  NVAPI_ENUMPHYSICALGPUS NvAPI_EnumPhysicalGPUs;
+  NVAPI_GPU_GETTHERMALSETTINGS NvAPI_GPU_GetThermalSettings;
+  NVAPI_GPU_GETTACHREADING NvAPI_GPU_GetTachReading;
+  NVAPI_GPU_GETDYNAMICPSTATESINFOEX NvAPI_GPU_GetDynamicPstatesInfoEx;
+
+} hm_nvapi_lib_t;
+
+#define NVAPI_PTR hm_nvapi_lib_t
+
+int nvapi_init (NVAPI_PTR *nvapi);
+void nvapi_close (NVAPI_PTR *nvapi);
+
+int hm_NvAPI_Initialize (NVAPI_PTR *nvapi);
+int hm_NvAPI_Unload (NVAPI_PTR *nvapi);
+int hm_NvAPI_GetErrorMessage (NVAPI_PTR *nvapi, NvAPI_Status nr, NvAPI_ShortString szDesc);
+int hm_NvAPI_EnumPhysicalGPUs (NVAPI_PTR *nvapi, NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount);
+int hm_NvAPI_GPU_GetThermalSettings (NVAPI_PTR *nvapi, NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings);
+int hm_NvAPI_GPU_GetTachReading (NVAPI_PTR *nvapi, NvPhysicalGpuHandle hPhysicalGPU, NvU32 *pValue);
+int hm_NvAPI_GPU_GetDynamicPstatesInfoEx (NVAPI_PTR *nvapi, NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DYNAMIC_PSTATES_INFO_EX *pDynamicPstatesInfoEx);
 
 #endif // HAVE_HWMON && HAVE_NVAPI
 
-#endif
+#endif // EXT_NVAPI_H

--- a/include/ext_nvml.h
+++ b/include/ext_nvml.h
@@ -1,5 +1,7 @@
 /**
- * Author......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *
  * License.....: MIT
  */
 
@@ -55,9 +57,11 @@ typedef enum nvmlReturn_enum {
 
 typedef nvmlDevice_t HM_ADAPTER_NV;
 
+#include <shared.h>
+
 typedef const char * (*NVML_ERROR_STRING) (nvmlReturn_t);
-typedef int (*NVML_INIT) ();
-typedef int (*NVML_SHUTDOWN) ();
+typedef int (*NVML_INIT) (void);
+typedef int (*NVML_SHUTDOWN) (void);
 typedef nvmlReturn_t (*NVML_DEVICE_GET_NAME) (nvmlDevice_t, char *, unsigned int);
 typedef nvmlReturn_t (*NVML_DEVICE_GET_HANDLE_BY_INDEX) (unsigned int, nvmlDevice_t *);
 typedef nvmlReturn_t (*NVML_DEVICE_GET_TEMPERATURE) (nvmlDevice_t, nvmlTemperatureSensors_t, unsigned int *);
@@ -65,15 +69,37 @@ typedef nvmlReturn_t (*NVML_DEVICE_GET_FAN_SPEED) (nvmlDevice_t, unsigned int *)
 typedef nvmlReturn_t (*NVML_DEVICE_GET_POWER_USAGE) (nvmlDevice_t, unsigned int *);
 typedef nvmlReturn_t (*NVML_DEVICE_GET_UTILIZATION_RATES) (nvmlDevice_t, nvmlUtilization_t *);
 
-nvmlReturn_t hc_NVML_nvmlInit (HM_LIB hDLL);
-nvmlReturn_t hc_NVML_nvmlShutdown (HM_LIB hDLL);
-nvmlReturn_t hc_NVML_nvmlDeviceGetName (HM_LIB hDLL, nvmlDevice_t device, char *name, unsigned int length);
-nvmlReturn_t hc_NVML_nvmlDeviceGetHandleByIndex (HM_LIB hDLL, int, unsigned int index, nvmlDevice_t *device);
-nvmlReturn_t hc_NVML_nvmlDeviceGetTemperature (HM_LIB hDLL, nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp);
-nvmlReturn_t hc_NVML_nvmlDeviceGetFanSpeed (HM_LIB hDLL, int, nvmlDevice_t device, unsigned int *speed);
-nvmlReturn_t hc_NVML_nvmlDeviceGetPowerUsage (HM_LIB hDLL, nvmlDevice_t device, unsigned int *power);
-nvmlReturn_t hc_NVML_nvmlDeviceGetUtilizationRates (HM_LIB hDLL, nvmlDevice_t device, nvmlUtilization_t *utilization);
+typedef struct
+{
+  NV_LIB lib;
+
+  NVML_ERROR_STRING nvmlErrorString;
+  NVML_INIT nvmlInit;
+  NVML_SHUTDOWN nvmlShutdown;
+  NVML_DEVICE_GET_NAME nvmlDeviceGetName;
+  NVML_DEVICE_GET_HANDLE_BY_INDEX nvmlDeviceGetHandleByIndex;
+  NVML_DEVICE_GET_TEMPERATURE nvmlDeviceGetTemperature;
+  NVML_DEVICE_GET_FAN_SPEED nvmlDeviceGetFanSpeed;
+  NVML_DEVICE_GET_POWER_USAGE nvmlDeviceGetPowerUsage;
+  NVML_DEVICE_GET_UTILIZATION_RATES nvmlDeviceGetUtilizationRates;
+
+} hm_nvml_lib_t;
+
+#define NVML_PTR hm_nvml_lib_t
+
+int nvml_init (NVML_PTR *lib);
+void nvml_close (NVML_PTR *lib);
+
+const char * hm_NVML_nvmlErrorString (NVML_PTR *nvml, nvmlReturn_t nvml_rc);
+nvmlReturn_t hm_NVML_nvmlInit (NVML_PTR *nvml);
+nvmlReturn_t hm_NVML_nvmlShutdown (NVML_PTR *nvml);
+nvmlReturn_t hm_NVML_nvmlDeviceGetName (NVML_PTR *nvml, nvmlDevice_t device, char *name, unsigned int length);
+nvmlReturn_t hm_NVML_nvmlDeviceGetHandleByIndex (NVML_PTR *nvml, int, unsigned int index, nvmlDevice_t *device);
+nvmlReturn_t hm_NVML_nvmlDeviceGetTemperature (NVML_PTR *nvml, nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp);
+nvmlReturn_t hm_NVML_nvmlDeviceGetFanSpeed (NVML_PTR *nvml, int, nvmlDevice_t device, unsigned int *speed);
+nvmlReturn_t hm_NVML_nvmlDeviceGetPowerUsage (NVML_PTR *nvml, nvmlDevice_t device, unsigned int *power);
+nvmlReturn_t hm_NVML_nvmlDeviceGetUtilizationRates (NVML_PTR *nvml, nvmlDevice_t device, nvmlUtilization_t *utilization);
 
 #endif // HAVE_HWMON && HAVE_NVML
 
-#endif
+#endif // EXT_NVML_H

--- a/include/shared.h
+++ b/include/shared.h
@@ -88,23 +88,15 @@
  * temperature management
  */
 
-#ifdef _POSIX
-#include <ext_ADL.h>
-#endif
-
-#ifdef _WIN
-#include <ext_ADL.h>
-#endif
-
-#ifdef LINUX
-#include <ext_nvml.h>
-#elif WIN
-#include <ext_nvapi.h>
-#endif
-
 #ifdef OSX
 #include <ext_smi.h>
 #include <ext_dummy.h>
+#elif _WIN
+#include <ext_ADL.h>
+#include <ext_nvapi.h>
+#else
+#include <ext_ADL.h>
+#include <ext_nvml.h>
 #endif
 
 /**
@@ -181,22 +173,22 @@ extern hc_thread_mutex_t mux_display;
  * password lengths supported
  */
 
-#define PW_LENGTH_MIN_0       0
-#define PW_LENGTH_MAX_0       55
-#define PW_LENGTH_MIN_400     0
-#define PW_LENGTH_MAX_400     40
-#define PW_LENGTH_MIN_500     0
-#define PW_LENGTH_MAX_500     15
-#define PW_LENGTH_MIN_1600    0
-#define PW_LENGTH_MAX_1600    15
-#define PW_LENGTH_MIN_1800    0
-#define PW_LENGTH_MAX_1800    15
-#define PW_LENGTH_MIN_2500    0
-#define PW_LENGTH_MAX_2500    64
-#define PW_LENGTH_MIN_6300    0
-#define PW_LENGTH_MAX_6300    15
-#define PW_LENGTH_MIN_7400    0
-#define PW_LENGTH_MAX_7400    15
+#define PW_LENGTH_MIN_0      0
+#define PW_LENGTH_MAX_0      55
+#define PW_LENGTH_MIN_400    0
+#define PW_LENGTH_MAX_400    40
+#define PW_LENGTH_MIN_500    0
+#define PW_LENGTH_MAX_500    15
+#define PW_LENGTH_MIN_1600   0
+#define PW_LENGTH_MAX_1600   15
+#define PW_LENGTH_MIN_1800   0
+#define PW_LENGTH_MAX_1800   15
+#define PW_LENGTH_MIN_2500   0
+#define PW_LENGTH_MAX_2500   64
+#define PW_LENGTH_MIN_6300   0
+#define PW_LENGTH_MAX_6300   15
+#define PW_LENGTH_MIN_7400   0
+#define PW_LENGTH_MAX_7400   15
 
 /**
  * device accel macro
@@ -1879,10 +1871,6 @@ void fsync (int fd);
 int hm_get_adapter_index_nv (HM_ADAPTER_NV nvGPUHandle[DEVICES_MAX]);
 #endif
 
-// int hm_get_device_num (HM_LIB hm_dll_amd, HM_ADAPTER_AMD hm_adapter_index, int *hm_device_num);
-
-// void hm_get_opencl_busid_devid (hm_attrs_t *hm_device, uint opencl_num_devices, cl_device_id *devices);
-
 #ifdef HAVE_ADL
 int get_adapters_num_amd (void *adl, int *iNumberAdapters);
 
@@ -1894,13 +1882,10 @@ u32 *hm_get_list_valid_adl_adapters (int iNumberAdapters, int *num_adl_adapters,
 
 int hm_get_overdrive_version  (void *adl, hm_attrs_t *hm_device, u32 *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
 int hm_check_fanspeed_control (void *adl, hm_attrs_t *hm_device, u32 *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
+
+// int hm_get_device_num (void *adl, HM_ADAPTER_AMD hm_adapter_index, int *hm_device_num);
+// void hm_get_opencl_busid_devid (hm_attrs_t *hm_device, uint opencl_num_devices, cl_device_id *devices);
 #endif // HAVE_ADL
-
-#if defined(HAVE_ADL) || defined(HAVE_NVML)
-void hm_close (HM_LIB hm_dll);
-
-HM_LIB hm_init (const cl_uint vendor_id);
-#endif
 
 int hm_get_temperature_with_device_id (const uint device_id);
 int hm_get_fanspeed_with_device_id    (const uint device_id);

--- a/include/types.h
+++ b/include/types.h
@@ -1068,8 +1068,8 @@ typedef struct
    */
 
   #ifdef HAVE_HWMON
-  HM_LIB  hm_dll_nv;
-  void   *adl;
+  void   *hm_nv;
+  void   *hm_amd;
   hm_attrs_t hm_device[DEVICES_MAX];
   #endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,38 +42,22 @@ SHARED_FOLDER            ?= $(PREFIX)/share/$(PROG_NAME)
 DOCUMENT_FOLDER          ?= $(PREFIX)/share/doc/$(PROG_NAME)
 
 ##
-## Dependencies
-##
-
-NVAPI                    := deps/R352-developer
-
-##
 ## Dependencies, cross compilation only
 ##
 
 OPENCL_HEADERS_KHRONOS   := deps/OpenCL-Headers
 
 ##
-## Library paths
+## Dependencies
 ##
 
-NVML                     := $(GDK)/usr/include/nvidia/gdk
+NVAPI                    := deps/R352-developer
 
-##
-## Check dependencies
 ##
 
 WITH_ADL                 := 1
 WITH_NVML                := 1
-FOUND_NVAPI              := 0
-
-ifneq ($(wildcard $(NVAPI)/nvapi.h),)
-FOUND_NVAPI              := 1
-endif
-
-ifeq ($(DEBUG),1)
-$(warning "## NVAPI is found ? $(FOUND_NVAPI)")
-endif
+WITH_NVAPI               := 1
 
 ##
 ## Native compiler paths
@@ -129,15 +113,9 @@ CFLAGS_NATIVE            += $(CFLAGS)
 
 LFLAGS_NATIVE            := -lpthread
 
-ifneq (,$(filter 1,$(WITH_ADL) $(WITH_NVML)))
-CFLAGS_NATIVE            += -DHAVE_HWMON
-ifeq ($(WITH_ADL),1)
-CFLAGS_NATIVE            += -DHAVE_ADL
-endif
-endif
-
+WITH_ADL                 := 0
 WITH_NVML                := 0
-endif
+endif # darwin
 
 ifeq ($(UNAME),Linux)
 CFLAGS_NATIVE            := -D_POSIX -DLINUX
@@ -147,15 +125,17 @@ LFLAGS_NATIVE            := -lpthread -ldl
 
 ifneq (,$(filter 1,$(WITH_ADL) $(WITH_NVML)))
 CFLAGS_NATIVE            += -DHAVE_HWMON
+
 ifeq ($(WITH_ADL),1)
 CFLAGS_NATIVE            += -DHAVE_ADL
 endif
+
 ifeq ($(WITH_NVML),1)
 CFLAGS_NATIVE            += -DHAVE_NVML
 endif
 endif
 
-endif
+endif # linux
 
 ##
 ## Cross compilation target
@@ -181,15 +161,15 @@ CFLAGS_CROSS_WIN         := -D_WIN   -DWIN -D__MSVCRT__ -D__USE_MINGW_ANSI_STDIO
 CFLAGS_CROSS_WIN         += -s $(filter-out -fsanitize=address,$(CFLAGS))
 CFLAGS_CROSS_WIN         += -I$(OPENCL_HEADERS_KHRONOS)/
 
-ifneq (,$(filter 1,$(WITH_ADL) $(FOUND_NVAPI)))
+ifneq (,$(filter 1,$(WITH_ADL) $(WITH_NVAPI)))
 CFLAGS_CROSS_WIN         += -DHAVE_HWMON
 
 ifeq ($(WITH_ADL),1)
 CFLAGS_CROSS_WIN         += -DHAVE_ADL
 endif
 
-ifeq ($(FOUND_NVAPI),1)
-CFLAGS_CROSS_WIN         += -DHAVE_NVAPI -I$(NVAPI)/
+ifeq ($(WITH_NVAPI),1)
+CFLAGS_CROSS_WIN         += -DHAVE_NVAPI
 endif
 endif
 
@@ -234,9 +214,9 @@ LINUX_32_OBJS            += obj/ext_nvml.LINUX.32.o
 LINUX_64_OBJS            += obj/ext_nvml.LINUX.64.o
 endif
 
-ifeq ($(FOUND_NVAPI),1)
-WIN_32_OBJS              += obj/ext_nvapi.WIN.32.o $(NVAPI)/x86/nvapi.lib
-WIN_64_OBJS              += obj/ext_nvapi.WIN.64.o $(NVAPI)/amd64/nvapi64.lib
+ifeq ($(WITH_NVAPI),1)
+WIN_32_OBJS              += obj/ext_nvapi.WIN.32.o
+WIN_64_OBJS              += obj/ext_nvapi.WIN.64.o
 endif
 
 ##

--- a/src/ext_ADL.c
+++ b/src/ext_ADL.c
@@ -75,7 +75,7 @@ void adl_close (ADL_PTR *adl)
   }
 }
 
-int hc_ADL_Main_Control_Destroy (ADL_PTR *adl)
+int hm_ADL_Main_Control_Destroy (ADL_PTR *adl)
 {
   if (!adl) return (-1);
 
@@ -89,7 +89,7 @@ int hc_ADL_Main_Control_Destroy (ADL_PTR *adl)
   return (ADL_rc);
 }
 
-int hc_ADL_Main_Control_Create (ADL_PTR *adl, ADL_MAIN_MALLOC_CALLBACK callback, int iEnumConnectedAdapters)
+int hm_ADL_Main_Control_Create (ADL_PTR *adl, ADL_MAIN_MALLOC_CALLBACK callback, int iEnumConnectedAdapters)
 {
   if (!adl) return (-1);
 
@@ -103,7 +103,7 @@ int hc_ADL_Main_Control_Create (ADL_PTR *adl, ADL_MAIN_MALLOC_CALLBACK callback,
   return (ADL_rc);
 }
 
-int hc_ADL_Adapter_NumberOfAdapters_Get (ADL_PTR *adl, int *lpNumAdapters)
+int hm_ADL_Adapter_NumberOfAdapters_Get (ADL_PTR *adl, int *lpNumAdapters)
 {
   if (!adl) return (-1);
 
@@ -117,7 +117,7 @@ int hc_ADL_Adapter_NumberOfAdapters_Get (ADL_PTR *adl, int *lpNumAdapters)
   return (ADL_rc);
 }
 
-int hc_ADL_Adapter_AdapterInfo_Get (ADL_PTR *adl, LPAdapterInfo lpInfo, int iInputSize)
+int hm_ADL_Adapter_AdapterInfo_Get (ADL_PTR *adl, LPAdapterInfo lpInfo, int iInputSize)
 {
   if (!adl) return (-1);
 
@@ -131,7 +131,7 @@ int hc_ADL_Adapter_AdapterInfo_Get (ADL_PTR *adl, LPAdapterInfo lpInfo, int iInp
   return (ADL_rc);
 }
 
-int hc_ADL_Display_DisplayInfo_Get (ADL_PTR *adl, int iAdapterIndex, int *iNumDisplays, ADLDisplayInfo **lppInfo, int iForceDetect)
+int hm_ADL_Display_DisplayInfo_Get (ADL_PTR *adl, int iAdapterIndex, int *iNumDisplays, ADLDisplayInfo **lppInfo, int iForceDetect)
 {
   if (!adl) return (-1);
 
@@ -145,7 +145,7 @@ int hc_ADL_Display_DisplayInfo_Get (ADL_PTR *adl, int iAdapterIndex, int *iNumDi
   return (ADL_rc);
 }
 
-int hc_ADL_Adapter_ID_Get (ADL_PTR *adl, int iAdapterIndex, int *lpAdapterID)
+int hm_ADL_Adapter_ID_Get (ADL_PTR *adl, int iAdapterIndex, int *lpAdapterID)
 {
   if (!adl) return (-1);
 
@@ -159,7 +159,7 @@ int hc_ADL_Adapter_ID_Get (ADL_PTR *adl, int iAdapterIndex, int *lpAdapterID)
   return ADL_rc;
 }
 
-int hc_ADL_Adapter_VideoBiosInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLBiosInfo *lpBiosInfo)
+int hm_ADL_Adapter_VideoBiosInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLBiosInfo *lpBiosInfo)
 {
   if (!adl) return (-1);
 
@@ -173,7 +173,7 @@ int hc_ADL_Adapter_VideoBiosInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLBiosIn
   return ADL_rc;
 }
 
-int hc_ADL_Overdrive_ThermalDevices_Enum (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLThermalControllerInfo *lpThermalControllerInfo)
+int hm_ADL_Overdrive_ThermalDevices_Enum (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLThermalControllerInfo *lpThermalControllerInfo)
 {
   if (!adl) return (-1);
 
@@ -187,7 +187,7 @@ int hc_ADL_Overdrive_ThermalDevices_Enum (ADL_PTR *adl, int iAdapterIndex, int i
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive5_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLTemperature *lpTemperature)
+int hm_ADL_Overdrive5_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLTemperature *lpTemperature)
 {
   if (!adl) return (-1);
 
@@ -201,7 +201,7 @@ int hc_ADL_Overdrive5_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int iThe
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive6_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int *iTemperature)
+int hm_ADL_Overdrive6_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int *iTemperature)
 {
   if (!adl) return (-1);
 
@@ -215,7 +215,7 @@ int hc_ADL_Overdrive6_Temperature_Get (ADL_PTR *adl, int iAdapterIndex, int *iTe
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_CurrentActivity_Get (ADL_PTR *adl, int iAdapterIndex, ADLPMActivity *lpActivity)
+int hm_ADL_Overdrive_CurrentActivity_Get (ADL_PTR *adl, int iAdapterIndex, ADLPMActivity *lpActivity)
 {
   if (!adl) return (-1);
 
@@ -229,7 +229,7 @@ int hc_ADL_Overdrive_CurrentActivity_Get (ADL_PTR *adl, int iAdapterIndex, ADLPM
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive5_FanSpeedInfo_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedInfo *lpFanSpeedInfo)
+int hm_ADL_Overdrive5_FanSpeedInfo_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedInfo *lpFanSpeedInfo)
 {
   if (!adl) return (-1);
 
@@ -243,7 +243,7 @@ int hc_ADL_Overdrive5_FanSpeedInfo_Get (ADL_PTR *adl, int iAdapterIndex, int iTh
   return ADL_rc;
 }
 
-int hc_ADL_Overdrive5_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue)
+int hm_ADL_Overdrive5_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue)
 {
   if (!adl) return (-1);
 
@@ -257,7 +257,7 @@ int hc_ADL_Overdrive5_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, int iTherma
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive6_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedInfo *lpFanSpeedInfo)
+int hm_ADL_Overdrive6_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedInfo *lpFanSpeedInfo)
 {
   if (!adl) return (-1);
 
@@ -271,7 +271,7 @@ int hc_ADL_Overdrive6_FanSpeed_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSp
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive5_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue)
+int hm_ADL_Overdrive5_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex, ADLFanSpeedValue *lpFanSpeedValue)
 {
   if (!adl) return (-1);
 
@@ -285,7 +285,7 @@ int hc_ADL_Overdrive5_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, int iTherma
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive6_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedValue *lpFanSpeedValue)
+int hm_ADL_Overdrive6_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSpeedValue *lpFanSpeedValue)
 {
   if (!adl) return (-1);
 
@@ -299,7 +299,7 @@ int hc_ADL_Overdrive6_FanSpeed_Set (ADL_PTR *adl, int iAdapterIndex, ADLOD6FanSp
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive5_FanSpeedToDefault_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex)
+int hm_ADL_Overdrive5_FanSpeedToDefault_Set (ADL_PTR *adl, int iAdapterIndex, int iThermalControllerIndex)
 {
   if (!adl) return (-1);
 
@@ -313,7 +313,7 @@ int hc_ADL_Overdrive5_FanSpeedToDefault_Set (ADL_PTR *adl, int iAdapterIndex, in
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_ODParameters_Get (ADL_PTR *adl, int iAdapterIndex, ADLODParameters *lpOdParameters)
+int hm_ADL_Overdrive_ODParameters_Get (ADL_PTR *adl, int iAdapterIndex, ADLODParameters *lpOdParameters)
 {
   if (!adl) return (-1);
 
@@ -327,7 +327,7 @@ int hc_ADL_Overdrive_ODParameters_Get (ADL_PTR *adl, int iAdapterIndex, ADLODPar
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_ODPerformanceLevels_Get (ADL_PTR *adl, int iAdapterIndex, int iDefault, ADLODPerformanceLevels *lpOdPerformanceLevels)
+int hm_ADL_Overdrive_ODPerformanceLevels_Get (ADL_PTR *adl, int iAdapterIndex, int iDefault, ADLODPerformanceLevels *lpOdPerformanceLevels)
 {
   if (!adl) return (-1);
 
@@ -341,7 +341,7 @@ int hc_ADL_Overdrive_ODPerformanceLevels_Get (ADL_PTR *adl, int iAdapterIndex, i
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_ODPerformanceLevels_Set (ADL_PTR *adl, int iAdapterIndex, ADLODPerformanceLevels *lpOdPerformanceLevels)
+int hm_ADL_Overdrive_ODPerformanceLevels_Set (ADL_PTR *adl, int iAdapterIndex, ADLODPerformanceLevels *lpOdPerformanceLevels)
 {
   if (!adl) return (-1);
 
@@ -355,7 +355,7 @@ int hc_ADL_Overdrive_ODPerformanceLevels_Set (ADL_PTR *adl, int iAdapterIndex, A
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_PowerControlInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6PowerControlInfo *powertune)
+int hm_ADL_Overdrive_PowerControlInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6PowerControlInfo *powertune)
 {
   if (!adl) return (-1);
 
@@ -364,7 +364,7 @@ int hc_ADL_Overdrive_PowerControlInfo_Get (ADL_PTR *adl, int iAdapterIndex, ADLO
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_PowerControl_Get (ADL_PTR *adl, int iAdapterIndex, int *iCurrentValue)
+int hm_ADL_Overdrive_PowerControl_Get (ADL_PTR *adl, int iAdapterIndex, int *iCurrentValue)
 {
   if (!adl) return (-1);
 
@@ -375,7 +375,7 @@ int hc_ADL_Overdrive_PowerControl_Get (ADL_PTR *adl, int iAdapterIndex, int *iCu
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_PowerControl_Set (ADL_PTR *adl, int iAdapterIndex, int level)
+int hm_ADL_Overdrive_PowerControl_Set (ADL_PTR *adl, int iAdapterIndex, int level)
 {
   if (!adl) return (-1);
 
@@ -383,7 +383,7 @@ int hc_ADL_Overdrive_PowerControl_Set (ADL_PTR *adl, int iAdapterIndex, int leve
 
   ADLOD6PowerControlInfo powertune = {0, 0, 0, 0, 0};
 
-  if ((ADL_rc = hc_ADL_Overdrive_PowerControlInfo_Get (adl, iAdapterIndex, &powertune)) != ADL_OK)
+  if ((ADL_rc = hm_ADL_Overdrive_PowerControlInfo_Get (adl, iAdapterIndex, &powertune)) != ADL_OK)
   {
     log_info ("WARN: %s\n", "ADL_Overdrive6_PowerControl_Get", ADL_rc);
   }
@@ -412,7 +412,7 @@ int hc_ADL_Overdrive_PowerControl_Set (ADL_PTR *adl, int iAdapterIndex, int leve
   return (ADL_rc);
 }
 
-int hc_ADL_Adapter_Active_Get (ADL_PTR *adl, int iAdapterIndex, int *lpStatus)
+int hm_ADL_Adapter_Active_Get (ADL_PTR *adl, int iAdapterIndex, int *lpStatus)
 {
   if (!adl) return (-1);
 
@@ -427,7 +427,7 @@ int hc_ADL_Adapter_Active_Get (ADL_PTR *adl, int iAdapterIndex, int *lpStatus)
 }
 
 /*
-int hc_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayIndexList, int iDisplayListSize, int bPersistOnly)
+int hm_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayIndexList, int iDisplayListSize, int bPersistOnly)
 {
   if (!adl) return (-1);
 
@@ -442,7 +442,7 @@ int hc_ADL_DisplayEnable_Set (ADL_PTR *adl, int iAdapterIndex, int *lpDisplayInd
 }
 */
 
-int hc_ADL_Overdrive_Caps (ADL_PTR *adl, int iAdapterIndex, int *od_supported, int *od_enabled, int *od_version)
+int hm_ADL_Overdrive_Caps (ADL_PTR *adl, int iAdapterIndex, int *od_supported, int *od_enabled, int *od_version)
 {
   if (!adl) return (-1);
 
@@ -451,7 +451,7 @@ int hc_ADL_Overdrive_Caps (ADL_PTR *adl, int iAdapterIndex, int *od_supported, i
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive6_PowerControl_Caps (ADL_PTR *adl, int iAdapterIndex, int *lpSupported)
+int hm_ADL_Overdrive6_PowerControl_Caps (ADL_PTR *adl, int iAdapterIndex, int *lpSupported)
 {
   if (!adl) return (-1);
 
@@ -460,7 +460,7 @@ int hc_ADL_Overdrive6_PowerControl_Caps (ADL_PTR *adl, int iAdapterIndex, int *l
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_Capabilities_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6Capabilities *caps)
+int hm_ADL_Overdrive_Capabilities_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6Capabilities *caps)
 {
   if (!adl) return (-1);
 
@@ -469,7 +469,7 @@ int hc_ADL_Overdrive_Capabilities_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6Ca
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_StateInfo_Get (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6MemClockState *state)
+int hm_ADL_Overdrive_StateInfo_Get (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6MemClockState *state)
 {
   if (!adl) return (-1);
 
@@ -482,7 +482,7 @@ int hc_ADL_Overdrive_StateInfo_Get (ADL_PTR *adl, int iAdapterIndex, int type, A
 
     ADLOD6Capabilities caps;
 
-    if ((hc_ADL_Overdrive_Capabilities_Get (adl, iAdapterIndex, &caps)) != ADL_OK)
+    if ((hm_ADL_Overdrive_Capabilities_Get (adl, iAdapterIndex, &caps)) != ADL_OK)
     {
       log_info ("ERROR: failed to get ADL device capabilities");
 
@@ -517,7 +517,7 @@ int hc_ADL_Overdrive_StateInfo_Get (ADL_PTR *adl, int iAdapterIndex, int type, A
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_CurrentStatus_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6CurrentStatus *status)
+int hm_ADL_Overdrive_CurrentStatus_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6CurrentStatus *status)
 {
   if (!adl) return (-1);
 
@@ -526,7 +526,7 @@ int hc_ADL_Overdrive_CurrentStatus_Get (ADL_PTR *adl, int iAdapterIndex, ADLOD6C
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive_State_Set (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6StateInfo *state)
+int hm_ADL_Overdrive_State_Set (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD6StateInfo *state)
 {
   if (!adl) return (-1);
 
@@ -534,7 +534,7 @@ int hc_ADL_Overdrive_State_Set (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD
 
   ADLOD6Capabilities caps;
 
-  if ((hc_ADL_Overdrive_Capabilities_Get (adl, iAdapterIndex, &caps)) != ADL_OK)
+  if ((hm_ADL_Overdrive_Capabilities_Get (adl, iAdapterIndex, &caps)) != ADL_OK)
   {
     log_info ("ERROR: failed to get ADL device capabilities");
 
@@ -574,7 +574,7 @@ int hc_ADL_Overdrive_State_Set (ADL_PTR *adl, int iAdapterIndex, int type, ADLOD
   return (ADL_rc);
 }
 
-int hc_ADL_Overdrive6_TargetTemperatureData_Get (ADL_PTR *adl, int iAdapterIndex, int *cur_temp, int *default_temp)
+int hm_ADL_Overdrive6_TargetTemperatureData_Get (ADL_PTR *adl, int iAdapterIndex, int *cur_temp, int *default_temp)
 {
   if (!adl) return (-1);
 

--- a/src/ext_nvapi.c
+++ b/src/ext_nvapi.c
@@ -5,15 +5,102 @@
 
 #include <ext_nvapi.h>
 
-int hc_NvAPI_EnumPhysicalGPUs (NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount)
+int nvapi_init (NVAPI_PTR *nvapi)
 {
-  NvAPI_Status NvAPI_rc = NvAPI_EnumPhysicalGPUs (nvGPUHandle, pGpuCount);
+  if (!nvapi) return (-1);
+
+  memset (nvapi, 0, sizeof (NVAPI_PTR));
+
+  #if __x86_64__
+  nvapi->lib = hc_dlopen ("nvapi64.lib");
+  #elif __x86__
+  nvapi->lib = hc_dlopen ("nvapi.lib");
+  #endif
+
+  if (!nvapi->lib)
+  {
+    if (data.quiet == 0)
+      log_info ("WARNING: load NVAPI library failed, proceed without NVAPI HWMon enabled.");
+
+    return (-1);
+  }
+
+  HC_LOAD_FUNC(nvapi, NvAPI_Initialize, NVAPI_INITIALIZE, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, NvAPI_Unload, NVAPI_UNLOAD, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, NvAPI_GetErrorMessage, NVAPI_GETERRORMESSAGE, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, NvAPI_EnumPhysicalGPUs, NVAPI_ENUMPHYSICALGPUS, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, NvAPI_GPU_GetThermalSettings, NVAPI_GPU_GETTHERMALSETTINGS, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, NvAPI_GPU_GetTachReading, NVAPI_GPU_GETTACHREADING, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, NvAPI_GPU_GetDynamicPstatesInfoEx, NVAPI_GPU_GETDYNAMICPSTATESINFOEX, NVAPI, 0)
+
+  return 0;
+}
+
+void nvapi_close (NVAPI_PTR *nvapi)
+{
+  if (nvapi)
+  {
+    if (nvapi->lib)
+      hc_dlclose (nvapi->lib);
+
+    myfree (nvapi);
+  }
+}
+
+int hm_NvAPI_Initialize (NVAPI_PTR *nvapi)
+{
+  if (!nvapi) return (-1);
+
+  NvAPI_Status NvAPI_rc = nvapi->NvAPI_Initialize ();
 
   if (NvAPI_rc != NVAPI_OK)
   {
     NvAPI_ShortString string;
 
-    NvAPI_GetErrorMessage (NvAPI_rc, string);
+    hm_NvAPI_GetErrorMessage (nvapi, NvAPI_rc, string);
+
+    log_info ("WARN: %s %d %s\n", "NvAPI_Initialize()", NvAPI_rc, string);
+  }
+
+  return NvAPI_rc;
+}
+
+int hm_NvAPI_Unload (NVAPI_PTR *nvapi)
+{
+  if (!nvapi) return (-1);
+
+  NvAPI_Status NvAPI_rc = nvapi->NvAPI_Unload ();
+
+  if (NvAPI_rc != NVAPI_OK)
+  {
+    NvAPI_ShortString string;
+
+    hm_NvAPI_GetErrorMessage (nvapi, NvAPI_rc, string);
+
+    log_info ("WARN: %s %d %s\n", "NvAPI_Unload()", NvAPI_rc, string);
+  }
+
+  return NvAPI_rc;
+}
+
+int hm_NvAPI_GetErrorMessage (NVAPI_PTR *nvapi, NvAPI_Status NvAPI_rc, NvAPI_ShortString string)
+{
+  if (!nvapi) return (-1);
+
+  return nvapi->NvAPI_GetErrorMessage (NvAPI_rc, string);
+}
+
+int hm_NvAPI_EnumPhysicalGPUs (NVAPI_PTR *nvapi, NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount)
+{
+  if (!nvapi) return (-1);
+
+  NvAPI_Status NvAPI_rc = nvapi->NvAPI_EnumPhysicalGPUs (nvGPUHandle, pGpuCount);
+
+  if (NvAPI_rc != NVAPI_OK)
+  {
+    NvAPI_ShortString string;
+
+    hm_NvAPI_GetErrorMessage (nvapi, NvAPI_rc, string);
 
     log_info ("WARN: %s %d %s\n", "NvAPI_EnumPhysicalGPUs()", NvAPI_rc, string);
   }
@@ -21,15 +108,17 @@ int hc_NvAPI_EnumPhysicalGPUs (NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICA
   return NvAPI_rc;
 }
 
-int hc_NvAPI_GPU_GetThermalSettings (NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings)
+int hm_NvAPI_GPU_GetThermalSettings (NVAPI_PTR *nvapi, NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings)
 {
-  NvAPI_Status NvAPI_rc = NvAPI_GPU_GetThermalSettings (hPhysicalGpu, sensorIndex, pThermalSettings);
+  if (!nvapi) return (-1);
+
+  NvAPI_Status NvAPI_rc = nvapi->NvAPI_GPU_GetThermalSettings (hPhysicalGpu, sensorIndex, pThermalSettings);
 
   if (NvAPI_rc != NVAPI_OK)
   {
     NvAPI_ShortString string;
 
-    NvAPI_GetErrorMessage (NvAPI_rc, string);
+    hm_NvAPI_GetErrorMessage (nvapi, NvAPI_rc, string);
 
     log_info ("WARN: %s %d %s\n", "NvAPI_GPU_GetThermalSettings()", NvAPI_rc, string);
   }
@@ -37,15 +126,17 @@ int hc_NvAPI_GPU_GetThermalSettings (NvPhysicalGpuHandle hPhysicalGpu, NvU32 sen
   return NvAPI_rc;
 }
 
-int hc_NvAPI_GPU_GetTachReading (NvPhysicalGpuHandle hPhysicalGPU, NvU32 *pValue)
+int hm_NvAPI_GPU_GetTachReading (NVAPI_PTR *nvapi, NvPhysicalGpuHandle hPhysicalGPU, NvU32 *pValue)
 {
-  NvAPI_Status NvAPI_rc = NvAPI_GPU_GetTachReading (hPhysicalGPU, pValue);
+  if (!nvapi) return (-1);
+
+  NvAPI_Status NvAPI_rc = nvapi->NvAPI_GPU_GetTachReading (hPhysicalGPU, pValue);
 
   if (NvAPI_rc != NVAPI_OK)
   {
     NvAPI_ShortString string;
 
-    NvAPI_GetErrorMessage (NvAPI_rc, string);
+    hm_NvAPI_GetErrorMessage (nvapi, NvAPI_rc, string);
 
     log_info ("WARN: %s %d %s\n", "NvAPI_GPU_GetTachReading()", NvAPI_rc, string);
   }
@@ -53,15 +144,17 @@ int hc_NvAPI_GPU_GetTachReading (NvPhysicalGpuHandle hPhysicalGPU, NvU32 *pValue
   return NvAPI_rc;
 }
 
-int hc_NvAPI_GPU_GetDynamicPstatesInfoEx (NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DYNAMIC_PSTATES_INFO_EX *pDynamicPstatesInfoEx)
+int hm_NvAPI_GPU_GetDynamicPstatesInfoEx (NVAPI_PTR *nvapi, NvPhysicalGpuHandle hPhysicalGpu, NV_GPU_DYNAMIC_PSTATES_INFO_EX *pDynamicPstatesInfoEx)
 {
-  NvAPI_Status NvAPI_rc = NvAPI_GPU_GetDynamicPstatesInfoEx (hPhysicalGpu, pDynamicPstatesInfoEx);
+  if (!nvapi) return (-1);
+
+  NvAPI_Status NvAPI_rc = nvapi->NvAPI_GPU_GetDynamicPstatesInfoEx (hPhysicalGpu, pDynamicPstatesInfoEx);
 
   if (NvAPI_rc != NVAPI_OK)
   {
     NvAPI_ShortString string;
 
-    NvAPI_GetErrorMessage (NvAPI_rc, string);
+    hm_NvAPI_GetErrorMessage (nvapi, NvAPI_rc, string);
 
     log_info ("WARN: %s %d %s\n", "NvAPI_GPU_GetDynamicPstatesInfoEx()", NvAPI_rc, string);
   }


### PR DESCRIPTION
- NVML and NVAPI loader
- mini NVAPI header builtin (check the updated ext_nvapi.h)
- renamed all hwmon functions prefix from "hc_" to "hm_"
- removed hm_init and hm_close functions and headers

Example for override default Makefile settings:

`make WITH_ADL=0 WITH_NVML=0 WITH_NVAPI=0
`

P.S. for windows + nvidia users:
with this patch oclHashcat is not linked with R352-developer libs.
Put your lib from R352-developer/x86 or R352-developer/amd64 dir, in the same folder of oclHashcat binary for test.
