### PR TITLE
Get rid of nvidia NvAPI static linking

### DIFF
--- a/include/ext_nvapi.h
+++ b/include/ext_nvapi.h
@@ -295,6 +295,7 @@ typedef struct
 // Macro for constructing the version field of NV_GPU_DYNAMIC_PSTATES_INFO_EX
 #define NV_GPU_DYNAMIC_PSTATES_INFO_EX_VER MAKE_NVAPI_VERSION(NV_GPU_DYNAMIC_PSTATES_INFO_EX,1)
 
+NVAPI_INTERFACE NvAPI_QueryInterface(uint offset);
 NVAPI_INTERFACE NvAPI_Initialize();
 NVAPI_INTERFACE NvAPI_Unload();
 NVAPI_INTERFACE NvAPI_GetErrorMessage(NvAPI_Status nr,NvAPI_ShortString szDesc);
@@ -361,18 +362,20 @@ typedef NvPhysicalGpuHandle HM_ADAPTER_NV;
 
 #include <shared.h>
 
-typedef NvAPI_Status (*NVAPI_INITIALIZE) (void);
-typedef NvAPI_Status (*NVAPI_UNLOAD) (void);
-typedef NvAPI_Status (*NVAPI_GETERRORMESSAGE) (NvAPI_Status, NvAPI_ShortString);
-typedef NvAPI_Status (*NVAPI_ENUMPHYSICALGPUS) (NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *);
-typedef NvAPI_Status (*NVAPI_GPU_GETTHERMALSETTINGS) (NvPhysicalGpuHandle, NvU32, NV_GPU_THERMAL_SETTINGS *);
-typedef NvAPI_Status (*NVAPI_GPU_GETTACHREADING) (NvPhysicalGpuHandle, NvU32 *);
-typedef NvAPI_Status (*NVAPI_GPU_GETDYNAMICPSTATESINFOEX) (NvPhysicalGpuHandle, NV_GPU_DYNAMIC_PSTATES_INFO_EX *);
+typedef int *(*NVAPI_QUERYINTERFACE) (uint);
+typedef int (*NVAPI_INITIALIZE) (void);
+typedef int (*NVAPI_UNLOAD) (void);
+typedef int (*NVAPI_GETERRORMESSAGE) (NvAPI_Status, NvAPI_ShortString);
+typedef int (*NVAPI_ENUMPHYSICALGPUS) (NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *);
+typedef int (*NVAPI_GPU_GETTHERMALSETTINGS) (NvPhysicalGpuHandle, NvU32, NV_GPU_THERMAL_SETTINGS *);
+typedef int (*NVAPI_GPU_GETTACHREADING) (NvPhysicalGpuHandle, NvU32 *);
+typedef int (*NVAPI_GPU_GETDYNAMICPSTATESINFOEX) (NvPhysicalGpuHandle, NV_GPU_DYNAMIC_PSTATES_INFO_EX *);
 
 typedef struct
 {
   NV_LIB lib;
 
+  NVAPI_QUERYINTERFACE nvapi_QueryInterface;
   NVAPI_INITIALIZE NvAPI_Initialize;
   NVAPI_UNLOAD NvAPI_Unload;
   NVAPI_GETERRORMESSAGE NvAPI_GetErrorMessage;
@@ -388,6 +391,7 @@ typedef struct
 int nvapi_init (NVAPI_PTR *nvapi);
 void nvapi_close (NVAPI_PTR *nvapi);
 
+int hm_NvAPI_QueryInterface (NVAPI_PTR *nvapi, uint offset);
 int hm_NvAPI_Initialize (NVAPI_PTR *nvapi);
 int hm_NvAPI_Unload (NVAPI_PTR *nvapi);
 int hm_NvAPI_GetErrorMessage (NVAPI_PTR *nvapi, NvAPI_Status nr, NvAPI_ShortString szDesc);

--- a/include/shared.h
+++ b/include/shared.h
@@ -72,6 +72,18 @@
     } \
   }
 
+#define HC_LOAD_ADDR(ptr,name,type,func,addr,libname,noerr) \
+  ptr->name = (type) (*ptr->func) (addr); \
+  if (!ptr->name) { \
+    if (noerr == 1) { \
+      log_error ("ERROR: %s at address %08x is missing from %s shared library.", #name, addr, #libname); \
+      exit (-1); \
+    } else { \
+      log_error ("WARNING: %s at address %08x is missing from %s shared library.", #name, addr, #libname); \
+      return (-1); \
+    } \
+  }
+
 /**
  * system stuff
  */

--- a/src/ext_nvapi.c
+++ b/src/ext_nvapi.c
@@ -12,9 +12,9 @@ int nvapi_init (NVAPI_PTR *nvapi)
   memset (nvapi, 0, sizeof (NVAPI_PTR));
 
   #if __x86_64__
-  nvapi->lib = hc_dlopen ("nvapi64.lib");
+  nvapi->lib = hc_dlopen ("nvapi64.dll");
   #elif __x86__
-  nvapi->lib = hc_dlopen ("nvapi.lib");
+  nvapi->lib = hc_dlopen ("nvapi.dll");
   #endif
 
   if (!nvapi->lib)
@@ -25,13 +25,14 @@ int nvapi_init (NVAPI_PTR *nvapi)
     return (-1);
   }
 
-  HC_LOAD_FUNC(nvapi, NvAPI_Initialize, NVAPI_INITIALIZE, NVAPI, 0)
-  HC_LOAD_FUNC(nvapi, NvAPI_Unload, NVAPI_UNLOAD, NVAPI, 0)
-  HC_LOAD_FUNC(nvapi, NvAPI_GetErrorMessage, NVAPI_GETERRORMESSAGE, NVAPI, 0)
-  HC_LOAD_FUNC(nvapi, NvAPI_EnumPhysicalGPUs, NVAPI_ENUMPHYSICALGPUS, NVAPI, 0)
-  HC_LOAD_FUNC(nvapi, NvAPI_GPU_GetThermalSettings, NVAPI_GPU_GETTHERMALSETTINGS, NVAPI, 0)
-  HC_LOAD_FUNC(nvapi, NvAPI_GPU_GetTachReading, NVAPI_GPU_GETTACHREADING, NVAPI, 0)
-  HC_LOAD_FUNC(nvapi, NvAPI_GPU_GetDynamicPstatesInfoEx, NVAPI_GPU_GETDYNAMICPSTATESINFOEX, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, nvapi_QueryInterface, NVAPI_QUERYINTERFACE, NVAPI, 0)
+  HC_LOAD_ADDR(nvapi, NvAPI_Initialize, NVAPI_INITIALIZE, nvapi_QueryInterface, 0x0150E828, NVAPI, 0)
+  HC_LOAD_ADDR(nvapi, NvAPI_Unload, NVAPI_UNLOAD, nvapi_QueryInterface, 0x0D22BDD7E, NVAPI, 0)
+  HC_LOAD_ADDR(nvapi, NvAPI_GetErrorMessage, NVAPI_GETERRORMESSAGE, nvapi_QueryInterface, 0x6C2D048C, NVAPI, 0)
+  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetDynamicPstatesInfoEx, NVAPI_GPU_GETDYNAMICPSTATESINFOEX, nvapi_QueryInterface, 0x60DED2ED, NVAPI, 0)
+  HC_LOAD_ADDR(nvapi, NvAPI_EnumPhysicalGPUs, NVAPI_ENUMPHYSICALGPUS, nvapi_QueryInterface, 0xE5AC921F, NVAPI, 0)
+  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetThermalSettings, NVAPI_GPU_GETTHERMALSETTINGS, nvapi_QueryInterface, 0xE3640A56, NVAPI, 0)
+  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetTachReading, NVAPI_GPU_GETTACHREADING, nvapi_QueryInterface, 0x5F608315, NVAPI, 0)
 
   return 0;
 }
@@ -52,6 +53,8 @@ int hm_NvAPI_Initialize (NVAPI_PTR *nvapi)
   if (!nvapi) return (-1);
 
   NvAPI_Status NvAPI_rc = nvapi->NvAPI_Initialize ();
+
+  if (NvAPI_rc == NVAPI_LIBRARY_NOT_FOUND) NvAPI_rc = NVAPI_OK; // not a bug
 
   if (NvAPI_rc != NVAPI_OK)
   {


### PR DESCRIPTION
From [nvidia nvapi concepts](http://docs.nvidia.com/gameworks/content/gameworkslibrary/coresdk/nvapi/concepts.html)

> Use a Static Link with Applications
> 
> NvAPI cannot be dynamically linked to applications. You must create a static link to the library and then call NvAPI_Initialize(), which loads nvapi.dll dynamically. 
> If the NVIDIA drivers are not installed on the system or nvapi.dll is not present when the application calls NvAPI_Initialize(), the call just returns an error. The application will still load. 

We can do it, and it seems to work.

nvapi.lib is basically a wrapper for nvapi.dll
Some of nvapi functions are not exported but addresses ... are online :)
By using the exported function "nvapi_QueryInterface" we can call internal dll functions => game over men ;)

No more NvAPI static linking.
The nvapi.dll or nvapi64.dll are shipped with the nvidia driver,
it is enough for what interests us.

Time to new beta ;)

~(=^‥^)ﾉ◎～
