### PR TITLE
Handling possible clEnqueueFillBuffer not found in opencl loader

### DIFF
--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -128,7 +128,7 @@ void hc_clReleaseProgram (OCL_PTR *ocl, cl_program program);
 void hc_clSetKernelArg (OCL_PTR *ocl, cl_kernel kernel, cl_uint arg_index, size_t arg_size, const void *arg_value);
 void *hc_clEnqueueMapBuffer (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_map, cl_map_flags map_flags, size_t offset, size_t cb, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event);
 void hc_clEnqueueUnmapMemObject (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem memobj, void *mapped_ptr, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event);
-void hc_clEnqueueFillBuffer (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem buffer, const void *pattern, size_t pattern_size, size_t offset, size_t size, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event);
+cl_int hc_clEnqueueFillBuffer (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem buffer, const void *pattern, size_t pattern_size, size_t offset, size_t size, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event);
 void hc_clGetKernelWorkGroupInfo (OCL_PTR *ocl, cl_kernel kernel, cl_device_id device, cl_kernel_work_group_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret);
 cl_int hc_clGetProgramBuildInfo (OCL_PTR *ocl, cl_program program, cl_device_id device, cl_program_build_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret);
 void hc_clGetProgramInfo (OCL_PTR *ocl, cl_program program, cl_program_info param_name, size_t param_value_size, void *param_value, size_t * param_value_size_ret);

--- a/include/shared.h
+++ b/include/shared.h
@@ -62,13 +62,15 @@
 
 #define HC_LOAD_FUNC(ptr,name,type,libname,noerr) \
   ptr->name = (type) hc_dlsym (ptr->lib, #name); \
-  if (!ptr->name) { \
-    if (noerr == 1) { \
-      log_error ("ERROR: %s is missing from %s shared library.", #name, #libname); \
-      exit (-1); \
-    } else { \
-      log_info ("WARNING: %s is missing from %s shared library.", #name, #libname); \
-      return (-1); \
+  if (noerr != -1) { \
+    if (!ptr->name) { \
+      if (noerr == 1) { \
+        log_error ("ERROR: %s is missing from %s shared library.", #name, #libname); \
+        exit (-1); \
+      } else { \
+        log_info ("WARNING: %s is missing from %s shared library.", #name, #libname); \
+        return (-1); \
+      } \
     } \
   }
 

--- a/include/types.h
+++ b/include/types.h
@@ -907,6 +907,8 @@ struct __hc_device_param
   char   *device_version;
   char   *driver_version;
 
+  bool    opencl_v12;
+
   cl_uint vendor_id;
 
   cl_kernel  kernel1;

--- a/src/ext_OpenCL.c
+++ b/src/ext_OpenCL.c
@@ -90,7 +90,7 @@ int ocl_init (OCL_PTR *ocl)
   HC_LOAD_FUNC(ocl, clCreateProgramWithBinary, OCL_CLCREATEPROGRAMWITHBINARY, OpenCL, 1)
   HC_LOAD_FUNC(ocl, clCreateProgramWithSource, OCL_CLCREATEPROGRAMWITHSOURCE, OpenCL, 1)
   HC_LOAD_FUNC(ocl, clEnqueueCopyBuffer, OCL_CLENQUEUECOPYBUFFER, OpenCL, 1)
-  HC_LOAD_FUNC(ocl, clEnqueueFillBuffer, OCL_CLENQUEUEFILLBUFFER, OpenCL, 1)
+  HC_LOAD_FUNC(ocl, clEnqueueFillBuffer, OCL_CLENQUEUEFILLBUFFER, OpenCL, -1)
   HC_LOAD_FUNC(ocl, clEnqueueMapBuffer, OCL_CLENQUEUEMAPBUFFER, OpenCL, 1)
   HC_LOAD_FUNC(ocl, clEnqueueNDRangeKernel, OCL_CLENQUEUENDRANGEKERNEL, OpenCL, 1)
   HC_LOAD_FUNC(ocl, clEnqueueReadBuffer, OCL_CLENQUEUEREADBUFFER, OpenCL, 1)
@@ -509,16 +509,19 @@ void hc_clEnqueueUnmapMemObject (OCL_PTR *ocl, cl_command_queue command_queue, c
   }
 }
 
-void hc_clEnqueueFillBuffer (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem buffer, const void *pattern, size_t pattern_size, size_t offset, size_t size, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event)
+cl_int hc_clEnqueueFillBuffer (OCL_PTR *ocl, cl_command_queue command_queue, cl_mem buffer, const void *pattern, size_t pattern_size, size_t offset, size_t size, cl_uint num_events_in_wait_list, const cl_event *event_wait_list, cl_event *event)
 {
-  cl_int CL_err = ocl->clEnqueueFillBuffer (command_queue, buffer, pattern, pattern_size, offset, size, num_events_in_wait_list, event_wait_list, event);
+  cl_int CL_err = -1;
 
-  if (CL_err != CL_SUCCESS)
+  if (ocl->clEnqueueFillBuffer)
   {
-    log_error ("ERROR: %s : %d : %s\n", "clEnqueueFillBuffer()", CL_err, val2cstr_cl (CL_err));
+    CL_err = ocl->clEnqueueFillBuffer (command_queue, buffer, pattern, pattern_size, offset, size, num_events_in_wait_list, event_wait_list, event);
 
-    exit (-1);
+    if (CL_err != CL_SUCCESS && data.quiet == 0)
+      log_error ("WARNING: %s : %d : %s\n", "clEnqueueFillBuffer()", CL_err, val2cstr_cl (CL_err));
   }
+
+  return CL_err;
 }
 
 void hc_clGetKernelWorkGroupInfo (OCL_PTR *ocl, cl_kernel kernel, cl_device_id device, cl_kernel_work_group_info param_name, size_t param_value_size, void *param_value, size_t *param_value_size_ret)


### PR DESCRIPTION
- If the _clEnqueueFillBuffer_ function is not available in your opencl lib the opencl fail end exit with -1.<br>For prevent that I moved the check for the availability of _clEnqueueFillBuffer_ from _ocl_init_ to _hc_clEnqueueFillBuffer_.
- changed some buffer alloc size (used by _hc_clGetDeviceInfo_ )
