### PR TITLE
Bugfix: putenv(3) was used with a stack variable, that's a no-no.

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -5072,7 +5072,7 @@ int main (int argc, char **argv)
 
   if (compute)
   {
-    char display[100] = { 0 };
+    static char display[100];
 
     snprintf (display, sizeof (display) - 1, "DISPLAY=%s", compute);
 


### PR DESCRIPTION
From my man page:  _The string pointed to by string becomes part of the environment.  A program should not alter or free the string, and should not use stack or other transient string variables as arguments to putenv().  The setenv() function is strongly preferred to putenv()._
