### PR TITLE
gpu loops/accel per-device

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -127,7 +127,8 @@
 
 #define VENDOR_ID_AMD         4098
 #define VENDOR_ID_NV          4318
-#define VENDOR_ID_APPLE       16925952
+#define VENDOR_ID_APPLE_INTEL 4294967295
+#define VENDOR_ID_APPLE_IRIS  16925952
 #define VENDOR_ID_GENERIC     9999
 
 #define BLOCK_SIZE            64
@@ -205,37 +206,36 @@ extern hc_thread_mutex_t mux_display;
  * device accel macro
  */
 
-#ifdef OSX
-#define KERNEL_ACCEL_1800    1
-#define KERNEL_ACCEL_2500    2
-#define KERNEL_ACCEL_5000    16
-#define KERNEL_ACCEL_6100    1
-#define KERNEL_ACCEL_6211    2
-#define KERNEL_ACCEL_6231    1
-#define KERNEL_ACCEL_6241    4
-#define KERNEL_ACCEL_6800    2
-#define KERNEL_ACCEL_7100    1
-#define KERNEL_ACCEL_7200    1
-#define KERNEL_ACCEL_7900    1
-#define KERNEL_ACCEL_8200    1
-#define KERNEL_ACCEL_8700    2
-#define KERNEL_ACCEL_9100    4
-#define KERNEL_ACCEL_9200    1
-#define KERNEL_ACCEL_9300    1
-#define KERNEL_ACCEL_9400    1
-#define KERNEL_ACCEL_9500    1
-#define KERNEL_ACCEL_9600    1
-#define KERNEL_ACCEL_10000   1
-#define KERNEL_ACCEL_10500   4
-#define KERNEL_ACCEL_11300   1
-#define KERNEL_ACCEL_11600   1
-#define KERNEL_ACCEL_11700   1
-#define KERNEL_ACCEL_11800   1
-#define KERNEL_ACCEL_12200   1
-#define KERNEL_ACCEL_12400   1
-#define KERNEL_ACCEL_12500   1
-#define KERNEL_ACCEL_13000   1
-#else
+#define KERNEL_ACCEL_OSX_1800    1
+#define KERNEL_ACCEL_OSX_2500    2
+#define KERNEL_ACCEL_OSX_5000    16
+#define KERNEL_ACCEL_OSX_6100    1
+#define KERNEL_ACCEL_OSX_6211    2
+#define KERNEL_ACCEL_OSX_6231    1
+#define KERNEL_ACCEL_OSX_6241    4
+#define KERNEL_ACCEL_OSX_6800    2
+#define KERNEL_ACCEL_OSX_7100    1
+#define KERNEL_ACCEL_OSX_7200    1
+#define KERNEL_ACCEL_OSX_7900    1
+#define KERNEL_ACCEL_OSX_8200    1
+#define KERNEL_ACCEL_OSX_8700    2
+#define KERNEL_ACCEL_OSX_9100    4
+#define KERNEL_ACCEL_OSX_9200    1
+#define KERNEL_ACCEL_OSX_9300    1
+#define KERNEL_ACCEL_OSX_9400    1
+#define KERNEL_ACCEL_OSX_9500    1
+#define KERNEL_ACCEL_OSX_9600    1
+#define KERNEL_ACCEL_OSX_10000   1
+#define KERNEL_ACCEL_OSX_10500   4
+#define KERNEL_ACCEL_OSX_11300   1
+#define KERNEL_ACCEL_OSX_11600   1
+#define KERNEL_ACCEL_OSX_11700   1
+#define KERNEL_ACCEL_OSX_11800   1
+#define KERNEL_ACCEL_OSX_12200   1
+#define KERNEL_ACCEL_OSX_12400   1
+#define KERNEL_ACCEL_OSX_12500   1
+#define KERNEL_ACCEL_OSX_13000   1
+
 #define KERNEL_ACCEL_1800    2
 #define KERNEL_ACCEL_2500    8
 #define KERNEL_ACCEL_5000    64
@@ -265,7 +265,6 @@ extern hc_thread_mutex_t mux_display;
 #define KERNEL_ACCEL_12400   64
 #define KERNEL_ACCEL_12500   8
 #define KERNEL_ACCEL_13000   8
-#endif // OSX
 
 #define KERNEL_ACCEL_0       128
 #define KERNEL_ACCEL_10      128
@@ -421,130 +420,129 @@ extern hc_thread_mutex_t mux_display;
  * device loops macro
  */
 
-#ifdef OSX
-#define KERNEL_LOOPS_0       2
-#define KERNEL_LOOPS_10      2
-#define KERNEL_LOOPS_11      2
-#define KERNEL_LOOPS_12      2
-#define KERNEL_LOOPS_20      2
-#define KERNEL_LOOPS_21      2
-#define KERNEL_LOOPS_22      2
-#define KERNEL_LOOPS_23      2
-#define KERNEL_LOOPS_30      2
-#define KERNEL_LOOPS_40      2
-#define KERNEL_LOOPS_50      2
-#define KERNEL_LOOPS_60      2
-#define KERNEL_LOOPS_100     2
-#define KERNEL_LOOPS_101     2
-#define KERNEL_LOOPS_110     2
-#define KERNEL_LOOPS_111     2
-#define KERNEL_LOOPS_112     2
-#define KERNEL_LOOPS_120     2
-#define KERNEL_LOOPS_121     2
-#define KERNEL_LOOPS_122     2
-#define KERNEL_LOOPS_124     2
-#define KERNEL_LOOPS_130     2
-#define KERNEL_LOOPS_131     2
-#define KERNEL_LOOPS_132     2
-#define KERNEL_LOOPS_133     2
-#define KERNEL_LOOPS_140     2
-#define KERNEL_LOOPS_141     2
-#define KERNEL_LOOPS_150     2
-#define KERNEL_LOOPS_160     2
-#define KERNEL_LOOPS_190     2
-#define KERNEL_LOOPS_200     2
-#define KERNEL_LOOPS_300     2
-#define KERNEL_LOOPS_900     2
-#define KERNEL_LOOPS_1000    2
-#define KERNEL_LOOPS_1100    2
-#define KERNEL_LOOPS_1400    2
-#define KERNEL_LOOPS_1410    2
-#define KERNEL_LOOPS_1420    2
-#define KERNEL_LOOPS_1421    2
-#define KERNEL_LOOPS_1430    2
-#define KERNEL_LOOPS_1440    2
-#define KERNEL_LOOPS_1441    2
-#define KERNEL_LOOPS_1450    2
-#define KERNEL_LOOPS_1460    2
-#define KERNEL_LOOPS_1700    2
-#define KERNEL_LOOPS_1710    2
-#define KERNEL_LOOPS_1711    2
-#define KERNEL_LOOPS_1720    2
-#define KERNEL_LOOPS_1722    2
-#define KERNEL_LOOPS_1730    2
-#define KERNEL_LOOPS_1731    2
-#define KERNEL_LOOPS_1740    2
-#define KERNEL_LOOPS_1750    2
-#define KERNEL_LOOPS_1760    2
-#define KERNEL_LOOPS_2400    2
-#define KERNEL_LOOPS_2410    2
-#define KERNEL_LOOPS_2600    2
-#define KERNEL_LOOPS_2611    2
-#define KERNEL_LOOPS_2612    2
-#define KERNEL_LOOPS_2711    2
-#define KERNEL_LOOPS_2811    2
-#define KERNEL_LOOPS_3100    2
-#define KERNEL_LOOPS_3200    2
-#define KERNEL_LOOPS_3710    2
-#define KERNEL_LOOPS_3711    2
-#define KERNEL_LOOPS_3800    2
-#define KERNEL_LOOPS_4300    2
-#define KERNEL_LOOPS_4400    2
-#define KERNEL_LOOPS_4500    2
-#define KERNEL_LOOPS_4700    2
-#define KERNEL_LOOPS_4800    2
-#define KERNEL_LOOPS_4900    2
-#define KERNEL_LOOPS_5000    2
-#define KERNEL_LOOPS_5100    2
-#define KERNEL_LOOPS_5300    2
-#define KERNEL_LOOPS_5400    2
-#define KERNEL_LOOPS_5500    2
-#define KERNEL_LOOPS_5600    2
-#define KERNEL_LOOPS_5700    2
-#define KERNEL_LOOPS_6000    2
-#define KERNEL_LOOPS_6100    2
-#define KERNEL_LOOPS_6231    2
-#define KERNEL_LOOPS_6232    2
-#define KERNEL_LOOPS_6233    2
-#define KERNEL_LOOPS_6900    2
-#define KERNEL_LOOPS_7300    2
-#define KERNEL_LOOPS_7500    2
-#define KERNEL_LOOPS_7600    2
-#define KERNEL_LOOPS_7700    2
-#define KERNEL_LOOPS_7800    2
-#define KERNEL_LOOPS_8000    2
-#define KERNEL_LOOPS_8100    2
-#define KERNEL_LOOPS_8200    1
-#define KERNEL_LOOPS_8300    2
-#define KERNEL_LOOPS_8400    2
-#define KERNEL_LOOPS_8500    2
-#define KERNEL_LOOPS_8600    2
-#define KERNEL_LOOPS_8700    2
-#define KERNEL_LOOPS_9700    2
-#define KERNEL_LOOPS_9710    2
-#define KERNEL_LOOPS_9720    8
-#define KERNEL_LOOPS_9800    2
-#define KERNEL_LOOPS_9810    2
-#define KERNEL_LOOPS_9820    2
-#define KERNEL_LOOPS_9900    2
-#define KERNEL_LOOPS_10100   2
-#define KERNEL_LOOPS_10200   2
-#define KERNEL_LOOPS_10400   2
-#define KERNEL_LOOPS_10410   2
-#define KERNEL_LOOPS_10420   2
-#define KERNEL_LOOPS_10600   2
-#define KERNEL_LOOPS_10700   2
-#define KERNEL_LOOPS_10800   2
-#define KERNEL_LOOPS_11000   2
-#define KERNEL_LOOPS_11100   2
-#define KERNEL_LOOPS_11200   2
-#define KERNEL_LOOPS_11300   1
-#define KERNEL_LOOPS_11400   2
-#define KERNEL_LOOPS_11500   2
-#define KERNEL_LOOPS_11700   2
-#define KERNEL_LOOPS_11800   2
-#define KERNEL_LOOPS_12600   2
-#else
+#define KERNEL_LOOPS_OSX_0       2
+#define KERNEL_LOOPS_OSX_10      2
+#define KERNEL_LOOPS_OSX_11      2
+#define KERNEL_LOOPS_OSX_12      2
+#define KERNEL_LOOPS_OSX_20      2
+#define KERNEL_LOOPS_OSX_21      2
+#define KERNEL_LOOPS_OSX_22      2
+#define KERNEL_LOOPS_OSX_23      2
+#define KERNEL_LOOPS_OSX_30      2
+#define KERNEL_LOOPS_OSX_40      2
+#define KERNEL_LOOPS_OSX_50      2
+#define KERNEL_LOOPS_OSX_60      2
+#define KERNEL_LOOPS_OSX_100     2
+#define KERNEL_LOOPS_OSX_101     2
+#define KERNEL_LOOPS_OSX_110     2
+#define KERNEL_LOOPS_OSX_111     2
+#define KERNEL_LOOPS_OSX_112     2
+#define KERNEL_LOOPS_OSX_120     2
+#define KERNEL_LOOPS_OSX_121     2
+#define KERNEL_LOOPS_OSX_122     2
+#define KERNEL_LOOPS_OSX_124     2
+#define KERNEL_LOOPS_OSX_130     2
+#define KERNEL_LOOPS_OSX_131     2
+#define KERNEL_LOOPS_OSX_132     2
+#define KERNEL_LOOPS_OSX_133     2
+#define KERNEL_LOOPS_OSX_140     2
+#define KERNEL_LOOPS_OSX_141     2
+#define KERNEL_LOOPS_OSX_150     2
+#define KERNEL_LOOPS_OSX_160     2
+#define KERNEL_LOOPS_OSX_190     2
+#define KERNEL_LOOPS_OSX_200     2
+#define KERNEL_LOOPS_OSX_300     2
+#define KERNEL_LOOPS_OSX_900     2
+#define KERNEL_LOOPS_OSX_1000    2
+#define KERNEL_LOOPS_OSX_1100    2
+#define KERNEL_LOOPS_OSX_1400    2
+#define KERNEL_LOOPS_OSX_1410    2
+#define KERNEL_LOOPS_OSX_1420    2
+#define KERNEL_LOOPS_OSX_1421    2
+#define KERNEL_LOOPS_OSX_1430    2
+#define KERNEL_LOOPS_OSX_1440    2
+#define KERNEL_LOOPS_OSX_1441    2
+#define KERNEL_LOOPS_OSX_1450    2
+#define KERNEL_LOOPS_OSX_1460    2
+#define KERNEL_LOOPS_OSX_1700    2
+#define KERNEL_LOOPS_OSX_1710    2
+#define KERNEL_LOOPS_OSX_1711    2
+#define KERNEL_LOOPS_OSX_1720    2
+#define KERNEL_LOOPS_OSX_1722    2
+#define KERNEL_LOOPS_OSX_1730    2
+#define KERNEL_LOOPS_OSX_1731    2
+#define KERNEL_LOOPS_OSX_1740    2
+#define KERNEL_LOOPS_OSX_1750    2
+#define KERNEL_LOOPS_OSX_1760    2
+#define KERNEL_LOOPS_OSX_2400    2
+#define KERNEL_LOOPS_OSX_2410    2
+#define KERNEL_LOOPS_OSX_2600    2
+#define KERNEL_LOOPS_OSX_2611    2
+#define KERNEL_LOOPS_OSX_2612    2
+#define KERNEL_LOOPS_OSX_2711    2
+#define KERNEL_LOOPS_OSX_2811    2
+#define KERNEL_LOOPS_OSX_3100    2
+#define KERNEL_LOOPS_OSX_3200    2
+#define KERNEL_LOOPS_OSX_3710    2
+#define KERNEL_LOOPS_OSX_3711    2
+#define KERNEL_LOOPS_OSX_3800    2
+#define KERNEL_LOOPS_OSX_4300    2
+#define KERNEL_LOOPS_OSX_4400    2
+#define KERNEL_LOOPS_OSX_4500    2
+#define KERNEL_LOOPS_OSX_4700    2
+#define KERNEL_LOOPS_OSX_4800    2
+#define KERNEL_LOOPS_OSX_4900    2
+#define KERNEL_LOOPS_OSX_5000    2
+#define KERNEL_LOOPS_OSX_5100    2
+#define KERNEL_LOOPS_OSX_5300    2
+#define KERNEL_LOOPS_OSX_5400    2
+#define KERNEL_LOOPS_OSX_5500    2
+#define KERNEL_LOOPS_OSX_5600    2
+#define KERNEL_LOOPS_OSX_5700    2
+#define KERNEL_LOOPS_OSX_6000    2
+#define KERNEL_LOOPS_OSX_6100    2
+#define KERNEL_LOOPS_OSX_6231    2
+#define KERNEL_LOOPS_OSX_6232    2
+#define KERNEL_LOOPS_OSX_6233    2
+#define KERNEL_LOOPS_OSX_6900    2
+#define KERNEL_LOOPS_OSX_7300    2
+#define KERNEL_LOOPS_OSX_7500    2
+#define KERNEL_LOOPS_OSX_7600    2
+#define KERNEL_LOOPS_OSX_7700    2
+#define KERNEL_LOOPS_OSX_7800    2
+#define KERNEL_LOOPS_OSX_8000    2
+#define KERNEL_LOOPS_OSX_8100    2
+#define KERNEL_LOOPS_OSX_8200    1
+#define KERNEL_LOOPS_OSX_8300    2
+#define KERNEL_LOOPS_OSX_8400    2
+#define KERNEL_LOOPS_OSX_8500    2
+#define KERNEL_LOOPS_OSX_8600    2
+#define KERNEL_LOOPS_OSX_8700    2
+#define KERNEL_LOOPS_OSX_9700    2
+#define KERNEL_LOOPS_OSX_9710    2
+#define KERNEL_LOOPS_OSX_9720    8
+#define KERNEL_LOOPS_OSX_9800    2
+#define KERNEL_LOOPS_OSX_9810    2
+#define KERNEL_LOOPS_OSX_9820    2
+#define KERNEL_LOOPS_OSX_9900    2
+#define KERNEL_LOOPS_OSX_10100   2
+#define KERNEL_LOOPS_OSX_10200   2
+#define KERNEL_LOOPS_OSX_10400   2
+#define KERNEL_LOOPS_OSX_10410   2
+#define KERNEL_LOOPS_OSX_10420   2
+#define KERNEL_LOOPS_OSX_10600   2
+#define KERNEL_LOOPS_OSX_10700   2
+#define KERNEL_LOOPS_OSX_10800   2
+#define KERNEL_LOOPS_OSX_11000   2
+#define KERNEL_LOOPS_OSX_11100   2
+#define KERNEL_LOOPS_OSX_11200   2
+#define KERNEL_LOOPS_OSX_11300   1
+#define KERNEL_LOOPS_OSX_11400   2
+#define KERNEL_LOOPS_OSX_11500   2
+#define KERNEL_LOOPS_OSX_11700   2
+#define KERNEL_LOOPS_OSX_11800   2
+#define KERNEL_LOOPS_OSX_12600   2
+
 #define KERNEL_LOOPS_0       256
 #define KERNEL_LOOPS_10      256
 #define KERNEL_LOOPS_11      256
@@ -667,7 +665,6 @@ extern hc_thread_mutex_t mux_display;
 #define KERNEL_LOOPS_11700   64
 #define KERNEL_LOOPS_11800   64
 #define KERNEL_LOOPS_12600   32
-#endif // OSX
 
 #define KERNEL_LOOPS_400     256
 #define KERNEL_LOOPS_500     256
@@ -1910,8 +1907,17 @@ void hm_device_val_to_str (char *target_buf, int max_buf_size, char *suffix, int
 void myabort ();
 void myquit ();
 
+#ifdef OSX
+uint set_kernel_loops_osx (uint hash_mode);
+uint set_kernel_accel_osx (uint hash_mode);
+
+uint set_kernel_accel (uint hash_mode, bool isGpu);
+uint set_kernel_loops (uint hash_mode, bool isGpu);
+#else
 uint set_kernel_accel (uint hash_mode);
 uint set_kernel_loops (uint hash_mode);
+#endif
+
 void set_cpu_affinity (char *cpu_affinity);
 
 void usage_mini_print (const char *progname);

--- a/include/types.h
+++ b/include/types.h
@@ -849,6 +849,7 @@ struct __hc_device_param
   uint    vector_width;
 
   uint    kernel_threads;
+  uint    kernel_loops;
   uint    kernel_accel;
   uint    kernel_power;          // these both are based on their _user counterpart
   uint    kernel_blocks;         // but are modified by autotuner and used inside crack loops
@@ -1160,8 +1161,6 @@ typedef struct
   uint    pw_min;
   uint    pw_max;
   float   kernel_blocks_div;
-  uint    kernel_accel;
-  uint    kernel_loops;
   uint    powertune_enable;
   uint    scrypt_tmto;
   uint    segment_size;

--- a/src/shared.c
+++ b/src/shared.c
@@ -19,6 +19,9 @@
 #define GET_ACCEL(x) KERNEL_ACCEL_ ## x
 #define GET_LOOPS(x) KERNEL_LOOPS_ ## x
 
+#define GET_LOOPS_OSX(x) KERNEL_LOOPS_OSX_ ## x
+#define GET_ACCEL_OSX(x) KERNEL_ACCEL_OSX_ ## x
+
 /**
  * basic bit handling
  */
@@ -8963,8 +8966,61 @@ void check_checkpoint ()
  * adjustments
  */
 
+#ifdef OSX
+uint set_kernel_accel_osx (uint hash_mode)
+{
+  switch (hash_mode)
+  {
+    case 1800: return GET_ACCEL_OSX (1800);
+    case 2500: return GET_ACCEL_OSX (2500);
+    case 5000: return GET_ACCEL_OSX (5000);
+    case 6100: return GET_ACCEL_OSX (6100);
+    case 6211: return GET_ACCEL_OSX (6211);
+    case 6231: return GET_ACCEL_OSX (6231);
+    case 6241: return GET_ACCEL_OSX (6241);
+    case 6800: return GET_ACCEL_OSX (6800);
+    case 7100: return GET_ACCEL_OSX (7100);
+    case 7200: return GET_ACCEL_OSX (7200);
+    case 7900: return GET_ACCEL_OSX (7900);
+    case 8200: return GET_ACCEL_OSX (8200);
+    case 8700: return GET_ACCEL_OSX (8700);
+    case 9100: return GET_ACCEL_OSX (9100);
+    case 9200: return GET_ACCEL_OSX (9200);
+    case 9300: return GET_ACCEL_OSX (9300);
+    case 9400: return GET_ACCEL_OSX (9400);
+    case 9500: return GET_ACCEL_OSX (9500);
+    case 9600: return GET_ACCEL_OSX (9600);
+    case 10000: return GET_ACCEL_OSX (10000);
+    case 10500: return GET_ACCEL_OSX (10500);
+    case 11300: return GET_ACCEL_OSX (11300);
+    case 11600: return GET_ACCEL_OSX (11600);
+    case 11700: return GET_ACCEL_OSX (11700);
+    case 11800: return GET_ACCEL_OSX (11800);
+    case 12200: return GET_ACCEL_OSX (12200);
+    case 12400: return GET_ACCEL_OSX (12400);
+    case 12500: return GET_ACCEL_OSX (12500);
+    case 13000: return GET_ACCEL_OSX (13000);
+  }
+
+  return (-1);
+}
+
+uint set_kernel_accel (uint hash_mode, bool isGpu)
+{
+  int accel = -1;
+
+  if (isGpu)
+    accel = set_kernel_accel_osx (hash_mode);
+
+  if (accel != -1)
+    return accel;
+#else
+
 uint set_kernel_accel (uint hash_mode)
 {
+
+#endif
+
   switch (hash_mode)
   {
     case     0: return GET_ACCEL (0);
@@ -9150,8 +9206,154 @@ uint set_kernel_accel (uint hash_mode)
   return 0;
 }
 
+#ifdef OSX
+uint set_kernel_loops_osx (uint hash_mode)
+{
+  switch (hash_mode)
+  {
+    case 0: return GET_LOOPS_OSX (0);
+    case 10: return GET_LOOPS_OSX (10);
+    case 11: return GET_LOOPS_OSX (11);
+    case 12: return GET_LOOPS_OSX (12);
+    case 20: return GET_LOOPS_OSX (20);
+    case 21: return GET_LOOPS_OSX (21);
+    case 22: return GET_LOOPS_OSX (22);
+    case 23: return GET_LOOPS_OSX (23);
+    case 30: return GET_LOOPS_OSX (30);
+    case 40: return GET_LOOPS_OSX (40);
+    case 50: return GET_LOOPS_OSX (50);
+    case 60: return GET_LOOPS_OSX (60);
+    case 100: return GET_LOOPS_OSX (100);
+    case 101: return GET_LOOPS_OSX (101);
+    case 110: return GET_LOOPS_OSX (110);
+    case 111: return GET_LOOPS_OSX (111);
+    case 112: return GET_LOOPS_OSX (112);
+    case 120: return GET_LOOPS_OSX (120);
+    case 121: return GET_LOOPS_OSX (121);
+    case 122: return GET_LOOPS_OSX (122);
+    case 124: return GET_LOOPS_OSX (124);
+    case 130: return GET_LOOPS_OSX (130);
+    case 131: return GET_LOOPS_OSX (131);
+    case 132: return GET_LOOPS_OSX (132);
+    case 133: return GET_LOOPS_OSX (133);
+    case 140: return GET_LOOPS_OSX (140);
+    case 141: return GET_LOOPS_OSX (141);
+    case 150: return GET_LOOPS_OSX (150);
+    case 160: return GET_LOOPS_OSX (160);
+    case 190: return GET_LOOPS_OSX (190);
+    case 200: return GET_LOOPS_OSX (200);
+    case 300: return GET_LOOPS_OSX (300);
+    case 900: return GET_LOOPS_OSX (900);
+    case 1000: return GET_LOOPS_OSX (1000);
+    case 1100: return GET_LOOPS_OSX (1100);
+    case 1400: return GET_LOOPS_OSX (1400);
+    case 1410: return GET_LOOPS_OSX (1410);
+    case 1420: return GET_LOOPS_OSX (1420);
+    case 1421: return GET_LOOPS_OSX (1421);
+    case 1430: return GET_LOOPS_OSX (1430);
+    case 1440: return GET_LOOPS_OSX (1440);
+    case 1441: return GET_LOOPS_OSX (1441);
+    case 1450: return GET_LOOPS_OSX (1450);
+    case 1460: return GET_LOOPS_OSX (1460);
+    case 1700: return GET_LOOPS_OSX (1700);
+    case 1710: return GET_LOOPS_OSX (1710);
+    case 1711: return GET_LOOPS_OSX (1711);
+    case 1720: return GET_LOOPS_OSX (1720);
+    case 1722: return GET_LOOPS_OSX (1722);
+    case 1730: return GET_LOOPS_OSX (1730);
+    case 1731: return GET_LOOPS_OSX (1731);
+    case 1740: return GET_LOOPS_OSX (1740);
+    case 1750: return GET_LOOPS_OSX (1750);
+    case 1760: return GET_LOOPS_OSX (1760);
+    case 2400: return GET_LOOPS_OSX (2400);
+    case 2410: return GET_LOOPS_OSX (2410);
+    case 2600: return GET_LOOPS_OSX (2600);
+    case 2611: return GET_LOOPS_OSX (2611);
+    case 2612: return GET_LOOPS_OSX (2612);
+    case 2711: return GET_LOOPS_OSX (2711);
+    case 2811: return GET_LOOPS_OSX (2811);
+    case 3100: return GET_LOOPS_OSX (3100);
+    case 3200: return GET_LOOPS_OSX (3200);
+    case 3710: return GET_LOOPS_OSX (3710);
+    case 3711: return GET_LOOPS_OSX (3711);
+    case 3800: return GET_LOOPS_OSX (3800);
+    case 4300: return GET_LOOPS_OSX (4300);
+    case 4400: return GET_LOOPS_OSX (4400);
+    case 4500: return GET_LOOPS_OSX (4500);
+    case 4700: return GET_LOOPS_OSX (4700);
+    case 4800: return GET_LOOPS_OSX (4800);
+    case 4900: return GET_LOOPS_OSX (4900);
+    case 5000: return GET_LOOPS_OSX (5000);
+    case 5100: return GET_LOOPS_OSX (5100);
+    case 5300: return GET_LOOPS_OSX (5300);
+    case 5400: return GET_LOOPS_OSX (5400);
+    case 5500: return GET_LOOPS_OSX (5500);
+    case 5600: return GET_LOOPS_OSX (5600);
+    case 5700: return GET_LOOPS_OSX (5700);
+    case 6000: return GET_LOOPS_OSX (6000);
+    case 6100: return GET_LOOPS_OSX (6100);
+    case 6231: return GET_LOOPS_OSX (6231);
+    case 6232: return GET_LOOPS_OSX (6232);
+    case 6233: return GET_LOOPS_OSX (6233);
+    case 6900: return GET_LOOPS_OSX (6900);
+    case 7300: return GET_LOOPS_OSX (7300);
+    case 7500: return GET_LOOPS_OSX (7500);
+    case 7600: return GET_LOOPS_OSX (7600);
+    case 7700: return GET_LOOPS_OSX (7700);
+    case 7800: return GET_LOOPS_OSX (7800);
+    case 8000: return GET_LOOPS_OSX (8000);
+    case 8100: return GET_LOOPS_OSX (8100);
+    case 8200: return GET_LOOPS_OSX (8200);
+    case 8300: return GET_LOOPS_OSX (8300);
+    case 8400: return GET_LOOPS_OSX (8400);
+    case 8500: return GET_LOOPS_OSX (8500);
+    case 8600: return GET_LOOPS_OSX (8600);
+    case 8700: return GET_LOOPS_OSX (8700);
+    case 9700: return GET_LOOPS_OSX (9700);
+    case 9710: return GET_LOOPS_OSX (9710);
+    case 9720: return GET_LOOPS_OSX (9720);
+    case 9800: return GET_LOOPS_OSX (9800);
+    case 9810: return GET_LOOPS_OSX (9810);
+    case 9820: return GET_LOOPS_OSX (9820);
+    case 9900: return GET_LOOPS_OSX (9900);
+    case 10100: return GET_LOOPS_OSX (10100);
+    case 10200: return GET_LOOPS_OSX (10200);
+    case 10400: return GET_LOOPS_OSX (10400);
+    case 10410: return GET_LOOPS_OSX (10410);
+    case 10420: return GET_LOOPS_OSX (10420);
+    case 10600: return GET_LOOPS_OSX (10600);
+    case 10700: return GET_LOOPS_OSX (10700);
+    case 10800: return GET_LOOPS_OSX (10800);
+    case 11000: return GET_LOOPS_OSX (11000);
+    case 11100: return GET_LOOPS_OSX (11100);
+    case 11200: return GET_LOOPS_OSX (11200);
+    case 11300: return GET_LOOPS_OSX (11300);
+    case 11400: return GET_LOOPS_OSX (11400);
+    case 11500: return GET_LOOPS_OSX (11500);
+    case 11700: return GET_LOOPS_OSX (11700);
+    case 11800: return GET_LOOPS_OSX (11800);
+    case 12600: return GET_LOOPS_OSX (12600);
+  }
+
+  return (-1);
+}
+
+uint set_kernel_loops (uint hash_mode, bool isGpu)
+{
+  int loops = -1;
+  if (isGpu)
+    loops = set_kernel_loops_osx (hash_mode);
+
+  if (loops != -1)
+    return loops;
+
+#else
+
 uint set_kernel_loops (uint hash_mode)
 {
+
+#endif // OSX
+
   switch (hash_mode)
   {
     case     0: return GET_LOOPS (0);


### PR DESCRIPTION
Per-device loops and accel for handling cpu and gpu devices with different tuning value

```
$ make clean && make && ./oclHashcat.app -b --opencl-device-type 1,2 -m 900
rm -f obj/*.o *.bin *.exe *.app *.restore *.out *.pot *.dictstat *.log oclHashcat core
rm -rf *.induct
rm -rf *.outfiles
rm -rf *.dSYM
rm -rf kernels
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -c -o obj/ext_OpenCL.NATIVE.o src/ext_OpenCL.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -c -o obj/shared.NATIVE.o src/shared.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/ -c -o obj/rp_kernel_on_cpu.NATIVE.o src/rp_kernel_on_cpu.c
gcc -D_POSIX -DOSX -O2 -pipe -W -Wall -std=c99 -Iinclude/    -o oclHashcat.app src/oclHashcat.c obj/ext_OpenCL.NATIVE.o obj/shared.NATIVE.o obj/rp_kernel_on_cpu.NATIVE.o -lpthread -DCOMPTIME=1454682613 -DVERSION_TAG=\"v2.01\" -DVERSION_SUM=\"gfa7465a\" -DINSTALL_FOLDER=\"/usr/local/bin\" -DSHARED_FOLDER=\"/usr/local/share/oclHashcat\" -DDOCUMENT_FOLDER=\"/usr/local/share/doc/oclHashcat\"
oclHashcat v2.01 (gfa7465a) starting in benchmark-mode...

Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, 2048/8192 MB allocatable, 3000Mhz, 4MCU
Device #2: Iris, 384/1536 MB allocatable, 1200Mhz, 40MCU

Hashtype: MD4

Workload.Dev#1 : loops 1024, accel 64
Workload.Dev#2 : loops 16, accel 256
Speed.Dev.#1.:   194.2 MH/s
Speed.Dev.#2.:   391.7 MH/s
Speed.Dev.#*.:   585.9 MH/s

Started: Fri Feb  5 15:30:20 2016
Stopped: Fri Feb  5 15:30:39 2016
```

Old benchmark from [https://hashcat.net/forum/thread-5135.html](url) output

```
oclHashcat v2.01 (gb542d4a) starting in benchmark-mode...

Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, 2048/8192 MB allocatable, 3000Mhz, 4MCU
Device #2: Iris, 384/1536 MB allocatable, 1200Mhz, 40MCU

Hashtype: MD4
Workload: 16 loops, 64 accel

Speed.Dev.#1.:   153.8 MH/s
Speed.Dev.#2.:   341.4 MH/s
Speed.Dev.#*.:   495.2 MH/s

```

The speed values changed a lot from old benchmark to new benchmark :)

(=^‥^=)
