### PR TITLE
Fix clEnqueueNDRangeKernel() error -54

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -2527,7 +2527,14 @@ static void run_kernel_tb (hc_device_param_t *device_param, const uint num)
   const size_t global_work_size[3] = { num_elements, 1, 1 };
   const size_t local_work_size[3]  = { kernel_threads,  1, 1 };
 
-  hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL, true);
+  const cl_int rc = hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL, false);
+
+  if (rc != CL_SUCCESS)
+  {
+    const size_t local_work_size_fallback[3]  = { 1, 1, 1 };
+
+    hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size_fallback, 0, NULL, NULL, true);
+  }
 
   hc_clFlush (data.ocl, device_param->command_queue);
 
@@ -2545,7 +2552,14 @@ static void run_kernel_tm (hc_device_param_t *device_param)
   const size_t global_work_size[3] = { num_elements, 1, 1 };
   const size_t local_work_size[3]  = { kernel_threads,  1, 1 };
 
-  hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL, true);
+  const cl_int rc = hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL, false);
+
+  if (rc != CL_SUCCESS)
+  {
+    const size_t local_work_size_fallback[3]  = { 1, 1, 1 };
+
+    hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size_fallback, 0, NULL, NULL, true);
+  }
 
   hc_clFlush (data.ocl, device_param->command_queue);
 
@@ -2574,7 +2588,14 @@ static void run_kernel_amp (hc_device_param_t *device_param, const uint num)
   const size_t global_work_size[3] = { num_elements, 1, 1 };
   const size_t local_work_size[3]  = { kernel_threads,  1, 1 };
 
-  hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL, true);
+  const cl_int rc = hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size, 0, NULL, NULL, false);
+
+  if (rc != CL_SUCCESS)
+  {
+    const size_t local_work_size_fallback[3]  = { 1, 1, 1 };
+
+    hc_clEnqueueNDRangeKernel (data.ocl, device_param->command_queue, kernel, 1, NULL, global_work_size, local_work_size_fallback, 0, NULL, NULL, true);
+  }
 
   hc_clFlush (data.ocl, device_param->command_queue);
 


### PR DESCRIPTION
```
ERROR: clEnqueueNDRangeKernel() : -54 : CL_INVALID_WORK_GROUP_SIZE
! unhandled return code 255, cmdline : echo -n 83780 | ./oclHashcat.app --quiet --force --potfile-disable --runtime 200 --gpu-temp-disable --weak-hash-threshold=0 --opencl-device-types 1,2 --opencl-vector-width 1 -a 0 -m 400 '$P$9244876758C3iLVSQg2.Erf8CwnApD0'
```
