### PR TITLE
Use device's preferred vector width, not its native one.

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -12478,11 +12478,11 @@ int main (int argc, char **argv)
         {
           if (tuningdb_entry->vector_width == -1)
           {
-            hc_clGetDeviceInfo (data.ocl, device_param->device, CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, sizeof (vector_width), &vector_width, NULL);
-
             if (opti_type & OPTI_TYPE_USES_BITS_64)
             {
-              if (vector_width > 1) vector_width /= 2;
+              hc_clGetDeviceInfo (data.ocl, device_param->device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, sizeof (vector_width), &vector_width, NULL);
+            } else {
+              hc_clGetDeviceInfo (data.ocl, device_param->device, CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, sizeof (vector_width), &vector_width, NULL);
             }
           }
           else


### PR DESCRIPTION
For example, the Intel MIC announces a native width of 16 but a preferred width of 1. That's because it will auto-vectorize. If you give it a vectorized kernel anyway, the driver will unconditionally auto-**de**-vectorize it and then auto-vectorize the result of _that_. Yes it's very stupid but that is what will happen. Build time will increase and the result will likely end up worse than if you give it scalar code (which it's politely asking for). Plain CPU drivers are the same. I've done a lot of tests with this.

Also, don't assume vector width for 'long' is half of that for 'int'. Usually it is, but there's no reason to make assumptions when we can get it with a proper query.
