### PR TITLE
Fairly strict stamping of WPA salt components

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -10073,6 +10073,7 @@ int wpa_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   uint32_t *p0 = (uint32_t *) in.essid;  
   uint32_t c0 = 0; 
+  uint32_t c1 = 0; 
   
   for (unsigned int i = 0; i < sizeof(in.essid)/sizeof(uint32_t); i++) c0 ^= *p0++;  
   for (unsigned int i = 0; i < sizeof(wpa->pke)/sizeof(wpa->pke[0]); i++) c1 ^= wpa->pke[i];

--- a/src/shared.c
+++ b/src/shared.c
@@ -10071,8 +10071,14 @@ int wpa_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
     }
   }
 
-  salt->salt_buf[10] = digest[1];
-  salt->salt_buf[11] = digest[2];
+  uint32_t *p0 = (uint32_t *) in.essid;  
+  uint32_t c0 = 0; 
+  
+  for (unsigned int i = 0; i < sizeof(in.essid)/sizeof(uint32_t); i++) c0 ^= *p0++;  
+  for (unsigned int i = 0; i < sizeof(wpa->pke)/sizeof(wpa->pke[0]); i++) c1 ^= wpa->pke[i];
+  
+  salt->salt_buf[10] = c0;
+  salt->salt_buf[11] = c1;
 
   return (PARSER_OK);
 }


### PR DESCRIPTION
While experimenting with synthetic handcrafted multi-handshake HCCAP files we discovered that oclHashcat does not recognize unique salts in WPA (-m 2500) mode even if all WPA salt components are the same (but the MIC fields are different due to different known passwords used). Despite this situation is practically impossible in real handshakes due to ANonce and SNonce randomness, it will be quite useful to have strict stamping of WPA salt components.
Possible use of this feature is some kind of WPA proof-of-work system then untrusted worker gets several synthetic HCCAP handshakes with the same salt components but with different MIC fields.
He should find all possible password candidates not knowing who is the real one. If oclHashcat recognises these handshake as non-unique salts the performance of cracking drops significantly.
We tested attached patch with few synthetic multi-handshake HCCAP files and found that now it reliable detects unique salts in WPA mode.
