### PR TITLE
cast to uint is required with some gcc versions, otherwise we get a shift-negative-value warning

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -12493,7 +12493,7 @@ int main (int argc, char **argv)
 
       if (opencl_platforms_filter != (uint) -1)
       {
-        uint platform_cnt_mask = ~((-1 >> platforms_cnt) << platforms_cnt);
+        uint platform_cnt_mask = ~(((uint) -1 >> platforms_cnt) << platforms_cnt);
 
         if (opencl_platforms_filter > platform_cnt_mask)
         {
@@ -12961,7 +12961,7 @@ int main (int argc, char **argv)
 
     if (devices_filter != (uint) -1)
     {
-      uint devices_cnt_mask = ~((-1 >> devices_cnt) << devices_cnt);
+      uint devices_cnt_mask = ~(((uint) -1 >> devices_cnt) << devices_cnt);
 
       if (devices_filter > devices_cnt_mask)
       {


### PR DESCRIPTION
The -1 >> x syntax without casting the value -1 to uint was showing this new warning:

```
warning: left shift of negative value [-Wshift-negative-value]
```

These changes should fix this problem.
Thx
