### PR TITLE
#244: ADL array out-of-bound fix

### DIFF
--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -160,11 +160,17 @@ typedef struct ADLODPerformanceLevel
   int iVddc;
 } ADLODPerformanceLevel;
 
+/*
+ * Attention: we had to change this struct due to an out-of-bound problem mentioned here:
+ * https://github.com/hashcat/oclHashcat/issues/244
+ * the change: ADLODPerformanceLevel aLevels [1] -> ADLODPerformanceLevel aLevels [2]
+ */
+
 typedef struct ADLODPerformanceLevels
 {
   int iSize;
   int iReserved;
-  ADLODPerformanceLevel aLevels [1];
+  ADLODPerformanceLevel aLevels [2];
 } ADLODPerformanceLevels;
 
 typedef struct ADLOD6FanSpeedInfo
@@ -221,12 +227,18 @@ typedef struct ADLOD6PerformanceLevel
   int iMemoryClock;
 } ADLOD6PerformanceLevel;
 
+/*
+ * Attention: we had to change this struct due to an out-of-bound problem mentioned here:
+ * https://github.com/hashcat/oclHashcat/issues/244
+ * the change: ADLOD6PerformanceLevel aLevels [1] -> ADLOD6PerformanceLevel aLevels [2]
+ */
+
 typedef struct ADLOD6StateInfo
 {
   int iNumberOfPerformanceLevels;
   int iExtValue;
   int iExtMask;
-  ADLOD6PerformanceLevel aLevels [1];
+  ADLOD6PerformanceLevel aLevels [2];
 } ADLOD6StateInfo;
 
 typedef struct ADLOD6PowerControlInfo


### PR DESCRIPTION
This fix should solved issue #244 for which we identified an array out-of-bound memory problem.
As discussed within the before mentioned issue we decided to temporarily fix this by increasing the number of array items (aLevels).
The fix works for me without any side effects and it solves the compiler warnings/errors.

(to test it you might need to set the --powertune-enable flag).

Thank you very much
