### PR TITLE
#234: increase max. salt length to 28 for -m 22 = Juniper Netscreen/SSG (ScreenOS)

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -718,9 +718,9 @@ extern hc_thread_mutex_t mux_display;
 #define DISPLAY_LEN_MIN_21H   32 + 1 + 2
 #define DISPLAY_LEN_MAX_21H   32 + 1 + 30
 #define DISPLAY_LEN_MIN_22    30 + 1 + 1
-#define DISPLAY_LEN_MAX_22    30 + 1 + 15
+#define DISPLAY_LEN_MAX_22    30 + 1 + 28
 #define DISPLAY_LEN_MIN_22H   30 + 1 + 2
-#define DISPLAY_LEN_MAX_22H   30 + 1 + 30
+#define DISPLAY_LEN_MAX_22H   30 + 1 + 56
 #define DISPLAY_LEN_MIN_23    32 + 1 + 0
 #define DISPLAY_LEN_MAX_23    32 + 1 + 23
 #define DISPLAY_LEN_MIN_101    5 + 28

--- a/src/shared.c
+++ b/src/shared.c
@@ -9880,8 +9880,10 @@ int netscreen_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt_len = parse_and_store_salt (salt_buf_ptr, salt_buf, salt_len);
 
-  // max. salt length: salt_buf[32] => 32 - 22 (":Administration Tools:") = 10
-  if (salt_len > 10) return (PARSER_SALT_LENGTH);
+  // max. salt length: 55 (max for MD5) - 22 (":Administration Tools:") - 1 (0x80) = 32
+  // 32 - 4 bytes (to fit w0lr for all attack modes) = 28
+
+  if (salt_len > 28) return (PARSER_SALT_LENGTH);
 
   salt->salt_len = salt_len;
 


### PR DESCRIPTION
This should fix the problem about too short salt support of -m 22 reported in issue #234.

We can now increase the max. salt length to 28 = 55 (MD5 max) - 22 (":Administration Tools:") - 1 (0x80) - 4 (the "pass"). More than this is currently not possible (at least not for all attack modes, especially -a 3). But this should be enough for a username.

If you agree that the problem in #234 is fixed by applying this patch, feel free to close that issue.
Thanks
