### PR TITLE
Fixed build program failure for -m 13100 on Apple Platform

### DIFF
--- a/OpenCL/m13100_a0.cl
+++ b/OpenCL/m13100_a0.cl
@@ -1,6 +1,7 @@
 /**
  * Authors......: Jens Steube <jens.steube@gmail.com>
- * Authors......: Fist0urs <eddy.maaalou@gmail.com>
+ *                Fist0urs <eddy.maaalou@gmail.com>
+ *                Gabriele Gristina <matrix@hashcat.net>
  *
  * License.....: MIT
  */
@@ -89,7 +90,7 @@ static void rc4_init_16 (__local RC4_KEY *rc4_key, const u32 data[4])
   }
 }
 
-static u8 rc4_next_16 (__local RC4_KEY *rc4_key, u8 i, u8 j, __global u32 in[4], u32 out[4])
+static u8 rc4_next_16 (__local RC4_KEY *rc4_key, u8 i, u8 j, __global u32 *in, u32 out[4])
 {
   #pragma unroll
   for (u32 k = 0; k < 4; k++)

--- a/OpenCL/m13100_a1.cl
+++ b/OpenCL/m13100_a1.cl
@@ -1,6 +1,7 @@
 /**
  * Authors......: Jens Steube <jens.steube@gmail.com>
- * Authors......: Fist0urs <eddy.maaalou@gmail.com>
+ *                Fist0urs <eddy.maaalou@gmail.com>
+ *                Gabriele Gristina <matrix@hashcat.net>
  *
  * License.....: MIT
  */
@@ -87,7 +88,7 @@ static void rc4_init_16 (__local RC4_KEY *rc4_key, const u32 data[4])
   }
 }
 
-static u8 rc4_next_16 (__local RC4_KEY *rc4_key, u8 i, u8 j, __global u32 in[4], u32 out[4])
+static u8 rc4_next_16 (__local RC4_KEY *rc4_key, u8 i, u8 j, __global u32 *in, u32 out[4])
 {
   #pragma unroll
   for (u32 k = 0; k < 4; k++)

--- a/OpenCL/m13100_a3.cl
+++ b/OpenCL/m13100_a3.cl
@@ -1,6 +1,7 @@
 /**
  * Authors......: Jens Steube <jens.steube@gmail.com>
- * Authors......: Fist0urs <eddy.maaalou@gmail.com>
+ *                Fist0urs <eddy.maaalou@gmail.com>
+ *                Gabriele Gristina <matrix@hashcat.net>
  *
  * License.....: MIT
  */
@@ -87,7 +88,7 @@ static void rc4_init_16 (__local RC4_KEY *rc4_key, const u32 data[4])
   }
 }
 
-static u8 rc4_next_16 (__local RC4_KEY *rc4_key, u8 i, u8 j, __global u32 in[4], u32 out[4])
+static u8 rc4_next_16 (__local RC4_KEY *rc4_key, u8 i, u8 j, __global u32 *in, u32 out[4])
 {
   #pragma unroll
   for (u32 k = 0; k < 4; k++)


### PR DESCRIPTION
Before:

```
$ ./oclHashcat.app -b -m 13100
oclHashcat v2.01 (g8a448fe) starting in benchmark-mode...

Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, skipped
Device #2: Iris, 384/1536 MB allocatable, 1200Mhz, 40MCU



ERROR: clBuildProgram() : -11 : CL_BUILD_PROGRAM_FAILURE





=== Build Options : -I./ -DVENDOR_ID=16925952 -DCUDA_ARCH=0 -DVECT_SIZE=1 -DDEVICE_TYPE=4 ===



=== Build Log (start) ===
<program source>:90:75: error: parameter may not be qualified with an address space
...
...
...
=== Build Log (end) ===
Device #2: Kernel ./OpenCL/m13100_a3.cl build failure. Proceed without this device.
Hashtype: Kerberos 5 TGS-REP etype 23


Started: Tue Mar  8 11:56:12 2016
Stopped: Tue Mar  8 11:56:13 2016
```

After:

```
$ ./oclHashcat.app -b -m 13100
oclHashcat v2.01 (g8a448fe) starting in benchmark-mode...

Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, skipped
Device #2: Iris, 384/1536 MB allocatable, 1200Mhz, 40MCU

Hashtype: Kerberos 5 TGS-REP etype 23

Speed.Dev.#2.:  5326.3 kH/s (61.16ms)

Started: Tue Mar  8 11:56:59 2016
Stopped: Tue Mar  8 11:57:57 2016
```
