### PR TITLE
added additional check for max. ESSID length to prevent possible crashes

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -10023,6 +10023,13 @@ int wpa_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   uint salt_len = strlen (in.essid);
 
+  if (salt_len > 36)
+  {
+    log_info ("WARNING: the length of the ESSID is too long. The hccap file may be invalid or corrupted");
+
+    return (PARSER_SALT_LENGTH);
+  }
+
   memcpy (salt->salt_buf, in.essid, salt_len);
 
   salt->salt_len = salt_len;


### PR DESCRIPTION
This additional check should prevent crashes of malformed/invalid/corrupted .hccap (this issue is only about the hash mode -m 2500 = WPA/WPA2) files.
We currently don't have a check for the salt_len value, this fix adds this additional checks to prevent buffer overflows and similar problems.

Thank you very much
