### PR TITLE
added some checks to the -m 111 parser

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -151,6 +151,10 @@ Type.: Bug
 File.: Host
 Desc.: Fixed a bug in line counter: Conditional jump or move depends on uninitialised value
 
+Type.: Bug
+File.: Host
+Desc.: Fixed some checks in the parser of -m 111 = nsldaps, SSHA-1(Base64), Netscape LDAP SSHA
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -11639,9 +11639,15 @@ int sha1b64s_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   int tmp_len = base64_decode (base64_to_int, (const u8 *) input_buf + 6, input_len - 6, tmp_buf);
 
+  if (tmp_len < 20) return (PARSER_HASH_LENGTH);
+
   memcpy (digest, tmp_buf, 20);
 
-  salt->salt_len = tmp_len - 20;
+  int salt_len = tmp_len - 20;
+
+  if (salt_len < 0) return (PARSER_SALT_LENGTH);
+
+  salt->salt_len = salt_len;
 
   memcpy (salt->salt_buf, tmp_buf + 20, salt->salt_len);
 


### PR DESCRIPTION
There was an important sanity check missing in the -m 111 = nsldaps, SSHA-1(Base64), Netscape LDAP SSHA parser.
This is an example to verify it:

```
{SSHA}AZKja2fbuuB9SpRlHqaoXxbTc3==
```

The problem occurred when the length of the base64 decoded input was less than 20, in this case we got a negative salt->salt_len = [number_less_than_20] - 20 < 0 and this salt->salt_len was afterwards used in the memcpy () function.

This missing sanity check (length check) could lead to a segmentation fault/crash, this pull request should reject such hashes with invalid decoded lenght(s).

Thank you very much
