### PR TITLE
fixed checks in -m 500 parser

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -155,6 +155,10 @@ Type.: Bug
 File.: Host
 Desc.: Fixed some checks in the parser of -m 111 = nsldaps, SSHA-1(Base64), Netscape LDAP SSHA
 
+Type.: Bug
+File.: Host
+Desc.: Fixed some checks in the parser of -m 500 = md5crypt, MD5(Unix), FreeBSD MD5, Cisco-IOS MD5
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -10272,6 +10272,8 @@ int phpass_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
 int md5crypt_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 {
+  if (input_len < DISPLAY_LEN_MIN_500) return (PARSER_GLOBAL_LENGTH);
+
   if (memcmp (SIGNATURE_MD5CRYPT, input_buf, 3)) return (PARSER_SIGNATURE_UNMATCHED);
 
   u32 *digest = (u32 *) hash_buf->digest;
@@ -10304,7 +10306,7 @@ int md5crypt_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
     salt->salt_iter = ROUNDS_MD5CRYPT;
   }
 
-  if ((input_len < DISPLAY_LEN_MIN_500) || (input_len > (DISPLAY_LEN_MAX_500 + iterations_len))) return (PARSER_GLOBAL_LENGTH);
+  if (input_len > (DISPLAY_LEN_MAX_500 + iterations_len)) return (PARSER_GLOBAL_LENGTH);
 
   char *hash_pos = strchr (salt_pos, '$');
 


### PR DESCRIPTION
This fix just moves the check for the min. -m 500 hash length (for md5crypt, MD5(Unix), FreeBSD MD5, Cisco-IOS MD5 hashes).
The problem here was that it could happen that the input length (line length of the current hash) was smaller than expected and hence some functions/syscalls could result in a segfault (like memcmp () etc).
By doing the minimum line length check at the very beginning of md5crypt_parse_hash (), we make sure that such invalid lines/hashes will be rejected immediately.

Thank you very much
