### PR TITLE
added some checks to the -m 1711 parser

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -159,6 +159,10 @@ Type.: Bug
 File.: Host
 Desc.: Fixed some checks in the parser of -m 500 = md5crypt, MD5(Unix), FreeBSD MD5, Cisco-IOS MD5
 
+Type.: Bug
+File.: Host
+Desc.: Fixed some checks in the parser of -m 1711 = SSHA-512(Base64), LDAP {SSHA512}
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -13154,6 +13154,8 @@ int sha512b64s_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   int tmp_len = base64_decode (base64_to_int, (const u8 *) input_buf + 9, input_len - 9, tmp_buf);
 
+  if (tmp_len < 64) return (PARSER_HASH_LENGTH);
+
   memcpy (digest, tmp_buf, 64);
 
   digest[0] = byte_swap_64 (digest[0]);
@@ -13174,7 +13176,11 @@ int sha512b64s_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
   digest[6] -= SHA512M_G;
   digest[7] -= SHA512M_H;
 
-  salt->salt_len = tmp_len - 64;
+  int salt_len = tmp_len - 64;
+
+  if (salt_len < 0) return (PARSER_SALT_LENGTH);
+
+  salt->salt_len = salt_len;
 
   memcpy (salt->salt_buf, tmp_buf + 64, salt->salt_len);
 


### PR DESCRIPTION
I just noticed that with hash mode -m 1711 = SSHA-512(Base64), LDAP {SSHA512} there could be similar parsing problems as mentioned in https://github.com/hashcat/oclHashcat/pull/264 .
Therefore, I applied a very similar fix to 1711 to avoid any crashes/segfaults. The crashes, in theory, should only have happened whenever there is a invalid/corrupted hash list (but as we all know this is sometimes the case, e.g. with corrupted "sql dumps" etc).

Thank you very much
