### PR TITLE
fixed some parser checks to avoid crashes (-m 5300/5400)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -163,6 +163,10 @@ Type.: Bug
 File.: Host
 Desc.: Fixed some checks in the parser of -m 1711 = SSHA-512(Base64), LDAP {SSHA512}
 
+Type.: Bug
+File.: Host
+Desc.: Fixed some checks in the parser of -m 5300 = IKE-PSK MD5 and -m 5400 = IKE-PSK SHA1
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -12195,6 +12195,8 @@ int ikepsk_md5_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   in_off[0] = strtok (input_buf, ":");
 
+  if (in_off[0] == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+
   in_len[0] = strlen (in_off[0]);
 
   size_t i;
@@ -12279,6 +12281,8 @@ int ikepsk_sha1_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
   size_t in_len[9] = { 0 };
 
   in_off[0] = strtok (input_buf, ":");
+
+  if (in_off[0] == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 
   in_len[0] = strlen (in_off[0]);
 


### PR DESCRIPTION
# These additional checks are needed to avoid segmentation faults/crashes when parsing .ikemd5 and .ikesha1 files (-m 5300 and -m 5400 accordingly).

In theory, it should be highly recommended to check for a NULL pointer directly/immediately after each call of strtok () to avoid such crashes. There are some other calls to strtok () within the source code, but I wasn't yet able to see crashes for those other instances of strtok () calls, mainly because in those cases the NULL pointers afterwards aren't used directly as a parameter to another function.

For those 2 fixed parser functions, instead, it is very easy to reproduce the crashes (i.e. if just the 1 call to strtok () returns NULL).

Thank you very much
