### PR TITLE
fixed -m 5500 parser, avoid strange crashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -167,6 +167,10 @@ Type.: Bug
 File.: Host
 Desc.: Fixed some checks in the parser of -m 5300 = IKE-PSK MD5 and -m 5400 = IKE-PSK SHA1
 
+Type.: Bug
+File.: Host
+Desc.: Fixed some checks in the parser of -m 5500 = NetNTLMv1
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -10795,7 +10795,7 @@ int netntlmv1_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   char *hash_pos = strchr (srvchall_pos, ':');
 
-  if (srvchall_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+  if (hash_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 
   uint srvchall_len = hash_pos - srvchall_pos;
 


### PR DESCRIPTION
There was a (probably copy-pasted) duplicated check for srvchall_pos, but no check if hash_pos is NULL.

This missing check for hash_pos == NULL was the culprit for several crashes with corrupted or invalid NetNTMLv1 hashes.

Thank you very much
