### PR TITLE
fixed problem with -m 5600 = NetNTLMv2 parser

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -171,6 +171,10 @@ Type.: Bug
 File.: Host
 Desc.: Fixed some checks in the parser of -m 5500 = NetNTLMv1
 
+Type.: Bug
+File.: Host
+Desc.: Fixed some checks in the parser of -m 5600 = NetNTLMv2
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -11031,7 +11031,7 @@ int netntlmv2_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   char *hash_pos = strchr (srvchall_pos, ':');
 
-  if (srvchall_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+  if (hash_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 
   uint srvchall_len = hash_pos - srvchall_pos;
 


### PR DESCRIPTION
I just noticed that the same problem that we fixed with https://github.com/hashcat/oclHashcat/pull/276 for -m 5500 = NetNVMLv1 hashes is also present in the NetNTMLv2 (-m 5600) parser.

I suggest that we apply the same fix because otherwise it could lead to crashes.

Thank you very much
