### PR TITLE
use a GCC equivalent for __stdcall where applicable

### DIFF
--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -250,9 +250,18 @@ typedef struct ADLOD6PowerControlInfo
   int iExtMask;
 } ADLOD6PowerControlInfo;
 
+/* __stdcall definition, platform-dependent:
+ * - Already defined on Windows compilers
+ * - GCC has a suitable equivalent on 32-bit platforms
+ * - Leave it blank for other platforms/compilers
+ */
 #if !(defined (_WIN32) || defined (_WIN64))
+#if (defined(__GNUC__) && defined(__i386__))
+#define __stdcall __attribute__((stdcall))
+#else
 #define __stdcall
-#endif
+#endif /* GCC 32-bit  */
+#endif /* Not windows */
 
 typedef void* (__stdcall *ADL_MAIN_MALLOC_CALLBACK )( int );
 


### PR DESCRIPTION
GCC has **attribute**((stdcall)) as an equivalent to Windows __stdcall, so use it conditionally instead of leaving it blank for all non-Windows platforms. This may benefit all platforms where GCC or compatible compilers are used, including (but not limited to) Linux.
