### PR TITLE
fixed base64_decode () input length validation for -m 8900

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -175,6 +175,10 @@ Type.: Bug
 File.: Host
 Desc.: Fixed some checks in the parser of -m 5600 = NetNTLMv2
 
+Type.: Bug
+File.: Host
+Desc.: Fixed some checks in the parser of -m 8900 = scrypt
+
 * changes v2.00 -> v2.01:
 
 Type.: Bug

--- a/src/shared.c
+++ b/src/shared.c
@@ -14688,9 +14688,13 @@ int scrypt_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   // base64 decode
 
+  int salt_len_base64 = hash_pos - saltbuf_pos;
+
+  if (salt_len_base64 > 45) return (PARSER_SALT_LENGTH);
+
   u8 tmp_buf[33] = { 0 };
 
-  int tmp_len = base64_decode (base64_to_int, (const u8 *) saltbuf_pos, hash_pos - saltbuf_pos, tmp_buf);
+  int tmp_len = base64_decode (base64_to_int, (const u8 *) saltbuf_pos, salt_len_base64, tmp_buf);
 
   char *salt_buf_ptr = (char *) salt->salt_buf;
 


### PR DESCRIPTION
There was a missing check within the scrypt (-m 8900) parser function which should prevent a buffer overflow of "tmp_buf". The (decoded) salt length should be limited to 32 bytes (max 45 base64 encoded).

This patch adds the missing check to prevent crashes/memory corruption with too long base64-encoded salts.

Thank you very much
