### PR TITLE
Added support of keyfiles within Keepass 1.x and Keepass 2.x

### DIFF
--- a/OpenCL/m13400.cl
+++ b/OpenCL/m13400.cl
@@ -1168,7 +1168,7 @@ __kernel void m13400_init (__global pw_t *pws, __global kernel_rule_t *rules_buf
 
   sha256_transform (w0, w1, w2, w3, digest);
 
-  if (esalt_bufs[salt_pos].version == 2)
+  if (esalt_bufs[salt_pos].version == 2 && esalt_bufs[salt_pos].keyfile_len == 0)
   {
     w0[0] = digest[0];
     w0[1] = digest[1];
@@ -1198,6 +1198,62 @@ __kernel void m13400_init (__global pw_t *pws, __global kernel_rule_t *rules_buf
     digest[5] = SHA256M_F;
     digest[6] = SHA256M_G;
     digest[7] = SHA256M_H;
+
+    sha256_transform (w0, w1, w2, w3, digest);
+  }
+
+  if (esalt_bufs[salt_pos].keyfile_len != 0)
+  {
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+
+    w2[0] = esalt_bufs[salt_pos].keyfile[0];
+    w2[1] = esalt_bufs[salt_pos].keyfile[1];
+    w2[2] = esalt_bufs[salt_pos].keyfile[2];
+    w2[3] = esalt_bufs[salt_pos].keyfile[3];
+
+    w3[0] = esalt_bufs[salt_pos].keyfile[4];
+    w3[1] = esalt_bufs[salt_pos].keyfile[5];
+    w3[3] = esalt_bufs[salt_pos].keyfile[7];
+    w3[2] = esalt_bufs[salt_pos].keyfile[6];
+
+    digest[0] = SHA256M_A;
+    digest[1] = SHA256M_B;
+    digest[2] = SHA256M_C;
+    digest[3] = SHA256M_D;
+    digest[4] = SHA256M_E;
+    digest[5] = SHA256M_F;
+    digest[6] = SHA256M_G;
+    digest[7] = SHA256M_H;
+
+    sha256_transform (w0, w1, w2, w3, digest);
+
+    w0[0] = 0x80000000;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 64 * 8;
 
     sha256_transform (w0, w1, w2, w3, digest);
   }
@@ -1420,7 +1476,7 @@ __kernel void m13400_comp (__global pw_t *pws, __global kernel_rule_t *rules_buf
   }
   else
   {
-    /* merkle-demgard implementation */
+    /* merkle-damgard implementation */
     u32 final_random_seed[8];
 
     final_random_seed[0] = esalt_bufs[salt_pos].final_random_seed[0];

--- a/OpenCL/types_ocl.c
+++ b/OpenCL/types_ocl.c
@@ -1597,6 +1597,10 @@ typedef struct
   u32 version;
   u32 algorithm;
 
+  /* key-file handling */
+  u32 keyfile_len;
+  u32 keyfile[8];
+  
   u32 final_random_seed[8];
   u32 transf_random_seed[8];
   u32 enc_iv[4];

--- a/include/shared.h
+++ b/include/shared.h
@@ -688,7 +688,7 @@ extern hc_thread_mutex_t mux_display;
 #define DISPLAY_LEN_MIN_13300  1 + 12 + 1 + 32
 #define DISPLAY_LEN_MAX_13300  1 + 12 + 1 + 40
 #define DISPLAY_LEN_MIN_13400  1 + 7 + 1 + 1 + 1 + 1 + 1 + 1 + 32 + 1 + 64 + 1 + 32 + 1 + 64 + 1 + 1 + 1 + 1
-#define DISPLAY_LEN_MAX_13400  1 + 7 + 1 + 1 + 10 + 1 + 3 + 1 + 64 + 1 + 64 + 1 + 32 + 1 + 64 + 1 + 4 + 1 + 100000
+#define DISPLAY_LEN_MAX_13400  1 + 7 + 1 + 1 + 10 + 1 + 3 + 1 + 64 + 1 + 64 + 1 + 32 + 1 + 64 + 1 + 4 + 1 + 100000 + 1 + 2 + 1 + 64
 
 #define DISPLAY_LEN_MIN_11    32 + 1 + 16
 #define DISPLAY_LEN_MAX_11    32 + 1 + 32

--- a/include/types.h
+++ b/include/types.h
@@ -141,6 +141,10 @@ typedef struct
   u32 version;
   u32 algorithm;
 
+  /* key-file handling */
+  u32 keyfile_len;
+  u32 keyfile[8];
+  
   u32 final_random_seed[8];
   u32 transf_random_seed[8];
   u32 enc_iv[4];


### PR DESCRIPTION
Hi guys,

this PR provides support of keyfile usage within Keepass 1.x and Keepass 2.x. You have to use keepass2john for John The Ripper suite to get right input format (actually the PR that makes things work within keepass2john is done on jtr).

Happy cracking!

Fist0urs
