### PR TITLE
-m 13400 increase max size of kdb cracking capability to 300KB

### DIFF
--- a/OpenCL/types_ocl.c
+++ b/OpenCL/types_ocl.c
@@ -1612,7 +1612,7 @@ typedef struct
 
   /* specific to version 1 */
   u32 contents_len;
-  u32 contents[12500];
+  u32 contents[75000];
 
   /* specific to version 2 */
   u32 expected_bytes[8];

--- a/include/common.h
+++ b/include/common.h
@@ -106,7 +106,7 @@ typedef uint32_t uint; // we need to get rid of this sooner or later, for consis
 #define SPEED_CACHE   128
 #define SPEED_MAXAGE  4096
 
-#define HCBUFSIZ      0x10000 // general large space buffer size in case the size is unknown at compile-time
+#define HCBUFSIZ      0x50000 // general large space buffer size in case the size is unknown at compile-time
 
 /**
  * functions

--- a/include/shared.h
+++ b/include/shared.h
@@ -689,7 +689,7 @@ extern hc_thread_mutex_t mux_display;
 #define DISPLAY_LEN_MIN_13300  1 + 12 + 1 + 32
 #define DISPLAY_LEN_MAX_13300  1 + 12 + 1 + 40
 #define DISPLAY_LEN_MIN_13400  1 + 7 + 1 + 1 + 1 + 1 + 1 + 1 + 32 + 1 + 64 + 1 + 32 + 1 + 64 + 1 + 1 + 1 + 1
-#define DISPLAY_LEN_MAX_13400  1 + 7 + 1 + 1 + 10 + 1 + 3 + 1 + 64 + 1 + 64 + 1 + 32 + 1 + 64 + 1 + 4 + 1 + 100000 + 1 + 2 + 1 + 64
+#define DISPLAY_LEN_MAX_13400  1 + 7 + 1 + 1 + 10 + 1 + 3 + 1 + 64 + 1 + 64 + 1 + 32 + 1 + 64 + 1 + 4 + 1 + 600000 + 1 + 2 + 1 + 64
 
 #define DISPLAY_LEN_MIN_11    32 + 1 + 16
 #define DISPLAY_LEN_MAX_11    32 + 1 + 32

--- a/include/types.h
+++ b/include/types.h
@@ -156,7 +156,7 @@ typedef struct
 
   /* specific to version 1 */
   u32 contents_len;
-  u32 contents[12500];
+  u32 contents[75000];
 
   /* specific to version 2 */
   u32 expected_bytes[8];


### PR DESCRIPTION
While trying to crack kdb (Keepass 1.x), it appears that there are some in the wild that can be quite big (actually, I've experienced some of approximatively 250 KB).

This increases capability to 300KB while capability of input hash is set to a max of 0x50000 bytes
