### PR TITLE
Fix LLVM compilation for OpenCL kernels

### DIFF
--- a/include/kernel_vendor.h
+++ b/include/kernel_vendor.h
@@ -4,6 +4,7 @@
  */
 
 #pragma OPENCL EXTENSION cl_khr_byte_addressable_store : enable
+#pragma OPENCL EXTENSION cl_clang_storage_class_specifiers : enable
 
 /**
  * vendor specific


### PR DESCRIPTION
They otherwise fail with "static type not supported". LLVM only does OpenCL 1.1.
