### PR TITLE
Remove clang extension

### DIFF
--- a/include/kernel_vendor.h
+++ b/include/kernel_vendor.h
@@ -7,10 +7,6 @@
 #pragma OPENCL EXTENSION cl_khr_byte_addressable_store : enable
 #endif
 
-#ifdef cl_clang_storage_class_specifiers
-#pragma OPENCL EXTENSION cl_clang_storage_class_specifiers : enable
-#endif
-
 /**
  * vendor specific
  */
@@ -28,10 +24,8 @@
  */
 
 #ifdef IS_AMD
-#ifndef cl_clang_storage_class_specifiers
 #pragma OPENCL EXTENSION cl_amd_media_ops  : enable
 #pragma OPENCL EXTENSION cl_amd_media_ops2 : enable
-#endif
 #endif
 
 /**


### PR DESCRIPTION
It's only needed for using the static keyword. Since you removed those, clover builds it fine without it. Also removed the check since Mesa is considered IS_GENERIC now.
