### PR TITLE
test fix: ArubaOS salts are 8 hexadecimal chars long (4 binary), not 10

### DIFF
--- a/tools/test.pl
+++ b/tools/test.pl
@@ -2836,7 +2836,7 @@ sub passthrough
     }
     elsif ($mode == 125)
     {
-      $tmp_hash = gen_hash ($mode, $word_buf, substr ($salt_buf, 0, 10));
+      $tmp_hash = gen_hash ($mode, $word_buf, substr ($salt_buf, 0, 8));
     }
     elsif ($mode == 141 || $mode == 1441)
     {


### PR DESCRIPTION
This is a fix for test.pl only. The salts for -m 125 = ArubaOS were always too long and didn't meet the requirements of oclHashcat's parser (8 hex salt + "01" + hash).
Because of this, the tests didn't really work for -m 125. Only the passthrough part was affected.

The total length of the salt is indeed 10, but only 8 hexadecimal chars are random (4 binary), not 10 (5 binary)... This is why the hashes were all too long and didn't pass the parser's max length test.

Thank you very much
