### PR TITLE
Added Travis building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+os:
+  - linux
+  - osx
+language: c
+install:
+  - mkdir -p deps/OpenCL-Headers
+  - git clone https://github.com/KhronosGroup/OpenCL-Headers deps/OpenCL-Headers/CL
+compiler:
+  - gcc
+script:
+  - make

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Please refer to the [Hashcat Wiki](https://hashcat.net/wiki/) and the output of 
 
 ### Building ###
 
+![Hashcat Build status](https://travis-ci.org/hashcat/oclHashcat.svg?branch=master)
+
 Refer to [BUILD.md](BUILD.md) for instructions on how to build **hashcat** from source.
 
 ### Contributing ###


### PR DESCRIPTION
Seeing that you guys review pull requests and all, I figured it may become handy to automatically check if stuff builds. I'm fairly new to your project, but I could imagine this happens from time to time. 

The changes presented here will include a yaml file for [Travis CI](travis-ci.org), which this project can use for free. A project admin only has to add it to Travis to get checked.

This just checks some basic build stuff, with information from the current [BUILD.md](https://github.com/hashcat/oclHashcat/blob/master/BUILD.md) for Linux and OS X.

Stuff Changed:
- Added Travis yaml file
- Change ReadMe to include build status image

An example of building can be found [here](https://travis-ci.org/y0sh1/oclHashcat/builds/130273869).

![chrome_2016-05-14_21-39-44](https://cloud.githubusercontent.com/assets/1150960/15270343/7fa0aa9e-1a1c-11e6-9915-20113932e3ba.png)
