### PR TITLE
fallback for Makefile version if its not a git checkout (tarball)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/Makefile export-subst

--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ CC_WIN_64                := x86_64-w64-mingw32-gcc
 ##
 
 COMPTIME                 := $(shell date +%s)
-VERSION_TAG              := $(shell git describe --tags --dirty=+)
+VERSION_TAG              := $(shell git describe --tags --dirty=+ || echo '$Format:%D$'|sed -r 's/.* ([^ ]+$)/\1/')
 
 ##
 ## Compiler flags


### PR DESCRIPTION
This makes use of git export-subst to insert the current ref names.
If git describe fails because because an extracted tarball is used
to build from source then the fallback will get called and the last
part of the ref names will be used for the version variable.

if it is a git checkout and HEAD is the current tag:
- v3.00-beta

If it is a git checkout and HEAD is ahead of the latest tag:
- v3.00-beta-36-g24a6095

If it is a tarball from a tag created via 'git archive HEAD --format=tar':
- v3.00-beta

If it is a tarball from the master created via 'git archive HEAD --format=tar':
- master

NOTE: If a tarball is manually created (without git archive) then the
version will "$Format:%D$", however before this commit it would not be
possible to build a release tarball at all (because git describe would fail)

Tarballs that you manually want to distribute on your website need to be either
downloaded from github and re-uploaded or need to be create via git-archive:

gzip:

```
git archive --format=tar HEAD|gzip > oclHashcat.tar.gz
```

bzip2:

```
git archive --format=tar HEAD|bzip2 > oclHashcat.tar.bz2
```

You can also use a tag for git archive like:

```
git archive --format=tar v2.01|bzip2 > oclHashcat-2.01.tar.bz2
```
