### PR TITLE
Revert "fallback for Makefile version if its not a git checkout (tarball)"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-src/Makefile export-subst

--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ CC_WIN_64                := x86_64-w64-mingw32-gcc
 ##
 
 COMPTIME                 := $(shell date +%s)
-VERSION_TAG              := $(shell git describe --tags --dirty=+ || echo '$Format:%D$'|sed -r 's/.* ([^ ]+$)/\1/')
+VERSION_TAG              := $(shell git describe --tags --dirty=+)
 
 ##
 ## Compiler flags


### PR DESCRIPTION
Reverts hashcat/oclHashcat#346

/bin/sh: 1: Syntax error: "(" unexpected

See PR for details
