### PR TITLE
docs: added notes about --machine-readable, replaced --status-automat notes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -63,7 +63,8 @@ It combines all features of all hashcat projects in one project.
 - Benchmark accuracy improved; Is now on par to: singlehash -a 3 -w 3 ?b?b?b?b?b?b?b
 - Benchmark no longer depends on a fixed time
 - Removed option --benchmark-mode, therefore support --workload-profile in benchmark-mode
-- Enabled support of --status-automat in combination with --benchmark for automated benchmark processing
+- Enabled support of --machine-readable in combination with --benchmark for automated benchmark processing
+- Replaced --status-automat entirely with --machine-readable to make it more consistent among benchmark and non-benchmark mode
 - Extended support from 14 to 255 functions calls per rule
 - Extended password length up to 32 for 7zip
 - Extended salt length up to 55 for raw hash types, eg: md5($pass.$salt)


### PR DESCRIPTION
This pull request improves docs/changes.txt with an additional note about the new --machine-readable switch (which replaces the --status-automat(e) switch).
In addition to that, I also replaced the notes about changes for --status-automat, because --status-automat does not exist anymore.

Thank you
