### PR TITLE
Add cygwin support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ PROG_NAME                := hashcat
 
 UNAME                    := $(shell uname -s)
 
-ifeq (,$(filter $(UNAME),Linux Darwin))
+ifeq (,$(filter $(UNAME),Linux Darwin CYGWIN_NT-10.0))
 $(error "! Your Operating System ($(UNAME)) is not supported by $(PROG_NAME) Makefile")
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,9 @@ PROG_NAME                := hashcat
 ##
 
 UNAME                    := $(shell uname -s)
+UNAME			 := $(patsubst CYGWIN_NT-%,CYGWIN_NT-,$(UNAME))
 
-ifeq (,$(filter $(UNAME),Linux Darwin CYGWIN_NT-10.0))
+ifeq (,$(filter $(UNAME),Linux Darwin CYGWIN_NT-))
 $(error "! Your Operating System ($(UNAME)) is not supported by $(PROG_NAME) Makefile")
 endif
 


### PR DESCRIPTION
Doesn't actually build but "make win64" or "make win32" still works.

Actually, why is the operating system even checked in the makefile?
