### PR TITLE
Removed obsolete entries from install: target.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -205,11 +205,6 @@ install: native
 	$(CP) -a charsets/*                             $(SHARED_FOLDER)/charsets/
 	$(INSTALL) -m 755 -d                            $(SHARED_FOLDER)/masks
 	$(CP) -a masks/*                                $(SHARED_FOLDER)/masks/
-	$(INSTALL) -m 755 -d                            $(SHARED_FOLDER)/include
-	$(INSTALL) -m 644 include/constants.h           $(SHARED_FOLDER)/include/
-	$(INSTALL) -m 644 include/kernel_functions.c    $(SHARED_FOLDER)/include/
-	$(INSTALL) -m 644 include/kernel_vendor.h       $(SHARED_FOLDER)/include/
-	$(INSTALL) -m 644 include/rp_kernel.h           $(SHARED_FOLDER)/include/
 	$(INSTALL) -m 755 -d                            $(SHARED_FOLDER)/OpenCL
 	$(CP) -a OpenCL/*                               $(SHARED_FOLDER)/OpenCL/
 	$(INSTALL) -m 755 -d                            $(SHARED_FOLDER)/rules


### PR DESCRIPTION
These files have been renamed+moved under OpenCL, and are already
installed from there elsewhere in the install: target.
