### PR TITLE
make: indentation fix + comments about cygwin builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,9 @@ PROG_NAME                := hashcat
 ##
 
 UNAME                    := $(shell uname -s)
-UNAME			 := $(patsubst CYGWIN_NT-%,CYGWIN_NT-,$(UNAME))
+
+# we need to strip the windows version number to be able to build hashcat on cygwin hosts
+UNAME                    := $(patsubst CYGWIN_NT-%,CYGWIN_NT-,$(UNAME))
 
 ifeq (,$(filter $(UNAME),Linux Darwin CYGWIN_NT-))
 $(error "! Your Operating System ($(UNAME)) is not supported by $(PROG_NAME) Makefile")


### PR DESCRIPTION
This is a cosmetic fix about the recently added support of building hashcat on (windows's) cygwin hosts (https://github.com/hashcat/oclHashcat/commit/37ff7fbc111e3fb8f7dbf9dac4f82aef3960aad1)
It fixes both the indentation and adds an additional comment about why this newly added line (the patsubst () ) needs to be present to be able to build on cygwin hosts.

Thank you very much 
