### PR TITLE
Removed duplicate rule 'cl' & 'l'

### DIFF
--- a/rules/T0XlC.rule
+++ b/rules/T0XlC.rule
@@ -1565,7 +1565,6 @@ d$a$c$l$e
 d$a$b$l$e
 d$a
 d$S
-cl
 c^z
 c^y^m
 c^y^l^o^p


### PR DESCRIPTION
'cl' (line 1568) will have the same effect as 'l' (line 1322), so I removed 'cl'.
