### PR TITLE
cosmetic fix: don't show prompt and warning within the same line

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -18084,6 +18084,8 @@ int main (int argc, char **argv)
           {
             if (quiet == 0)
             {
+              clear_prompt ();
+
               log_info ("ATTENTION!");
               log_info ("  The wordlist or mask you are using is too small.");
               log_info ("  Therefore, hashcat is unable to utilize the full parallelization power of your device(s).");


### PR DESCRIPTION
This commit will fix a display problem where the output is something like this:

```
[s]tatus [p]ause [r]esume [b]ypass [c]heckpoint [q]uit => ATTENTION!
  The wordlist or mask you are using is too small.
  Therefore, hashcat is unable to utilize the full parallelization power of your device(s).
  The cracking speed will drop.
  Workaround: https://hashcat.net/wiki/doku.php?id=frequently_asked_questions#how_to_create_more_work_for_full_speed
```

This can be reproduced with several commands, including a case where there are small masks within a .hcmask file, using the --increment flag (e.g. without --increment-min, s.t. it uses small masks again), several small word lists etc etc

This is a minimal fix that should fix all these cases (and doesn't use a workaround with extra newlines).

Thank you very much
