### PR TITLE
do not ignore keypress / status changes

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -18125,6 +18125,11 @@ int main (int argc, char **argv)
          * create cracker threads
          */
 
+        if (data.devices_status == STATUS_STOP_AT_CHECKPOINT) check_checkpoint ();
+
+        if (data.devices_status == STATUS_ABORTED) break;
+        if (data.devices_status == STATUS_QUIT)    break;
+
         data.devices_status = STATUS_RUNNING;
 
         if (initial_restore_done == 0)


### PR DESCRIPTION
The problem here was that the data.devices_status variable was, at this very specific location in code,  always (silently and without checks) overridden. This implies that any status change was ignored... even if the user might want hashcat to quit immediately.
The fix checks the data.devices_status and acts accordingly.

Thank you very much
