### PR TITLE
hashcat.c: change osx to OSX use shared_dir

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -6171,7 +6171,7 @@ int main (int argc, char **argv)
 
   char *exec_path = get_exec_path ();
 
-  #ifdef LINUX
+  #if defined(LINUX) || defined(__APPLE__)
 
   char *resolved_install_folder = realpath (INSTALL_FOLDER, NULL);
   char *resolved_exec_path      = realpath (exec_path, NULL);


### PR DESCRIPTION
This fixes #408. 

_Note: I originally created the issue because I thought I didn't have enough time to look into a fix, but turns out I needed a fix enough to make time._
