### PR TITLE
this fixes #400: --loopback was not working

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Fixed a bug where hashcat is suppressing --machine-readable output in the final status update
 - Fixed a bug where hashcat did not check the return of realpath() and crashes uncontrolled if the path does not exist
 - Fixed a bug where hashcat crashes for accessing deallocated buffer if user spams "s" shortly before hashcat shuts down
+- Fixed a bug where hashcat did not correctly use the newly cracked plains whenever --loopback or the induction folder was used
 
 * changes v2.01 -> v3.00:
 

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -18392,6 +18392,10 @@ int main (int argc, char **argv)
         if (induction_dictionaries_cnt)
         {
           qsort (induction_dictionaries, induction_dictionaries_cnt, sizeof (char *), sort_by_mtime);
+
+          // yeah, this next statement is a little hack to make sure that --loopback runs correctly (because with it we guarantee that the loop iterates one more time)
+
+          dictpos--;
         }
 
         time_t runtime_stop;


### PR DESCRIPTION
There was a new problem with --loopback (mentioned in issue #400), which made the --loopback command line option do nothing.

The fix I propose here is to allow --loopback (and the induction folder in general) work again by just allowing additional inner loop run (variable dictpos).

Of course, this is a little hack. But the comment I added and the otherwise very complicated way to properly fix it, should be enough to justify a "little hack" in this particular case.

Thank you very much
