### PR TITLE
fixed problem where hashcat did not remove WPA/WPA2 hashes found in potfile

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -16,6 +16,7 @@
 - Fixed a bug where hashcat crashes for accessing deallocated buffer if user spams "s" shortly before hashcat shuts down
 - Fixed a bug where hashcat crashes in case of a scrypt P setting > 1
 - Fixed a bug where hashcat did not correctly use the newly cracked plains whenever --loopback or the induction folder was used
+- Fixed a bug where hashcat did not correctly remove hashes of type WPA/WPA2 even if present in potfile
 
 * changes v2.01 -> v3.00:
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -4695,8 +4695,9 @@ int sort_by_hash_t_salt_hccap (const void *v1, const void *v2)
   const salt_t *s1 = h1->salt;
   const salt_t *s2 = h2->salt;
 
-  // 16 - 2 (since last 2 uints contain the digest)
-  uint n = 14;
+  // last 2: salt_buf[10] and salt_buf[11] contain the digest (skip them)
+
+  uint n = 9; // 9 * 4 = 36 bytes (max length of ESSID)
 
   while (n--)
   {


### PR DESCRIPTION
The removing of hashes found in potfiles was not working for hash mode WPA/WPA2 because the comparison of the hashes/salts within the potfile versus the ones in the current hash list was not correct.

The comparison did compare too many bytes and therefore failed.

Thank you very much
