### PR TITLE
fixes -m #424: problem removing multiple already found WPA hashes

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -13017,6 +13017,7 @@ int main (int argc, char **argv)
                   // here we have in line_buf: ESSID:MAC1:MAC2   (without the plain)
                   // manipulate salt_buf
 
+                  memset (line_buf_cpy, 0, HCBUFSIZ);
                   memcpy (line_buf_cpy, line_buf, i);
 
                   char *mac2_pos = strrchr (line_buf_cpy, ':');


### PR DESCRIPTION
There was a slight problem with removing WPA hashes if several of matching lines (using hash mode -m 2500 = WPA/WPA2) were present within the potfile.
If the length was different the buffer was not correct, because it wasn't correctly initialized (each and every time a WPA/WPA2 hash match was found).

This commit initializes the buffer correctly and therefore should make sure that each and every already cracked WPA/WPA2 "hash" will be correctly removed (if potfile support was not disabled) at startup.

Thank you very much 
