### PR TITLE
Added functionality to crack DES-ECB for known-plaintext. The "hashty…

### DIFF
--- a/OpenCL/m01510_a0.cl
+++ b/OpenCL/m01510_a0.cl
@@ -1,0 +1,741 @@
+/**
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *               magnum <john.magnum@hushmail.com>
+ *               Frans Lategan <frans.lategan+hashcat@gmail.com>
+ *
+ * License.....: MIT
+ */
+
+#define _DES_
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_rp.h"
+#include "inc_rp.cl"
+#include "inc_simd.cl"
+
+#define PERM_OP(a,b,tt,n,m) \
+{                           \
+  tt = a >> n;              \
+  tt = tt ^ b;              \
+  tt = tt & m;              \
+  b = b ^ tt;               \
+  tt = tt << n;             \
+  a = a ^ tt;               \
+}
+
+#define HPERM_OP(a,tt,n,m)  \
+{                           \
+  tt = a << (16 + n);       \
+  tt = tt ^ a;              \
+  tt = tt & m;              \
+  a  = a ^ tt;              \
+  tt = tt >> (16 + n);      \
+  a  = a ^ tt;              \
+}
+
+#define IP(l,r,tt)                     \
+{                                      \
+  PERM_OP (r, l, tt,  4, 0x0f0f0f0f);  \
+  PERM_OP (l, r, tt, 16, 0x0000ffff);  \
+  PERM_OP (r, l, tt,  2, 0x33333333);  \
+  PERM_OP (l, r, tt,  8, 0x00ff00ff);  \
+  PERM_OP (r, l, tt,  1, 0x55555555);  \
+}
+
+#define FP(l,r,tt)                     \
+{                                      \
+  PERM_OP (l, r, tt,  1, 0x55555555);  \
+  PERM_OP (r, l, tt,  8, 0x00ff00ff);  \
+  PERM_OP (l, r, tt,  2, 0x33333333);  \
+  PERM_OP (r, l, tt, 16, 0x0000ffff);  \
+  PERM_OP (l, r, tt,  4, 0x0f0f0f0f);  \
+}
+
+__constant u32 c_SPtrans[8][64] =
+{
+  {
+    /* nibble 0 */
+    0x02080800, 0x00080000, 0x02000002, 0x02080802,
+    0x02000000, 0x00080802, 0x00080002, 0x02000002,
+    0x00080802, 0x02080800, 0x02080000, 0x00000802,
+    0x02000802, 0x02000000, 0x00000000, 0x00080002,
+    0x00080000, 0x00000002, 0x02000800, 0x00080800,
+    0x02080802, 0x02080000, 0x00000802, 0x02000800,
+    0x00000002, 0x00000800, 0x00080800, 0x02080002,
+    0x00000800, 0x02000802, 0x02080002, 0x00000000,
+    0x00000000, 0x02080802, 0x02000800, 0x00080002,
+    0x02080800, 0x00080000, 0x00000802, 0x02000800,
+    0x02080002, 0x00000800, 0x00080800, 0x02000002,
+    0x00080802, 0x00000002, 0x02000002, 0x02080000,
+    0x02080802, 0x00080800, 0x02080000, 0x02000802,
+    0x02000000, 0x00000802, 0x00080002, 0x00000000,
+    0x00080000, 0x02000000, 0x02000802, 0x02080800,
+    0x00000002, 0x02080002, 0x00000800, 0x00080802,
+  },
+  {
+    /* nibble 1 */
+    0x40108010, 0x00000000, 0x00108000, 0x40100000,
+    0x40000010, 0x00008010, 0x40008000, 0x00108000,
+    0x00008000, 0x40100010, 0x00000010, 0x40008000,
+    0x00100010, 0x40108000, 0x40100000, 0x00000010,
+    0x00100000, 0x40008010, 0x40100010, 0x00008000,
+    0x00108010, 0x40000000, 0x00000000, 0x00100010,
+    0x40008010, 0x00108010, 0x40108000, 0x40000010,
+    0x40000000, 0x00100000, 0x00008010, 0x40108010,
+    0x00100010, 0x40108000, 0x40008000, 0x00108010,
+    0x40108010, 0x00100010, 0x40000010, 0x00000000,
+    0x40000000, 0x00008010, 0x00100000, 0x40100010,
+    0x00008000, 0x40000000, 0x00108010, 0x40008010,
+    0x40108000, 0x00008000, 0x00000000, 0x40000010,
+    0x00000010, 0x40108010, 0x00108000, 0x40100000,
+    0x40100010, 0x00100000, 0x00008010, 0x40008000,
+    0x40008010, 0x00000010, 0x40100000, 0x00108000,
+  },
+  {
+    /* nibble 2 */
+    0x04000001, 0x04040100, 0x00000100, 0x04000101,
+    0x00040001, 0x04000000, 0x04000101, 0x00040100,
+    0x04000100, 0x00040000, 0x04040000, 0x00000001,
+    0x04040101, 0x00000101, 0x00000001, 0x04040001,
+    0x00000000, 0x00040001, 0x04040100, 0x00000100,
+    0x00000101, 0x04040101, 0x00040000, 0x04000001,
+    0x04040001, 0x04000100, 0x00040101, 0x04040000,
+    0x00040100, 0x00000000, 0x04000000, 0x00040101,
+    0x04040100, 0x00000100, 0x00000001, 0x00040000,
+    0x00000101, 0x00040001, 0x04040000, 0x04000101,
+    0x00000000, 0x04040100, 0x00040100, 0x04040001,
+    0x00040001, 0x04000000, 0x04040101, 0x00000001,
+    0x00040101, 0x04000001, 0x04000000, 0x04040101,
+    0x00040000, 0x04000100, 0x04000101, 0x00040100,
+    0x04000100, 0x00000000, 0x04040001, 0x00000101,
+    0x04000001, 0x00040101, 0x00000100, 0x04040000,
+  },
+  {
+    /* nibble 3 */
+    0x00401008, 0x10001000, 0x00000008, 0x10401008,
+    0x00000000, 0x10400000, 0x10001008, 0x00400008,
+    0x10401000, 0x10000008, 0x10000000, 0x00001008,
+    0x10000008, 0x00401008, 0x00400000, 0x10000000,
+    0x10400008, 0x00401000, 0x00001000, 0x00000008,
+    0x00401000, 0x10001008, 0x10400000, 0x00001000,
+    0x00001008, 0x00000000, 0x00400008, 0x10401000,
+    0x10001000, 0x10400008, 0x10401008, 0x00400000,
+    0x10400008, 0x00001008, 0x00400000, 0x10000008,
+    0x00401000, 0x10001000, 0x00000008, 0x10400000,
+    0x10001008, 0x00000000, 0x00001000, 0x00400008,
+    0x00000000, 0x10400008, 0x10401000, 0x00001000,
+    0x10000000, 0x10401008, 0x00401008, 0x00400000,
+    0x10401008, 0x00000008, 0x10001000, 0x00401008,
+    0x00400008, 0x00401000, 0x10400000, 0x10001008,
+    0x00001008, 0x10000000, 0x10000008, 0x10401000,
+  },
+  {
+    /* nibble 4 */
+    0x08000000, 0x00010000, 0x00000400, 0x08010420,
+    0x08010020, 0x08000400, 0x00010420, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x00010400,
+    0x08000420, 0x08010020, 0x08010400, 0x00000000,
+    0x00010400, 0x08000000, 0x00010020, 0x00000420,
+    0x08000400, 0x00010420, 0x00000000, 0x08000020,
+    0x00000020, 0x08000420, 0x08010420, 0x00010020,
+    0x08010000, 0x00000400, 0x00000420, 0x08010400,
+    0x08010400, 0x08000420, 0x00010020, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x08000400,
+    0x08000000, 0x00010400, 0x08010420, 0x00000000,
+    0x00010420, 0x08000000, 0x00000400, 0x00010020,
+    0x08000420, 0x00000400, 0x00000000, 0x08010420,
+    0x08010020, 0x08010400, 0x00000420, 0x00010000,
+    0x00010400, 0x08010020, 0x08000400, 0x00000420,
+    0x00000020, 0x00010420, 0x08010000, 0x08000020,
+  },
+  {
+    /* nibble 5 */
+    0x80000040, 0x00200040, 0x00000000, 0x80202000,
+    0x00200040, 0x00002000, 0x80002040, 0x00200000,
+    0x00002040, 0x80202040, 0x00202000, 0x80000000,
+    0x80002000, 0x80000040, 0x80200000, 0x00202040,
+    0x00200000, 0x80002040, 0x80200040, 0x00000000,
+    0x00002000, 0x00000040, 0x80202000, 0x80200040,
+    0x80202040, 0x80200000, 0x80000000, 0x00002040,
+    0x00000040, 0x00202000, 0x00202040, 0x80002000,
+    0x00002040, 0x80000000, 0x80002000, 0x00202040,
+    0x80202000, 0x00200040, 0x00000000, 0x80002000,
+    0x80000000, 0x00002000, 0x80200040, 0x00200000,
+    0x00200040, 0x80202040, 0x00202000, 0x00000040,
+    0x80202040, 0x00202000, 0x00200000, 0x80002040,
+    0x80000040, 0x80200000, 0x00202040, 0x00000000,
+    0x00002000, 0x80000040, 0x80002040, 0x80202000,
+    0x80200000, 0x00002040, 0x00000040, 0x80200040,
+  },
+  {
+    /* nibble 6 */
+    0x00004000, 0x00000200, 0x01000200, 0x01000004,
+    0x01004204, 0x00004004, 0x00004200, 0x00000000,
+    0x01000000, 0x01000204, 0x00000204, 0x01004000,
+    0x00000004, 0x01004200, 0x01004000, 0x00000204,
+    0x01000204, 0x00004000, 0x00004004, 0x01004204,
+    0x00000000, 0x01000200, 0x01000004, 0x00004200,
+    0x01004004, 0x00004204, 0x01004200, 0x00000004,
+    0x00004204, 0x01004004, 0x00000200, 0x01000000,
+    0x00004204, 0x01004000, 0x01004004, 0x00000204,
+    0x00004000, 0x00000200, 0x01000000, 0x01004004,
+    0x01000204, 0x00004204, 0x00004200, 0x00000000,
+    0x00000200, 0x01000004, 0x00000004, 0x01000200,
+    0x00000000, 0x01000204, 0x01000200, 0x00004200,
+    0x00000204, 0x00004000, 0x01004204, 0x01000000,
+    0x01004200, 0x00000004, 0x00004004, 0x01004204,
+    0x01000004, 0x01004200, 0x01004000, 0x00004004,
+  },
+  {
+    /* nibble 7 */
+    0x20800080, 0x20820000, 0x00020080, 0x00000000,
+    0x20020000, 0x00800080, 0x20800000, 0x20820080,
+    0x00000080, 0x20000000, 0x00820000, 0x00020080,
+    0x00820080, 0x20020080, 0x20000080, 0x20800000,
+    0x00020000, 0x00820080, 0x00800080, 0x20020000,
+    0x20820080, 0x20000080, 0x00000000, 0x00820000,
+    0x20000000, 0x00800000, 0x20020080, 0x20800080,
+    0x00800000, 0x00020000, 0x20820000, 0x00000080,
+    0x00800000, 0x00020000, 0x20000080, 0x20820080,
+    0x00020080, 0x20000000, 0x00000000, 0x00820000,
+    0x20800080, 0x20020080, 0x20020000, 0x00800080,
+    0x20820000, 0x00000080, 0x00800080, 0x20020000,
+    0x20820080, 0x00800000, 0x20800000, 0x20000080,
+    0x00820000, 0x00020080, 0x20020080, 0x20800000,
+    0x00000080, 0x20820000, 0x00820080, 0x00000000,
+    0x20000000, 0x20800080, 0x00020000, 0x00820080,
+  },
+};
+__constant u32 c_skb[8][64] =
+{
+  {
+    0x00000000, 0x00000010, 0x20000000, 0x20000010,
+    0x00010000, 0x00010010, 0x20010000, 0x20010010,
+    0x00000800, 0x00000810, 0x20000800, 0x20000810,
+    0x00010800, 0x00010810, 0x20010800, 0x20010810,
+    0x00000020, 0x00000030, 0x20000020, 0x20000030,
+    0x00010020, 0x00010030, 0x20010020, 0x20010030,
+    0x00000820, 0x00000830, 0x20000820, 0x20000830,
+    0x00010820, 0x00010830, 0x20010820, 0x20010830,
+    0x00080000, 0x00080010, 0x20080000, 0x20080010,
+    0x00090000, 0x00090010, 0x20090000, 0x20090010,
+    0x00080800, 0x00080810, 0x20080800, 0x20080810,
+    0x00090800, 0x00090810, 0x20090800, 0x20090810,
+    0x00080020, 0x00080030, 0x20080020, 0x20080030,
+    0x00090020, 0x00090030, 0x20090020, 0x20090030,
+    0x00080820, 0x00080830, 0x20080820, 0x20080830,
+    0x00090820, 0x00090830, 0x20090820, 0x20090830,
+  },
+  {
+    0x00000000, 0x02000000, 0x00002000, 0x02002000,
+    0x00200000, 0x02200000, 0x00202000, 0x02202000,
+    0x00000004, 0x02000004, 0x00002004, 0x02002004,
+    0x00200004, 0x02200004, 0x00202004, 0x02202004,
+    0x00000400, 0x02000400, 0x00002400, 0x02002400,
+    0x00200400, 0x02200400, 0x00202400, 0x02202400,
+    0x00000404, 0x02000404, 0x00002404, 0x02002404,
+    0x00200404, 0x02200404, 0x00202404, 0x02202404,
+    0x10000000, 0x12000000, 0x10002000, 0x12002000,
+    0x10200000, 0x12200000, 0x10202000, 0x12202000,
+    0x10000004, 0x12000004, 0x10002004, 0x12002004,
+    0x10200004, 0x12200004, 0x10202004, 0x12202004,
+    0x10000400, 0x12000400, 0x10002400, 0x12002400,
+    0x10200400, 0x12200400, 0x10202400, 0x12202400,
+    0x10000404, 0x12000404, 0x10002404, 0x12002404,
+    0x10200404, 0x12200404, 0x10202404, 0x12202404,
+  },
+  {
+    0x00000000, 0x00000001, 0x00040000, 0x00040001,
+    0x01000000, 0x01000001, 0x01040000, 0x01040001,
+    0x00000002, 0x00000003, 0x00040002, 0x00040003,
+    0x01000002, 0x01000003, 0x01040002, 0x01040003,
+    0x00000200, 0x00000201, 0x00040200, 0x00040201,
+    0x01000200, 0x01000201, 0x01040200, 0x01040201,
+    0x00000202, 0x00000203, 0x00040202, 0x00040203,
+    0x01000202, 0x01000203, 0x01040202, 0x01040203,
+    0x08000000, 0x08000001, 0x08040000, 0x08040001,
+    0x09000000, 0x09000001, 0x09040000, 0x09040001,
+    0x08000002, 0x08000003, 0x08040002, 0x08040003,
+    0x09000002, 0x09000003, 0x09040002, 0x09040003,
+    0x08000200, 0x08000201, 0x08040200, 0x08040201,
+    0x09000200, 0x09000201, 0x09040200, 0x09040201,
+    0x08000202, 0x08000203, 0x08040202, 0x08040203,
+    0x09000202, 0x09000203, 0x09040202, 0x09040203,
+  },
+  {
+    0x00000000, 0x00100000, 0x00000100, 0x00100100,
+    0x00000008, 0x00100008, 0x00000108, 0x00100108,
+    0x00001000, 0x00101000, 0x00001100, 0x00101100,
+    0x00001008, 0x00101008, 0x00001108, 0x00101108,
+    0x04000000, 0x04100000, 0x04000100, 0x04100100,
+    0x04000008, 0x04100008, 0x04000108, 0x04100108,
+    0x04001000, 0x04101000, 0x04001100, 0x04101100,
+    0x04001008, 0x04101008, 0x04001108, 0x04101108,
+    0x00020000, 0x00120000, 0x00020100, 0x00120100,
+    0x00020008, 0x00120008, 0x00020108, 0x00120108,
+    0x00021000, 0x00121000, 0x00021100, 0x00121100,
+    0x00021008, 0x00121008, 0x00021108, 0x00121108,
+    0x04020000, 0x04120000, 0x04020100, 0x04120100,
+    0x04020008, 0x04120008, 0x04020108, 0x04120108,
+    0x04021000, 0x04121000, 0x04021100, 0x04121100,
+    0x04021008, 0x04121008, 0x04021108, 0x04121108,
+  },
+  {
+    0x00000000, 0x10000000, 0x00010000, 0x10010000,
+    0x00000004, 0x10000004, 0x00010004, 0x10010004,
+    0x20000000, 0x30000000, 0x20010000, 0x30010000,
+    0x20000004, 0x30000004, 0x20010004, 0x30010004,
+    0x00100000, 0x10100000, 0x00110000, 0x10110000,
+    0x00100004, 0x10100004, 0x00110004, 0x10110004,
+    0x20100000, 0x30100000, 0x20110000, 0x30110000,
+    0x20100004, 0x30100004, 0x20110004, 0x30110004,
+    0x00001000, 0x10001000, 0x00011000, 0x10011000,
+    0x00001004, 0x10001004, 0x00011004, 0x10011004,
+    0x20001000, 0x30001000, 0x20011000, 0x30011000,
+    0x20001004, 0x30001004, 0x20011004, 0x30011004,
+    0x00101000, 0x10101000, 0x00111000, 0x10111000,
+    0x00101004, 0x10101004, 0x00111004, 0x10111004,
+    0x20101000, 0x30101000, 0x20111000, 0x30111000,
+    0x20101004, 0x30101004, 0x20111004, 0x30111004,
+  },
+  {
+    0x00000000, 0x08000000, 0x00000008, 0x08000008,
+    0x00000400, 0x08000400, 0x00000408, 0x08000408,
+    0x00020000, 0x08020000, 0x00020008, 0x08020008,
+    0x00020400, 0x08020400, 0x00020408, 0x08020408,
+    0x00000001, 0x08000001, 0x00000009, 0x08000009,
+    0x00000401, 0x08000401, 0x00000409, 0x08000409,
+    0x00020001, 0x08020001, 0x00020009, 0x08020009,
+    0x00020401, 0x08020401, 0x00020409, 0x08020409,
+    0x02000000, 0x0A000000, 0x02000008, 0x0A000008,
+    0x02000400, 0x0A000400, 0x02000408, 0x0A000408,
+    0x02020000, 0x0A020000, 0x02020008, 0x0A020008,
+    0x02020400, 0x0A020400, 0x02020408, 0x0A020408,
+    0x02000001, 0x0A000001, 0x02000009, 0x0A000009,
+    0x02000401, 0x0A000401, 0x02000409, 0x0A000409,
+    0x02020001, 0x0A020001, 0x02020009, 0x0A020009,
+    0x02020401, 0x0A020401, 0x02020409, 0x0A020409,
+  },
+  {
+    0x00000000, 0x00000100, 0x00080000, 0x00080100,
+    0x01000000, 0x01000100, 0x01080000, 0x01080100,
+    0x00000010, 0x00000110, 0x00080010, 0x00080110,
+    0x01000010, 0x01000110, 0x01080010, 0x01080110,
+    0x00200000, 0x00200100, 0x00280000, 0x00280100,
+    0x01200000, 0x01200100, 0x01280000, 0x01280100,
+    0x00200010, 0x00200110, 0x00280010, 0x00280110,
+    0x01200010, 0x01200110, 0x01280010, 0x01280110,
+    0x00000200, 0x00000300, 0x00080200, 0x00080300,
+    0x01000200, 0x01000300, 0x01080200, 0x01080300,
+    0x00000210, 0x00000310, 0x00080210, 0x00080310,
+    0x01000210, 0x01000310, 0x01080210, 0x01080310,
+    0x00200200, 0x00200300, 0x00280200, 0x00280300,
+    0x01200200, 0x01200300, 0x01280200, 0x01280300,
+    0x00200210, 0x00200310, 0x00280210, 0x00280310,
+    0x01200210, 0x01200310, 0x01280210, 0x01280310,
+  },
+  {
+    0x00000000, 0x04000000, 0x00040000, 0x04040000,
+    0x00000002, 0x04000002, 0x00040002, 0x04040002,
+    0x00002000, 0x04002000, 0x00042000, 0x04042000,
+    0x00002002, 0x04002002, 0x00042002, 0x04042002,
+    0x00000020, 0x04000020, 0x00040020, 0x04040020,
+    0x00000022, 0x04000022, 0x00040022, 0x04040022,
+    0x00002020, 0x04002020, 0x00042020, 0x04042020,
+    0x00002022, 0x04002022, 0x00042022, 0x04042022,
+    0x00000800, 0x04000800, 0x00040800, 0x04040800,
+    0x00000802, 0x04000802, 0x00040802, 0x04040802,
+    0x00002800, 0x04002800, 0x00042800, 0x04042800,
+    0x00002802, 0x04002802, 0x00042802, 0x04042802,
+    0x00000820, 0x04000820, 0x00040820, 0x04040820,
+    0x00000822, 0x04000822, 0x00040822, 0x04040822,
+    0x00002820, 0x04002820, 0x00042820, 0x04042820,
+    0x00002822, 0x04002822, 0x00042822, 0x04042822
+  }
+};
+
+#if   VECT_SIZE == 1
+#define BOX(i,n,S) (S)[(n)][(i)]
+#elif VECT_SIZE == 2
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1])
+#elif VECT_SIZE == 4
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3])
+#elif VECT_SIZE == 8
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
+#elif VECT_SIZE == 16
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7], (S)[(n)][(i).s8], (S)[(n)][(i).s9], (S)[(n)][(i).sa], (S)[(n)][(i).sb], (S)[(n)][(i).sc], (S)[(n)][(i).sd], (S)[(n)][(i).se], (S)[(n)][(i).sf])
+#endif
+
+#if   VECT_SIZE == 1
+#define BOX1(i,S) (S)[(i)]
+#elif VECT_SIZE == 2
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1])
+#elif VECT_SIZE == 4
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3])
+#elif VECT_SIZE == 8
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7])
+#elif VECT_SIZE == 16
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7], (S)[(i).s8], (S)[(i).s9], (S)[(i).sa], (S)[(i).sb], (S)[(i).sc], (S)[(i).sd], (S)[(i).se], (S)[(i).sf])
+#endif
+
+void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  u32x tt;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i += 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i + 0] ^ r;
+    t = Kd[i + 0] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i + 1] ^ l;
+    t = Kd[i + 1] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+
+}
+
+void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 (*s_skb)[64])
+{
+  u32x tt;
+
+  PERM_OP  (d, c, tt, 4, 0x0f0f0f0f);
+  HPERM_OP (c,    tt, 2, 0xcccc0000);
+  HPERM_OP (d,    tt, 2, 0xcccc0000);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+  PERM_OP  (c, d, tt, 8, 0x00ff00ff);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+
+  d = ((d & 0x000000ff) << 16)
+    | ((d & 0x0000ff00) <<  0)
+    | ((d & 0x00ff0000) >> 16)
+    | ((c & 0xf0000000) >>  4);
+
+  c = c & 0x0fffffff;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i++)
+  {
+    if ((i < 2) || (i == 8) || (i == 15))
+    {
+      c = ((c >> 1) | (c << 27));
+      d = ((d >> 1) | (d << 27));
+    }
+    else
+    {
+      c = ((c >> 2) | (c << 26));
+      d = ((d >> 2) | (d << 26));
+    }
+
+    c = c & 0x0fffffff;
+    d = d & 0x0fffffff;
+
+    const u32x c00 = (c >>  0) & 0x0000003f;
+    const u32x c06 = (c >>  6) & 0x00383003;
+    const u32x c07 = (c >>  7) & 0x0000003c;
+    const u32x c13 = (c >> 13) & 0x0000060f;
+    const u32x c20 = (c >> 20) & 0x00000001;
+
+    u32x s = BOX (((c00 >>  0) & 0xff), 0, s_skb)
+           | BOX (((c06 >>  0) & 0xff)
+                 |((c07 >>  0) & 0xff), 1, s_skb)
+           | BOX (((c13 >>  0) & 0xff)
+                 |((c06 >>  8) & 0xff), 2, s_skb)
+           | BOX (((c20 >>  0) & 0xff)
+                 |((c13 >>  8) & 0xff)
+                 |((c06 >> 16) & 0xff), 3, s_skb);
+
+    const u32x d00 = (d >>  0) & 0x00003c3f;
+    const u32x d07 = (d >>  7) & 0x00003f03;
+    const u32x d21 = (d >> 21) & 0x0000000f;
+    const u32x d22 = (d >> 22) & 0x00000030;
+
+    u32x t = BOX (((d00 >>  0) & 0xff), 4, s_skb)
+           | BOX (((d07 >>  0) & 0xff)
+                 |((d00 >>  8) & 0xff), 5, s_skb)
+           | BOX (((d07 >>  8) & 0xff), 6, s_skb)
+           | BOX (((d21 >>  0) & 0xff)
+                 |((d22 >>  0) & 0xff), 7, s_skb);
+
+    Kc[i] = ((t << 16) | (s & 0x0000ffff));
+    Kd[i] = ((s >> 16) | (t & 0xffff0000));
+
+    Kc[i] = rotl32 (Kc[i], 2u);
+    Kd[i] = rotl32 (Kd[i], 2u);
+  }
+}
+
+__kernel void m01510_m04 (__global pw_t *pws, __global kernel_rule_t *  rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = 0;
+  pw_buf0[3] = 0;
+  pw_buf1[0] = 0;
+  pw_buf1[1] = 0;
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * main
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    apply_rules_vect (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    const u32x c = (w0[0]);
+    const u32x d = (w0[1]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, data, Kc, Kd, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01510_m08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_m16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_s04 (__global pw_t *pws, __global kernel_rule_t *  rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = 0;
+  pw_buf0[3] = 0;
+  pw_buf1[0] = 0;
+  pw_buf1[1] = 0;
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[digests_offset].digest_buf[DGST_R0],
+    digests_buf[digests_offset].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * main
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    apply_rules_vect (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    const u32x c = (w0[0]);
+    const u32x d = (w0[1]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, data, Kc, Kd, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01510_s08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_s16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}

--- a/OpenCL/m01510_a1.cl
+++ b/OpenCL/m01510_a1.cl
@@ -1,0 +1,815 @@
+/**
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *               Frans Lategan <frans.lategan+hashcat@gmail.com>
+ *
+ * License.....: MIT
+ */
+
+#define _DES_
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+
+#define PERM_OP(a,b,tt,n,m) \
+{                           \
+  tt = a >> n;              \
+  tt = tt ^ b;              \
+  tt = tt & m;              \
+  b = b ^ tt;               \
+  tt = tt << n;             \
+  a = a ^ tt;               \
+}
+
+#define HPERM_OP(a,tt,n,m)  \
+{                           \
+  tt = a << (16 + n);       \
+  tt = tt ^ a;              \
+  tt = tt & m;              \
+  a  = a ^ tt;              \
+  tt = tt >> (16 + n);      \
+  a  = a ^ tt;              \
+}
+
+#define IP(l,r,tt)                     \
+{                                      \
+  PERM_OP (r, l, tt,  4, 0x0f0f0f0f);  \
+  PERM_OP (l, r, tt, 16, 0x0000ffff);  \
+  PERM_OP (r, l, tt,  2, 0x33333333);  \
+  PERM_OP (l, r, tt,  8, 0x00ff00ff);  \
+  PERM_OP (r, l, tt,  1, 0x55555555);  \
+}
+
+#define FP(l,r,tt)                     \
+{                                      \
+  PERM_OP (l, r, tt,  1, 0x55555555);  \
+  PERM_OP (r, l, tt,  8, 0x00ff00ff);  \
+  PERM_OP (l, r, tt,  2, 0x33333333);  \
+  PERM_OP (r, l, tt, 16, 0x0000ffff);  \
+  PERM_OP (l, r, tt,  4, 0x0f0f0f0f);  \
+}
+
+__constant u32 c_SPtrans[8][64] =
+{
+  {
+    0x02080800, 0x00080000, 0x02000002, 0x02080802,
+    0x02000000, 0x00080802, 0x00080002, 0x02000002,
+    0x00080802, 0x02080800, 0x02080000, 0x00000802,
+    0x02000802, 0x02000000, 0x00000000, 0x00080002,
+    0x00080000, 0x00000002, 0x02000800, 0x00080800,
+    0x02080802, 0x02080000, 0x00000802, 0x02000800,
+    0x00000002, 0x00000800, 0x00080800, 0x02080002,
+    0x00000800, 0x02000802, 0x02080002, 0x00000000,
+    0x00000000, 0x02080802, 0x02000800, 0x00080002,
+    0x02080800, 0x00080000, 0x00000802, 0x02000800,
+    0x02080002, 0x00000800, 0x00080800, 0x02000002,
+    0x00080802, 0x00000002, 0x02000002, 0x02080000,
+    0x02080802, 0x00080800, 0x02080000, 0x02000802,
+    0x02000000, 0x00000802, 0x00080002, 0x00000000,
+    0x00080000, 0x02000000, 0x02000802, 0x02080800,
+    0x00000002, 0x02080002, 0x00000800, 0x00080802,
+  },
+  {
+    0x40108010, 0x00000000, 0x00108000, 0x40100000,
+    0x40000010, 0x00008010, 0x40008000, 0x00108000,
+    0x00008000, 0x40100010, 0x00000010, 0x40008000,
+    0x00100010, 0x40108000, 0x40100000, 0x00000010,
+    0x00100000, 0x40008010, 0x40100010, 0x00008000,
+    0x00108010, 0x40000000, 0x00000000, 0x00100010,
+    0x40008010, 0x00108010, 0x40108000, 0x40000010,
+    0x40000000, 0x00100000, 0x00008010, 0x40108010,
+    0x00100010, 0x40108000, 0x40008000, 0x00108010,
+    0x40108010, 0x00100010, 0x40000010, 0x00000000,
+    0x40000000, 0x00008010, 0x00100000, 0x40100010,
+    0x00008000, 0x40000000, 0x00108010, 0x40008010,
+    0x40108000, 0x00008000, 0x00000000, 0x40000010,
+    0x00000010, 0x40108010, 0x00108000, 0x40100000,
+    0x40100010, 0x00100000, 0x00008010, 0x40008000,
+    0x40008010, 0x00000010, 0x40100000, 0x00108000,
+  },
+  {
+    0x04000001, 0x04040100, 0x00000100, 0x04000101,
+    0x00040001, 0x04000000, 0x04000101, 0x00040100,
+    0x04000100, 0x00040000, 0x04040000, 0x00000001,
+    0x04040101, 0x00000101, 0x00000001, 0x04040001,
+    0x00000000, 0x00040001, 0x04040100, 0x00000100,
+    0x00000101, 0x04040101, 0x00040000, 0x04000001,
+    0x04040001, 0x04000100, 0x00040101, 0x04040000,
+    0x00040100, 0x00000000, 0x04000000, 0x00040101,
+    0x04040100, 0x00000100, 0x00000001, 0x00040000,
+    0x00000101, 0x00040001, 0x04040000, 0x04000101,
+    0x00000000, 0x04040100, 0x00040100, 0x04040001,
+    0x00040001, 0x04000000, 0x04040101, 0x00000001,
+    0x00040101, 0x04000001, 0x04000000, 0x04040101,
+    0x00040000, 0x04000100, 0x04000101, 0x00040100,
+    0x04000100, 0x00000000, 0x04040001, 0x00000101,
+    0x04000001, 0x00040101, 0x00000100, 0x04040000,
+  },
+  {
+    0x00401008, 0x10001000, 0x00000008, 0x10401008,
+    0x00000000, 0x10400000, 0x10001008, 0x00400008,
+    0x10401000, 0x10000008, 0x10000000, 0x00001008,
+    0x10000008, 0x00401008, 0x00400000, 0x10000000,
+    0x10400008, 0x00401000, 0x00001000, 0x00000008,
+    0x00401000, 0x10001008, 0x10400000, 0x00001000,
+    0x00001008, 0x00000000, 0x00400008, 0x10401000,
+    0x10001000, 0x10400008, 0x10401008, 0x00400000,
+    0x10400008, 0x00001008, 0x00400000, 0x10000008,
+    0x00401000, 0x10001000, 0x00000008, 0x10400000,
+    0x10001008, 0x00000000, 0x00001000, 0x00400008,
+    0x00000000, 0x10400008, 0x10401000, 0x00001000,
+    0x10000000, 0x10401008, 0x00401008, 0x00400000,
+    0x10401008, 0x00000008, 0x10001000, 0x00401008,
+    0x00400008, 0x00401000, 0x10400000, 0x10001008,
+    0x00001008, 0x10000000, 0x10000008, 0x10401000,
+  },
+  {
+    0x08000000, 0x00010000, 0x00000400, 0x08010420,
+    0x08010020, 0x08000400, 0x00010420, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x00010400,
+    0x08000420, 0x08010020, 0x08010400, 0x00000000,
+    0x00010400, 0x08000000, 0x00010020, 0x00000420,
+    0x08000400, 0x00010420, 0x00000000, 0x08000020,
+    0x00000020, 0x08000420, 0x08010420, 0x00010020,
+    0x08010000, 0x00000400, 0x00000420, 0x08010400,
+    0x08010400, 0x08000420, 0x00010020, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x08000400,
+    0x08000000, 0x00010400, 0x08010420, 0x00000000,
+    0x00010420, 0x08000000, 0x00000400, 0x00010020,
+    0x08000420, 0x00000400, 0x00000000, 0x08010420,
+    0x08010020, 0x08010400, 0x00000420, 0x00010000,
+    0x00010400, 0x08010020, 0x08000400, 0x00000420,
+    0x00000020, 0x00010420, 0x08010000, 0x08000020,
+  },
+  {
+    0x80000040, 0x00200040, 0x00000000, 0x80202000,
+    0x00200040, 0x00002000, 0x80002040, 0x00200000,
+    0x00002040, 0x80202040, 0x00202000, 0x80000000,
+    0x80002000, 0x80000040, 0x80200000, 0x00202040,
+    0x00200000, 0x80002040, 0x80200040, 0x00000000,
+    0x00002000, 0x00000040, 0x80202000, 0x80200040,
+    0x80202040, 0x80200000, 0x80000000, 0x00002040,
+    0x00000040, 0x00202000, 0x00202040, 0x80002000,
+    0x00002040, 0x80000000, 0x80002000, 0x00202040,
+    0x80202000, 0x00200040, 0x00000000, 0x80002000,
+    0x80000000, 0x00002000, 0x80200040, 0x00200000,
+    0x00200040, 0x80202040, 0x00202000, 0x00000040,
+    0x80202040, 0x00202000, 0x00200000, 0x80002040,
+    0x80000040, 0x80200000, 0x00202040, 0x00000000,
+    0x00002000, 0x80000040, 0x80002040, 0x80202000,
+    0x80200000, 0x00002040, 0x00000040, 0x80200040,
+  },
+  {
+    0x00004000, 0x00000200, 0x01000200, 0x01000004,
+    0x01004204, 0x00004004, 0x00004200, 0x00000000,
+    0x01000000, 0x01000204, 0x00000204, 0x01004000,
+    0x00000004, 0x01004200, 0x01004000, 0x00000204,
+    0x01000204, 0x00004000, 0x00004004, 0x01004204,
+    0x00000000, 0x01000200, 0x01000004, 0x00004200,
+    0x01004004, 0x00004204, 0x01004200, 0x00000004,
+    0x00004204, 0x01004004, 0x00000200, 0x01000000,
+    0x00004204, 0x01004000, 0x01004004, 0x00000204,
+    0x00004000, 0x00000200, 0x01000000, 0x01004004,
+    0x01000204, 0x00004204, 0x00004200, 0x00000000,
+    0x00000200, 0x01000004, 0x00000004, 0x01000200,
+    0x00000000, 0x01000204, 0x01000200, 0x00004200,
+    0x00000204, 0x00004000, 0x01004204, 0x01000000,
+    0x01004200, 0x00000004, 0x00004004, 0x01004204,
+    0x01000004, 0x01004200, 0x01004000, 0x00004004,
+  },
+  {
+    0x20800080, 0x20820000, 0x00020080, 0x00000000,
+    0x20020000, 0x00800080, 0x20800000, 0x20820080,
+    0x00000080, 0x20000000, 0x00820000, 0x00020080,
+    0x00820080, 0x20020080, 0x20000080, 0x20800000,
+    0x00020000, 0x00820080, 0x00800080, 0x20020000,
+    0x20820080, 0x20000080, 0x00000000, 0x00820000,
+    0x20000000, 0x00800000, 0x20020080, 0x20800080,
+    0x00800000, 0x00020000, 0x20820000, 0x00000080,
+    0x00800000, 0x00020000, 0x20000080, 0x20820080,
+    0x00020080, 0x20000000, 0x00000000, 0x00820000,
+    0x20800080, 0x20020080, 0x20020000, 0x00800080,
+    0x20820000, 0x00000080, 0x00800080, 0x20020000,
+    0x20820080, 0x00800000, 0x20800000, 0x20000080,
+    0x00820000, 0x00020080, 0x20020080, 0x20800000,
+    0x00000080, 0x20820000, 0x00820080, 0x00000000,
+    0x20000000, 0x20800080, 0x00020000, 0x00820080,
+  }
+};
+
+__constant u32 c_skb[8][64] =
+{
+  {
+    0x00000000, 0x00000010, 0x20000000, 0x20000010,
+    0x00010000, 0x00010010, 0x20010000, 0x20010010,
+    0x00000800, 0x00000810, 0x20000800, 0x20000810,
+    0x00010800, 0x00010810, 0x20010800, 0x20010810,
+    0x00000020, 0x00000030, 0x20000020, 0x20000030,
+    0x00010020, 0x00010030, 0x20010020, 0x20010030,
+    0x00000820, 0x00000830, 0x20000820, 0x20000830,
+    0x00010820, 0x00010830, 0x20010820, 0x20010830,
+    0x00080000, 0x00080010, 0x20080000, 0x20080010,
+    0x00090000, 0x00090010, 0x20090000, 0x20090010,
+    0x00080800, 0x00080810, 0x20080800, 0x20080810,
+    0x00090800, 0x00090810, 0x20090800, 0x20090810,
+    0x00080020, 0x00080030, 0x20080020, 0x20080030,
+    0x00090020, 0x00090030, 0x20090020, 0x20090030,
+    0x00080820, 0x00080830, 0x20080820, 0x20080830,
+    0x00090820, 0x00090830, 0x20090820, 0x20090830,
+  },
+  {
+    0x00000000, 0x02000000, 0x00002000, 0x02002000,
+    0x00200000, 0x02200000, 0x00202000, 0x02202000,
+    0x00000004, 0x02000004, 0x00002004, 0x02002004,
+    0x00200004, 0x02200004, 0x00202004, 0x02202004,
+    0x00000400, 0x02000400, 0x00002400, 0x02002400,
+    0x00200400, 0x02200400, 0x00202400, 0x02202400,
+    0x00000404, 0x02000404, 0x00002404, 0x02002404,
+    0x00200404, 0x02200404, 0x00202404, 0x02202404,
+    0x10000000, 0x12000000, 0x10002000, 0x12002000,
+    0x10200000, 0x12200000, 0x10202000, 0x12202000,
+    0x10000004, 0x12000004, 0x10002004, 0x12002004,
+    0x10200004, 0x12200004, 0x10202004, 0x12202004,
+    0x10000400, 0x12000400, 0x10002400, 0x12002400,
+    0x10200400, 0x12200400, 0x10202400, 0x12202400,
+    0x10000404, 0x12000404, 0x10002404, 0x12002404,
+    0x10200404, 0x12200404, 0x10202404, 0x12202404,
+  },
+  {
+    0x00000000, 0x00000001, 0x00040000, 0x00040001,
+    0x01000000, 0x01000001, 0x01040000, 0x01040001,
+    0x00000002, 0x00000003, 0x00040002, 0x00040003,
+    0x01000002, 0x01000003, 0x01040002, 0x01040003,
+    0x00000200, 0x00000201, 0x00040200, 0x00040201,
+    0x01000200, 0x01000201, 0x01040200, 0x01040201,
+    0x00000202, 0x00000203, 0x00040202, 0x00040203,
+    0x01000202, 0x01000203, 0x01040202, 0x01040203,
+    0x08000000, 0x08000001, 0x08040000, 0x08040001,
+    0x09000000, 0x09000001, 0x09040000, 0x09040001,
+    0x08000002, 0x08000003, 0x08040002, 0x08040003,
+    0x09000002, 0x09000003, 0x09040002, 0x09040003,
+    0x08000200, 0x08000201, 0x08040200, 0x08040201,
+    0x09000200, 0x09000201, 0x09040200, 0x09040201,
+    0x08000202, 0x08000203, 0x08040202, 0x08040203,
+    0x09000202, 0x09000203, 0x09040202, 0x09040203,
+  },
+  {
+    0x00000000, 0x00100000, 0x00000100, 0x00100100,
+    0x00000008, 0x00100008, 0x00000108, 0x00100108,
+    0x00001000, 0x00101000, 0x00001100, 0x00101100,
+    0x00001008, 0x00101008, 0x00001108, 0x00101108,
+    0x04000000, 0x04100000, 0x04000100, 0x04100100,
+    0x04000008, 0x04100008, 0x04000108, 0x04100108,
+    0x04001000, 0x04101000, 0x04001100, 0x04101100,
+    0x04001008, 0x04101008, 0x04001108, 0x04101108,
+    0x00020000, 0x00120000, 0x00020100, 0x00120100,
+    0x00020008, 0x00120008, 0x00020108, 0x00120108,
+    0x00021000, 0x00121000, 0x00021100, 0x00121100,
+    0x00021008, 0x00121008, 0x00021108, 0x00121108,
+    0x04020000, 0x04120000, 0x04020100, 0x04120100,
+    0x04020008, 0x04120008, 0x04020108, 0x04120108,
+    0x04021000, 0x04121000, 0x04021100, 0x04121100,
+    0x04021008, 0x04121008, 0x04021108, 0x04121108,
+  },
+  {
+    0x00000000, 0x10000000, 0x00010000, 0x10010000,
+    0x00000004, 0x10000004, 0x00010004, 0x10010004,
+    0x20000000, 0x30000000, 0x20010000, 0x30010000,
+    0x20000004, 0x30000004, 0x20010004, 0x30010004,
+    0x00100000, 0x10100000, 0x00110000, 0x10110000,
+    0x00100004, 0x10100004, 0x00110004, 0x10110004,
+    0x20100000, 0x30100000, 0x20110000, 0x30110000,
+    0x20100004, 0x30100004, 0x20110004, 0x30110004,
+    0x00001000, 0x10001000, 0x00011000, 0x10011000,
+    0x00001004, 0x10001004, 0x00011004, 0x10011004,
+    0x20001000, 0x30001000, 0x20011000, 0x30011000,
+    0x20001004, 0x30001004, 0x20011004, 0x30011004,
+    0x00101000, 0x10101000, 0x00111000, 0x10111000,
+    0x00101004, 0x10101004, 0x00111004, 0x10111004,
+    0x20101000, 0x30101000, 0x20111000, 0x30111000,
+    0x20101004, 0x30101004, 0x20111004, 0x30111004,
+  },
+  {
+    0x00000000, 0x08000000, 0x00000008, 0x08000008,
+    0x00000400, 0x08000400, 0x00000408, 0x08000408,
+    0x00020000, 0x08020000, 0x00020008, 0x08020008,
+    0x00020400, 0x08020400, 0x00020408, 0x08020408,
+    0x00000001, 0x08000001, 0x00000009, 0x08000009,
+    0x00000401, 0x08000401, 0x00000409, 0x08000409,
+    0x00020001, 0x08020001, 0x00020009, 0x08020009,
+    0x00020401, 0x08020401, 0x00020409, 0x08020409,
+    0x02000000, 0x0A000000, 0x02000008, 0x0A000008,
+    0x02000400, 0x0A000400, 0x02000408, 0x0A000408,
+    0x02020000, 0x0A020000, 0x02020008, 0x0A020008,
+    0x02020400, 0x0A020400, 0x02020408, 0x0A020408,
+    0x02000001, 0x0A000001, 0x02000009, 0x0A000009,
+    0x02000401, 0x0A000401, 0x02000409, 0x0A000409,
+    0x02020001, 0x0A020001, 0x02020009, 0x0A020009,
+    0x02020401, 0x0A020401, 0x02020409, 0x0A020409,
+  },
+  {
+    0x00000000, 0x00000100, 0x00080000, 0x00080100,
+    0x01000000, 0x01000100, 0x01080000, 0x01080100,
+    0x00000010, 0x00000110, 0x00080010, 0x00080110,
+    0x01000010, 0x01000110, 0x01080010, 0x01080110,
+    0x00200000, 0x00200100, 0x00280000, 0x00280100,
+    0x01200000, 0x01200100, 0x01280000, 0x01280100,
+    0x00200010, 0x00200110, 0x00280010, 0x00280110,
+    0x01200010, 0x01200110, 0x01280010, 0x01280110,
+    0x00000200, 0x00000300, 0x00080200, 0x00080300,
+    0x01000200, 0x01000300, 0x01080200, 0x01080300,
+    0x00000210, 0x00000310, 0x00080210, 0x00080310,
+    0x01000210, 0x01000310, 0x01080210, 0x01080310,
+    0x00200200, 0x00200300, 0x00280200, 0x00280300,
+    0x01200200, 0x01200300, 0x01280200, 0x01280300,
+    0x00200210, 0x00200310, 0x00280210, 0x00280310,
+    0x01200210, 0x01200310, 0x01280210, 0x01280310,
+  },
+  {
+    0x00000000, 0x04000000, 0x00040000, 0x04040000,
+    0x00000002, 0x04000002, 0x00040002, 0x04040002,
+    0x00002000, 0x04002000, 0x00042000, 0x04042000,
+    0x00002002, 0x04002002, 0x00042002, 0x04042002,
+    0x00000020, 0x04000020, 0x00040020, 0x04040020,
+    0x00000022, 0x04000022, 0x00040022, 0x04040022,
+    0x00002020, 0x04002020, 0x00042020, 0x04042020,
+    0x00002022, 0x04002022, 0x00042022, 0x04042022,
+    0x00000800, 0x04000800, 0x00040800, 0x04040800,
+    0x00000802, 0x04000802, 0x00040802, 0x04040802,
+    0x00002800, 0x04002800, 0x00042800, 0x04042800,
+    0x00002802, 0x04002802, 0x00042802, 0x04042802,
+    0x00000820, 0x04000820, 0x00040820, 0x04040820,
+    0x00000822, 0x04000822, 0x00040822, 0x04040822,
+    0x00002820, 0x04002820, 0x00042820, 0x04042820,
+    0x00002822, 0x04002822, 0x00042822, 0x04042822
+  }
+};
+
+#if   VECT_SIZE == 1
+#define BOX(i,n,S) (S)[(n)][(i)]
+#elif VECT_SIZE == 2
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1])
+#elif VECT_SIZE == 4
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3])
+#elif VECT_SIZE == 8
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
+#elif VECT_SIZE == 16
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7], (S)[(n)][(i).s8], (S)[(n)][(i).s9], (S)[(n)][(i).sa], (S)[(n)][(i).sb], (S)[(n)][(i).sc], (S)[(n)][(i).sd], (S)[(n)][(i).se], (S)[(n)][(i).sf])
+#endif
+
+#if   VECT_SIZE == 1
+#define BOX1(i,S) (S)[(i)]
+#elif VECT_SIZE == 2
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1])
+#elif VECT_SIZE == 4
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3])
+#elif VECT_SIZE == 8
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7])
+#elif VECT_SIZE == 16
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7], (S)[(i).s8], (S)[(i).s9], (S)[(i).sa], (S)[(i).sb], (S)[(i).sc], (S)[(i).sd], (S)[(i).se], (S)[(i).sf])
+#endif
+
+void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i += 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i + 0] ^ r;
+    t = Kd[i + 0] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i + 1] ^ l;
+    t = Kd[i + 1] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+}
+
+void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 (*s_skb)[64])
+{
+  u32x tt;
+
+  PERM_OP  (d, c, tt, 4, 0x0f0f0f0f);
+  HPERM_OP (c,    tt, 2, 0xcccc0000);
+  HPERM_OP (d,    tt, 2, 0xcccc0000);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+  PERM_OP  (c, d, tt, 8, 0x00ff00ff);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+
+  d = ((d & 0x000000ff) << 16)
+    | ((d & 0x0000ff00) <<  0)
+    | ((d & 0x00ff0000) >> 16)
+    | ((c & 0xf0000000) >>  4);
+
+  c = c & 0x0fffffff;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i++)
+  {
+    if ((i < 2) || (i == 8) || (i == 15))
+    {
+      c = ((c >> 1) | (c << 27));
+      d = ((d >> 1) | (d << 27));
+    }
+    else
+    {
+      c = ((c >> 2) | (c << 26));
+      d = ((d >> 2) | (d << 26));
+    }
+
+    c = c & 0x0fffffff;
+    d = d & 0x0fffffff;
+
+    const u32x c00 = (c >>  0) & 0x0000003f;
+    const u32x c06 = (c >>  6) & 0x00383003;
+    const u32x c07 = (c >>  7) & 0x0000003c;
+    const u32x c13 = (c >> 13) & 0x0000060f;
+    const u32x c20 = (c >> 20) & 0x00000001;
+
+    u32x s = BOX (((c00 >>  0) & 0xff), 0, s_skb)
+           | BOX (((c06 >>  0) & 0xff)
+                 |((c07 >>  0) & 0xff), 1, s_skb)
+           | BOX (((c13 >>  0) & 0xff)
+                 |((c06 >>  8) & 0xff), 2, s_skb)
+           | BOX (((c20 >>  0) & 0xff)
+                 |((c13 >>  8) & 0xff)
+                 |((c06 >> 16) & 0xff), 3, s_skb);
+
+    const u32x d00 = (d >>  0) & 0x00003c3f;
+    const u32x d07 = (d >>  7) & 0x00003f03;
+    const u32x d21 = (d >> 21) & 0x0000000f;
+    const u32x d22 = (d >> 22) & 0x00000030;
+
+    u32x t = BOX (((d00 >>  0) & 0xff), 4, s_skb)
+           | BOX (((d07 >>  0) & 0xff)
+                 |((d00 >>  8) & 0xff), 5, s_skb)
+           | BOX (((d07 >>  8) & 0xff), 6, s_skb)
+           | BOX (((d21 >>  0) & 0xff)
+                 |((d22 >>  0) & 0xff), 7, s_skb);
+
+    Kc[i] = ((t << 16) | (s & 0x0000ffff));
+    Kd[i] = ((s >> 16) | (t & 0xffff0000));
+
+    Kc[i] = rotl32 (Kc[i], 2u);
+    Kd[i] = rotl32 (Kd[i], 2u);
+  }
+}
+
+__kernel void m01510_m04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = 0;
+  pw_buf0[3] = 0;
+  pw_buf1[0] = 0;
+  pw_buf1[1] = 0;
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+  const u32 pw_l_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos);
+
+    const u32x pw_len = pw_l_len + pw_r_len;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[2];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+
+    const u32x c = w0[0];
+    const u32x d = w0[1];
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, data, Kc, Kd, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01510_m08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_m16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = 0;
+  pw_buf0[3] = 0;
+  pw_buf1[0] = 0;
+  pw_buf1[1] = 0;
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+  const u32 pw_l_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[digests_offset].digest_buf[DGST_R0],
+    digests_buf[digests_offset].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos);
+
+    const u32x pw_len = pw_l_len + pw_r_len;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[2];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+
+
+    const u32x c = (w0[0]);
+    const u32x d = (w0[1]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, data, Kc, Kd, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01510_s08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_s16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}

--- a/OpenCL/m01510_a3.cl
+++ b/OpenCL/m01510_a3.cl
@@ -1,0 +1,776 @@
+/**
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *               magnum <john.magnum@hushmail.com>
+ *               Frans Lategan <frans.lategan+hashcat@gmail.com>
+ *
+ * License.....: MIT
+ */
+
+#define _DES_
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+
+#define PERM_OP(a,b,tt,n,m) \
+{                           \
+  tt = a >> n;              \
+  tt = tt ^ b;              \
+  tt = tt & m;              \
+  b = b ^ tt;               \
+  tt = tt << n;             \
+  a = a ^ tt;               \
+}
+
+#define HPERM_OP(a,tt,n,m)  \
+{                           \
+  tt = a << (16 + n);       \
+  tt = tt ^ a;              \
+  tt = tt & m;              \
+  a  = a ^ tt;              \
+  tt = tt >> (16 + n);      \
+  a  = a ^ tt;              \
+}
+
+#define IP(l,r,tt)                     \
+{                                      \
+  PERM_OP (r, l, tt,  4, 0x0f0f0f0f);  \
+  PERM_OP (l, r, tt, 16, 0x0000ffff);  \
+  PERM_OP (r, l, tt,  2, 0x33333333);  \
+  PERM_OP (l, r, tt,  8, 0x00ff00ff);  \
+  PERM_OP (r, l, tt,  1, 0x55555555);  \
+}
+
+#define FP(l,r,tt)                     \
+{                                      \
+  PERM_OP (l, r, tt,  1, 0x55555555);  \
+  PERM_OP (r, l, tt,  8, 0x00ff00ff);  \
+  PERM_OP (l, r, tt,  2, 0x33333333);  \
+  PERM_OP (r, l, tt, 16, 0x0000ffff);  \
+  PERM_OP (l, r, tt,  4, 0x0f0f0f0f);  \
+}
+
+__constant u32 c_SPtrans[8][64] =
+{
+  {
+    0x02080800, 0x00080000, 0x02000002, 0x02080802,
+    0x02000000, 0x00080802, 0x00080002, 0x02000002,
+    0x00080802, 0x02080800, 0x02080000, 0x00000802,
+    0x02000802, 0x02000000, 0x00000000, 0x00080002,
+    0x00080000, 0x00000002, 0x02000800, 0x00080800,
+    0x02080802, 0x02080000, 0x00000802, 0x02000800,
+    0x00000002, 0x00000800, 0x00080800, 0x02080002,
+    0x00000800, 0x02000802, 0x02080002, 0x00000000,
+    0x00000000, 0x02080802, 0x02000800, 0x00080002,
+    0x02080800, 0x00080000, 0x00000802, 0x02000800,
+    0x02080002, 0x00000800, 0x00080800, 0x02000002,
+    0x00080802, 0x00000002, 0x02000002, 0x02080000,
+    0x02080802, 0x00080800, 0x02080000, 0x02000802,
+    0x02000000, 0x00000802, 0x00080002, 0x00000000,
+    0x00080000, 0x02000000, 0x02000802, 0x02080800,
+    0x00000002, 0x02080002, 0x00000800, 0x00080802,
+  },
+  {
+    0x40108010, 0x00000000, 0x00108000, 0x40100000,
+    0x40000010, 0x00008010, 0x40008000, 0x00108000,
+    0x00008000, 0x40100010, 0x00000010, 0x40008000,
+    0x00100010, 0x40108000, 0x40100000, 0x00000010,
+    0x00100000, 0x40008010, 0x40100010, 0x00008000,
+    0x00108010, 0x40000000, 0x00000000, 0x00100010,
+    0x40008010, 0x00108010, 0x40108000, 0x40000010,
+    0x40000000, 0x00100000, 0x00008010, 0x40108010,
+    0x00100010, 0x40108000, 0x40008000, 0x00108010,
+    0x40108010, 0x00100010, 0x40000010, 0x00000000,
+    0x40000000, 0x00008010, 0x00100000, 0x40100010,
+    0x00008000, 0x40000000, 0x00108010, 0x40008010,
+    0x40108000, 0x00008000, 0x00000000, 0x40000010,
+    0x00000010, 0x40108010, 0x00108000, 0x40100000,
+    0x40100010, 0x00100000, 0x00008010, 0x40008000,
+    0x40008010, 0x00000010, 0x40100000, 0x00108000,
+  },
+  {
+    0x04000001, 0x04040100, 0x00000100, 0x04000101,
+    0x00040001, 0x04000000, 0x04000101, 0x00040100,
+    0x04000100, 0x00040000, 0x04040000, 0x00000001,
+    0x04040101, 0x00000101, 0x00000001, 0x04040001,
+    0x00000000, 0x00040001, 0x04040100, 0x00000100,
+    0x00000101, 0x04040101, 0x00040000, 0x04000001,
+    0x04040001, 0x04000100, 0x00040101, 0x04040000,
+    0x00040100, 0x00000000, 0x04000000, 0x00040101,
+    0x04040100, 0x00000100, 0x00000001, 0x00040000,
+    0x00000101, 0x00040001, 0x04040000, 0x04000101,
+    0x00000000, 0x04040100, 0x00040100, 0x04040001,
+    0x00040001, 0x04000000, 0x04040101, 0x00000001,
+    0x00040101, 0x04000001, 0x04000000, 0x04040101,
+    0x00040000, 0x04000100, 0x04000101, 0x00040100,
+    0x04000100, 0x00000000, 0x04040001, 0x00000101,
+    0x04000001, 0x00040101, 0x00000100, 0x04040000,
+  },
+  {
+    0x00401008, 0x10001000, 0x00000008, 0x10401008,
+    0x00000000, 0x10400000, 0x10001008, 0x00400008,
+    0x10401000, 0x10000008, 0x10000000, 0x00001008,
+    0x10000008, 0x00401008, 0x00400000, 0x10000000,
+    0x10400008, 0x00401000, 0x00001000, 0x00000008,
+    0x00401000, 0x10001008, 0x10400000, 0x00001000,
+    0x00001008, 0x00000000, 0x00400008, 0x10401000,
+    0x10001000, 0x10400008, 0x10401008, 0x00400000,
+    0x10400008, 0x00001008, 0x00400000, 0x10000008,
+    0x00401000, 0x10001000, 0x00000008, 0x10400000,
+    0x10001008, 0x00000000, 0x00001000, 0x00400008,
+    0x00000000, 0x10400008, 0x10401000, 0x00001000,
+    0x10000000, 0x10401008, 0x00401008, 0x00400000,
+    0x10401008, 0x00000008, 0x10001000, 0x00401008,
+    0x00400008, 0x00401000, 0x10400000, 0x10001008,
+    0x00001008, 0x10000000, 0x10000008, 0x10401000,
+  },
+  {
+    0x08000000, 0x00010000, 0x00000400, 0x08010420,
+    0x08010020, 0x08000400, 0x00010420, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x00010400,
+    0x08000420, 0x08010020, 0x08010400, 0x00000000,
+    0x00010400, 0x08000000, 0x00010020, 0x00000420,
+    0x08000400, 0x00010420, 0x00000000, 0x08000020,
+    0x00000020, 0x08000420, 0x08010420, 0x00010020,
+    0x08010000, 0x00000400, 0x00000420, 0x08010400,
+    0x08010400, 0x08000420, 0x00010020, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x08000400,
+    0x08000000, 0x00010400, 0x08010420, 0x00000000,
+    0x00010420, 0x08000000, 0x00000400, 0x00010020,
+    0x08000420, 0x00000400, 0x00000000, 0x08010420,
+    0x08010020, 0x08010400, 0x00000420, 0x00010000,
+    0x00010400, 0x08010020, 0x08000400, 0x00000420,
+    0x00000020, 0x00010420, 0x08010000, 0x08000020,
+  },
+  {
+    0x80000040, 0x00200040, 0x00000000, 0x80202000,
+    0x00200040, 0x00002000, 0x80002040, 0x00200000,
+    0x00002040, 0x80202040, 0x00202000, 0x80000000,
+    0x80002000, 0x80000040, 0x80200000, 0x00202040,
+    0x00200000, 0x80002040, 0x80200040, 0x00000000,
+    0x00002000, 0x00000040, 0x80202000, 0x80200040,
+    0x80202040, 0x80200000, 0x80000000, 0x00002040,
+    0x00000040, 0x00202000, 0x00202040, 0x80002000,
+    0x00002040, 0x80000000, 0x80002000, 0x00202040,
+    0x80202000, 0x00200040, 0x00000000, 0x80002000,
+    0x80000000, 0x00002000, 0x80200040, 0x00200000,
+    0x00200040, 0x80202040, 0x00202000, 0x00000040,
+    0x80202040, 0x00202000, 0x00200000, 0x80002040,
+    0x80000040, 0x80200000, 0x00202040, 0x00000000,
+    0x00002000, 0x80000040, 0x80002040, 0x80202000,
+    0x80200000, 0x00002040, 0x00000040, 0x80200040,
+  },
+  {
+    0x00004000, 0x00000200, 0x01000200, 0x01000004,
+    0x01004204, 0x00004004, 0x00004200, 0x00000000,
+    0x01000000, 0x01000204, 0x00000204, 0x01004000,
+    0x00000004, 0x01004200, 0x01004000, 0x00000204,
+    0x01000204, 0x00004000, 0x00004004, 0x01004204,
+    0x00000000, 0x01000200, 0x01000004, 0x00004200,
+    0x01004004, 0x00004204, 0x01004200, 0x00000004,
+    0x00004204, 0x01004004, 0x00000200, 0x01000000,
+    0x00004204, 0x01004000, 0x01004004, 0x00000204,
+    0x00004000, 0x00000200, 0x01000000, 0x01004004,
+    0x01000204, 0x00004204, 0x00004200, 0x00000000,
+    0x00000200, 0x01000004, 0x00000004, 0x01000200,
+    0x00000000, 0x01000204, 0x01000200, 0x00004200,
+    0x00000204, 0x00004000, 0x01004204, 0x01000000,
+    0x01004200, 0x00000004, 0x00004004, 0x01004204,
+    0x01000004, 0x01004200, 0x01004000, 0x00004004,
+  },
+  {
+    0x20800080, 0x20820000, 0x00020080, 0x00000000,
+    0x20020000, 0x00800080, 0x20800000, 0x20820080,
+    0x00000080, 0x20000000, 0x00820000, 0x00020080,
+    0x00820080, 0x20020080, 0x20000080, 0x20800000,
+    0x00020000, 0x00820080, 0x00800080, 0x20020000,
+    0x20820080, 0x20000080, 0x00000000, 0x00820000,
+    0x20000000, 0x00800000, 0x20020080, 0x20800080,
+    0x00800000, 0x00020000, 0x20820000, 0x00000080,
+    0x00800000, 0x00020000, 0x20000080, 0x20820080,
+    0x00020080, 0x20000000, 0x00000000, 0x00820000,
+    0x20800080, 0x20020080, 0x20020000, 0x00800080,
+    0x20820000, 0x00000080, 0x00800080, 0x20020000,
+    0x20820080, 0x00800000, 0x20800000, 0x20000080,
+    0x00820000, 0x00020080, 0x20020080, 0x20800000,
+    0x00000080, 0x20820000, 0x00820080, 0x00000000,
+    0x20000000, 0x20800080, 0x00020000, 0x00820080,
+  }
+};
+
+__constant u32 c_skb[8][64] =
+{
+  {
+    0x00000000, 0x00000010, 0x20000000, 0x20000010,
+    0x00010000, 0x00010010, 0x20010000, 0x20010010,
+    0x00000800, 0x00000810, 0x20000800, 0x20000810,
+    0x00010800, 0x00010810, 0x20010800, 0x20010810,
+    0x00000020, 0x00000030, 0x20000020, 0x20000030,
+    0x00010020, 0x00010030, 0x20010020, 0x20010030,
+    0x00000820, 0x00000830, 0x20000820, 0x20000830,
+    0x00010820, 0x00010830, 0x20010820, 0x20010830,
+    0x00080000, 0x00080010, 0x20080000, 0x20080010,
+    0x00090000, 0x00090010, 0x20090000, 0x20090010,
+    0x00080800, 0x00080810, 0x20080800, 0x20080810,
+    0x00090800, 0x00090810, 0x20090800, 0x20090810,
+    0x00080020, 0x00080030, 0x20080020, 0x20080030,
+    0x00090020, 0x00090030, 0x20090020, 0x20090030,
+    0x00080820, 0x00080830, 0x20080820, 0x20080830,
+    0x00090820, 0x00090830, 0x20090820, 0x20090830,
+  },
+  {
+    0x00000000, 0x02000000, 0x00002000, 0x02002000,
+    0x00200000, 0x02200000, 0x00202000, 0x02202000,
+    0x00000004, 0x02000004, 0x00002004, 0x02002004,
+    0x00200004, 0x02200004, 0x00202004, 0x02202004,
+    0x00000400, 0x02000400, 0x00002400, 0x02002400,
+    0x00200400, 0x02200400, 0x00202400, 0x02202400,
+    0x00000404, 0x02000404, 0x00002404, 0x02002404,
+    0x00200404, 0x02200404, 0x00202404, 0x02202404,
+    0x10000000, 0x12000000, 0x10002000, 0x12002000,
+    0x10200000, 0x12200000, 0x10202000, 0x12202000,
+    0x10000004, 0x12000004, 0x10002004, 0x12002004,
+    0x10200004, 0x12200004, 0x10202004, 0x12202004,
+    0x10000400, 0x12000400, 0x10002400, 0x12002400,
+    0x10200400, 0x12200400, 0x10202400, 0x12202400,
+    0x10000404, 0x12000404, 0x10002404, 0x12002404,
+    0x10200404, 0x12200404, 0x10202404, 0x12202404,
+  },
+  {
+    0x00000000, 0x00000001, 0x00040000, 0x00040001,
+    0x01000000, 0x01000001, 0x01040000, 0x01040001,
+    0x00000002, 0x00000003, 0x00040002, 0x00040003,
+    0x01000002, 0x01000003, 0x01040002, 0x01040003,
+    0x00000200, 0x00000201, 0x00040200, 0x00040201,
+    0x01000200, 0x01000201, 0x01040200, 0x01040201,
+    0x00000202, 0x00000203, 0x00040202, 0x00040203,
+    0x01000202, 0x01000203, 0x01040202, 0x01040203,
+    0x08000000, 0x08000001, 0x08040000, 0x08040001,
+    0x09000000, 0x09000001, 0x09040000, 0x09040001,
+    0x08000002, 0x08000003, 0x08040002, 0x08040003,
+    0x09000002, 0x09000003, 0x09040002, 0x09040003,
+    0x08000200, 0x08000201, 0x08040200, 0x08040201,
+    0x09000200, 0x09000201, 0x09040200, 0x09040201,
+    0x08000202, 0x08000203, 0x08040202, 0x08040203,
+    0x09000202, 0x09000203, 0x09040202, 0x09040203,
+  },
+  {
+    0x00000000, 0x00100000, 0x00000100, 0x00100100,
+    0x00000008, 0x00100008, 0x00000108, 0x00100108,
+    0x00001000, 0x00101000, 0x00001100, 0x00101100,
+    0x00001008, 0x00101008, 0x00001108, 0x00101108,
+    0x04000000, 0x04100000, 0x04000100, 0x04100100,
+    0x04000008, 0x04100008, 0x04000108, 0x04100108,
+    0x04001000, 0x04101000, 0x04001100, 0x04101100,
+    0x04001008, 0x04101008, 0x04001108, 0x04101108,
+    0x00020000, 0x00120000, 0x00020100, 0x00120100,
+    0x00020008, 0x00120008, 0x00020108, 0x00120108,
+    0x00021000, 0x00121000, 0x00021100, 0x00121100,
+    0x00021008, 0x00121008, 0x00021108, 0x00121108,
+    0x04020000, 0x04120000, 0x04020100, 0x04120100,
+    0x04020008, 0x04120008, 0x04020108, 0x04120108,
+    0x04021000, 0x04121000, 0x04021100, 0x04121100,
+    0x04021008, 0x04121008, 0x04021108, 0x04121108,
+  },
+  {
+    0x00000000, 0x10000000, 0x00010000, 0x10010000,
+    0x00000004, 0x10000004, 0x00010004, 0x10010004,
+    0x20000000, 0x30000000, 0x20010000, 0x30010000,
+    0x20000004, 0x30000004, 0x20010004, 0x30010004,
+    0x00100000, 0x10100000, 0x00110000, 0x10110000,
+    0x00100004, 0x10100004, 0x00110004, 0x10110004,
+    0x20100000, 0x30100000, 0x20110000, 0x30110000,
+    0x20100004, 0x30100004, 0x20110004, 0x30110004,
+    0x00001000, 0x10001000, 0x00011000, 0x10011000,
+    0x00001004, 0x10001004, 0x00011004, 0x10011004,
+    0x20001000, 0x30001000, 0x20011000, 0x30011000,
+    0x20001004, 0x30001004, 0x20011004, 0x30011004,
+    0x00101000, 0x10101000, 0x00111000, 0x10111000,
+    0x00101004, 0x10101004, 0x00111004, 0x10111004,
+    0x20101000, 0x30101000, 0x20111000, 0x30111000,
+    0x20101004, 0x30101004, 0x20111004, 0x30111004,
+  },
+  {
+    0x00000000, 0x08000000, 0x00000008, 0x08000008,
+    0x00000400, 0x08000400, 0x00000408, 0x08000408,
+    0x00020000, 0x08020000, 0x00020008, 0x08020008,
+    0x00020400, 0x08020400, 0x00020408, 0x08020408,
+    0x00000001, 0x08000001, 0x00000009, 0x08000009,
+    0x00000401, 0x08000401, 0x00000409, 0x08000409,
+    0x00020001, 0x08020001, 0x00020009, 0x08020009,
+    0x00020401, 0x08020401, 0x00020409, 0x08020409,
+    0x02000000, 0x0A000000, 0x02000008, 0x0A000008,
+    0x02000400, 0x0A000400, 0x02000408, 0x0A000408,
+    0x02020000, 0x0A020000, 0x02020008, 0x0A020008,
+    0x02020400, 0x0A020400, 0x02020408, 0x0A020408,
+    0x02000001, 0x0A000001, 0x02000009, 0x0A000009,
+    0x02000401, 0x0A000401, 0x02000409, 0x0A000409,
+    0x02020001, 0x0A020001, 0x02020009, 0x0A020009,
+    0x02020401, 0x0A020401, 0x02020409, 0x0A020409,
+  },
+  {
+    0x00000000, 0x00000100, 0x00080000, 0x00080100,
+    0x01000000, 0x01000100, 0x01080000, 0x01080100,
+    0x00000010, 0x00000110, 0x00080010, 0x00080110,
+    0x01000010, 0x01000110, 0x01080010, 0x01080110,
+    0x00200000, 0x00200100, 0x00280000, 0x00280100,
+    0x01200000, 0x01200100, 0x01280000, 0x01280100,
+    0x00200010, 0x00200110, 0x00280010, 0x00280110,
+    0x01200010, 0x01200110, 0x01280010, 0x01280110,
+    0x00000200, 0x00000300, 0x00080200, 0x00080300,
+    0x01000200, 0x01000300, 0x01080200, 0x01080300,
+    0x00000210, 0x00000310, 0x00080210, 0x00080310,
+    0x01000210, 0x01000310, 0x01080210, 0x01080310,
+    0x00200200, 0x00200300, 0x00280200, 0x00280300,
+    0x01200200, 0x01200300, 0x01280200, 0x01280300,
+    0x00200210, 0x00200310, 0x00280210, 0x00280310,
+    0x01200210, 0x01200310, 0x01280210, 0x01280310,
+  },
+  {
+    0x00000000, 0x04000000, 0x00040000, 0x04040000,
+    0x00000002, 0x04000002, 0x00040002, 0x04040002,
+    0x00002000, 0x04002000, 0x00042000, 0x04042000,
+    0x00002002, 0x04002002, 0x00042002, 0x04042002,
+    0x00000020, 0x04000020, 0x00040020, 0x04040020,
+    0x00000022, 0x04000022, 0x00040022, 0x04040022,
+    0x00002020, 0x04002020, 0x00042020, 0x04042020,
+    0x00002022, 0x04002022, 0x00042022, 0x04042022,
+    0x00000800, 0x04000800, 0x00040800, 0x04040800,
+    0x00000802, 0x04000802, 0x00040802, 0x04040802,
+    0x00002800, 0x04002800, 0x00042800, 0x04042800,
+    0x00002802, 0x04002802, 0x00042802, 0x04042802,
+    0x00000820, 0x04000820, 0x00040820, 0x04040820,
+    0x00000822, 0x04000822, 0x00040822, 0x04040822,
+    0x00002820, 0x04002820, 0x00042820, 0x04042820,
+    0x00002822, 0x04002822, 0x00042822, 0x04042822
+  }
+};
+
+#if   VECT_SIZE == 1
+#define BOX(i,n,S) (S)[(n)][(i)]
+#elif VECT_SIZE == 2
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1])
+#elif VECT_SIZE == 4
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3])
+#elif VECT_SIZE == 8
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
+#elif VECT_SIZE == 16
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7], (S)[(n)][(i).s8], (S)[(n)][(i).s9], (S)[(n)][(i).sa], (S)[(n)][(i).sb], (S)[(n)][(i).sc], (S)[(n)][(i).sd], (S)[(n)][(i).se], (S)[(n)][(i).sf])
+#endif
+
+#if   VECT_SIZE == 1
+#define BOX1(i,S) (S)[(i)]
+#elif VECT_SIZE == 2
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1])
+#elif VECT_SIZE == 4
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3])
+#elif VECT_SIZE == 8
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7])
+#elif VECT_SIZE == 16
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7], (S)[(i).s8], (S)[(i).s9], (S)[(i).sa], (S)[(i).sb], (S)[(i).sc], (S)[(i).sd], (S)[(i).se], (S)[(i).sf])
+#endif
+
+void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i += 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i + 0] ^ r;
+    t = Kd[i + 0] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i + 1] ^ l;
+    t = Kd[i + 1] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+}
+
+void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 (*s_skb)[64])
+{
+  u32x tt;
+
+  PERM_OP  (d, c, tt, 4, 0x0f0f0f0f);
+  HPERM_OP (c,    tt, 2, 0xcccc0000);
+  HPERM_OP (d,    tt, 2, 0xcccc0000);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+  PERM_OP  (c, d, tt, 8, 0x00ff00ff);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+
+  d = ((d & 0x000000ff) << 16)
+    | ((d & 0x0000ff00) <<  0)
+    | ((d & 0x00ff0000) >> 16)
+    | ((c & 0xf0000000) >>  4);
+
+  c = c & 0x0fffffff;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i++)
+  {
+    if ((i < 2) || (i == 8) || (i == 15))
+    {
+      c = ((c >> 1) | (c << 27));
+      d = ((d >> 1) | (d << 27));
+    }
+    else
+    {
+      c = ((c >> 2) | (c << 26));
+      d = ((d >> 2) | (d << 26));
+    }
+
+    c = c & 0x0fffffff;
+    d = d & 0x0fffffff;
+
+    const u32x c00 = (c >>  0) & 0x0000003f;
+    const u32x c06 = (c >>  6) & 0x00383003;
+    const u32x c07 = (c >>  7) & 0x0000003c;
+    const u32x c13 = (c >> 13) & 0x0000060f;
+    const u32x c20 = (c >> 20) & 0x00000001;
+
+    u32x s = BOX (((c00 >>  0) & 0xff), 0, s_skb)
+           | BOX (((c06 >>  0) & 0xff)
+                 |((c07 >>  0) & 0xff), 1, s_skb)
+           | BOX (((c13 >>  0) & 0xff)
+                 |((c06 >>  8) & 0xff), 2, s_skb)
+           | BOX (((c20 >>  0) & 0xff)
+                 |((c13 >>  8) & 0xff)
+                 |((c06 >> 16) & 0xff), 3, s_skb);
+
+    const u32x d00 = (d >>  0) & 0x00003c3f;
+    const u32x d07 = (d >>  7) & 0x00003f03;
+    const u32x d21 = (d >> 21) & 0x0000000f;
+    const u32x d22 = (d >> 22) & 0x00000030;
+
+    u32x t = BOX (((d00 >>  0) & 0xff), 4, s_skb)
+           | BOX (((d07 >>  0) & 0xff)
+                 |((d00 >>  8) & 0xff), 5, s_skb)
+           | BOX (((d07 >>  8) & 0xff), 6, s_skb)
+           | BOX (((d21 >>  0) & 0xff)
+                 |((d22 >>  0) & 0xff), 7, s_skb);
+
+    Kc[i] = ((t << 16) | (s & 0x0000ffff));
+    Kd[i] = ((s >> 16) | (t & 0xffff0000));
+
+    Kc[i] = rotl32 (Kc[i], 2u);
+    Kd[i] = rotl32 (Kd[i], 2u);
+  }
+}
+
+void m01510m (__local u32 (*s_SPtrans)[64], __local u32 (*s_skb)[64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset)
+{
+  /**
+   * modifier
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  u32 w1 = w[1];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x c = w0;
+    const u32x d = w1;
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, data, Kc, Kd, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+void m01510s (__local u32 (*s_SPtrans)[64], __local u32 (*s_skb)[64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset)
+{
+  /**
+   * modifier
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[digests_offset].digest_buf[DGST_R0],
+    digests_buf[digests_offset].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  u32 w1 = w[1];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x c = w0;
+    const u32x d = w1;
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, data, Kc, Kd, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01510_m04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = 0;
+  w[ 3] = 0;
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01510m (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}
+
+__kernel void m01510_m08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_m16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = 0;
+  w[ 3] = 0;
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01510s (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}
+
+__kernel void m01510_s08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01510_s16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}

--- a/OpenCL/m01530_a0.cl
+++ b/OpenCL/m01530_a0.cl
@@ -1,0 +1,846 @@
+/**
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *               magnum <john.magnum@hushmail.com>
+ *               Frans Lategan <frans.lategan+hashcat@gmail.com>
+ *
+ * License.....: MIT
+ */
+
+#define _DES_
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_rp.h"
+#include "inc_rp.cl"
+#include "inc_simd.cl"
+
+#define PERM_OP(a,b,tt,n,m) \
+{                           \
+  tt = a >> n;              \
+  tt = tt ^ b;              \
+  tt = tt & m;              \
+  b = b ^ tt;               \
+  tt = tt << n;             \
+  a = a ^ tt;               \
+}
+
+#define HPERM_OP(a,tt,n,m)  \
+{                           \
+  tt = a << (16 + n);       \
+  tt = tt ^ a;              \
+  tt = tt & m;              \
+  a  = a ^ tt;              \
+  tt = tt >> (16 + n);      \
+  a  = a ^ tt;              \
+}
+
+#define IP(l,r,tt)                     \
+{                                      \
+  PERM_OP (r, l, tt,  4, 0x0f0f0f0f);  \
+  PERM_OP (l, r, tt, 16, 0x0000ffff);  \
+  PERM_OP (r, l, tt,  2, 0x33333333);  \
+  PERM_OP (l, r, tt,  8, 0x00ff00ff);  \
+  PERM_OP (r, l, tt,  1, 0x55555555);  \
+}
+
+#define FP(l,r,tt)                     \
+{                                      \
+  PERM_OP (l, r, tt,  1, 0x55555555);  \
+  PERM_OP (r, l, tt,  8, 0x00ff00ff);  \
+  PERM_OP (l, r, tt,  2, 0x33333333);  \
+  PERM_OP (r, l, tt, 16, 0x0000ffff);  \
+  PERM_OP (l, r, tt,  4, 0x0f0f0f0f);  \
+}
+
+__constant u32 c_SPtrans[8][64] =
+{
+  {
+    /* nibble 0 */
+    0x02080800, 0x00080000, 0x02000002, 0x02080802,
+    0x02000000, 0x00080802, 0x00080002, 0x02000002,
+    0x00080802, 0x02080800, 0x02080000, 0x00000802,
+    0x02000802, 0x02000000, 0x00000000, 0x00080002,
+    0x00080000, 0x00000002, 0x02000800, 0x00080800,
+    0x02080802, 0x02080000, 0x00000802, 0x02000800,
+    0x00000002, 0x00000800, 0x00080800, 0x02080002,
+    0x00000800, 0x02000802, 0x02080002, 0x00000000,
+    0x00000000, 0x02080802, 0x02000800, 0x00080002,
+    0x02080800, 0x00080000, 0x00000802, 0x02000800,
+    0x02080002, 0x00000800, 0x00080800, 0x02000002,
+    0x00080802, 0x00000002, 0x02000002, 0x02080000,
+    0x02080802, 0x00080800, 0x02080000, 0x02000802,
+    0x02000000, 0x00000802, 0x00080002, 0x00000000,
+    0x00080000, 0x02000000, 0x02000802, 0x02080800,
+    0x00000002, 0x02080002, 0x00000800, 0x00080802,
+  },
+  {
+    /* nibble 1 */
+    0x40108010, 0x00000000, 0x00108000, 0x40100000,
+    0x40000010, 0x00008010, 0x40008000, 0x00108000,
+    0x00008000, 0x40100010, 0x00000010, 0x40008000,
+    0x00100010, 0x40108000, 0x40100000, 0x00000010,
+    0x00100000, 0x40008010, 0x40100010, 0x00008000,
+    0x00108010, 0x40000000, 0x00000000, 0x00100010,
+    0x40008010, 0x00108010, 0x40108000, 0x40000010,
+    0x40000000, 0x00100000, 0x00008010, 0x40108010,
+    0x00100010, 0x40108000, 0x40008000, 0x00108010,
+    0x40108010, 0x00100010, 0x40000010, 0x00000000,
+    0x40000000, 0x00008010, 0x00100000, 0x40100010,
+    0x00008000, 0x40000000, 0x00108010, 0x40008010,
+    0x40108000, 0x00008000, 0x00000000, 0x40000010,
+    0x00000010, 0x40108010, 0x00108000, 0x40100000,
+    0x40100010, 0x00100000, 0x00008010, 0x40008000,
+    0x40008010, 0x00000010, 0x40100000, 0x00108000,
+  },
+  {
+    /* nibble 2 */
+    0x04000001, 0x04040100, 0x00000100, 0x04000101,
+    0x00040001, 0x04000000, 0x04000101, 0x00040100,
+    0x04000100, 0x00040000, 0x04040000, 0x00000001,
+    0x04040101, 0x00000101, 0x00000001, 0x04040001,
+    0x00000000, 0x00040001, 0x04040100, 0x00000100,
+    0x00000101, 0x04040101, 0x00040000, 0x04000001,
+    0x04040001, 0x04000100, 0x00040101, 0x04040000,
+    0x00040100, 0x00000000, 0x04000000, 0x00040101,
+    0x04040100, 0x00000100, 0x00000001, 0x00040000,
+    0x00000101, 0x00040001, 0x04040000, 0x04000101,
+    0x00000000, 0x04040100, 0x00040100, 0x04040001,
+    0x00040001, 0x04000000, 0x04040101, 0x00000001,
+    0x00040101, 0x04000001, 0x04000000, 0x04040101,
+    0x00040000, 0x04000100, 0x04000101, 0x00040100,
+    0x04000100, 0x00000000, 0x04040001, 0x00000101,
+    0x04000001, 0x00040101, 0x00000100, 0x04040000,
+  },
+  {
+    /* nibble 3 */
+    0x00401008, 0x10001000, 0x00000008, 0x10401008,
+    0x00000000, 0x10400000, 0x10001008, 0x00400008,
+    0x10401000, 0x10000008, 0x10000000, 0x00001008,
+    0x10000008, 0x00401008, 0x00400000, 0x10000000,
+    0x10400008, 0x00401000, 0x00001000, 0x00000008,
+    0x00401000, 0x10001008, 0x10400000, 0x00001000,
+    0x00001008, 0x00000000, 0x00400008, 0x10401000,
+    0x10001000, 0x10400008, 0x10401008, 0x00400000,
+    0x10400008, 0x00001008, 0x00400000, 0x10000008,
+    0x00401000, 0x10001000, 0x00000008, 0x10400000,
+    0x10001008, 0x00000000, 0x00001000, 0x00400008,
+    0x00000000, 0x10400008, 0x10401000, 0x00001000,
+    0x10000000, 0x10401008, 0x00401008, 0x00400000,
+    0x10401008, 0x00000008, 0x10001000, 0x00401008,
+    0x00400008, 0x00401000, 0x10400000, 0x10001008,
+    0x00001008, 0x10000000, 0x10000008, 0x10401000,
+  },
+  {
+    /* nibble 4 */
+    0x08000000, 0x00010000, 0x00000400, 0x08010420,
+    0x08010020, 0x08000400, 0x00010420, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x00010400,
+    0x08000420, 0x08010020, 0x08010400, 0x00000000,
+    0x00010400, 0x08000000, 0x00010020, 0x00000420,
+    0x08000400, 0x00010420, 0x00000000, 0x08000020,
+    0x00000020, 0x08000420, 0x08010420, 0x00010020,
+    0x08010000, 0x00000400, 0x00000420, 0x08010400,
+    0x08010400, 0x08000420, 0x00010020, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x08000400,
+    0x08000000, 0x00010400, 0x08010420, 0x00000000,
+    0x00010420, 0x08000000, 0x00000400, 0x00010020,
+    0x08000420, 0x00000400, 0x00000000, 0x08010420,
+    0x08010020, 0x08010400, 0x00000420, 0x00010000,
+    0x00010400, 0x08010020, 0x08000400, 0x00000420,
+    0x00000020, 0x00010420, 0x08010000, 0x08000020,
+  },
+  {
+    /* nibble 5 */
+    0x80000040, 0x00200040, 0x00000000, 0x80202000,
+    0x00200040, 0x00002000, 0x80002040, 0x00200000,
+    0x00002040, 0x80202040, 0x00202000, 0x80000000,
+    0x80002000, 0x80000040, 0x80200000, 0x00202040,
+    0x00200000, 0x80002040, 0x80200040, 0x00000000,
+    0x00002000, 0x00000040, 0x80202000, 0x80200040,
+    0x80202040, 0x80200000, 0x80000000, 0x00002040,
+    0x00000040, 0x00202000, 0x00202040, 0x80002000,
+    0x00002040, 0x80000000, 0x80002000, 0x00202040,
+    0x80202000, 0x00200040, 0x00000000, 0x80002000,
+    0x80000000, 0x00002000, 0x80200040, 0x00200000,
+    0x00200040, 0x80202040, 0x00202000, 0x00000040,
+    0x80202040, 0x00202000, 0x00200000, 0x80002040,
+    0x80000040, 0x80200000, 0x00202040, 0x00000000,
+    0x00002000, 0x80000040, 0x80002040, 0x80202000,
+    0x80200000, 0x00002040, 0x00000040, 0x80200040,
+  },
+  {
+    /* nibble 6 */
+    0x00004000, 0x00000200, 0x01000200, 0x01000004,
+    0x01004204, 0x00004004, 0x00004200, 0x00000000,
+    0x01000000, 0x01000204, 0x00000204, 0x01004000,
+    0x00000004, 0x01004200, 0x01004000, 0x00000204,
+    0x01000204, 0x00004000, 0x00004004, 0x01004204,
+    0x00000000, 0x01000200, 0x01000004, 0x00004200,
+    0x01004004, 0x00004204, 0x01004200, 0x00000004,
+    0x00004204, 0x01004004, 0x00000200, 0x01000000,
+    0x00004204, 0x01004000, 0x01004004, 0x00000204,
+    0x00004000, 0x00000200, 0x01000000, 0x01004004,
+    0x01000204, 0x00004204, 0x00004200, 0x00000000,
+    0x00000200, 0x01000004, 0x00000004, 0x01000200,
+    0x00000000, 0x01000204, 0x01000200, 0x00004200,
+    0x00000204, 0x00004000, 0x01004204, 0x01000000,
+    0x01004200, 0x00000004, 0x00004004, 0x01004204,
+    0x01000004, 0x01004200, 0x01004000, 0x00004004,
+  },
+  {
+    /* nibble 7 */
+    0x20800080, 0x20820000, 0x00020080, 0x00000000,
+    0x20020000, 0x00800080, 0x20800000, 0x20820080,
+    0x00000080, 0x20000000, 0x00820000, 0x00020080,
+    0x00820080, 0x20020080, 0x20000080, 0x20800000,
+    0x00020000, 0x00820080, 0x00800080, 0x20020000,
+    0x20820080, 0x20000080, 0x00000000, 0x00820000,
+    0x20000000, 0x00800000, 0x20020080, 0x20800080,
+    0x00800000, 0x00020000, 0x20820000, 0x00000080,
+    0x00800000, 0x00020000, 0x20000080, 0x20820080,
+    0x00020080, 0x20000000, 0x00000000, 0x00820000,
+    0x20800080, 0x20020080, 0x20020000, 0x00800080,
+    0x20820000, 0x00000080, 0x00800080, 0x20020000,
+    0x20820080, 0x00800000, 0x20800000, 0x20000080,
+    0x00820000, 0x00020080, 0x20020080, 0x20800000,
+    0x00000080, 0x20820000, 0x00820080, 0x00000000,
+    0x20000000, 0x20800080, 0x00020000, 0x00820080,
+  },
+};
+__constant u32 c_skb[8][64] =
+{
+  {
+    0x00000000, 0x00000010, 0x20000000, 0x20000010,
+    0x00010000, 0x00010010, 0x20010000, 0x20010010,
+    0x00000800, 0x00000810, 0x20000800, 0x20000810,
+    0x00010800, 0x00010810, 0x20010800, 0x20010810,
+    0x00000020, 0x00000030, 0x20000020, 0x20000030,
+    0x00010020, 0x00010030, 0x20010020, 0x20010030,
+    0x00000820, 0x00000830, 0x20000820, 0x20000830,
+    0x00010820, 0x00010830, 0x20010820, 0x20010830,
+    0x00080000, 0x00080010, 0x20080000, 0x20080010,
+    0x00090000, 0x00090010, 0x20090000, 0x20090010,
+    0x00080800, 0x00080810, 0x20080800, 0x20080810,
+    0x00090800, 0x00090810, 0x20090800, 0x20090810,
+    0x00080020, 0x00080030, 0x20080020, 0x20080030,
+    0x00090020, 0x00090030, 0x20090020, 0x20090030,
+    0x00080820, 0x00080830, 0x20080820, 0x20080830,
+    0x00090820, 0x00090830, 0x20090820, 0x20090830,
+  },
+  {
+    0x00000000, 0x02000000, 0x00002000, 0x02002000,
+    0x00200000, 0x02200000, 0x00202000, 0x02202000,
+    0x00000004, 0x02000004, 0x00002004, 0x02002004,
+    0x00200004, 0x02200004, 0x00202004, 0x02202004,
+    0x00000400, 0x02000400, 0x00002400, 0x02002400,
+    0x00200400, 0x02200400, 0x00202400, 0x02202400,
+    0x00000404, 0x02000404, 0x00002404, 0x02002404,
+    0x00200404, 0x02200404, 0x00202404, 0x02202404,
+    0x10000000, 0x12000000, 0x10002000, 0x12002000,
+    0x10200000, 0x12200000, 0x10202000, 0x12202000,
+    0x10000004, 0x12000004, 0x10002004, 0x12002004,
+    0x10200004, 0x12200004, 0x10202004, 0x12202004,
+    0x10000400, 0x12000400, 0x10002400, 0x12002400,
+    0x10200400, 0x12200400, 0x10202400, 0x12202400,
+    0x10000404, 0x12000404, 0x10002404, 0x12002404,
+    0x10200404, 0x12200404, 0x10202404, 0x12202404,
+  },
+  {
+    0x00000000, 0x00000001, 0x00040000, 0x00040001,
+    0x01000000, 0x01000001, 0x01040000, 0x01040001,
+    0x00000002, 0x00000003, 0x00040002, 0x00040003,
+    0x01000002, 0x01000003, 0x01040002, 0x01040003,
+    0x00000200, 0x00000201, 0x00040200, 0x00040201,
+    0x01000200, 0x01000201, 0x01040200, 0x01040201,
+    0x00000202, 0x00000203, 0x00040202, 0x00040203,
+    0x01000202, 0x01000203, 0x01040202, 0x01040203,
+    0x08000000, 0x08000001, 0x08040000, 0x08040001,
+    0x09000000, 0x09000001, 0x09040000, 0x09040001,
+    0x08000002, 0x08000003, 0x08040002, 0x08040003,
+    0x09000002, 0x09000003, 0x09040002, 0x09040003,
+    0x08000200, 0x08000201, 0x08040200, 0x08040201,
+    0x09000200, 0x09000201, 0x09040200, 0x09040201,
+    0x08000202, 0x08000203, 0x08040202, 0x08040203,
+    0x09000202, 0x09000203, 0x09040202, 0x09040203,
+  },
+  {
+    0x00000000, 0x00100000, 0x00000100, 0x00100100,
+    0x00000008, 0x00100008, 0x00000108, 0x00100108,
+    0x00001000, 0x00101000, 0x00001100, 0x00101100,
+    0x00001008, 0x00101008, 0x00001108, 0x00101108,
+    0x04000000, 0x04100000, 0x04000100, 0x04100100,
+    0x04000008, 0x04100008, 0x04000108, 0x04100108,
+    0x04001000, 0x04101000, 0x04001100, 0x04101100,
+    0x04001008, 0x04101008, 0x04001108, 0x04101108,
+    0x00020000, 0x00120000, 0x00020100, 0x00120100,
+    0x00020008, 0x00120008, 0x00020108, 0x00120108,
+    0x00021000, 0x00121000, 0x00021100, 0x00121100,
+    0x00021008, 0x00121008, 0x00021108, 0x00121108,
+    0x04020000, 0x04120000, 0x04020100, 0x04120100,
+    0x04020008, 0x04120008, 0x04020108, 0x04120108,
+    0x04021000, 0x04121000, 0x04021100, 0x04121100,
+    0x04021008, 0x04121008, 0x04021108, 0x04121108,
+  },
+  {
+    0x00000000, 0x10000000, 0x00010000, 0x10010000,
+    0x00000004, 0x10000004, 0x00010004, 0x10010004,
+    0x20000000, 0x30000000, 0x20010000, 0x30010000,
+    0x20000004, 0x30000004, 0x20010004, 0x30010004,
+    0x00100000, 0x10100000, 0x00110000, 0x10110000,
+    0x00100004, 0x10100004, 0x00110004, 0x10110004,
+    0x20100000, 0x30100000, 0x20110000, 0x30110000,
+    0x20100004, 0x30100004, 0x20110004, 0x30110004,
+    0x00001000, 0x10001000, 0x00011000, 0x10011000,
+    0x00001004, 0x10001004, 0x00011004, 0x10011004,
+    0x20001000, 0x30001000, 0x20011000, 0x30011000,
+    0x20001004, 0x30001004, 0x20011004, 0x30011004,
+    0x00101000, 0x10101000, 0x00111000, 0x10111000,
+    0x00101004, 0x10101004, 0x00111004, 0x10111004,
+    0x20101000, 0x30101000, 0x20111000, 0x30111000,
+    0x20101004, 0x30101004, 0x20111004, 0x30111004,
+  },
+  {
+    0x00000000, 0x08000000, 0x00000008, 0x08000008,
+    0x00000400, 0x08000400, 0x00000408, 0x08000408,
+    0x00020000, 0x08020000, 0x00020008, 0x08020008,
+    0x00020400, 0x08020400, 0x00020408, 0x08020408,
+    0x00000001, 0x08000001, 0x00000009, 0x08000009,
+    0x00000401, 0x08000401, 0x00000409, 0x08000409,
+    0x00020001, 0x08020001, 0x00020009, 0x08020009,
+    0x00020401, 0x08020401, 0x00020409, 0x08020409,
+    0x02000000, 0x0A000000, 0x02000008, 0x0A000008,
+    0x02000400, 0x0A000400, 0x02000408, 0x0A000408,
+    0x02020000, 0x0A020000, 0x02020008, 0x0A020008,
+    0x02020400, 0x0A020400, 0x02020408, 0x0A020408,
+    0x02000001, 0x0A000001, 0x02000009, 0x0A000009,
+    0x02000401, 0x0A000401, 0x02000409, 0x0A000409,
+    0x02020001, 0x0A020001, 0x02020009, 0x0A020009,
+    0x02020401, 0x0A020401, 0x02020409, 0x0A020409,
+  },
+  {
+    0x00000000, 0x00000100, 0x00080000, 0x00080100,
+    0x01000000, 0x01000100, 0x01080000, 0x01080100,
+    0x00000010, 0x00000110, 0x00080010, 0x00080110,
+    0x01000010, 0x01000110, 0x01080010, 0x01080110,
+    0x00200000, 0x00200100, 0x00280000, 0x00280100,
+    0x01200000, 0x01200100, 0x01280000, 0x01280100,
+    0x00200010, 0x00200110, 0x00280010, 0x00280110,
+    0x01200010, 0x01200110, 0x01280010, 0x01280110,
+    0x00000200, 0x00000300, 0x00080200, 0x00080300,
+    0x01000200, 0x01000300, 0x01080200, 0x01080300,
+    0x00000210, 0x00000310, 0x00080210, 0x00080310,
+    0x01000210, 0x01000310, 0x01080210, 0x01080310,
+    0x00200200, 0x00200300, 0x00280200, 0x00280300,
+    0x01200200, 0x01200300, 0x01280200, 0x01280300,
+    0x00200210, 0x00200310, 0x00280210, 0x00280310,
+    0x01200210, 0x01200310, 0x01280210, 0x01280310,
+  },
+  {
+    0x00000000, 0x04000000, 0x00040000, 0x04040000,
+    0x00000002, 0x04000002, 0x00040002, 0x04040002,
+    0x00002000, 0x04002000, 0x00042000, 0x04042000,
+    0x00002002, 0x04002002, 0x00042002, 0x04042002,
+    0x00000020, 0x04000020, 0x00040020, 0x04040020,
+    0x00000022, 0x04000022, 0x00040022, 0x04040022,
+    0x00002020, 0x04002020, 0x00042020, 0x04042020,
+    0x00002022, 0x04002022, 0x00042022, 0x04042022,
+    0x00000800, 0x04000800, 0x00040800, 0x04040800,
+    0x00000802, 0x04000802, 0x00040802, 0x04040802,
+    0x00002800, 0x04002800, 0x00042800, 0x04042800,
+    0x00002802, 0x04002802, 0x00042802, 0x04042802,
+    0x00000820, 0x04000820, 0x00040820, 0x04040820,
+    0x00000822, 0x04000822, 0x00040822, 0x04040822,
+    0x00002820, 0x04002820, 0x00042820, 0x04042820,
+    0x00002822, 0x04002822, 0x00042822, 0x04042822
+  }
+};
+
+#if   VECT_SIZE == 1
+#define BOX(i,n,S) (S)[(n)][(i)]
+#elif VECT_SIZE == 2
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1])
+#elif VECT_SIZE == 4
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3])
+#elif VECT_SIZE == 8
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
+#elif VECT_SIZE == 16
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7], (S)[(n)][(i).s8], (S)[(n)][(i).s9], (S)[(n)][(i).sa], (S)[(n)][(i).sb], (S)[(n)][(i).sc], (S)[(n)][(i).sd], (S)[(n)][(i).se], (S)[(n)][(i).sf])
+#endif
+
+#if   VECT_SIZE == 1
+#define BOX1(i,S) (S)[(i)]
+#elif VECT_SIZE == 2
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1])
+#elif VECT_SIZE == 4
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3])
+#elif VECT_SIZE == 8
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7])
+#elif VECT_SIZE == 16
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7], (S)[(i).s8], (S)[(i).s9], (S)[(i).sa], (S)[(i).sb], (S)[(i).sc], (S)[(i).sd], (S)[(i).se], (S)[(i).sf])
+#endif
+
+void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  u32x tt;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i += 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i + 0] ^ r;
+    t = Kd[i + 0] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i + 1] ^ l;
+    t = Kd[i + 1] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+
+}
+
+void _des_crypt_decrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  u32x tt;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 16; i > 0; i -= 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i - 1] ^ r;
+    t = Kd[i - 1] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i - 2] ^ l;
+    t = Kd[i - 2] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+
+}
+
+void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 (*s_skb)[64])
+{
+  u32x tt;
+
+  PERM_OP  (d, c, tt, 4, 0x0f0f0f0f);
+  HPERM_OP (c,    tt, 2, 0xcccc0000);
+  HPERM_OP (d,    tt, 2, 0xcccc0000);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+  PERM_OP  (c, d, tt, 8, 0x00ff00ff);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+
+  d = ((d & 0x000000ff) << 16)
+    | ((d & 0x0000ff00) <<  0)
+    | ((d & 0x00ff0000) >> 16)
+    | ((c & 0xf0000000) >>  4);
+
+  c = c & 0x0fffffff;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i++)
+  {
+    if ((i < 2) || (i == 8) || (i == 15))
+    {
+      c = ((c >> 1) | (c << 27));
+      d = ((d >> 1) | (d << 27));
+    }
+    else
+    {
+      c = ((c >> 2) | (c << 26));
+      d = ((d >> 2) | (d << 26));
+    }
+
+    c = c & 0x0fffffff;
+    d = d & 0x0fffffff;
+
+    const u32x c00 = (c >>  0) & 0x0000003f;
+    const u32x c06 = (c >>  6) & 0x00383003;
+    const u32x c07 = (c >>  7) & 0x0000003c;
+    const u32x c13 = (c >> 13) & 0x0000060f;
+    const u32x c20 = (c >> 20) & 0x00000001;
+
+    u32x s = BOX (((c00 >>  0) & 0xff), 0, s_skb)
+           | BOX (((c06 >>  0) & 0xff)
+                 |((c07 >>  0) & 0xff), 1, s_skb)
+           | BOX (((c13 >>  0) & 0xff)
+                 |((c06 >>  8) & 0xff), 2, s_skb)
+           | BOX (((c20 >>  0) & 0xff)
+                 |((c13 >>  8) & 0xff)
+                 |((c06 >> 16) & 0xff), 3, s_skb);
+
+    const u32x d00 = (d >>  0) & 0x00003c3f;
+    const u32x d07 = (d >>  7) & 0x00003f03;
+    const u32x d21 = (d >> 21) & 0x0000000f;
+    const u32x d22 = (d >> 22) & 0x00000030;
+
+    u32x t = BOX (((d00 >>  0) & 0xff), 4, s_skb)
+           | BOX (((d07 >>  0) & 0xff)
+                 |((d00 >>  8) & 0xff), 5, s_skb)
+           | BOX (((d07 >>  8) & 0xff), 6, s_skb)
+           | BOX (((d21 >>  0) & 0xff)
+                 |((d22 >>  0) & 0xff), 7, s_skb);
+
+    Kc[i] = ((t << 16) | (s & 0x0000ffff));
+    Kd[i] = ((s >> 16) | (t & 0xffff0000));
+
+    Kc[i] = rotl32 (Kc[i], 2u);
+    Kd[i] = rotl32 (Kd[i], 2u);
+  }
+}
+
+__kernel void m01530_m04 (__global pw_t *pws, __global kernel_rule_t *  rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = pws[gid].i[ 2];
+  pw_buf0[3] = pws[gid].i[ 3];
+  pw_buf1[0] = pws[gid].i[ 4];
+  pw_buf1[1] = pws[gid].i[ 5];
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * main
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    apply_rules_vect (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    /* First Pass */
+
+    const u32x a = (w0[0]);
+    const u32x b = (w0[1]);
+
+    u32x Ka[16];
+    u32x Kb[16];
+
+    _des_crypt_keysetup (a, b, Ka, Kb, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x p1[2];
+
+    _des_crypt_encrypt (p1, data, Ka, Kb, s_SPtrans);
+
+    /* Second Pass */
+
+    const u32x c = (w0[2]);
+    const u32x d = (w0[3]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x p2[2];
+
+    _des_crypt_decrypt (p2, p1, Kc, Kd, s_SPtrans);
+
+    /* Third Pass */
+
+    const u32x e = (w1[0]);
+    const u32x f = (w1[1]);
+
+    u32x Ke[16];
+    u32x Kf[16];
+
+    _des_crypt_keysetup (e, f, Ke, Kf, s_skb);
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, p2, Ke, Kf, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01530_m08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01530_m16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01530_s04 (__global pw_t *pws, __global kernel_rule_t *  rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = pws[gid].i[ 2];
+  pw_buf0[3] = pws[gid].i[ 3];
+  pw_buf1[0] = pws[gid].i[ 4];
+  pw_buf1[1] = pws[gid].i[ 5];
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[digests_offset].digest_buf[DGST_R0],
+    digests_buf[digests_offset].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * main
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    apply_rules_vect (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    /* First Pass */
+
+    const u32x a = (w0[0]);
+    const u32x b = (w0[1]);
+
+    u32x Ka[16];
+    u32x Kb[16];
+
+    _des_crypt_keysetup (a, b, Ka, Kb, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x p1[2];
+
+    _des_crypt_encrypt (p1, data, Ka, Kb, s_SPtrans);
+
+    /* Second Pass */
+
+    const u32x c = (w0[2]);
+    const u32x d = (w0[3]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x p2[2];
+
+    _des_crypt_decrypt (p2, p1, Kc, Kd, s_SPtrans);
+
+    /* Third Pass */
+
+    const u32x e = (w1[0]);
+    const u32x f = (w1[1]);
+
+    u32x Ke[16];
+    u32x Kf[16];
+
+    _des_crypt_keysetup (e, f, Ke, Kf, s_skb);
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, p2, Ke, Kf, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01530_s08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01530_s16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}

--- a/OpenCL/m01530_a1.cl
+++ b/OpenCL/m01530_a1.cl
@@ -1,0 +1,931 @@
+/**
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *               Frans Lategan <frans.lategan+hashcat@gmail.com>
+ *
+ * License.....: MIT
+ */
+
+#define _DES_
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+
+#define PERM_OP(a,b,tt,n,m) \
+{                           \
+  tt = a >> n;              \
+  tt = tt ^ b;              \
+  tt = tt & m;              \
+  b = b ^ tt;               \
+  tt = tt << n;             \
+  a = a ^ tt;               \
+}
+
+#define HPERM_OP(a,tt,n,m)  \
+{                           \
+  tt = a << (16 + n);       \
+  tt = tt ^ a;              \
+  tt = tt & m;              \
+  a  = a ^ tt;              \
+  tt = tt >> (16 + n);      \
+  a  = a ^ tt;              \
+}
+
+#define IP(l,r,tt)                     \
+{                                      \
+  PERM_OP (r, l, tt,  4, 0x0f0f0f0f);  \
+  PERM_OP (l, r, tt, 16, 0x0000ffff);  \
+  PERM_OP (r, l, tt,  2, 0x33333333);  \
+  PERM_OP (l, r, tt,  8, 0x00ff00ff);  \
+  PERM_OP (r, l, tt,  1, 0x55555555);  \
+}
+
+#define FP(l,r,tt)                     \
+{                                      \
+  PERM_OP (l, r, tt,  1, 0x55555555);  \
+  PERM_OP (r, l, tt,  8, 0x00ff00ff);  \
+  PERM_OP (l, r, tt,  2, 0x33333333);  \
+  PERM_OP (r, l, tt, 16, 0x0000ffff);  \
+  PERM_OP (l, r, tt,  4, 0x0f0f0f0f);  \
+}
+
+__constant u32 c_SPtrans[8][64] =
+{
+  {
+    0x02080800, 0x00080000, 0x02000002, 0x02080802,
+    0x02000000, 0x00080802, 0x00080002, 0x02000002,
+    0x00080802, 0x02080800, 0x02080000, 0x00000802,
+    0x02000802, 0x02000000, 0x00000000, 0x00080002,
+    0x00080000, 0x00000002, 0x02000800, 0x00080800,
+    0x02080802, 0x02080000, 0x00000802, 0x02000800,
+    0x00000002, 0x00000800, 0x00080800, 0x02080002,
+    0x00000800, 0x02000802, 0x02080002, 0x00000000,
+    0x00000000, 0x02080802, 0x02000800, 0x00080002,
+    0x02080800, 0x00080000, 0x00000802, 0x02000800,
+    0x02080002, 0x00000800, 0x00080800, 0x02000002,
+    0x00080802, 0x00000002, 0x02000002, 0x02080000,
+    0x02080802, 0x00080800, 0x02080000, 0x02000802,
+    0x02000000, 0x00000802, 0x00080002, 0x00000000,
+    0x00080000, 0x02000000, 0x02000802, 0x02080800,
+    0x00000002, 0x02080002, 0x00000800, 0x00080802,
+  },
+  {
+    0x40108010, 0x00000000, 0x00108000, 0x40100000,
+    0x40000010, 0x00008010, 0x40008000, 0x00108000,
+    0x00008000, 0x40100010, 0x00000010, 0x40008000,
+    0x00100010, 0x40108000, 0x40100000, 0x00000010,
+    0x00100000, 0x40008010, 0x40100010, 0x00008000,
+    0x00108010, 0x40000000, 0x00000000, 0x00100010,
+    0x40008010, 0x00108010, 0x40108000, 0x40000010,
+    0x40000000, 0x00100000, 0x00008010, 0x40108010,
+    0x00100010, 0x40108000, 0x40008000, 0x00108010,
+    0x40108010, 0x00100010, 0x40000010, 0x00000000,
+    0x40000000, 0x00008010, 0x00100000, 0x40100010,
+    0x00008000, 0x40000000, 0x00108010, 0x40008010,
+    0x40108000, 0x00008000, 0x00000000, 0x40000010,
+    0x00000010, 0x40108010, 0x00108000, 0x40100000,
+    0x40100010, 0x00100000, 0x00008010, 0x40008000,
+    0x40008010, 0x00000010, 0x40100000, 0x00108000,
+  },
+  {
+    0x04000001, 0x04040100, 0x00000100, 0x04000101,
+    0x00040001, 0x04000000, 0x04000101, 0x00040100,
+    0x04000100, 0x00040000, 0x04040000, 0x00000001,
+    0x04040101, 0x00000101, 0x00000001, 0x04040001,
+    0x00000000, 0x00040001, 0x04040100, 0x00000100,
+    0x00000101, 0x04040101, 0x00040000, 0x04000001,
+    0x04040001, 0x04000100, 0x00040101, 0x04040000,
+    0x00040100, 0x00000000, 0x04000000, 0x00040101,
+    0x04040100, 0x00000100, 0x00000001, 0x00040000,
+    0x00000101, 0x00040001, 0x04040000, 0x04000101,
+    0x00000000, 0x04040100, 0x00040100, 0x04040001,
+    0x00040001, 0x04000000, 0x04040101, 0x00000001,
+    0x00040101, 0x04000001, 0x04000000, 0x04040101,
+    0x00040000, 0x04000100, 0x04000101, 0x00040100,
+    0x04000100, 0x00000000, 0x04040001, 0x00000101,
+    0x04000001, 0x00040101, 0x00000100, 0x04040000,
+  },
+  {
+    0x00401008, 0x10001000, 0x00000008, 0x10401008,
+    0x00000000, 0x10400000, 0x10001008, 0x00400008,
+    0x10401000, 0x10000008, 0x10000000, 0x00001008,
+    0x10000008, 0x00401008, 0x00400000, 0x10000000,
+    0x10400008, 0x00401000, 0x00001000, 0x00000008,
+    0x00401000, 0x10001008, 0x10400000, 0x00001000,
+    0x00001008, 0x00000000, 0x00400008, 0x10401000,
+    0x10001000, 0x10400008, 0x10401008, 0x00400000,
+    0x10400008, 0x00001008, 0x00400000, 0x10000008,
+    0x00401000, 0x10001000, 0x00000008, 0x10400000,
+    0x10001008, 0x00000000, 0x00001000, 0x00400008,
+    0x00000000, 0x10400008, 0x10401000, 0x00001000,
+    0x10000000, 0x10401008, 0x00401008, 0x00400000,
+    0x10401008, 0x00000008, 0x10001000, 0x00401008,
+    0x00400008, 0x00401000, 0x10400000, 0x10001008,
+    0x00001008, 0x10000000, 0x10000008, 0x10401000,
+  },
+  {
+    0x08000000, 0x00010000, 0x00000400, 0x08010420,
+    0x08010020, 0x08000400, 0x00010420, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x00010400,
+    0x08000420, 0x08010020, 0x08010400, 0x00000000,
+    0x00010400, 0x08000000, 0x00010020, 0x00000420,
+    0x08000400, 0x00010420, 0x00000000, 0x08000020,
+    0x00000020, 0x08000420, 0x08010420, 0x00010020,
+    0x08010000, 0x00000400, 0x00000420, 0x08010400,
+    0x08010400, 0x08000420, 0x00010020, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x08000400,
+    0x08000000, 0x00010400, 0x08010420, 0x00000000,
+    0x00010420, 0x08000000, 0x00000400, 0x00010020,
+    0x08000420, 0x00000400, 0x00000000, 0x08010420,
+    0x08010020, 0x08010400, 0x00000420, 0x00010000,
+    0x00010400, 0x08010020, 0x08000400, 0x00000420,
+    0x00000020, 0x00010420, 0x08010000, 0x08000020,
+  },
+  {
+    0x80000040, 0x00200040, 0x00000000, 0x80202000,
+    0x00200040, 0x00002000, 0x80002040, 0x00200000,
+    0x00002040, 0x80202040, 0x00202000, 0x80000000,
+    0x80002000, 0x80000040, 0x80200000, 0x00202040,
+    0x00200000, 0x80002040, 0x80200040, 0x00000000,
+    0x00002000, 0x00000040, 0x80202000, 0x80200040,
+    0x80202040, 0x80200000, 0x80000000, 0x00002040,
+    0x00000040, 0x00202000, 0x00202040, 0x80002000,
+    0x00002040, 0x80000000, 0x80002000, 0x00202040,
+    0x80202000, 0x00200040, 0x00000000, 0x80002000,
+    0x80000000, 0x00002000, 0x80200040, 0x00200000,
+    0x00200040, 0x80202040, 0x00202000, 0x00000040,
+    0x80202040, 0x00202000, 0x00200000, 0x80002040,
+    0x80000040, 0x80200000, 0x00202040, 0x00000000,
+    0x00002000, 0x80000040, 0x80002040, 0x80202000,
+    0x80200000, 0x00002040, 0x00000040, 0x80200040,
+  },
+  {
+    0x00004000, 0x00000200, 0x01000200, 0x01000004,
+    0x01004204, 0x00004004, 0x00004200, 0x00000000,
+    0x01000000, 0x01000204, 0x00000204, 0x01004000,
+    0x00000004, 0x01004200, 0x01004000, 0x00000204,
+    0x01000204, 0x00004000, 0x00004004, 0x01004204,
+    0x00000000, 0x01000200, 0x01000004, 0x00004200,
+    0x01004004, 0x00004204, 0x01004200, 0x00000004,
+    0x00004204, 0x01004004, 0x00000200, 0x01000000,
+    0x00004204, 0x01004000, 0x01004004, 0x00000204,
+    0x00004000, 0x00000200, 0x01000000, 0x01004004,
+    0x01000204, 0x00004204, 0x00004200, 0x00000000,
+    0x00000200, 0x01000004, 0x00000004, 0x01000200,
+    0x00000000, 0x01000204, 0x01000200, 0x00004200,
+    0x00000204, 0x00004000, 0x01004204, 0x01000000,
+    0x01004200, 0x00000004, 0x00004004, 0x01004204,
+    0x01000004, 0x01004200, 0x01004000, 0x00004004,
+  },
+  {
+    0x20800080, 0x20820000, 0x00020080, 0x00000000,
+    0x20020000, 0x00800080, 0x20800000, 0x20820080,
+    0x00000080, 0x20000000, 0x00820000, 0x00020080,
+    0x00820080, 0x20020080, 0x20000080, 0x20800000,
+    0x00020000, 0x00820080, 0x00800080, 0x20020000,
+    0x20820080, 0x20000080, 0x00000000, 0x00820000,
+    0x20000000, 0x00800000, 0x20020080, 0x20800080,
+    0x00800000, 0x00020000, 0x20820000, 0x00000080,
+    0x00800000, 0x00020000, 0x20000080, 0x20820080,
+    0x00020080, 0x20000000, 0x00000000, 0x00820000,
+    0x20800080, 0x20020080, 0x20020000, 0x00800080,
+    0x20820000, 0x00000080, 0x00800080, 0x20020000,
+    0x20820080, 0x00800000, 0x20800000, 0x20000080,
+    0x00820000, 0x00020080, 0x20020080, 0x20800000,
+    0x00000080, 0x20820000, 0x00820080, 0x00000000,
+    0x20000000, 0x20800080, 0x00020000, 0x00820080,
+  }
+};
+
+__constant u32 c_skb[8][64] =
+{
+  {
+    0x00000000, 0x00000010, 0x20000000, 0x20000010,
+    0x00010000, 0x00010010, 0x20010000, 0x20010010,
+    0x00000800, 0x00000810, 0x20000800, 0x20000810,
+    0x00010800, 0x00010810, 0x20010800, 0x20010810,
+    0x00000020, 0x00000030, 0x20000020, 0x20000030,
+    0x00010020, 0x00010030, 0x20010020, 0x20010030,
+    0x00000820, 0x00000830, 0x20000820, 0x20000830,
+    0x00010820, 0x00010830, 0x20010820, 0x20010830,
+    0x00080000, 0x00080010, 0x20080000, 0x20080010,
+    0x00090000, 0x00090010, 0x20090000, 0x20090010,
+    0x00080800, 0x00080810, 0x20080800, 0x20080810,
+    0x00090800, 0x00090810, 0x20090800, 0x20090810,
+    0x00080020, 0x00080030, 0x20080020, 0x20080030,
+    0x00090020, 0x00090030, 0x20090020, 0x20090030,
+    0x00080820, 0x00080830, 0x20080820, 0x20080830,
+    0x00090820, 0x00090830, 0x20090820, 0x20090830,
+  },
+  {
+    0x00000000, 0x02000000, 0x00002000, 0x02002000,
+    0x00200000, 0x02200000, 0x00202000, 0x02202000,
+    0x00000004, 0x02000004, 0x00002004, 0x02002004,
+    0x00200004, 0x02200004, 0x00202004, 0x02202004,
+    0x00000400, 0x02000400, 0x00002400, 0x02002400,
+    0x00200400, 0x02200400, 0x00202400, 0x02202400,
+    0x00000404, 0x02000404, 0x00002404, 0x02002404,
+    0x00200404, 0x02200404, 0x00202404, 0x02202404,
+    0x10000000, 0x12000000, 0x10002000, 0x12002000,
+    0x10200000, 0x12200000, 0x10202000, 0x12202000,
+    0x10000004, 0x12000004, 0x10002004, 0x12002004,
+    0x10200004, 0x12200004, 0x10202004, 0x12202004,
+    0x10000400, 0x12000400, 0x10002400, 0x12002400,
+    0x10200400, 0x12200400, 0x10202400, 0x12202400,
+    0x10000404, 0x12000404, 0x10002404, 0x12002404,
+    0x10200404, 0x12200404, 0x10202404, 0x12202404,
+  },
+  {
+    0x00000000, 0x00000001, 0x00040000, 0x00040001,
+    0x01000000, 0x01000001, 0x01040000, 0x01040001,
+    0x00000002, 0x00000003, 0x00040002, 0x00040003,
+    0x01000002, 0x01000003, 0x01040002, 0x01040003,
+    0x00000200, 0x00000201, 0x00040200, 0x00040201,
+    0x01000200, 0x01000201, 0x01040200, 0x01040201,
+    0x00000202, 0x00000203, 0x00040202, 0x00040203,
+    0x01000202, 0x01000203, 0x01040202, 0x01040203,
+    0x08000000, 0x08000001, 0x08040000, 0x08040001,
+    0x09000000, 0x09000001, 0x09040000, 0x09040001,
+    0x08000002, 0x08000003, 0x08040002, 0x08040003,
+    0x09000002, 0x09000003, 0x09040002, 0x09040003,
+    0x08000200, 0x08000201, 0x08040200, 0x08040201,
+    0x09000200, 0x09000201, 0x09040200, 0x09040201,
+    0x08000202, 0x08000203, 0x08040202, 0x08040203,
+    0x09000202, 0x09000203, 0x09040202, 0x09040203,
+  },
+  {
+    0x00000000, 0x00100000, 0x00000100, 0x00100100,
+    0x00000008, 0x00100008, 0x00000108, 0x00100108,
+    0x00001000, 0x00101000, 0x00001100, 0x00101100,
+    0x00001008, 0x00101008, 0x00001108, 0x00101108,
+    0x04000000, 0x04100000, 0x04000100, 0x04100100,
+    0x04000008, 0x04100008, 0x04000108, 0x04100108,
+    0x04001000, 0x04101000, 0x04001100, 0x04101100,
+    0x04001008, 0x04101008, 0x04001108, 0x04101108,
+    0x00020000, 0x00120000, 0x00020100, 0x00120100,
+    0x00020008, 0x00120008, 0x00020108, 0x00120108,
+    0x00021000, 0x00121000, 0x00021100, 0x00121100,
+    0x00021008, 0x00121008, 0x00021108, 0x00121108,
+    0x04020000, 0x04120000, 0x04020100, 0x04120100,
+    0x04020008, 0x04120008, 0x04020108, 0x04120108,
+    0x04021000, 0x04121000, 0x04021100, 0x04121100,
+    0x04021008, 0x04121008, 0x04021108, 0x04121108,
+  },
+  {
+    0x00000000, 0x10000000, 0x00010000, 0x10010000,
+    0x00000004, 0x10000004, 0x00010004, 0x10010004,
+    0x20000000, 0x30000000, 0x20010000, 0x30010000,
+    0x20000004, 0x30000004, 0x20010004, 0x30010004,
+    0x00100000, 0x10100000, 0x00110000, 0x10110000,
+    0x00100004, 0x10100004, 0x00110004, 0x10110004,
+    0x20100000, 0x30100000, 0x20110000, 0x30110000,
+    0x20100004, 0x30100004, 0x20110004, 0x30110004,
+    0x00001000, 0x10001000, 0x00011000, 0x10011000,
+    0x00001004, 0x10001004, 0x00011004, 0x10011004,
+    0x20001000, 0x30001000, 0x20011000, 0x30011000,
+    0x20001004, 0x30001004, 0x20011004, 0x30011004,
+    0x00101000, 0x10101000, 0x00111000, 0x10111000,
+    0x00101004, 0x10101004, 0x00111004, 0x10111004,
+    0x20101000, 0x30101000, 0x20111000, 0x30111000,
+    0x20101004, 0x30101004, 0x20111004, 0x30111004,
+  },
+  {
+    0x00000000, 0x08000000, 0x00000008, 0x08000008,
+    0x00000400, 0x08000400, 0x00000408, 0x08000408,
+    0x00020000, 0x08020000, 0x00020008, 0x08020008,
+    0x00020400, 0x08020400, 0x00020408, 0x08020408,
+    0x00000001, 0x08000001, 0x00000009, 0x08000009,
+    0x00000401, 0x08000401, 0x00000409, 0x08000409,
+    0x00020001, 0x08020001, 0x00020009, 0x08020009,
+    0x00020401, 0x08020401, 0x00020409, 0x08020409,
+    0x02000000, 0x0A000000, 0x02000008, 0x0A000008,
+    0x02000400, 0x0A000400, 0x02000408, 0x0A000408,
+    0x02020000, 0x0A020000, 0x02020008, 0x0A020008,
+    0x02020400, 0x0A020400, 0x02020408, 0x0A020408,
+    0x02000001, 0x0A000001, 0x02000009, 0x0A000009,
+    0x02000401, 0x0A000401, 0x02000409, 0x0A000409,
+    0x02020001, 0x0A020001, 0x02020009, 0x0A020009,
+    0x02020401, 0x0A020401, 0x02020409, 0x0A020409,
+  },
+  {
+    0x00000000, 0x00000100, 0x00080000, 0x00080100,
+    0x01000000, 0x01000100, 0x01080000, 0x01080100,
+    0x00000010, 0x00000110, 0x00080010, 0x00080110,
+    0x01000010, 0x01000110, 0x01080010, 0x01080110,
+    0x00200000, 0x00200100, 0x00280000, 0x00280100,
+    0x01200000, 0x01200100, 0x01280000, 0x01280100,
+    0x00200010, 0x00200110, 0x00280010, 0x00280110,
+    0x01200010, 0x01200110, 0x01280010, 0x01280110,
+    0x00000200, 0x00000300, 0x00080200, 0x00080300,
+    0x01000200, 0x01000300, 0x01080200, 0x01080300,
+    0x00000210, 0x00000310, 0x00080210, 0x00080310,
+    0x01000210, 0x01000310, 0x01080210, 0x01080310,
+    0x00200200, 0x00200300, 0x00280200, 0x00280300,
+    0x01200200, 0x01200300, 0x01280200, 0x01280300,
+    0x00200210, 0x00200310, 0x00280210, 0x00280310,
+    0x01200210, 0x01200310, 0x01280210, 0x01280310,
+  },
+  {
+    0x00000000, 0x04000000, 0x00040000, 0x04040000,
+    0x00000002, 0x04000002, 0x00040002, 0x04040002,
+    0x00002000, 0x04002000, 0x00042000, 0x04042000,
+    0x00002002, 0x04002002, 0x00042002, 0x04042002,
+    0x00000020, 0x04000020, 0x00040020, 0x04040020,
+    0x00000022, 0x04000022, 0x00040022, 0x04040022,
+    0x00002020, 0x04002020, 0x00042020, 0x04042020,
+    0x00002022, 0x04002022, 0x00042022, 0x04042022,
+    0x00000800, 0x04000800, 0x00040800, 0x04040800,
+    0x00000802, 0x04000802, 0x00040802, 0x04040802,
+    0x00002800, 0x04002800, 0x00042800, 0x04042800,
+    0x00002802, 0x04002802, 0x00042802, 0x04042802,
+    0x00000820, 0x04000820, 0x00040820, 0x04040820,
+    0x00000822, 0x04000822, 0x00040822, 0x04040822,
+    0x00002820, 0x04002820, 0x00042820, 0x04042820,
+    0x00002822, 0x04002822, 0x00042822, 0x04042822
+  }
+};
+
+#if   VECT_SIZE == 1
+#define BOX(i,n,S) (S)[(n)][(i)]
+#elif VECT_SIZE == 2
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1])
+#elif VECT_SIZE == 4
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3])
+#elif VECT_SIZE == 8
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
+#elif VECT_SIZE == 16
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7], (S)[(n)][(i).s8], (S)[(n)][(i).s9], (S)[(n)][(i).sa], (S)[(n)][(i).sb], (S)[(n)][(i).sc], (S)[(n)][(i).sd], (S)[(n)][(i).se], (S)[(n)][(i).sf])
+#endif
+
+#if   VECT_SIZE == 1
+#define BOX1(i,S) (S)[(i)]
+#elif VECT_SIZE == 2
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1])
+#elif VECT_SIZE == 4
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3])
+#elif VECT_SIZE == 8
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7])
+#elif VECT_SIZE == 16
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7], (S)[(i).s8], (S)[(i).s9], (S)[(i).sa], (S)[(i).sb], (S)[(i).sc], (S)[(i).sd], (S)[(i).se], (S)[(i).sf])
+#endif
+
+void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i += 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i + 0] ^ r;
+    t = Kd[i + 0] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i + 1] ^ l;
+    t = Kd[i + 1] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+}
+
+void _des_crypt_decrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  u32x tt;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 16; i > 0; i -= 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i - 1] ^ r;
+    t = Kd[i - 1] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i - 2] ^ l;
+    t = Kd[i - 2] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+
+}
+
+void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 (*s_skb)[64])
+{
+  u32x tt;
+
+  PERM_OP  (d, c, tt, 4, 0x0f0f0f0f);
+  HPERM_OP (c,    tt, 2, 0xcccc0000);
+  HPERM_OP (d,    tt, 2, 0xcccc0000);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+  PERM_OP  (c, d, tt, 8, 0x00ff00ff);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+
+  d = ((d & 0x000000ff) << 16)
+    | ((d & 0x0000ff00) <<  0)
+    | ((d & 0x00ff0000) >> 16)
+    | ((c & 0xf0000000) >>  4);
+
+  c = c & 0x0fffffff;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i++)
+  {
+    if ((i < 2) || (i == 8) || (i == 15))
+    {
+      c = ((c >> 1) | (c << 27));
+      d = ((d >> 1) | (d << 27));
+    }
+    else
+    {
+      c = ((c >> 2) | (c << 26));
+      d = ((d >> 2) | (d << 26));
+    }
+
+    c = c & 0x0fffffff;
+    d = d & 0x0fffffff;
+
+    const u32x c00 = (c >>  0) & 0x0000003f;
+    const u32x c06 = (c >>  6) & 0x00383003;
+    const u32x c07 = (c >>  7) & 0x0000003c;
+    const u32x c13 = (c >> 13) & 0x0000060f;
+    const u32x c20 = (c >> 20) & 0x00000001;
+
+    u32x s = BOX (((c00 >>  0) & 0xff), 0, s_skb)
+           | BOX (((c06 >>  0) & 0xff)
+                 |((c07 >>  0) & 0xff), 1, s_skb)
+           | BOX (((c13 >>  0) & 0xff)
+                 |((c06 >>  8) & 0xff), 2, s_skb)
+           | BOX (((c20 >>  0) & 0xff)
+                 |((c13 >>  8) & 0xff)
+                 |((c06 >> 16) & 0xff), 3, s_skb);
+
+    const u32x d00 = (d >>  0) & 0x00003c3f;
+    const u32x d07 = (d >>  7) & 0x00003f03;
+    const u32x d21 = (d >> 21) & 0x0000000f;
+    const u32x d22 = (d >> 22) & 0x00000030;
+
+    u32x t = BOX (((d00 >>  0) & 0xff), 4, s_skb)
+           | BOX (((d07 >>  0) & 0xff)
+                 |((d00 >>  8) & 0xff), 5, s_skb)
+           | BOX (((d07 >>  8) & 0xff), 6, s_skb)
+           | BOX (((d21 >>  0) & 0xff)
+                 |((d22 >>  0) & 0xff), 7, s_skb);
+
+    Kc[i] = ((t << 16) | (s & 0x0000ffff));
+    Kd[i] = ((s >> 16) | (t & 0xffff0000));
+
+    Kc[i] = rotl32 (Kc[i], 2u);
+    Kd[i] = rotl32 (Kd[i], 2u);
+  }
+}
+
+__kernel void m01530_m04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = pws[gid].i[ 2];
+  pw_buf0[3] = pws[gid].i[ 3];
+  pw_buf1[0] = pws[gid].i[ 4];
+  pw_buf1[1] = pws[gid].i[ 5];
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+
+  const u32 pw_l_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos);
+
+    const u32x pw_len = pw_l_len + pw_r_len;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+
+    /* First Pass */
+
+    const u32x a = (w0[0]);
+    const u32x b = (w0[1]);
+
+    u32x Ka[16];
+    u32x Kb[16];
+
+    _des_crypt_keysetup (a, b, Ka, Kb, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x p1[2];
+
+    _des_crypt_encrypt (p1, data, Ka, Kb, s_SPtrans);
+
+    /* Second Pass */
+
+    const u32x c = (w0[2]);
+    const u32x d = (w0[3]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x p2[2];
+
+    _des_crypt_decrypt (p2, p1, Kc, Kd, s_SPtrans);
+
+    /* Third Pass */
+
+    const u32x e = (w1[0]);
+    const u32x f = (w1[1]);
+
+    u32x Ke[16];
+    u32x Kf[16];
+
+    _des_crypt_keysetup (e, f, Ke, Kf, s_skb);
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, p2, Ke, Kf, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01530_m08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01530_m16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01530_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[ 0];
+  pw_buf0[1] = pws[gid].i[ 1];
+  pw_buf0[2] = pws[gid].i[ 2];
+  pw_buf0[3] = pws[gid].i[ 3];
+  pw_buf1[0] = pws[gid].i[ 4];
+  pw_buf1[1] = pws[gid].i[ 5];
+  pw_buf1[2] = 0;
+  pw_buf1[3] = 0;
+
+
+  const u32 pw_l_len = pws[gid].pw_len;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[digests_offset].digest_buf[DGST_R0],
+    digests_buf[digests_offset].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos);
+
+    const u32x pw_len = pw_l_len + pw_r_len;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+
+    /* First Pass */
+
+    const u32x a = (w0[0]);
+    const u32x b = (w0[1]);
+
+    u32x Ka[16];
+    u32x Kb[16];
+
+    _des_crypt_keysetup (a, b, Ka, Kb, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x p1[2];
+
+    _des_crypt_encrypt (p1, data, Ka, Kb, s_SPtrans);
+
+    /* Second Pass */
+
+    const u32x c = (w0[2]);
+    const u32x d = (w0[3]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x p2[2];
+
+    _des_crypt_decrypt (p2, p1, Kc, Kd, s_SPtrans);
+
+    /* Third Pass */
+
+    const u32x e = (w1[0]);
+    const u32x f = (w1[1]);
+
+    u32x Ke[16];
+    u32x Kf[16];
+
+    _des_crypt_keysetup (e, f, Ke, Kf, s_skb);
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, p2, Ke, Kf, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01530_s08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}
+
+__kernel void m01530_s16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+}

--- a/OpenCL/m01530_a3.cl
+++ b/OpenCL/m01530_a3.cl
@@ -1,0 +1,1162 @@
+/**
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Gabriele Gristina <matrix@hashcat.net>
+ *               magnum <john.magnum@hushmail.com>
+ *               Frans Lategan <frans.lategan+hashcat@gmail.com>
+ *
+ * License.....: MIT
+ */
+
+#define _DES_
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+
+#define PERM_OP(a,b,tt,n,m) \
+{                           \
+  tt = a >> n;              \
+  tt = tt ^ b;              \
+  tt = tt & m;              \
+  b = b ^ tt;               \
+  tt = tt << n;             \
+  a = a ^ tt;               \
+}
+
+#define HPERM_OP(a,tt,n,m)  \
+{                           \
+  tt = a << (16 + n);       \
+  tt = tt ^ a;              \
+  tt = tt & m;              \
+  a  = a ^ tt;              \
+  tt = tt >> (16 + n);      \
+  a  = a ^ tt;              \
+}
+
+#define IP(l,r,tt)                     \
+{                                      \
+  PERM_OP (r, l, tt,  4, 0x0f0f0f0f);  \
+  PERM_OP (l, r, tt, 16, 0x0000ffff);  \
+  PERM_OP (r, l, tt,  2, 0x33333333);  \
+  PERM_OP (l, r, tt,  8, 0x00ff00ff);  \
+  PERM_OP (r, l, tt,  1, 0x55555555);  \
+}
+
+#define FP(l,r,tt)                     \
+{                                      \
+  PERM_OP (l, r, tt,  1, 0x55555555);  \
+  PERM_OP (r, l, tt,  8, 0x00ff00ff);  \
+  PERM_OP (l, r, tt,  2, 0x33333333);  \
+  PERM_OP (r, l, tt, 16, 0x0000ffff);  \
+  PERM_OP (l, r, tt,  4, 0x0f0f0f0f);  \
+}
+
+__constant u32 c_SPtrans[8][64] =
+{
+  {
+    0x02080800, 0x00080000, 0x02000002, 0x02080802,
+    0x02000000, 0x00080802, 0x00080002, 0x02000002,
+    0x00080802, 0x02080800, 0x02080000, 0x00000802,
+    0x02000802, 0x02000000, 0x00000000, 0x00080002,
+    0x00080000, 0x00000002, 0x02000800, 0x00080800,
+    0x02080802, 0x02080000, 0x00000802, 0x02000800,
+    0x00000002, 0x00000800, 0x00080800, 0x02080002,
+    0x00000800, 0x02000802, 0x02080002, 0x00000000,
+    0x00000000, 0x02080802, 0x02000800, 0x00080002,
+    0x02080800, 0x00080000, 0x00000802, 0x02000800,
+    0x02080002, 0x00000800, 0x00080800, 0x02000002,
+    0x00080802, 0x00000002, 0x02000002, 0x02080000,
+    0x02080802, 0x00080800, 0x02080000, 0x02000802,
+    0x02000000, 0x00000802, 0x00080002, 0x00000000,
+    0x00080000, 0x02000000, 0x02000802, 0x02080800,
+    0x00000002, 0x02080002, 0x00000800, 0x00080802,
+  },
+  {
+    0x40108010, 0x00000000, 0x00108000, 0x40100000,
+    0x40000010, 0x00008010, 0x40008000, 0x00108000,
+    0x00008000, 0x40100010, 0x00000010, 0x40008000,
+    0x00100010, 0x40108000, 0x40100000, 0x00000010,
+    0x00100000, 0x40008010, 0x40100010, 0x00008000,
+    0x00108010, 0x40000000, 0x00000000, 0x00100010,
+    0x40008010, 0x00108010, 0x40108000, 0x40000010,
+    0x40000000, 0x00100000, 0x00008010, 0x40108010,
+    0x00100010, 0x40108000, 0x40008000, 0x00108010,
+    0x40108010, 0x00100010, 0x40000010, 0x00000000,
+    0x40000000, 0x00008010, 0x00100000, 0x40100010,
+    0x00008000, 0x40000000, 0x00108010, 0x40008010,
+    0x40108000, 0x00008000, 0x00000000, 0x40000010,
+    0x00000010, 0x40108010, 0x00108000, 0x40100000,
+    0x40100010, 0x00100000, 0x00008010, 0x40008000,
+    0x40008010, 0x00000010, 0x40100000, 0x00108000,
+  },
+  {
+    0x04000001, 0x04040100, 0x00000100, 0x04000101,
+    0x00040001, 0x04000000, 0x04000101, 0x00040100,
+    0x04000100, 0x00040000, 0x04040000, 0x00000001,
+    0x04040101, 0x00000101, 0x00000001, 0x04040001,
+    0x00000000, 0x00040001, 0x04040100, 0x00000100,
+    0x00000101, 0x04040101, 0x00040000, 0x04000001,
+    0x04040001, 0x04000100, 0x00040101, 0x04040000,
+    0x00040100, 0x00000000, 0x04000000, 0x00040101,
+    0x04040100, 0x00000100, 0x00000001, 0x00040000,
+    0x00000101, 0x00040001, 0x04040000, 0x04000101,
+    0x00000000, 0x04040100, 0x00040100, 0x04040001,
+    0x00040001, 0x04000000, 0x04040101, 0x00000001,
+    0x00040101, 0x04000001, 0x04000000, 0x04040101,
+    0x00040000, 0x04000100, 0x04000101, 0x00040100,
+    0x04000100, 0x00000000, 0x04040001, 0x00000101,
+    0x04000001, 0x00040101, 0x00000100, 0x04040000,
+  },
+  {
+    0x00401008, 0x10001000, 0x00000008, 0x10401008,
+    0x00000000, 0x10400000, 0x10001008, 0x00400008,
+    0x10401000, 0x10000008, 0x10000000, 0x00001008,
+    0x10000008, 0x00401008, 0x00400000, 0x10000000,
+    0x10400008, 0x00401000, 0x00001000, 0x00000008,
+    0x00401000, 0x10001008, 0x10400000, 0x00001000,
+    0x00001008, 0x00000000, 0x00400008, 0x10401000,
+    0x10001000, 0x10400008, 0x10401008, 0x00400000,
+    0x10400008, 0x00001008, 0x00400000, 0x10000008,
+    0x00401000, 0x10001000, 0x00000008, 0x10400000,
+    0x10001008, 0x00000000, 0x00001000, 0x00400008,
+    0x00000000, 0x10400008, 0x10401000, 0x00001000,
+    0x10000000, 0x10401008, 0x00401008, 0x00400000,
+    0x10401008, 0x00000008, 0x10001000, 0x00401008,
+    0x00400008, 0x00401000, 0x10400000, 0x10001008,
+    0x00001008, 0x10000000, 0x10000008, 0x10401000,
+  },
+  {
+    0x08000000, 0x00010000, 0x00000400, 0x08010420,
+    0x08010020, 0x08000400, 0x00010420, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x00010400,
+    0x08000420, 0x08010020, 0x08010400, 0x00000000,
+    0x00010400, 0x08000000, 0x00010020, 0x00000420,
+    0x08000400, 0x00010420, 0x00000000, 0x08000020,
+    0x00000020, 0x08000420, 0x08010420, 0x00010020,
+    0x08010000, 0x00000400, 0x00000420, 0x08010400,
+    0x08010400, 0x08000420, 0x00010020, 0x08010000,
+    0x00010000, 0x00000020, 0x08000020, 0x08000400,
+    0x08000000, 0x00010400, 0x08010420, 0x00000000,
+    0x00010420, 0x08000000, 0x00000400, 0x00010020,
+    0x08000420, 0x00000400, 0x00000000, 0x08010420,
+    0x08010020, 0x08010400, 0x00000420, 0x00010000,
+    0x00010400, 0x08010020, 0x08000400, 0x00000420,
+    0x00000020, 0x00010420, 0x08010000, 0x08000020,
+  },
+  {
+    0x80000040, 0x00200040, 0x00000000, 0x80202000,
+    0x00200040, 0x00002000, 0x80002040, 0x00200000,
+    0x00002040, 0x80202040, 0x00202000, 0x80000000,
+    0x80002000, 0x80000040, 0x80200000, 0x00202040,
+    0x00200000, 0x80002040, 0x80200040, 0x00000000,
+    0x00002000, 0x00000040, 0x80202000, 0x80200040,
+    0x80202040, 0x80200000, 0x80000000, 0x00002040,
+    0x00000040, 0x00202000, 0x00202040, 0x80002000,
+    0x00002040, 0x80000000, 0x80002000, 0x00202040,
+    0x80202000, 0x00200040, 0x00000000, 0x80002000,
+    0x80000000, 0x00002000, 0x80200040, 0x00200000,
+    0x00200040, 0x80202040, 0x00202000, 0x00000040,
+    0x80202040, 0x00202000, 0x00200000, 0x80002040,
+    0x80000040, 0x80200000, 0x00202040, 0x00000000,
+    0x00002000, 0x80000040, 0x80002040, 0x80202000,
+    0x80200000, 0x00002040, 0x00000040, 0x80200040,
+  },
+  {
+    0x00004000, 0x00000200, 0x01000200, 0x01000004,
+    0x01004204, 0x00004004, 0x00004200, 0x00000000,
+    0x01000000, 0x01000204, 0x00000204, 0x01004000,
+    0x00000004, 0x01004200, 0x01004000, 0x00000204,
+    0x01000204, 0x00004000, 0x00004004, 0x01004204,
+    0x00000000, 0x01000200, 0x01000004, 0x00004200,
+    0x01004004, 0x00004204, 0x01004200, 0x00000004,
+    0x00004204, 0x01004004, 0x00000200, 0x01000000,
+    0x00004204, 0x01004000, 0x01004004, 0x00000204,
+    0x00004000, 0x00000200, 0x01000000, 0x01004004,
+    0x01000204, 0x00004204, 0x00004200, 0x00000000,
+    0x00000200, 0x01000004, 0x00000004, 0x01000200,
+    0x00000000, 0x01000204, 0x01000200, 0x00004200,
+    0x00000204, 0x00004000, 0x01004204, 0x01000000,
+    0x01004200, 0x00000004, 0x00004004, 0x01004204,
+    0x01000004, 0x01004200, 0x01004000, 0x00004004,
+  },
+  {
+    0x20800080, 0x20820000, 0x00020080, 0x00000000,
+    0x20020000, 0x00800080, 0x20800000, 0x20820080,
+    0x00000080, 0x20000000, 0x00820000, 0x00020080,
+    0x00820080, 0x20020080, 0x20000080, 0x20800000,
+    0x00020000, 0x00820080, 0x00800080, 0x20020000,
+    0x20820080, 0x20000080, 0x00000000, 0x00820000,
+    0x20000000, 0x00800000, 0x20020080, 0x20800080,
+    0x00800000, 0x00020000, 0x20820000, 0x00000080,
+    0x00800000, 0x00020000, 0x20000080, 0x20820080,
+    0x00020080, 0x20000000, 0x00000000, 0x00820000,
+    0x20800080, 0x20020080, 0x20020000, 0x00800080,
+    0x20820000, 0x00000080, 0x00800080, 0x20020000,
+    0x20820080, 0x00800000, 0x20800000, 0x20000080,
+    0x00820000, 0x00020080, 0x20020080, 0x20800000,
+    0x00000080, 0x20820000, 0x00820080, 0x00000000,
+    0x20000000, 0x20800080, 0x00020000, 0x00820080,
+  }
+};
+
+__constant u32 c_skb[8][64] =
+{
+  {
+    0x00000000, 0x00000010, 0x20000000, 0x20000010,
+    0x00010000, 0x00010010, 0x20010000, 0x20010010,
+    0x00000800, 0x00000810, 0x20000800, 0x20000810,
+    0x00010800, 0x00010810, 0x20010800, 0x20010810,
+    0x00000020, 0x00000030, 0x20000020, 0x20000030,
+    0x00010020, 0x00010030, 0x20010020, 0x20010030,
+    0x00000820, 0x00000830, 0x20000820, 0x20000830,
+    0x00010820, 0x00010830, 0x20010820, 0x20010830,
+    0x00080000, 0x00080010, 0x20080000, 0x20080010,
+    0x00090000, 0x00090010, 0x20090000, 0x20090010,
+    0x00080800, 0x00080810, 0x20080800, 0x20080810,
+    0x00090800, 0x00090810, 0x20090800, 0x20090810,
+    0x00080020, 0x00080030, 0x20080020, 0x20080030,
+    0x00090020, 0x00090030, 0x20090020, 0x20090030,
+    0x00080820, 0x00080830, 0x20080820, 0x20080830,
+    0x00090820, 0x00090830, 0x20090820, 0x20090830,
+  },
+  {
+    0x00000000, 0x02000000, 0x00002000, 0x02002000,
+    0x00200000, 0x02200000, 0x00202000, 0x02202000,
+    0x00000004, 0x02000004, 0x00002004, 0x02002004,
+    0x00200004, 0x02200004, 0x00202004, 0x02202004,
+    0x00000400, 0x02000400, 0x00002400, 0x02002400,
+    0x00200400, 0x02200400, 0x00202400, 0x02202400,
+    0x00000404, 0x02000404, 0x00002404, 0x02002404,
+    0x00200404, 0x02200404, 0x00202404, 0x02202404,
+    0x10000000, 0x12000000, 0x10002000, 0x12002000,
+    0x10200000, 0x12200000, 0x10202000, 0x12202000,
+    0x10000004, 0x12000004, 0x10002004, 0x12002004,
+    0x10200004, 0x12200004, 0x10202004, 0x12202004,
+    0x10000400, 0x12000400, 0x10002400, 0x12002400,
+    0x10200400, 0x12200400, 0x10202400, 0x12202400,
+    0x10000404, 0x12000404, 0x10002404, 0x12002404,
+    0x10200404, 0x12200404, 0x10202404, 0x12202404,
+  },
+  {
+    0x00000000, 0x00000001, 0x00040000, 0x00040001,
+    0x01000000, 0x01000001, 0x01040000, 0x01040001,
+    0x00000002, 0x00000003, 0x00040002, 0x00040003,
+    0x01000002, 0x01000003, 0x01040002, 0x01040003,
+    0x00000200, 0x00000201, 0x00040200, 0x00040201,
+    0x01000200, 0x01000201, 0x01040200, 0x01040201,
+    0x00000202, 0x00000203, 0x00040202, 0x00040203,
+    0x01000202, 0x01000203, 0x01040202, 0x01040203,
+    0x08000000, 0x08000001, 0x08040000, 0x08040001,
+    0x09000000, 0x09000001, 0x09040000, 0x09040001,
+    0x08000002, 0x08000003, 0x08040002, 0x08040003,
+    0x09000002, 0x09000003, 0x09040002, 0x09040003,
+    0x08000200, 0x08000201, 0x08040200, 0x08040201,
+    0x09000200, 0x09000201, 0x09040200, 0x09040201,
+    0x08000202, 0x08000203, 0x08040202, 0x08040203,
+    0x09000202, 0x09000203, 0x09040202, 0x09040203,
+  },
+  {
+    0x00000000, 0x00100000, 0x00000100, 0x00100100,
+    0x00000008, 0x00100008, 0x00000108, 0x00100108,
+    0x00001000, 0x00101000, 0x00001100, 0x00101100,
+    0x00001008, 0x00101008, 0x00001108, 0x00101108,
+    0x04000000, 0x04100000, 0x04000100, 0x04100100,
+    0x04000008, 0x04100008, 0x04000108, 0x04100108,
+    0x04001000, 0x04101000, 0x04001100, 0x04101100,
+    0x04001008, 0x04101008, 0x04001108, 0x04101108,
+    0x00020000, 0x00120000, 0x00020100, 0x00120100,
+    0x00020008, 0x00120008, 0x00020108, 0x00120108,
+    0x00021000, 0x00121000, 0x00021100, 0x00121100,
+    0x00021008, 0x00121008, 0x00021108, 0x00121108,
+    0x04020000, 0x04120000, 0x04020100, 0x04120100,
+    0x04020008, 0x04120008, 0x04020108, 0x04120108,
+    0x04021000, 0x04121000, 0x04021100, 0x04121100,
+    0x04021008, 0x04121008, 0x04021108, 0x04121108,
+  },
+  {
+    0x00000000, 0x10000000, 0x00010000, 0x10010000,
+    0x00000004, 0x10000004, 0x00010004, 0x10010004,
+    0x20000000, 0x30000000, 0x20010000, 0x30010000,
+    0x20000004, 0x30000004, 0x20010004, 0x30010004,
+    0x00100000, 0x10100000, 0x00110000, 0x10110000,
+    0x00100004, 0x10100004, 0x00110004, 0x10110004,
+    0x20100000, 0x30100000, 0x20110000, 0x30110000,
+    0x20100004, 0x30100004, 0x20110004, 0x30110004,
+    0x00001000, 0x10001000, 0x00011000, 0x10011000,
+    0x00001004, 0x10001004, 0x00011004, 0x10011004,
+    0x20001000, 0x30001000, 0x20011000, 0x30011000,
+    0x20001004, 0x30001004, 0x20011004, 0x30011004,
+    0x00101000, 0x10101000, 0x00111000, 0x10111000,
+    0x00101004, 0x10101004, 0x00111004, 0x10111004,
+    0x20101000, 0x30101000, 0x20111000, 0x30111000,
+    0x20101004, 0x30101004, 0x20111004, 0x30111004,
+  },
+  {
+    0x00000000, 0x08000000, 0x00000008, 0x08000008,
+    0x00000400, 0x08000400, 0x00000408, 0x08000408,
+    0x00020000, 0x08020000, 0x00020008, 0x08020008,
+    0x00020400, 0x08020400, 0x00020408, 0x08020408,
+    0x00000001, 0x08000001, 0x00000009, 0x08000009,
+    0x00000401, 0x08000401, 0x00000409, 0x08000409,
+    0x00020001, 0x08020001, 0x00020009, 0x08020009,
+    0x00020401, 0x08020401, 0x00020409, 0x08020409,
+    0x02000000, 0x0A000000, 0x02000008, 0x0A000008,
+    0x02000400, 0x0A000400, 0x02000408, 0x0A000408,
+    0x02020000, 0x0A020000, 0x02020008, 0x0A020008,
+    0x02020400, 0x0A020400, 0x02020408, 0x0A020408,
+    0x02000001, 0x0A000001, 0x02000009, 0x0A000009,
+    0x02000401, 0x0A000401, 0x02000409, 0x0A000409,
+    0x02020001, 0x0A020001, 0x02020009, 0x0A020009,
+    0x02020401, 0x0A020401, 0x02020409, 0x0A020409,
+  },
+  {
+    0x00000000, 0x00000100, 0x00080000, 0x00080100,
+    0x01000000, 0x01000100, 0x01080000, 0x01080100,
+    0x00000010, 0x00000110, 0x00080010, 0x00080110,
+    0x01000010, 0x01000110, 0x01080010, 0x01080110,
+    0x00200000, 0x00200100, 0x00280000, 0x00280100,
+    0x01200000, 0x01200100, 0x01280000, 0x01280100,
+    0x00200010, 0x00200110, 0x00280010, 0x00280110,
+    0x01200010, 0x01200110, 0x01280010, 0x01280110,
+    0x00000200, 0x00000300, 0x00080200, 0x00080300,
+    0x01000200, 0x01000300, 0x01080200, 0x01080300,
+    0x00000210, 0x00000310, 0x00080210, 0x00080310,
+    0x01000210, 0x01000310, 0x01080210, 0x01080310,
+    0x00200200, 0x00200300, 0x00280200, 0x00280300,
+    0x01200200, 0x01200300, 0x01280200, 0x01280300,
+    0x00200210, 0x00200310, 0x00280210, 0x00280310,
+    0x01200210, 0x01200310, 0x01280210, 0x01280310,
+  },
+  {
+    0x00000000, 0x04000000, 0x00040000, 0x04040000,
+    0x00000002, 0x04000002, 0x00040002, 0x04040002,
+    0x00002000, 0x04002000, 0x00042000, 0x04042000,
+    0x00002002, 0x04002002, 0x00042002, 0x04042002,
+    0x00000020, 0x04000020, 0x00040020, 0x04040020,
+    0x00000022, 0x04000022, 0x00040022, 0x04040022,
+    0x00002020, 0x04002020, 0x00042020, 0x04042020,
+    0x00002022, 0x04002022, 0x00042022, 0x04042022,
+    0x00000800, 0x04000800, 0x00040800, 0x04040800,
+    0x00000802, 0x04000802, 0x00040802, 0x04040802,
+    0x00002800, 0x04002800, 0x00042800, 0x04042800,
+    0x00002802, 0x04002802, 0x00042802, 0x04042802,
+    0x00000820, 0x04000820, 0x00040820, 0x04040820,
+    0x00000822, 0x04000822, 0x00040822, 0x04040822,
+    0x00002820, 0x04002820, 0x00042820, 0x04042820,
+    0x00002822, 0x04002822, 0x00042822, 0x04042822
+  }
+};
+
+#if   VECT_SIZE == 1
+#define BOX(i,n,S) (S)[(n)][(i)]
+#elif VECT_SIZE == 2
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1])
+#elif VECT_SIZE == 4
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3])
+#elif VECT_SIZE == 8
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7])
+#elif VECT_SIZE == 16
+#define BOX(i,n,S) (u32x) ((S)[(n)][(i).s0], (S)[(n)][(i).s1], (S)[(n)][(i).s2], (S)[(n)][(i).s3], (S)[(n)][(i).s4], (S)[(n)][(i).s5], (S)[(n)][(i).s6], (S)[(n)][(i).s7], (S)[(n)][(i).s8], (S)[(n)][(i).s9], (S)[(n)][(i).sa], (S)[(n)][(i).sb], (S)[(n)][(i).sc], (S)[(n)][(i).sd], (S)[(n)][(i).se], (S)[(n)][(i).sf])
+#endif
+
+#if   VECT_SIZE == 1
+#define BOX1(i,S) (S)[(i)]
+#elif VECT_SIZE == 2
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1])
+#elif VECT_SIZE == 4
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3])
+#elif VECT_SIZE == 8
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7])
+#elif VECT_SIZE == 16
+#define BOX1(i,S) (u32x) ((S)[(i).s0], (S)[(i).s1], (S)[(i).s2], (S)[(i).s3], (S)[(i).s4], (S)[(i).s5], (S)[(i).s6], (S)[(i).s7], (S)[(i).s8], (S)[(i).s9], (S)[(i).sa], (S)[(i).sb], (S)[(i).sc], (S)[(i).sd], (S)[(i).se], (S)[(i).sf])
+#endif
+
+void _des_crypt_encrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i += 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i + 0] ^ r;
+    t = Kd[i + 0] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i + 1] ^ l;
+    t = Kd[i + 1] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+}
+
+void _des_crypt_decrypt (u32x iv[2], u32x data[2], u32x Kc[16], u32x Kd[16], __local u32 (*s_SPtrans)[64])
+{
+  u32x r = data[0];
+  u32x l = data[1];
+
+  u32x tt;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 16; i > 0; i -= 2)
+  {
+    u32x u;
+    u32x t;
+
+    u = Kc[i - 1] ^ r;
+    t = Kd[i - 1] ^ rotl32 (r, 28u);
+
+    l ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+
+    u = Kc[i - 2] ^ l;
+    t = Kd[i - 2] ^ rotl32 (l, 28u);
+
+    r ^= BOX (((u >>  2) & 0x3f), 0, s_SPtrans)
+       | BOX (((u >> 10) & 0x3f), 2, s_SPtrans)
+       | BOX (((u >> 18) & 0x3f), 4, s_SPtrans)
+       | BOX (((u >> 26) & 0x3f), 6, s_SPtrans)
+       | BOX (((t >>  2) & 0x3f), 1, s_SPtrans)
+       | BOX (((t >> 10) & 0x3f), 3, s_SPtrans)
+       | BOX (((t >> 18) & 0x3f), 5, s_SPtrans)
+       | BOX (((t >> 26) & 0x3f), 7, s_SPtrans);
+  }
+
+  iv[0] = l;
+  iv[1] = r;
+
+}
+
+void _des_crypt_keysetup (u32x c, u32x d, u32x Kc[16], u32x Kd[16], __local u32 (*s_skb)[64])
+{
+  u32x tt;
+
+  PERM_OP  (d, c, tt, 4, 0x0f0f0f0f);
+  HPERM_OP (c,    tt, 2, 0xcccc0000);
+  HPERM_OP (d,    tt, 2, 0xcccc0000);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+  PERM_OP  (c, d, tt, 8, 0x00ff00ff);
+  PERM_OP  (d, c, tt, 1, 0x55555555);
+
+  d = ((d & 0x000000ff) << 16)
+    | ((d & 0x0000ff00) <<  0)
+    | ((d & 0x00ff0000) >> 16)
+    | ((c & 0xf0000000) >>  4);
+
+  c = c & 0x0fffffff;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 16; i++)
+  {
+    if ((i < 2) || (i == 8) || (i == 15))
+    {
+      c = ((c >> 1) | (c << 27));
+      d = ((d >> 1) | (d << 27));
+    }
+    else
+    {
+      c = ((c >> 2) | (c << 26));
+      d = ((d >> 2) | (d << 26));
+    }
+
+    c = c & 0x0fffffff;
+    d = d & 0x0fffffff;
+
+    const u32x c00 = (c >>  0) & 0x0000003f;
+    const u32x c06 = (c >>  6) & 0x00383003;
+    const u32x c07 = (c >>  7) & 0x0000003c;
+    const u32x c13 = (c >> 13) & 0x0000060f;
+    const u32x c20 = (c >> 20) & 0x00000001;
+
+    u32x s = BOX (((c00 >>  0) & 0xff), 0, s_skb)
+           | BOX (((c06 >>  0) & 0xff)
+                 |((c07 >>  0) & 0xff), 1, s_skb)
+           | BOX (((c13 >>  0) & 0xff)
+                 |((c06 >>  8) & 0xff), 2, s_skb)
+           | BOX (((c20 >>  0) & 0xff)
+                 |((c13 >>  8) & 0xff)
+                 |((c06 >> 16) & 0xff), 3, s_skb);
+
+    const u32x d00 = (d >>  0) & 0x00003c3f;
+    const u32x d07 = (d >>  7) & 0x00003f03;
+    const u32x d21 = (d >> 21) & 0x0000000f;
+    const u32x d22 = (d >> 22) & 0x00000030;
+
+    u32x t = BOX (((d00 >>  0) & 0xff), 4, s_skb)
+           | BOX (((d07 >>  0) & 0xff)
+                 |((d00 >>  8) & 0xff), 5, s_skb)
+           | BOX (((d07 >>  8) & 0xff), 6, s_skb)
+           | BOX (((d21 >>  0) & 0xff)
+                 |((d22 >>  0) & 0xff), 7, s_skb);
+
+    Kc[i] = ((t << 16) | (s & 0x0000ffff));
+    Kd[i] = ((s >> 16) | (t & 0xffff0000));
+
+    Kc[i] = rotl32 (Kc[i], 2u);
+    Kd[i] = rotl32 (Kd[i], 2u);
+  }
+}
+
+void m01530m (__local u32 (*s_SPtrans)[64], __local u32 (*s_skb)[64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset)
+{
+  /**
+   * modifier
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  u32 w1 = w[1];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    /* First Pass */
+
+    const u32x a = (w0);
+    const u32x b = (w1);
+
+    u32x Ka[16];
+    u32x Kb[16];
+
+    _des_crypt_keysetup (a, b, Ka, Kb, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x p1[2];
+
+    _des_crypt_encrypt (p1, data, Ka, Kb, s_SPtrans);
+
+    /* Second Pass */
+
+    const u32x c = (w[2]);
+    const u32x d = (w[3]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x p2[2];
+
+    _des_crypt_decrypt (p2, p1, Kc, Kd, s_SPtrans);
+
+    /* Third Pass */
+
+    const u32x e = (w[4]);
+    const u32x f = (w[5]);
+
+    u32x Ke[16];
+    u32x Kf[16];
+
+    _des_crypt_keysetup (e, f, Ke, Kf, s_skb);
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, p2, Ke, Kf, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+void m01530s (__local u32 (*s_SPtrans)[64], __local u32 (*s_skb)[64], u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset)
+{
+  /**
+   * modifier
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[2];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf_pc[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf_pc[1];
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[digests_offset].digest_buf[DGST_R0],
+    digests_buf[digests_offset].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  u32 w1 = w[1];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    /* First Pass */
+
+    const u32x a = (w0);
+    const u32x b = (w1);
+
+    u32x Ka[16];
+    u32x Kb[16];
+
+    _des_crypt_keysetup (a, b, Ka, Kb, s_skb);
+
+    u32x data[2];
+
+    data[0] = salt_buf0[0];
+    data[1] = salt_buf0[1];
+
+    u32x p1[2];
+
+    _des_crypt_encrypt (p1, data, Ka, Kb, s_SPtrans);
+
+    /* Second Pass */
+
+    const u32x c = (w[2]);
+    const u32x d = (w[3]);
+
+    u32x Kc[16];
+    u32x Kd[16];
+
+    _des_crypt_keysetup (c, d, Kc, Kd, s_skb);
+
+    u32x p2[2];
+
+    _des_crypt_decrypt (p2, p1, Kc, Kd, s_SPtrans);
+
+    /* Third Pass */
+
+    const u32x e = (w[4]);
+    const u32x f = (w[5]);
+
+    u32x Ke[16];
+    u32x Kf[16];
+
+    _des_crypt_keysetup (e, f, Ke, Kf, s_skb);
+
+    u32x iv[2];
+
+    _des_crypt_encrypt (iv, p2, Ke, Kf, s_SPtrans);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (iv[0], iv[1], z, z);
+  }
+}
+
+__kernel void m01530_m04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01530m (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}
+
+__kernel void m01530_m08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01530m (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}
+
+__kernel void m01530_m16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01530m (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}
+
+__kernel void m01530_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01530s (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}
+
+__kernel void m01530_s08 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01530s (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}
+
+__kernel void m01530_s16 (__global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __constant u32x * words_buf_r, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global void *esalt_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset, const u32 combs_mode, const u32 gid_max)
+{
+  /**
+   * base
+   */
+
+  const u32 gid = get_global_id (0);
+  const u32 lid = get_local_id (0);
+  const u32 lsz = get_local_size (0);
+
+  /**
+   * shared
+   */
+
+  __local u32 s_SPtrans[8][64];
+  __local u32 s_skb[8][64];
+
+  for (u32 i = lid; i < 64; i += lsz)
+  {
+    s_SPtrans[0][i] = c_SPtrans[0][i];
+    s_SPtrans[1][i] = c_SPtrans[1][i];
+    s_SPtrans[2][i] = c_SPtrans[2][i];
+    s_SPtrans[3][i] = c_SPtrans[3][i];
+    s_SPtrans[4][i] = c_SPtrans[4][i];
+    s_SPtrans[5][i] = c_SPtrans[5][i];
+    s_SPtrans[6][i] = c_SPtrans[6][i];
+    s_SPtrans[7][i] = c_SPtrans[7][i];
+
+    s_skb[0][i] = c_skb[0][i];
+    s_skb[1][i] = c_skb[1][i];
+    s_skb[2][i] = c_skb[2][i];
+    s_skb[3][i] = c_skb[3][i];
+    s_skb[4][i] = c_skb[4][i];
+    s_skb[5][i] = c_skb[5][i];
+    s_skb[6][i] = c_skb[6][i];
+    s_skb[7][i] = c_skb[7][i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * main
+   */
+
+  m01530s (s_SPtrans, s_skb, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_scryptV0_buf, d_scryptV1_buf, d_scryptV2_buf, d_scryptV3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset);
+}

--- a/include/shared.h
+++ b/include/shared.h
@@ -152,15 +152,15 @@ static inline int  CPU_ISSET (int num, cpu_set_t *cs) { return (cs->count & (1 <
 #define CL_VENDOR_NV            "NVIDIA Corporation"
 #define CL_VENDOR_POCL          "The pocl project"
 
-#define VENDOR_ID_AMD           (1u << 0)
-#define VENDOR_ID_APPLE         (1u << 1)
-#define VENDOR_ID_INTEL_BEIGNET (1u << 2)
-#define VENDOR_ID_INTEL_SDK     (1u << 3)
-#define VENDOR_ID_MESA          (1u << 4)
-#define VENDOR_ID_NV            (1u << 5)
-#define VENDOR_ID_POCL          (1u << 6)
-#define VENDOR_ID_AMD_USE_INTEL (1u << 7)
-#define VENDOR_ID_GENERIC       (1u << 31)
+#define VENDOR_ID_AMD           (1 << 0)
+#define VENDOR_ID_APPLE         (1 << 1)
+#define VENDOR_ID_INTEL_BEIGNET (1 << 2)
+#define VENDOR_ID_INTEL_SDK     (1 << 3)
+#define VENDOR_ID_MESA          (1 << 4)
+#define VENDOR_ID_NV            (1 << 5)
+#define VENDOR_ID_POCL          (1 << 6)
+#define VENDOR_ID_AMD_USE_INTEL (1 << 7)
+#define VENDOR_ID_GENERIC       (1 << 31)
 
 #define BLOCK_SIZE              64
 
@@ -253,6 +253,7 @@ extern hc_thread_mutex_t mux_display;
 #define HT_01460  "HMAC-SHA256 (key = $salt)"
 #define HT_01500  "descrypt, DES(Unix), Traditional DES"
 #define HT_01510  "DES"
+#define HT_01530  "3DES"
 #define HT_01600  "md5apr1, MD5(APR), Apache MD5"
 #define HT_01700  "SHA512"
 #define HT_01710  "sha512($pass.$salt)"
@@ -512,6 +513,10 @@ extern hc_thread_mutex_t mux_display;
 #define DISPLAY_LEN_MAX_1510  16+1+8
 #define DISPLAY_LEN_MIN_1510H 16+1+16
 #define DISPLAY_LEN_MAX_1510H 16+1+16
+#define DISPLAY_LEN_MIN_1530  16+1+8
+#define DISPLAY_LEN_MAX_1530  16+1+8
+#define DISPLAY_LEN_MIN_1530H 16+1+16
+#define DISPLAY_LEN_MAX_1530H 16+1+16
 #define DISPLAY_LEN_MIN_1600  29 + 0
 #define DISPLAY_LEN_MAX_1600  29 + 8
 #define DISPLAY_LEN_MIN_1700  128
@@ -855,7 +860,7 @@ extern hc_thread_mutex_t mux_display;
 #define HASH_TYPE_RAR3HP         49
 #define HASH_TYPE_KRB5TGS        50
 #define HASH_TYPE_STDOUT         51
-#define HASH_TYPE_DES            52
+#define HASH_TYPE_DES     52
 
 #define KERN_TYPE_MD5                 0
 #define KERN_TYPE_MD5_PWSLT           10
@@ -887,6 +892,7 @@ extern hc_thread_mutex_t mux_display;
 #define KERN_TYPE_HMACSHA256_SLT      1460
 #define KERN_TYPE_DESCRYPT            1500
 #define KERN_TYPE_DES                 1510
+#define KERN_TYPE_3DES                1530
 #define KERN_TYPE_APR1CRYPT           1600
 #define KERN_TYPE_SHA512              1700
 #define KERN_TYPE_SHA512_PWSLT        1710

--- a/include/shared.h
+++ b/include/shared.h
@@ -252,6 +252,7 @@ extern hc_thread_mutex_t mux_display;
 #define HT_01450  "HMAC-SHA256 (key = $pass)"
 #define HT_01460  "HMAC-SHA256 (key = $salt)"
 #define HT_01500  "descrypt, DES(Unix), Traditional DES"
+#define HT_01510  "DES"
 #define HT_01600  "md5apr1, MD5(APR), Apache MD5"
 #define HT_01700  "SHA512"
 #define HT_01710  "sha512($pass.$salt)"
@@ -507,6 +508,10 @@ extern hc_thread_mutex_t mux_display;
 #define DISPLAY_LEN_MAX_1450H 64 + 1 + 102
 #define DISPLAY_LEN_MIN_1500  13
 #define DISPLAY_LEN_MAX_1500  13
+#define DISPLAY_LEN_MIN_1510  16+1+8
+#define DISPLAY_LEN_MAX_1510  16+1+8
+#define DISPLAY_LEN_MIN_1510H 16+1+16
+#define DISPLAY_LEN_MAX_1510H 16+1+16
 #define DISPLAY_LEN_MIN_1600  29 + 0
 #define DISPLAY_LEN_MAX_1600  29 + 8
 #define DISPLAY_LEN_MIN_1700  128
@@ -850,6 +855,7 @@ extern hc_thread_mutex_t mux_display;
 #define HASH_TYPE_RAR3HP         49
 #define HASH_TYPE_KRB5TGS        50
 #define HASH_TYPE_STDOUT         51
+#define HASH_TYPE_DES            52
 
 #define KERN_TYPE_MD5                 0
 #define KERN_TYPE_MD5_PWSLT           10
@@ -880,6 +886,7 @@ extern hc_thread_mutex_t mux_display;
 #define KERN_TYPE_HMACSHA256_PW       1450
 #define KERN_TYPE_HMACSHA256_SLT      1460
 #define KERN_TYPE_DESCRYPT            1500
+#define KERN_TYPE_DES                 1510
 #define KERN_TYPE_APR1CRYPT           1600
 #define KERN_TYPE_SHA512              1700
 #define KERN_TYPE_SHA512_PWSLT        1710
@@ -1518,6 +1525,7 @@ int cisco4_parse_hash             (char *input_buf, uint input_len, hash_t *hash
 int dcc_parse_hash                (char *input_buf, uint input_len, hash_t *hash_buf);
 int dcc2_parse_hash               (char *input_buf, uint input_len, hash_t *hash_buf);
 int descrypt_parse_hash           (char *input_buf, uint input_len, hash_t *hash_buf);
+int des_parse_hash                (char *input_buf, uint input_len, hash_t *hash_buf);
 int episerver_parse_hash          (char *input_buf, uint input_len, hash_t *hash_buf);
 int ipb2_parse_hash               (char *input_buf, uint input_len, hash_t *hash_buf);
 int joomla_parse_hash             (char *input_buf, uint input_len, hash_t *hash_buf);

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -491,6 +491,7 @@ const char *USAGE_BIG[] =
   "   1730 | sha512(unicode($pass).$salt)                     | Raw Hash, Salted and / or Iterated",
   "   1740 | sha512($salt.unicode($pass))                     | Raw Hash, Salted and / or Iterated",
   "   1510 | DES-ECB (PT = $salt, key = $pass)                | Raw Hash, Salted and / or Iterated",
+  "   1530 | 3DES-ECB (PT = $salt, key = $pass)               | Raw Hash, Salted and / or Iterated",
   "     50 | HMAC-MD5 (key = $pass)                           | Raw Hash, Authenticated",
   "     60 | HMAC-MD5 (key = $salt)                           | Raw Hash, Authenticated",
   "    150 | HMAC-SHA1 (key = $pass)                          | Raw Hash, Authenticated",
@@ -8959,6 +8960,23 @@ int main (int argc, char **argv)
                    dgst_pos3   = 3;
                    break;
 
+      case  1530:  hash_type   = HASH_TYPE_DES;
+                   salt_type   = SALT_TYPE_EMBEDDED;
+                   attack_exec = ATTACK_EXEC_INSIDE_KERNEL;
+                   opts_type   = OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_ST_GENERATE_LE;
+                   kern_type   = KERN_TYPE_3DES;
+                   dgst_size   = DGST_SIZE_4_4; // originally DGST_SIZE_4_2
+                   parse_func  = des_parse_hash;
+                   sort_by_digest = sort_by_digest_4_4; // originally sort_by_digest_4_2
+                   opti_type   = OPTI_TYPE_ZERO_BYTE
+                               | OPTI_TYPE_PRECOMPUTE_PERMUT;
+                   dgst_pos0   = 0;
+                   dgst_pos1   = 1;
+                   dgst_pos2   = 2;
+                   dgst_pos3   = 3;
+                   break;
+
       case  1600:  hash_type   = HASH_TYPE_MD5;
                    salt_type   = SALT_TYPE_EMBEDDED;
                    attack_exec = ATTACK_EXEC_OUTSIDE_KERNEL;
@@ -12116,6 +12134,8 @@ int main (int argc, char **argv)
                   break;
       case  1510: if (pw_max >  8) pw_max =  8;
                   break;
+      case  1530: if (pw_max >  24) pw_max =  24;
+                  break;
       case  1600: if (pw_max > 16) pw_max = 16;
                   break;
       case  1800: if (pw_max > 16) pw_max = 16;
@@ -12800,6 +12820,8 @@ int main (int argc, char **argv)
                       hashes_buf[0].salt->salt_buf[0] = 388; // pure magic
                       break;
           case  1510: hashes_buf[0].salt->salt_len = 8;
+                      break;
+          case  1530: hashes_buf[0].salt->salt_len = 8;
                       break;
           case  1731: hashes_buf[0].salt->salt_len = 4;
                       break;
@@ -15922,6 +15944,14 @@ int main (int argc, char **argv)
       }
 
       if (hash_mode == 1510 && attack_mode == ATTACK_MODE_BF)
+      {
+        const u32 kernel_loops_fixed = 1024;
+
+        device_param->kernel_loops_min = kernel_loops_fixed;
+        device_param->kernel_loops_max = kernel_loops_fixed;
+      }
+
+      if (hash_mode == 1530 && attack_mode == ATTACK_MODE_BF)
       {
         const u32 kernel_loops_fixed = 1024;
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -4584,7 +4584,7 @@ void set_cpu_affinity (char *cpu_affinity)
       }
 
       #ifdef _WIN
-      aff_mask |= 1u << (cpu_id - 1);
+      aff_mask |= 1 << (cpu_id - 1);
       #elif _POSIX
       CPU_SET ((cpu_id - 1), &cpuset);
       #endif
@@ -5508,7 +5508,7 @@ uint setup_opencl_platforms_filter (char *opencl_platforms)
         exit (-1);
       }
 
-      opencl_platforms_filter |= 1u << (platform - 1);
+      opencl_platforms_filter |= 1 << (platform - 1);
 
     } while ((next = strtok (NULL, ",")) != NULL);
 
@@ -5543,7 +5543,7 @@ u32 setup_devices_filter (char *opencl_devices)
         exit (-1);
       }
 
-      devices_filter |= 1u << (device_id - 1);
+      devices_filter |= 1 << (device_id - 1);
 
     } while ((next = strtok (NULL, ",")) != NULL);
 
@@ -5578,7 +5578,7 @@ cl_device_type setup_device_types_filter (char *opencl_device_types)
         exit (-1);
       }
 
-      device_types_filter |= 1u << device_type;
+      device_types_filter |= 1 << device_type;
 
     } while ((next = strtok (NULL, ",")) != NULL);
 
@@ -5994,6 +5994,7 @@ char *strhashtype (const uint hash_mode)
     case  1460: return ((char *) HT_01460); break;
     case  1500: return ((char *) HT_01500); break;
     case  1510: return ((char *) HT_01510); break;
+    case  1530: return ((char *) HT_01530); break;
     case  1600: return ((char *) HT_01600); break;
     case  1700: return ((char *) HT_01700); break;
     case  1710: return ((char *) HT_01710); break;
@@ -6732,7 +6733,10 @@ void ascii_digest (char *out_buf, uint salt_pos, uint digest_pos)
   {
     snprintf (out_buf, len-1, "%s:%08X%08X", (char *) salt.salt_buf, digest_buf[0], digest_buf[1]);
   }
-
+    else if (hash_mode == 1530)
+  {
+    snprintf (out_buf, len-1, "%s:%08X%08X", (char *) salt.salt_buf, digest_buf[0], digest_buf[1]);
+  }
   else if (hash_mode == 1600)
   {
     // the encoder is a bit too intelligent, it expects the input data in the wrong BOM
@@ -10112,7 +10116,7 @@ int bcrypt_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   char *iter_pos = input_buf + 4;
 
-  salt->salt_iter = 1u << atoi (iter_pos);
+  salt->salt_iter = 1 << atoi (iter_pos);
 
   char *salt_pos = strchr (iter_pos, '$');
 
@@ -10848,7 +10852,7 @@ int phpass_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   char *iter_pos = input_buf + 3;
 
-  uint salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  uint salt_iter = 1 << itoa64_to_int (iter_pos[0]);
 
   if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
 
@@ -11072,6 +11076,8 @@ int descrypt_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   return (PARSER_OK);
 }
+
+
 
 int md4_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 {
@@ -13458,7 +13464,7 @@ int sha1aix_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt->salt_sign[0] = atoi (salt_iter);
 
-  salt->salt_iter = (1u << atoi (salt_iter)) - 1;
+  salt->salt_iter = (1 << atoi (salt_iter)) - 1;
 
   hash_pos++;
 
@@ -13507,7 +13513,7 @@ int sha256aix_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt->salt_sign[0] = atoi (salt_iter);
 
-  salt->salt_iter = (1u << atoi (salt_iter)) - 1;
+  salt->salt_iter = (1 << atoi (salt_iter)) - 1;
 
   hash_pos++;
 
@@ -13559,7 +13565,7 @@ int sha512aix_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt->salt_sign[0] = atoi (salt_iter);
 
-  salt->salt_iter = (1u << atoi (salt_iter)) - 1;
+  salt->salt_iter = (1 << atoi (salt_iter)) - 1;
 
   hash_pos++;
 
@@ -14492,7 +14498,7 @@ int drupal7_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   char *iter_pos = input_buf + 3;
 
-  uint salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  uint salt_iter = 1 << itoa64_to_int (iter_pos[0]);
 
   if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
 
@@ -19146,7 +19152,7 @@ int seven_zip_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt->salt_sign[0] = iter;
 
-  salt->salt_iter = 1u << iter;
+  salt->salt_iter = 1 << iter;
 
   /**
    * digest
@@ -19765,7 +19771,7 @@ int rar5_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt->salt_sign[0] = iterations;
 
-  salt->salt_iter = ((1u << iterations) + 32) - 1;
+  salt->salt_iter = ((1 << iterations) + 32) - 1;
 
   /**
    * digest buf


### PR DESCRIPTION
…pe" is 1510, and the format to crack is:

plaintext:ciphertext, where plaintext is a single block of plaintext, and ciphertext is the output of standard
DES encryption of the plaintext in ECB mode, no padding, in hex.
For example, encrypting the plaintext PlainTXT with password S3cr3ts1 will result in the ciphertext
a1ff88c804540b1f. The format for the input file should be:
PlainTXT:a1ff88c804540b1f
And cracking it with:
hashcat -m 1510 -a 3 S?dcr?ats?d might result in the following:
PlainTXT:a1ff88c804540b1f:S3cr2ts0
Note that DES only uses the MSB 7 bits out of each 8 of the password, so the resultant password might not quite match
the orginal used, but will still decrypt the ciphertext.
OpenSSL command used to generate the above example:
echo -n "PlainTXT" | openssl enc -des-ecb -K "5333637233747331" -nopad | xxd

As per https://github.com/hashcat/hashcat/issues/129
