### PR TITLE
some kernels used COMPARE_M_SIMD instead of COMPARE_S_SIMD in singlehash mode

### DIFF
--- a/OpenCL/m00900_a1.cl
+++ b/OpenCL/m00900_a1.cl
@@ -367,7 +367,7 @@ __kernel void m00900_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf,
     MD4_STEP (MD4_H , c, d, a, b, w1[3], MD4C02, MD4S22);
     MD4_STEP (MD4_H , b, c, d, a, w3[3], MD4C02, MD4S23);
 
-    COMPARE_M_SIMD (a, d, c, b);
+    COMPARE_S_SIMD (a, d, c, b);
   }
 }
 

--- a/OpenCL/m01710_a0.cl
+++ b/OpenCL/m01710_a0.cl
@@ -487,7 +487,7 @@ __kernel void m01710_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf,
     const u32x r2 = l32_from_64 (digest[3]);
     const u32x r3 = h32_from_64 (digest[3]);
 
-    COMPARE_M_SIMD (r0, r1, r2, r3);
+    COMPARE_S_SIMD (r0, r1, r2, r3);
   }
 }
 

--- a/OpenCL/m06900_a3.cl
+++ b/OpenCL/m06900_a3.cl
@@ -1056,7 +1056,7 @@ void m06900s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __gl
 
     /* store */
 
-    COMPARE_M_SIMD (state[0], state[1], state[2], state[3]);
+    COMPARE_S_SIMD (state[0], state[1], state[2], state[3]);
   }
 }
 

--- a/OpenCL/m13300_a0.cl
+++ b/OpenCL/m13300_a0.cl
@@ -392,7 +392,7 @@ __kernel void m13300_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf,
 
     e &= 0x00000000;
 
-    COMPARE_M_SIMD (a, e, d, c);
+    COMPARE_S_SIMD (a, e, d, c);
   }
 }
 

--- a/OpenCL/m13300_a1.cl
+++ b/OpenCL/m13300_a1.cl
@@ -506,7 +506,7 @@ __kernel void m13300_s04 (__global pw_t *pws, __global kernel_rule_t *rules_buf,
 
     e &= 0x00000000;
 
-    COMPARE_M_SIMD (a, e, d, c);
+    COMPARE_S_SIMD (a, e, d, c);
   }
 }
 

--- a/OpenCL/m13300_a3.cl
+++ b/OpenCL/m13300_a3.cl
@@ -526,7 +526,7 @@ void m13300s (u32 w[16], const u32 pw_len, __global pw_t *pws, __global kernel_r
 
     e &= 0x00000000;
 
-    COMPARE_M_SIMD (a, e, d, c);
+    COMPARE_S_SIMD (a, e, d, c);
   }
 }
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -36,6 +36,7 @@
 - Fixed a bug where hashcat did not correctly remove hashes of type WPA/WPA2 even if present in potfile
 - Fixed a bug where hashcat reported an invalid password for a zero-length password in LM
 - Fixed a bug where hashcat did not take into account how long it takes to prepare a session when auto-aborting with --runtime is in use
+- Fixed a bug where some kernels used COMPARE_M_SIMD instead of COMPARE_S_SIMD in singlehash mode
 
 ##
 ## Algorithms


### PR DESCRIPTION
The following kernels used COMPARE_M_SIMD in singlehash mode:
m00900_a1, m01710_a0, m06900_a3, m13300_a0, m13300_a1, m13300_a3
