### PR TITLE
new feature: allow -o to be used in stdout mode

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -22,6 +22,7 @@
 - Replace RegGetValue() with RegQueryValueEx() to enable Windows XP 32 bit compatibility
 - Slightly increased NVidias rule-processing performance by using generic instructions instead of byte_perm()
 - Add support for @ rule (RULE_OP_MANGLE_PURGECHAR) to use on GPU
+- Add support for --outfile (short -o) to be used together with --stdout
 
 ##
 ## Bugs

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -2548,7 +2548,11 @@ static void process_stdout (hc_device_param_t *device_param, const uint pws_cnt)
 
   if (data.outfile != NULL)
   {
-    if ((out.fp = fopen (data.outfile, "ab")) == NULL)
+    if ((out.fp = fopen (data.outfile, "ab")) != NULL)
+    {
+      lock_file (out.fp);
+    }
+    else
     {
       log_error ("ERROR: %s: %s", data.outfile, strerror (errno));
 
@@ -2726,6 +2730,8 @@ static void process_stdout (hc_device_param_t *device_param, const uint pws_cnt)
 
   if (out.fp != stdout)
   {
+    unlock_file (out.fp);
+
     fclose (out.fp);
   }
 }

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -2544,7 +2544,18 @@ static void process_stdout (hc_device_param_t *device_param, const uint pws_cnt)
 {
   out_t out;
 
-  out.fp  = stdout;
+  out.fp = stdout;
+
+  if (data.outfile != NULL)
+  {
+    if ((out.fp = fopen (data.outfile, "ab")) == NULL)
+    {
+      log_error ("ERROR: %s: %s", data.outfile, strerror (errno));
+
+      out.fp = stdout;
+    }
+  }
+
   out.len = 0;
 
   uint plain_buf[16] = { 0 };
@@ -2712,6 +2723,11 @@ static void process_stdout (hc_device_param_t *device_param, const uint pws_cnt)
   }
 
   out_flush (&out);
+
+  if (out.fp != stdout)
+  {
+    fclose (out.fp);
+  }
 }
 
 static void save_hash ()


### PR DESCRIPTION
This is basically a new feature request and diff that implements the following:
when using --stdout together with --outfile nothing happened so far, i.e. the -o option was just ignored.

I found this a little bit disturbing, either it should allow it or it should give an error (we can decide whatever is best for hashcat, but ignoring it is not a good option IMO).

Of course hashcat didn't support it so far, therefore this is a _new feature_ and not really a bug fix. But still I think we should either use this variant (i.e. supporting -o in --stdout) or be very strict and give an error ("-o is not allowed in stdout mode").

This PR implements the option using the outfile. Feel free to argument against or for it.
Thank you so much.
~ Phil
