### PR TITLE
skip periodic status updates in stdin+stdout mode to prevent output pollution

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -23,6 +23,7 @@
 - Slightly increased NVidias rule-processing performance by using generic instructions instead of byte_perm()
 - Add support for @ rule (RULE_OP_MANGLE_PURGECHAR) to use on GPU
 - Add support for --outfile (short -o) to be used together with --stdout
+- Skip periodic status output whenever --stdout is used together with stdin mode, but no outfile was specified
 
 ##
 ## Bugs

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -7898,7 +7898,10 @@ int main (int argc, char **argv)
 
   if (wordlist_mode == WL_MODE_STDIN)
   {
-    status = 1;
+    // enable status (in stdin mode) whenever we do not use --stdout together with an outfile
+
+    if      (stdout_flag == 0) status = 1;
+    else if (outfile != NULL)  status = 1;
 
     data.status = status;
   }


### PR DESCRIPTION
Bare with me because this is a very specific case, but still a useful and maybe a frequent configuration too:
- user gets input from stdin (not from a file directly)
- user wants to output everything to stdout (without using an outfile)

The problem here was: the status display, since we use stdin, was periodically updated and outputted to stdout... but this doesn't make much sense in this very specific case since we want to use stdout (in this case) only for showing the password candidates.
That means, that the output was "polluted" with status display updates besides the password candidates, which in my opinion doesn't make much sense in this very specific stdin+stdout mode.

This commit only allows status display together within the stdin  mode if:
- either the --stdout flag was not used at all OR
- if --stdout was specified but the user specified an outfile too (therefore the clean output goes to the output file and isn't mixed up with the status display output)

Hope this is understandable and the fix is acceptable.
Thank you very much
