### PR TITLE
add sanity check to disallow --show and --outfile-autohex-disable

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -24,6 +24,7 @@
 - Add support for @ rule (RULE_OP_MANGLE_PURGECHAR) to use on GPU
 - Add support for --outfile (short -o) to be used together with --stdout
 - Skip periodic status output whenever --stdout is used together with stdin mode, but no outfile was specified
+- Show error message if --show is used together with --outfile-autohex-disable (this is currently not supported)
 
 ##
 ## Bugs

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -7226,6 +7226,16 @@ int main (int argc, char **argv)
     }
   }
 
+  if (show == 1)
+  {
+    if (outfile_autohex == 0)
+    {
+      log_error ("ERROR: Mixing outfile-autohex-disable parameter not allowed with show parameter");
+
+      return -1;
+    }
+  }
+
   uint attack_kern = ATTACK_KERN_NONE;
 
   switch (attack_mode)


### PR DESCRIPTION
These few lines of code change prohibit the user of using --outfile-autohex-disable together with --show (or better said ... if the hashcat user specifies --outfile-autohex-disable with --show he will now see an error).

The best fix would be to allow outfile-autohex-disable also within --show, meaning that the pot file output would be converted and "unhexed" if it is a $HEX[xx...] converted string.

Since we currently do not manipulate the output of the .pot file at all when using --show, --left ... this would be a major change and maybe not worth the time/effort. (at least I don't know of any user requesting this in the past).

Therefore, I would suggest that (like this commit is trying to accomplish) it's best to filter such command lines and disallow --show together with --outfile-autohex-disable for the time being.

Thank you very much indeed  
