### PR TITLE
sanity check for #457: do not allow mask files or increment w/ --skip/--limit

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -25,6 +25,7 @@
 - Add support for --outfile (short -o) to be used together with --stdout
 - Skip periodic status output whenever --stdout is used together with stdin mode, but no outfile was specified
 - Show error message if --show is used together with --outfile-autohex-disable (this is currently not supported)
+- Show error message if --skip/--limit is used together with mask files or --increment
 
 ##
 ## Bugs

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -18915,8 +18915,23 @@ int main (int argc, char **argv)
       }
 
       /**
+       * prevent the user from using --skip/--limit together w/ maskfile and or dictfile
+       */
+
+      if (skip != 0 || limit != 0)
+      {
+        if ((maskcnt > 1) || (dictcnt > 1))
+        {
+          log_error ("ERROR: --skip/--limit are not supported with --increment or mask files");
+
+          return -1;
+        }
+      }
+
+      /**
        * prevent the user from using --keyspace together w/ maskfile and or dictfile
        */
+
       if (keyspace == 1)
       {
         if ((maskcnt > 1) || (dictcnt > 1))


### PR DESCRIPTION
This should fix the issue mentioned in #457.

The problem here is that --skip and --limit are not supported with increment and mask files and therefore an error should be shown.

The current version applies skip and limit to the first mask and therefore some strange behavior or error messages could appear.

I suggest we prohibit the use of --skip and/or --limit altogether for the time being - together with mask file and/or --increment - (until we support --skip and/or --limit in those very special cases, if we decide to support it at all in the future).

Thank you very much
~ phil
