### PR TITLE
fixes #425: flexible way of searching for CRT_glob.o on linux and cygwin

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -177,9 +177,13 @@ endif
 LINUX_32_OBJS            := obj/ext_OpenCL.LINUX.32.o obj/shared.LINUX.32.o obj/rp_kernel_on_cpu.LINUX.32.o obj/ext_ADL.LINUX.32.o obj/ext_nvml.LINUX.32.o obj/ext_nvapi.LINUX.32.o obj/ext_xnvctrl.LINUX.32.o
 LINUX_64_OBJS            := obj/ext_OpenCL.LINUX.64.o obj/shared.LINUX.64.o obj/rp_kernel_on_cpu.LINUX.64.o obj/ext_ADL.LINUX.64.o obj/ext_nvml.LINUX.64.o obj/ext_nvapi.LINUX.64.o obj/ext_xnvctrl.LINUX.64.o
 
-## may need to adjust according to your mingw distribution
-CRT_GLOB_32              := /usr/i686-w64-mingw32/lib/CRT_glob.o
-CRT_GLOB_64              := /usr/x86_64-w64-mingw32/lib/CRT_glob.o
+# Windows CRT file globbing:
+
+CRT_GLOB_32              :=
+CRT_GLOB_64              :=
+CRT_GLOB_INCLUDE_FOLDER  := $(dir $(lastword $(MAKEFILE_LIST)))
+
+include $(CRT_GLOB_INCLUDE_FOLDER)win_file_globbing.mk
 
 WIN_32_OBJS              := obj/ext_OpenCL.WIN.32.o   obj/shared.WIN.32.o   obj/rp_kernel_on_cpu.WIN.32.o   obj/ext_ADL.WIN.32.o   obj/ext_nvml.WIN.32.o   obj/ext_nvapi.WIN.32.o   obj/ext_xnvctrl.WIN.32.o   $(CRT_GLOB_32)
 WIN_64_OBJS              := obj/ext_OpenCL.WIN.64.o   obj/shared.WIN.64.o   obj/rp_kernel_on_cpu.WIN.64.o   obj/ext_ADL.WIN.64.o   obj/ext_nvml.WIN.64.o   obj/ext_nvapi.WIN.64.o   obj/ext_xnvctrl.WIN.64.o   $(CRT_GLOB_64)

--- a/src/Makefile
+++ b/src/Makefile
@@ -183,7 +183,7 @@ CRT_GLOB_32              :=
 CRT_GLOB_64              :=
 CRT_GLOB_INCLUDE_FOLDER  := $(dir $(lastword $(MAKEFILE_LIST)))
 
-include $(CRT_GLOB_INCLUDE_FOLDER)win_file_globbing.mk
+include $(CRT_GLOB_INCLUDE_FOLDER)/win_file_globbing.mk
 
 WIN_32_OBJS              := obj/ext_OpenCL.WIN.32.o   obj/shared.WIN.32.o   obj/rp_kernel_on_cpu.WIN.32.o   obj/ext_ADL.WIN.32.o   obj/ext_nvml.WIN.32.o   obj/ext_nvapi.WIN.32.o   obj/ext_xnvctrl.WIN.32.o   $(CRT_GLOB_32)
 WIN_64_OBJS              := obj/ext_OpenCL.WIN.64.o   obj/shared.WIN.64.o   obj/rp_kernel_on_cpu.WIN.64.o   obj/ext_ADL.WIN.64.o   obj/ext_nvml.WIN.64.o   obj/ext_nvapi.WIN.64.o   obj/ext_xnvctrl.WIN.64.o   $(CRT_GLOB_64)

--- a/src/win_file_globbing.mk
+++ b/src/win_file_globbing.mk
@@ -1,5 +1,5 @@
 ##
-## Authors.....: Jens Steube <jens.steube@gmail.com>
+## Authors.....: Philipp Schmidt <philsmd@hashcat.net>
 ##
 ## License.....: MIT
 ##

--- a/src/win_file_globbing.mk
+++ b/src/win_file_globbing.mk
@@ -1,0 +1,62 @@
+##
+## Authors.....: Jens Steube <jens.steube@gmail.com>
+##
+## License.....: MIT
+##
+
+# MinGW's CRT GLOB (for windows builds only)
+
+EGREP              := egrep
+MG                 := $(MAKECMDGOALS)
+
+CRT_GLOB_FILE_NAME ?= CRT_glob.o
+
+# we can skip the CRT_glob.o check/search if we do not build windows binaries
+
+IS_WIN_BUILD       := $(filter binaries,$(MG))$(filter win32,$(MG))$(filter win64,$(MG))$(filter hashcat32.exe,$(MG))$(filter hashcat64.exe,$(MG))
+
+ifneq (,$(IS_WIN_BUILD))
+
+# entering this code path means: we need to check for CRT_glob.o since we try to build binaries for windows operating systems
+
+CRT_GLOB_LIB_PATH_32    ?= /usr/i686-w64-mingw32/lib/
+CRT_GLOB_LIB_PATH_64    ?= /usr/x86_64-w64-mingw32/lib/
+
+CRT_GLOB_LIB_SYSROOT_32 := $(shell $(CC_WIN_32) --verbose 2>&1 | $(EGREP) -m 1 -o '(with-sysroot="[^"]"|with-sysroot=[^ ]*)' | $(SED) 's/^with-sysroot="\?\([^"]*\)"\?$$/\1/')
+CRT_GLOB_LIB_SYSROOT_64 := $(shell $(CC_WIN_64) --verbose 2>&1 | $(EGREP) -m 1 -o '(with-sysroot="[^"]"|with-sysroot=[^ ]*)' | $(SED) 's/^with-sysroot="\?\([^"]*\)"\?$$/\1/')
+
+ifneq (,$(CRT_GLOB_LIB_SYSROOT_32))
+CRT_GLOB_LIB_PATH_32    := $(CRT_GLOB_LIB_SYSROOT_32)
+endif
+
+ifneq (,$(CRT_GLOB_LIB_SYSROOT_64))
+CRT_GLOB_LIB_PATH_64    := $(CRT_GLOB_LIB_SYSROOT_64)
+endif
+
+CRT_GLOB_32 := $(shell $(FIND) "$(CRT_GLOB_LIB_PATH_32)" -name $(CRT_GLOB_FILE_NAME) -print -quit)
+
+ifeq (,$(CRT_GLOB_32))
+define WARNING_MESSAGE=
+
+
+! The MinGW CRT GLOB library for 32-bit compilation was not found on your system. Please make sure that $(CRT_GLOB_FILE_NAME) exists
+! ATTENTION: File globbing will be disabled
+
+endef
+$(warning $(WARNING_MESSAGE))
+endif
+
+CRT_GLOB_64 := $(shell $(FIND) "$(CRT_GLOB_LIB_PATH_64)" -name $(CRT_GLOB_FILE_NAME) -print -quit)
+
+ifeq (,$(CRT_GLOB_64))
+define WARNING_MESSAGE=
+
+
+! The MinGW CRT GLOB library for 64-bit compilation was not found on your system. Please make sure that $(CRT_GLOB_FILE_NAME) exists
+! ATTENTION: File globbing will be disabled
+
+endef
+$(warning $(WARNING_MESSAGE))
+endif
+
+endif


### PR DESCRIPTION
This should fix the problem mentioned in issue #425.

The problem was that CRT_glob.o was not successfully found on cygwin/windows machines (if you tried to build the source code within the cygwin shell).

This adds a new file to do the searching in case it detects that windows binaries need to be compiled.

Thank you very much
