### PR TITLE
Add build support for Msys2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,10 @@ UNAME                    := $(shell uname -s)
 
 # we need to strip the windows version number to be able to build hashcat on cygwin hosts
 UNAME                    := $(patsubst CYGWIN_NT-%,CYGWIN_NT-,$(UNAME))
+# we need to strip the windows version number to be able to build hashcat on msys hosts
+UNAME                    := $(patsubst MSYS_NT-%,MSYS_NT-,$(UNAME))
 
-ifeq (,$(filter $(UNAME),Linux Darwin CYGWIN_NT- FreeBSD))
+ifeq (,$(filter $(UNAME),Linux Darwin MSYS_NT- CYGWIN_NT- FreeBSD))
 $(error "! Your Operating System ($(UNAME)) is not supported by $(PROG_NAME) Makefile")
 endif
 

--- a/src/win_file_globbing.mk
+++ b/src/win_file_globbing.mk
@@ -21,6 +21,11 @@ ifneq (,$(IS_WIN_BUILD))
 CRT_GLOB_LIB_PATH_32    ?= /usr/i686-w64-mingw32/lib/
 CRT_GLOB_LIB_PATH_64    ?= /usr/x86_64-w64-mingw32/lib/
 
+ifeq (,$(filter $(UNAME),MSYS_NT-))
+	CRT_GLOB_LIB_PATH_32    ?= /mingw32/i686-w64-mingw32/lib/
+	CRT_GLOB_LIB_PATH_64    ?= /mingw64/x86_64-w64-mingw32/lib/
+endif
+
 CRT_GLOB_LIB_SYSROOT_32 := $(shell $(CC_WIN_32) --verbose 2>&1 | $(EGREP) -m 1 -o '(with-sysroot="[^"]"|with-sysroot=[^ ]*)' | $(SED) 's/^with-sysroot="\?\([^"]*\)"\?$$/\1/')
 CRT_GLOB_LIB_SYSROOT_64 := $(shell $(CC_WIN_64) --verbose 2>&1 | $(EGREP) -m 1 -o '(with-sysroot="[^"]"|with-sysroot=[^ ]*)' | $(SED) 's/^with-sysroot="\?\([^"]*\)"\?$$/\1/')
 


### PR DESCRIPTION
[Msys2](https://msys2.github.io/), while similar in some aspects to Cygwin, uses a different setup / structure.

Changes:
- Recognize `MSYS-NT` as supported platform
- Correctly setup GLOB paths, when `MSYS-NT` is detected
