### PR TITLE
More cleanups

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -6,12 +6,12 @@
 #ifndef _BITOPS_H
 #define _BITOPS_H
 
-u32 rotl32 (const u32 a, const u32 n);
-u32 rotr32 (const u32 a, const u32 n);
-u64 rotl64 (const u64 a, const u64 n);
-u64 rotr64 (const u64 a, const u64 n);
+u32 rotl32 (const u32 a, const u32 n) __attribute__ ((const));
+u32 rotr32 (const u32 a, const u32 n) __attribute__ ((const));
+u64 rotl64 (const u64 a, const u64 n) __attribute__ ((const));
+u64 rotr64 (const u64 a, const u64 n) __attribute__ ((const));
 
-u32 byte_swap_32 (const u32 n);
-u64 byte_swap_64 (const u64 n);
+u32 byte_swap_32 (const u32 n) __attribute__ ((const));
+u64 byte_swap_64 (const u64 n) __attribute__ ((const));
 
 #endif // _BITOPS_H

--- a/include/convert.h
+++ b/include/convert.h
@@ -8,34 +8,34 @@
 
 #include <ctype.h>
 
-bool need_hexify (const u8 *buf, const int len);
+bool need_hexify (const u8 *buf, const int len) __attribute__ ((const));
 void exec_hexify (const u8 *buf, const int len, u8 *out);
 
-bool is_valid_hex_char (const u8 c);
+bool is_valid_hex_char (const u8 c) __attribute__ ((const));
 
-u8 hex_convert (const u8 c);
+u8 hex_convert (const u8 c) __attribute__ ((const));
 
-u8  hex_to_u8  (const u8 hex[2]);
-u32 hex_to_u32 (const u8 hex[8]);
-u64 hex_to_u64 (const u8 hex[16]);
+u8  hex_to_u8  (const u8 hex[2])  __attribute__ ((const));
+u32 hex_to_u32 (const u8 hex[8])  __attribute__ ((const));
+u64 hex_to_u64 (const u8 hex[16]) __attribute__ ((const));
 
 void bin_to_hex_lower (const u32 v, u8 hex[8]);
 
-u8 int_to_base32  (const u8 c);
-u8 base32_to_int  (const u8 c);
-u8 int_to_base64  (const u8 c);
-u8 base64_to_int  (const u8 c);
+u8 int_to_base32  (const u8 c) __attribute__ ((const));
+u8 base32_to_int  (const u8 c) __attribute__ ((const));
+u8 int_to_base64  (const u8 c) __attribute__ ((const));
+u8 base64_to_int  (const u8 c) __attribute__ ((const));
 
-u8 int_to_itoa32  (const u8 c);
-u8 itoa32_to_int  (const u8 c);
-u8 int_to_itoa64  (const u8 c);
-u8 itoa64_to_int  (const u8 c);
+u8 int_to_itoa32  (const u8 c) __attribute__ ((const));
+u8 itoa32_to_int  (const u8 c) __attribute__ ((const));
+u8 int_to_itoa64  (const u8 c) __attribute__ ((const));
+u8 itoa64_to_int  (const u8 c) __attribute__ ((const));
 
-u8 int_to_bf64    (const u8 c);
-u8 bf64_to_int    (const u8 c);
+u8 int_to_bf64    (const u8 c) __attribute__ ((const));
+u8 bf64_to_int    (const u8 c) __attribute__ ((const));
 
-u8 int_to_lotus64 (const u8 c);
-u8 lotus64_to_int (const u8 c);
+u8 int_to_lotus64 (const u8 c) __attribute__ ((const));
+u8 lotus64_to_int (const u8 c) __attribute__ ((const));
 
 int base32_decode (u8 (*f) (const u8), const u8 *in_buf, int in_len, u8 *out_buf);
 int base32_encode (u8 (*f) (const u8), const u8 *in_buf, int in_len, u8 *out_buf);

--- a/include/event.h
+++ b/include/event.h
@@ -14,13 +14,13 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
 #define EVENT(id)              event_call ((id), hashcat_ctx, NULL,  0)
 #define EVENT_DATA(id,buf,len) event_call ((id), hashcat_ctx, (buf), (len))
 
-size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)  __attribute__ ((format (printf, 2, 3)));
+size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)  __attribute__ ((format (printf, 2, 3)));
+size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)  __attribute__ ((format (printf, 2, 3)));
 
-size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)  __attribute__ ((format (printf, 2, 3)));
+size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)  __attribute__ ((format (printf, 2, 3)));
+size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)  __attribute__ ((format (printf, 2, 3)));
 
 int  event_ctx_init         (hashcat_ctx_t *hashcat_ctx);
 void event_ctx_destroy      (hashcat_ctx_t *hashcat_ctx);

--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -107,6 +107,6 @@ typedef struct hc_opencl_lib
 
 typedef hc_opencl_lib_t OCL_PTR;
 
-const char *val2cstr_cl (cl_int CL_err);
+const char *val2cstr_cl (cl_int CL_err) __attribute__ ((const));
 
 #endif // _EXT_OPENCL_H

--- a/include/folder.h
+++ b/include/folder.h
@@ -27,9 +27,9 @@
 #define DOT_HASHCAT     ".hashcat"
 #define SESSIONS_FOLDER "sessions"
 
-int sort_by_stringptr (const void *p1, const void *p2);
+int sort_by_stringptr (const void *p1, const void *p2) __attribute__ ((pure));
 
-int count_dictionaries (char **dictionary_files);
+int count_dictionaries (char **dictionary_files) __attribute__ ((pure));
 
 char **scan_directory (hashcat_ctx_t *hashcat_ctx, const char *path);
 

--- a/include/hlfmt.h
+++ b/include/hlfmt.h
@@ -10,7 +10,7 @@
 
 #define HLFMTS_CNT 11
 
-char *strhlfmt (const u32 hashfile_format);
+char *strhlfmt (const u32 hashfile_format) __attribute__ ((const));
 
 void hlfmt_hash (hashcat_ctx_t *hashcat_ctx, u32 hashfile_format, char *line_buf, int line_len, char **hashbuf_pos, int *hashbuf_len);
 void hlfmt_user (hashcat_ctx_t *hashcat_ctx, u32 hashfile_format, char *line_buf, int line_len, char **userbuf_pos, int *userbuf_len);

--- a/include/interface.h
+++ b/include/interface.h
@@ -1501,9 +1501,9 @@ int opencart_parse_hash           (u8 *input_buf, u32 input_len, hash_t *hash_bu
  * output functions
  */
 
-char *stroptitype (const u32 opti_type);
-char *strhashtype (const u32 hash_mode);
-char *strparser   (const u32 parser_status);
+char *stroptitype (const u32 opti_type)     __attribute__ ((const));
+char *strhashtype (const u32 hash_mode)     __attribute__ ((const));
+char *strparser   (const u32 parser_status) __attribute__ ((const));
 
 void to_hccap_t (hashcat_ctx_t *hashcat_ctx, hccap_t *hccap, const u32 salt_pos, const u32 digest_pos);
 

--- a/include/logfile.h
+++ b/include/logfile.h
@@ -36,7 +36,7 @@
 
 void logfile_generate_topid (hashcat_ctx_t *hashcat_ctx);
 void logfile_generate_subid (hashcat_ctx_t *hashcat_ctx);
-void logfile_append         (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+void logfile_append         (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)  __attribute__ ((format (printf, 2, 3)));
 int  logfile_init           (hashcat_ctx_t *hashcat_ctx);
 void logfile_destroy        (hashcat_ctx_t *hashcat_ctx);
 

--- a/include/potfile.h
+++ b/include/potfile.h
@@ -14,8 +14,8 @@
 
 int sort_by_pot               (const void *v1, const void *v2, MAYBE_UNUSED void *v3);
 int sort_by_salt_buf          (const void *v1, const void *v2, MAYBE_UNUSED void *v3);
-int sort_by_hash_t_salt       (const void *v1, const void *v2);
-int sort_by_hash_t_salt_hccap (const void *v1, const void *v2);
+int sort_by_hash_t_salt       (const void *v1, const void *v2) __attribute__ ((pure));
+int sort_by_hash_t_salt_hccap (const void *v1, const void *v2) __attribute__ ((pure));
 
 void  hc_qsort_r (void *base, size_t nmemb, size_t size, int (*compar) (const void *, const void *, void *), void *arg);
 void *hc_bsearch_r (const void *key, const void *base, size_t nmemb, size_t size, int (*compar) (const void *, const void *, void *), void *arg);

--- a/include/rp.h
+++ b/include/rp.h
@@ -15,13 +15,13 @@
 #define RULES_MAX 32
 #define MAX_KERNEL_RULES (RULES_MAX - 1)
 
-bool class_num   (const u8 c);
-bool class_lower (const u8 c);
-bool class_upper (const u8 c);
-bool class_alpha (const u8 c);
+bool class_num   (const u8 c) __attribute__ ((const));
+bool class_lower (const u8 c) __attribute__ ((const));
+bool class_upper (const u8 c) __attribute__ ((const));
+bool class_alpha (const u8 c) __attribute__ ((const));
 
-int conv_ctoi (const u8 c);
-int conv_itoc (const u8 c);
+int conv_ctoi (const u8 c) __attribute__ ((const));
+int conv_itoc (const u8 c) __attribute__ ((const));
 
 int generate_random_rule (char rule_buf[RP_RULE_BUFSIZ], const u32 rp_gen_func_min, const u32 rp_gen_func_max);
 

--- a/include/rp_kernel_on_cpu.h
+++ b/include/rp_kernel_on_cpu.h
@@ -6,7 +6,7 @@
 #ifndef _RP_KERNEL_ON_CPU_H
 #define _RP_KERNEL_ON_CPU_H
 
-u32 swap_workaround (const u32 n);
+u32 swap_workaround (const u32 n)  __attribute__ ((const));
 
 u32 apply_rule (const u32 name, const u32 p0, const u32 p1, u32 buf0[4], u32 buf1[4], const u32 in_len);
 u32 apply_rules (u32 *cmds, u32 buf0[4], u32 buf1[4], const u32 len);

--- a/include/shared.h
+++ b/include/shared.h
@@ -12,12 +12,12 @@
 #include <time.h>
 #include <fcntl.h>
 
-bool is_power_of_2 (const u32 v);
+bool is_power_of_2 (const u32 v) __attribute__ ((const));
 
 u32 get_random_num (const u32 min, const u32 max);
 
-u32 mydivc32 (const u32 dividend, const u32 divisor);
-u64 mydivc64 (const u64 dividend, const u64 divisor);
+u32 mydivc32 (const u32 dividend, const u32 divisor) __attribute__ ((const));
+u64 mydivc64 (const u64 dividend, const u64 divisor) __attribute__ ((const));
 
 char *filename_from_filepath (char *filepath);
 

--- a/src/autotune.c
+++ b/src/autotune.c
@@ -243,7 +243,7 @@ static int autotune (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
   const double exec_accel_min = MIN (exec_left, accel_left); // we want that to be int
 
-  if (exec_accel_min >= 1.0)
+  if (exec_accel_min >= 1.0f)
   {
     // this is safe to not overflow kernel_accel_max because of accel_left
 

--- a/src/combinator.c
+++ b/src/combinator.c
@@ -68,7 +68,7 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if (S_ISDIR (tmp_stat.st_mode))
     {
-      event_log_error (hashcat_ctx, "%s must be a regular file", dictfile1, strerror (errno));
+      event_log_error (hashcat_ctx, "%s must be a regular file", dictfile1);
 
       fclose (fp1);
 
@@ -96,7 +96,7 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if (S_ISDIR (tmp_stat.st_mode))
     {
-      event_log_error (hashcat_ctx, "%s must be a regular file", dictfile2, strerror (errno));
+      event_log_error (hashcat_ctx, "%s must be a regular file", dictfile2);
 
       fclose (fp1);
       fclose (fp2);

--- a/src/convert.c
+++ b/src/convert.c
@@ -374,7 +374,7 @@ int base32_encode (u8 (*f) (const u8), const u8 *in_buf, int in_len, u8 *out_buf
     out_ptr += 8;
   }
 
-  int out_len = (int) (((0.5 + (double) in_len) * 8) / 5); // ceil (in_len * 8 / 5)
+  int out_len = (int) (((0.5f + (double) in_len) * 8) / 5); // ceil (in_len * 8 / 5)
 
   while (out_len % 8)
   {
@@ -441,7 +441,7 @@ int base64_encode (u8 (*f) (const u8), const u8 *in_buf, int in_len, u8 *out_buf
     out_ptr += 4;
   }
 
-  int out_len = (int) (((0.5 + (double) in_len) * 8) / 6); // ceil (in_len * 8 / 6)
+  int out_len = (int) (((0.5f + (double) in_len) * 8) / 6); // ceil (in_len * 8 / 6)
 
   while (out_len % 4)
   {

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -3032,11 +3032,11 @@ int hwmon_ctx_init (hashcat_ctx_t *hashcat_ctx)
             return -1;
           }
 
-          int engine_clock_max =       (int) (0.6666 * caps.sEngineClockRange.iMax);
-          int memory_clock_max =       (int) (0.6250 * caps.sMemoryClockRange.iMax);
+          int engine_clock_max =       (int) (0.6666f * caps.sEngineClockRange.iMax);
+          int memory_clock_max =       (int) (0.6250f * caps.sMemoryClockRange.iMax);
 
-          int warning_trigger_engine = (int) (0.25   * engine_clock_max);
-          int warning_trigger_memory = (int) (0.25   * memory_clock_max);
+          int warning_trigger_engine = (int) (0.25f   * engine_clock_max);
+          int warning_trigger_memory = (int) (0.25f   * memory_clock_max);
 
           int engine_clock_profile_max = hwmon_ctx->od_clock_mem_status[device_id].state.aLevels[1].iEngineClock;
           int memory_clock_profile_max = hwmon_ctx->od_clock_mem_status[device_id].state.aLevels[1].iMemoryClock;

--- a/src/main.c
+++ b/src/main.c
@@ -719,11 +719,11 @@ static void main_hashlist_parse_hash (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, M
 
   if (hashes_cnt < hashes_avail)
   {
-    event_log_info_nn (hashcat_ctx, "Parsing Hashes: %u/%u (%0.2f%%)...", hashes_cnt, hashes_avail, ((double) hashes_cnt / hashes_avail) * 100);
+    event_log_info_nn (hashcat_ctx, "Parsing Hashes: %u/%u (%0.2f%%)...", hashes_cnt, hashes_avail, (hashes_cnt / hashes_avail) * 100.0f);
   }
   else
   {
-    event_log_info_nn (hashcat_ctx, "Parsed Hashes: %u/%u (%0.2f%%)", hashes_cnt, hashes_avail, 100);
+    event_log_info_nn (hashcat_ctx, "Parsed Hashes: %u/%u (%0.2f%%)", hashes_cnt, hashes_avail, 100.0f);
   }
 }
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -509,8 +509,8 @@ void opencl_info (hashcat_ctx_t *hashcat_ctx)
       event_log_info (hashcat_ctx, "    Processor(s)   : %u", device_processors);
       event_log_info (hashcat_ctx, "    Clock          : %u", device_maxclock_frequency);
       event_log_info (hashcat_ctx, "    Memory         : %" PRIu64 "/%" PRIu64 " MB allocatable", device_maxmem_alloc / 1024 / 1024, device_global_mem / 1024 / 1024);
-      event_log_info (hashcat_ctx, "    OpenCL Version : %u", device_opencl_version);
-      event_log_info (hashcat_ctx, "    Driver Version : %u", driver_version);
+      event_log_info (hashcat_ctx, "    OpenCL Version : %s", device_opencl_version);
+      event_log_info (hashcat_ctx, "    Driver Version : %s", driver_version);
       event_log_info (hashcat_ctx, "");
     }
   }
@@ -566,12 +566,12 @@ void opencl_info_compact (hashcat_ctx_t *hashcat_ctx)
 
       if (device_param->skipped == false)
       {
-        event_log_info (hashcat_ctx, "* Device #%u: %s, %lu/%lu MB allocatable, %uMCU",
+        event_log_info (hashcat_ctx, "* Device #%u: %s, %llu/%llu MB allocatable, %uMCU",
                   devices_idx + 1,
                   device_name,
-                  (unsigned int) (device_maxmem_alloc / 1024 / 1024),
-                  (unsigned int) (device_global_mem   / 1024 / 1024),
-                  (unsigned int)  device_processors);
+                  device_maxmem_alloc / 1024 / 1024,
+                  device_global_mem   / 1024 / 1024,
+                  device_processors);
       }
       else
       {


### PR DESCRIPTION
Since GCC now sees a few functions as format string functions, new warnings have popped up. I fixed several but many more remain.