### PR TITLE
Fix file locking (again).

### DIFF
--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -8,6 +8,7 @@
 #include "memory.h"
 #include "event.h"
 #include "debugfile.h"
+#include "locking.h"
 
 static void debugfile_format_plain (hashcat_ctx_t *hashcat_ctx, const u8 *plain_ptr, const u32 plain_len)
 {
@@ -109,6 +110,13 @@ int debugfile_init (hashcat_ctx_t *hashcat_ctx)
     if (debugfile_ctx->fp == NULL)
     {
       event_log_error (hashcat_ctx, "Could not open debug-file for writing");
+
+      return -1;
+    }
+
+    if (lock_file (debugfile_ctx->fp) == -1)
+    {
+      event_log_error (hashcat_ctx, "%s: %s", debugfile_ctx->filename, strerror (errno));
 
       return -1;
     }

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -8,6 +8,7 @@
 #include "memory.h"
 #include "event.h"
 #include "dictstat.h"
+#include "locking.h"
 
 int sort_by_dictstat (const void *s1, const void *s2)
 {
@@ -119,6 +120,13 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
   FILE *fp = fopen (dictstat_ctx->filename, "wb");
 
   if (fp == NULL)
+  {
+    event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
+
+    return -1;
+  }
+
+  if (lock_file (fp) == -1)
   {
     event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -24,6 +24,7 @@
 #include "shared.h"
 #include "thread.h"
 #include "timer.h"
+#include "locking.h"
 
 int sort_by_digest_p0p1 (const void *v1, const void *v2, void *v3)
 {
@@ -138,6 +139,13 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
   FILE *fp = fopen (new_hashfile, "wb");
 
   if (fp == NULL)
+  {
+    event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
+
+    return -1;
+  }
+
+  if (lock_file (fp) == -1)
   {
     event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
 

--- a/src/locking.c
+++ b/src/locking.c
@@ -18,7 +18,11 @@ int lock_file (FILE *fp)
 
   lock.l_type = F_WRLCK;
 
-  if (fcntl (fileno (fp), F_SETLKW, &lock)) return -1;
+  /* Needs this loop because a signal may interrupt a wait for lock */
+  while (fcntl (fileno (fp), F_SETLKW, &lock))
+  {
+    if (errno != EINTR) return -1;
+  }
 
   return 0;
 }

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -8,6 +8,7 @@
 #include "memory.h"
 #include "event.h"
 #include "logfile.h"
+#include "locking.h"
 
 static int logfile_generate_id (void)
 {
@@ -49,6 +50,8 @@ void logfile_append (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)
   if (logfile_ctx->enabled == false) return;
 
   FILE *fp = fopen (logfile_ctx->logfile, "ab");
+
+  lock_file (fp);
 
   va_list ap;
 

--- a/src/loopback.c
+++ b/src/loopback.c
@@ -9,6 +9,7 @@
 #include "event.h"
 #include "shared.h"
 #include "loopback.h"
+#include "locking.h"
 
 static void loopback_format_plain (hashcat_ctx_t *hashcat_ctx, const u8 *plain_ptr, const unsigned int plain_len)
 {
@@ -105,6 +106,13 @@ int loopback_write_open (hashcat_ctx_t *hashcat_ctx)
   loopback_ctx->fp = fopen (loopback_ctx->filename, "ab");
 
   if (loopback_ctx->fp == NULL)
+  {
+    event_log_error (hashcat_ctx, "%s: %s", loopback_ctx->filename, strerror (errno));
+
+    return -1;
+  }
+
+  if (lock_file (loopback_ctx->fp) == -1)
   {
     event_log_error (hashcat_ctx, "%s: %s", loopback_ctx->filename, strerror (errno));
 

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -16,6 +16,7 @@
 #include "opencl.h"
 #include "shared.h"
 #include "outfile.h"
+#include "locking.h"
 
 int build_plain (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, plain_t *plain, u32 *plain_buf, int *out_len)
 {
@@ -306,6 +307,13 @@ int outfile_write_open (hashcat_ctx_t *hashcat_ctx)
   outfile_ctx->fp = fopen (outfile_ctx->filename, "ab");
 
   if (outfile_ctx->fp == NULL)
+  {
+    event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
+
+    return -1;
+  }
+
+  if (lock_file (outfile_ctx->fp) == -1)
   {
     event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
 

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -12,6 +12,7 @@
 #include "filehandling.h"
 #include "outfile.h"
 #include "potfile.h"
+#include "locking.h"
 
 #if defined (_WIN)
 #define __WINDOWS__
@@ -315,7 +316,15 @@ void potfile_write_append (hashcat_ctx_t *hashcat_ctx, const char *out_buf, u8 *
 
   tmp_buf[tmp_len] = 0;
 
+  if (lock_file (potfile_ctx->fp) == -1)
+  {
+    event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
+  }
+
   fprintf (potfile_ctx->fp, "%s" EOL, tmp_buf);
+
+  fflush(potfile_ctx->fp);
+  unlock_file (potfile_ctx->fp);
 }
 
 int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)


### PR DESCRIPTION
I added file locking in #177 but unfortunately it's been completely ruined since. First, lock_file() isn't even called anymore for pot file writing (which is what really **needs** locking).

Second (and much less of a problem), the lock_file() function was modified in 27bec8b so it's no longer signal safe. Why? The while loop in my original code wasn't something I made up just for lulz. It has to be there.

This fixes both issues.