### PR TITLE
Change need_hexify so it optionally tests for printable UTF-8. See #568

### DIFF
--- a/include/convert.h
+++ b/include/convert.h
@@ -8,7 +8,7 @@
 
 #include <ctype.h>
 
-bool need_hexify (const u8 *buf, const int len);
+bool need_hexify (const u8 *buf, const int len, bool accept_utf8);
 void exec_hexify (const u8 *buf, const int len, u8 *out);
 
 bool is_valid_hex_char (const u8 c);

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -367,7 +367,9 @@ int outfile_write (hashcat_ctx_t *hashcat_ctx, const char *out_buf, const unsign
 
   if (outfile_ctx->outfile_format & OUTFILE_FMT_PLAIN)
   {
-    if ((user_options->outfile_autohex == true) && (need_hexify (plain_ptr, plain_len) == true))
+    bool accept_utf8 = hashcat_ctx->hashconfig->hash_type != HASH_TYPE_LM;
+
+    if ((user_options->outfile_autohex == true) && (need_hexify (plain_ptr, plain_len, accept_utf8) == true))
     {
       tmp_buf[tmp_len++] = '$';
       tmp_buf[tmp_len++] = 'H';

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -291,7 +291,9 @@ void potfile_write_append (hashcat_ctx_t *hashcat_ctx, const char *out_buf, u8 *
 
   if (1)
   {
-    if ((user_options->outfile_autohex == true) && (need_hexify (plain_ptr, plain_len) == true))
+    bool accept_utf8 = hashcat_ctx->hashconfig->hash_type != HASH_TYPE_LM;
+
+    if ((user_options->outfile_autohex == true) && (need_hexify (plain_ptr, plain_len, accept_utf8) == true))
     {
       tmp_buf[tmp_len++] = '$';
       tmp_buf[tmp_len++] = 'H';

--- a/src/status.c
+++ b/src/status.c
@@ -582,8 +582,10 @@ char *status_get_input_candidates_dev (const hashcat_ctx_t *hashcat_ctx, const i
   build_plain ((hashcat_ctx_t *) hashcat_ctx, device_param, &plain1, plain_buf1, &plain_len1);
   build_plain ((hashcat_ctx_t *) hashcat_ctx, device_param, &plain2, plain_buf2, &plain_len2);
 
-  const bool need_hex1 = need_hexify (plain_ptr1, plain_len1);
-  const bool need_hex2 = need_hexify (plain_ptr2, plain_len2);
+  bool accept_utf8 = hashcat_ctx->hashconfig->hash_type != HASH_TYPE_LM;
+
+  const bool need_hex1 = need_hexify (plain_ptr1, plain_len1, accept_utf8);
+  const bool need_hex2 = need_hexify (plain_ptr2, plain_len2, accept_utf8);
 
   if ((need_hex1 == true) || (need_hex2 == true))
   {


### PR DESCRIPTION
Here's code for #568. Currently it falls back to ASCII for the LM format only (possibly a few other formats could be added, and maybe even a command line option although I see no need for one).