### PR TITLE
Fix clang warning on OSX

### DIFF
--- a/src/opencl.c
+++ b/src/opencl.c
@@ -26,10 +26,12 @@
 #include "dynloader.h"
 #include "opencl.h"
 
+#if defined (__linux__)
 static const char dri_card0_path[] = "/dev/dri/card0";
 
 static const char drm_card0_vendor_path[] = "/sys/class/drm/card0/device/vendor";
 static const char drm_card0_driver_path[] = "/sys/class/drm/card0/device/driver";
+#endif
 
 static const u32 full01 = 0x01010101;
 static const u32 full80 = 0x80808080;


### PR DESCRIPTION
```
src/opencl.c:29:19: warning: unused variable 'dri_card0_path' [-Wunused-const-variable]
static const char dri_card0_path[] = "/dev/dri/card0";
                  ^
src/opencl.c:31:19: warning: unused variable 'drm_card0_vendor_path' [-Wunused-const-variable]
static const char drm_card0_vendor_path[] = "/sys/class/drm/card0/device/vendor";
                  ^
src/opencl.c:32:19: warning: unused variable 'drm_card0_driver_path' [-Wunused-const-variable]
static const char drm_card0_driver_path[] = "/sys/class/drm/card0/device/driver";
                  ^
3 warnings generated.
```