### PR TITLE
Fix CL_BUILD_PROGRAM_FAILURE on OSX (#412)

### DIFF
--- a/OpenCL/inc_vendor.cl
+++ b/OpenCL/inc_vendor.cl
@@ -217,3 +217,4 @@
 #endif
 
 #endif
+


### PR DESCRIPTION
ω(=＾・＾=)ω