### PR TITLE
Fix m10420 OSX build error

### DIFF
--- a/OpenCL/m10420_a3.cl
+++ b/OpenCL/m10420_a3.cl
@@ -26,6 +26,104 @@ __constant u32 padding[8] =
   0x7a695364
 };
 
+void md5_transform_S (const u32 w0[4], const u32 w1[4], const u32 w2[4], const u32 w3[4], u32 digest[4])
+{
+  u32 a = digest[0];
+  u32 b = digest[1];
+  u32 c = digest[2];
+  u32 d = digest[3];
+
+  u32 w0_t = w0[0];
+  u32 w1_t = w0[1];
+  u32 w2_t = w0[2];
+  u32 w3_t = w0[3];
+  u32 w4_t = w1[0];
+  u32 w5_t = w1[1];
+  u32 w6_t = w1[2];
+  u32 w7_t = w1[3];
+  u32 w8_t = w2[0];
+  u32 w9_t = w2[1];
+  u32 wa_t = w2[2];
+  u32 wb_t = w2[3];
+  u32 wc_t = w3[0];
+  u32 wd_t = w3[1];
+  u32 we_t = w3[2];
+  u32 wf_t = w3[3];
+
+  MD5_STEP_S (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+  MD5_STEP_S (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+  MD5_STEP_S (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+  MD5_STEP_S (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+  MD5_STEP_S (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+  MD5_STEP_S (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+  MD5_STEP_S (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+  MD5_STEP_S (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+  MD5_STEP_S (MD5_H , a, b, c, d, w5_t, MD5C20, MD5S20);
+  MD5_STEP_S (MD5_H , d, a, b, c, w8_t, MD5C21, MD5S21);
+  MD5_STEP_S (MD5_H , c, d, a, b, wb_t, MD5C22, MD5S22);
+  MD5_STEP_S (MD5_H , b, c, d, a, we_t, MD5C23, MD5S23);
+  MD5_STEP_S (MD5_H , a, b, c, d, w1_t, MD5C24, MD5S20);
+  MD5_STEP_S (MD5_H , d, a, b, c, w4_t, MD5C25, MD5S21);
+  MD5_STEP_S (MD5_H , c, d, a, b, w7_t, MD5C26, MD5S22);
+  MD5_STEP_S (MD5_H , b, c, d, a, wa_t, MD5C27, MD5S23);
+  MD5_STEP_S (MD5_H , a, b, c, d, wd_t, MD5C28, MD5S20);
+  MD5_STEP_S (MD5_H , d, a, b, c, w0_t, MD5C29, MD5S21);
+  MD5_STEP_S (MD5_H , c, d, a, b, w3_t, MD5C2a, MD5S22);
+  MD5_STEP_S (MD5_H , b, c, d, a, w6_t, MD5C2b, MD5S23);
+  MD5_STEP_S (MD5_H , a, b, c, d, w9_t, MD5C2c, MD5S20);
+  MD5_STEP_S (MD5_H , d, a, b, c, wc_t, MD5C2d, MD5S21);
+  MD5_STEP_S (MD5_H , c, d, a, b, wf_t, MD5C2e, MD5S22);
+  MD5_STEP_S (MD5_H , b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+  MD5_STEP_S (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+  MD5_STEP_S (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+  MD5_STEP_S (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+  MD5_STEP_S (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+  MD5_STEP_S (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+  MD5_STEP_S (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+  MD5_STEP_S (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+  MD5_STEP_S (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+  MD5_STEP_S (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+  MD5_STEP_S (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+  MD5_STEP_S (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+  MD5_STEP_S (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+  MD5_STEP_S (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+  MD5_STEP_S (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+  MD5_STEP_S (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+  MD5_STEP_S (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+  digest[0] += a;
+  digest[1] += b;
+  digest[2] += c;
+  digest[3] += d;
+}
+
 void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
 {
   u32x a = digest[0];
@@ -179,7 +277,7 @@ void m10420m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __gl
   p3[2] = 0;
   p3[3] = 0;
 
-  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
+  switch_buffer_by_offset_le_S (p0, p1, p2, p3, pw_len);
 
   w0[0] |= p0[0];
   w0[1] |= p0[1];
@@ -206,7 +304,7 @@ void m10420m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __gl
 
   for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
   {
-    const u32 w0r = ix_create_bft (bfs_buf, il_pos);
+    const u32 w0r = (u32) bfs_buf[il_pos + 0].i;
 
     w0[0] = w0l | w0r;
 
@@ -247,7 +345,7 @@ void m10420m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __gl
     digest[2] = MD5M_C;
     digest[3] = MD5M_D;
 
-    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
+    md5_transform_S (w0_t, w1_t, w2_t, w3_t, digest);
 
     w0_t[0] = P;
     w0_t[1] = id_buf[0];
@@ -266,7 +364,7 @@ void m10420m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __gl
     w3_t[2] = 84 * 8;
     w3_t[3] = 0;
 
-    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
+    md5_transform_S (w0_t, w1_t, w2_t, w3_t, digest);
 
     u32x a = digest[0];
     u32x b = digest[1] & 0xff;
@@ -332,7 +430,7 @@ void m10420s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __gl
   p3[2] = 0;
   p3[3] = 0;
 
-  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
+  switch_buffer_by_offset_le_S (p0, p1, p2, p3, pw_len);
 
   w0[0] |= p0[0];
   w0[1] |= p0[1];
@@ -371,7 +469,7 @@ void m10420s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __gl
 
   for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
   {
-    const u32 w0r = ix_create_bft (bfs_buf, il_pos);
+    const u32 w0r = (u32) bfs_buf[il_pos].i;
 
     w0[0] = w0l | w0r;
 


### PR DESCRIPTION
Fixed
```
$ ./hashcat -b -m 10420 -D1
hashcat (v3.10-715-ga085fc1) starting in benchmark mode...
 
OpenCL Platform #1: Apple
=========================
* Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, 2047/8192 MB allocatable, 4MCU
* Device #2: Iris, skipped
 
Hashtype: PDF 1.1 - 1.3 (Acrobat 2 - 4) + collider-mode #2
 
clBuildProgram(): CL_BUILD_PROGRAM_FAILURE
 
<program source>:29:6: warning: no previous prototype for function 'md5_transform'
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
     ^
<program source>:127:6: warning: no previous prototype for function 'm10420m'
void m10420m (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global pdf_t *pdf_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset)
     ^
<program source>:182:31: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                              ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:46: note: passing argument to parameter 'w0' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                             ^
<program source>:182:35: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                                  ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:58: note: passing argument to parameter 'w1' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                                         ^
<program source>:182:39: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                                      ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:70: note: passing argument to parameter 'w2' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                                                     ^
<program source>:182:43: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                                          ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:82: note: passing argument to parameter 'w3' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                                                                 ^
<program source>:209:15: error: initializing 'const u32' (aka 'const unsigned int') with an expression of incompatible type 'u32x' (aka '__uint4')
    const u32 w0r = ix_create_bft (bfs_buf, il_pos);
              ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<program source>:250:20: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                   ^~~~
<program source>:29:32: note: passing argument to parameter 'w0' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                               ^
<program source>:250:26: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                         ^~~~
<program source>:29:50: note: passing argument to parameter 'w1' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                 ^
<program source>:250:32: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                               ^~~~
<program source>:29:68: note: passing argument to parameter 'w2' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                   ^
<program source>:250:38: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                     ^~~~
<program source>:29:86: note: passing argument to parameter 'w3' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                     ^
<program source>:250:44: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                           ^~~~~~
<program source>:29:98: note: passing argument to parameter 'digest' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                                 ^
<program source>:269:20: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                   ^~~~
<program source>:29:32: note: passing argument to parameter 'w0' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                               ^
<program source>:269:26: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                         ^~~~
<program source>:29:50: note: passing argument to parameter 'w1' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                 ^
<program source>:269:32: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                               ^~~~
<program source>:29:68: note: passing argument to parameter 'w2' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                   ^
<program source>:269:38: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                     ^~~~
<program source>:29:86: note: passing argument to parameter 'w3' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                     ^
<program source>:269:44: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                           ^~~~~~
<program source>:29:98: note: passing argument to parameter 'digest' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                                 ^
<program source>:280:6: warning: no previous prototype for function 'm10420s'
void m10420s (u32 w0[4], u32 w1[4], u32 w2[4], u32 w3[4], const u32 pw_len, __global pw_t *pws, __global kernel_rule_t *rules_buf, __global comb_t *combs_buf, __global bf_t *bfs_buf, __global void *tmps, __global void *hooks, __global u32 *bitmaps_buf_s1_a, __global u32 *bitmaps_buf_s1_b, __global u32 *bitmaps_buf_s1_c, __global u32 *bitmaps_buf_s1_d, __global u32 *bitmaps_buf_s2_a, __global u32 *bitmaps_buf_s2_b, __global u32 *bitmaps_buf_s2_c, __global u32 *bitmaps_buf_s2_d, __global plain_t *plains_buf, __global digest_t *digests_buf, __global u32 *hashes_shown, __global salt_t *salt_bufs, __global pdf_t *pdf_bufs, __global u32 *d_return_buf, __global u32 *d_scryptV0_buf, __global u32 *d_scryptV1_buf, __global u32 *d_scryptV2_buf, __global u32 *d_scryptV3_buf, const u32 bitmap_mask, const u32 bitmap_shift1, const u32 bitmap_shift2, const u32 salt_pos, const u32 loop_pos, const u32 loop_cnt, const u32 il_cnt, const u32 digests_cnt, const u32 digests_offset)
     ^
<program source>:335:31: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                              ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:46: note: passing argument to parameter 'w0' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                             ^
<program source>:335:35: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                                  ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:58: note: passing argument to parameter 'w1' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                                         ^
<program source>:335:39: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                                      ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:70: note: passing argument to parameter 'w2' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                                                     ^
<program source>:335:43: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
  switch_buffer_by_offset_le (p0, p1, p2, p3, pw_len);
                                          ^~
/Users/matrix/h/h/a/hashcat/OpenCL/inc_common.cl:2211:82: note: passing argument to parameter 'w3' here
inline void switch_buffer_by_offset_le (u32x w0[4], u32x w1[4], u32x w2[4], u32x w3[4], const u32 offset)
                                                                                 ^
<program source>:374:15: error: initializing 'const u32' (aka 'const unsigned int') with an expression of incompatible type 'u32x' (aka '__uint4')
    const u32 w0r = ix_create_bft (bfs_buf, il_pos);
              ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<program source>:415:20: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                   ^~~~
<program source>:29:32: note: passing argument to parameter 'w0' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                               ^
<program source>:415:26: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                         ^~~~
<program source>:29:50: note: passing argument to parameter 'w1' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                 ^
<program source>:415:32: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                               ^~~~
<program source>:29:68: note: passing argument to parameter 'w2' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                   ^
<program source>:415:38: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                     ^~~~
<program source>:29:86: note: passing argument to parameter 'w3' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                     ^
<program source>:415:44: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                           ^~~~~~
<program source>:29:98: note: passing argument to parameter 'digest' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                                 ^
<program source>:434:20: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                   ^~~~
<program source>:29:32: note: passing argument to parameter 'w0' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                               ^
<program source>:434:26: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                         ^~~~
<program source>:29:50: note: passing argument to parameter 'w1' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                 ^
<program source>:434:32: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                               ^~~~
<program source>:29:68: note: passing argument to parameter 'w2' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                   ^
<program source>:434:38: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'const u32x *' (aka 'const __uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                     ^~~~
<program source>:29:86: note: passing argument to parameter 'w3' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                     ^
<program source>:434:44: warning: incompatible pointer types passing 'u32 [4]' to parameter of type 'u32x *' (aka '__uint4 *')
    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
                                           ^~~~~~
<program source>:29:98: note: passing argument to parameter 'digest' here
void md5_transform (const u32x w0[4], const u32x w1[4], const u32x w2[4], const u32x w3[4], u32x digest[4])
                                                                                                 ^
 
* Device #1: Kernel /Users/matrix/h/h/a/hashcat/OpenCL/m10420_a3.cl build failure. Proceeding without this device.
 
Started: Tue Nov 15 18:58:41 2016
Stopped: Tue Nov 15 18:58:42 2016
```