### PR TITLE
add missing includes for FreeBSD

### DIFF
--- a/src/affinity.c
+++ b/src/affinity.c
@@ -41,6 +41,7 @@ static int pthread_setaffinity_np (pthread_t thread, size_t cpu_size, cpu_set_t 
 #endif
 
 #if defined (__FreeBSD__)
+#include <pthread_np.h>
 typedef cpuset_t cpu_set_t;
 #endif
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -50,6 +50,8 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   #elif defined (__FreeBSD__)
 
+  #include <sys/sysctl.h>
+
   int mib[4];
 
   mib[0] = CTL_KERN;


### PR DESCRIPTION
These were lost during refactoring and found again
in preparation for port update to upcoming 3.20.