### PR TITLE
Fix compilation for native Cygwin

### DIFF
--- a/include/affinity.h
+++ b/include/affinity.h
@@ -11,7 +11,9 @@
 
 #if defined (_POSIX)
 #include <pthread.h>
+#if defined (__linux__)
 #include <sys/sysctl.h>
+#endif // __linux__
 #endif // _POSIX
 
 #if defined (__APPLE__)

--- a/include/common.h
+++ b/include/common.h
@@ -8,7 +8,7 @@
 
 #define PROGNAME "hashcat"
 
-#if   defined (__linux__)
+#if   defined (__linux__) || defined (__CYGWIN__)
 #define _POSIX
 #elif defined (__APPLE__)
 #define _POSIX
@@ -38,7 +38,7 @@
 
 #if defined (__MSC_VER)
 #define HC_API_CALL __cdecl
-#elif defined (_WIN32) || defined (__WIN32__) || defined (__CYGWIN__)
+#elif defined (_WIN32) || defined (__WIN32__)
 #define HC_API_CALL __stdcall
 #else
 #define HC_API_CALL

--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -252,7 +252,7 @@ typedef struct ADLOD6PowerControlInfo
 
 #if defined (__MSC_VER)
 #define ADL_API_CALL __cdecl
-#elif defined (_WIN32) || defined (__WIN32__) || defined (__CYGWIN__)
+#elif defined (_WIN32) || defined (__WIN32__)
 #define ADL_API_CALL __stdcall
 #else
 #define ADL_API_CALL

--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -25,6 +25,10 @@
 #include <CL/cl.h>
 #endif
 
+#if defined (__CYGWIN__)
+#include <CL/cl.h>
+#endif
+
 // NVIDIA extras
 
 #define CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV       0x4000

--- a/include/ext_nvapi.h
+++ b/include/ext_nvapi.h
@@ -215,7 +215,7 @@ NVAPI_INTERFACE NvAPI_GPU_RestoreCoolerSettings (NvPhysicalGpuHandle hPhysicalGp
 
 typedef NvPhysicalGpuHandle HM_ADAPTER_NVAPI;
 
-#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__WIN32__)
 #define NVAPI_API_CALL __stdcall
 #else
 #define NVAPI_API_CALL

--- a/include/ext_nvml.h
+++ b/include/ext_nvml.h
@@ -159,7 +159,7 @@ typedef enum nvmlGom_enum
 
 typedef nvmlDevice_t HM_ADAPTER_NVML;
 
-#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__WIN32__)
 #define NVML_API_CALL __stdcall
 #else
 #define NVML_API_CALL

--- a/include/ext_xnvctrl.h
+++ b/include/ext_xnvctrl.h
@@ -40,7 +40,7 @@ typedef int   (*XCLOSEDISPLAY) (void *);
 
 typedef int HM_ADAPTER_XNVCTRL;
 
-#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__WIN32__)
 #define XNVCTRL_API_CALL __stdcall
 #else
 #define XNVCTRL_API_CALL

--- a/include/sort_r.h
+++ b/include/sort_r.h
@@ -28,7 +28,7 @@ Slightly modified to work with hashcat to no falsly detect _SORT_R_LINUX with mi
      defined __FreeBSD__ || defined __DragonFly__)
 #  define _SORT_R_BSD
 #  define _SORT_R_INLINE inline
-#elif (defined __linux__)
+#elif (defined __linux__) || defined (__CYGWIN__)
 #  define _SORT_R_LINUX
 #  define _SORT_R_INLINE inline
 #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)

--- a/src/affinity.c
+++ b/src/affinity.c
@@ -45,8 +45,11 @@ static int pthread_setaffinity_np (pthread_t thread, size_t cpu_size, cpu_set_t 
 typedef cpuset_t cpu_set_t;
 #endif
 
-int set_cpu_affinity (hashcat_ctx_t *hashcat_ctx)
+int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 {
+#if defined (__CYGWIN__)
+  return 0;
+#else
   const user_options_t *user_options = hashcat_ctx->user_options;
 
   if (user_options->cpu_affinity == NULL) return 0;
@@ -121,4 +124,5 @@ int set_cpu_affinity (hashcat_ctx_t *hashcat_ctx)
   #endif
 
   return 0;
+#endif
 }

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -15,7 +15,7 @@ int sort_by_dictstat (const void *s1, const void *s2)
   dictstat_t *d1 = (dictstat_t *) s1;
   dictstat_t *d2 = (dictstat_t *) s2;
 
-  #if defined (__linux__)
+  #if defined (__linux__) || defined (__CYGWIN__)
   d2->stat.st_atim = d1->stat.st_atim;
   #else
   d2->stat.st_atime = d1->stat.st_atime;

--- a/src/folder.c
+++ b/src/folder.c
@@ -24,7 +24,7 @@ int sort_by_stringptr (const void *p1, const void *p2)
 
 static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 {
-  #if defined (__linux__)
+  #if defined (__linux__) || defined (__CYGWIN__)
 
   char tmp[32] = { 0 };
 
@@ -302,7 +302,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
     return -1;
   }
 
-  #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+  #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined (__CYGWIN__)
 
   static const char SLASH[] = "/";
 

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -369,6 +369,8 @@ int ocl_init (hashcat_ctx_t *hashcat_ctx)
   ocl->lib = hc_dlopen ("OpenCL");
   #elif defined(__APPLE__)
   ocl->lib = hc_dlopen ("/System/Library/Frameworks/OpenCL.framework/OpenCL", RTLD_NOW);
+  #elif defined (__CYGWIN__)
+  ocl->lib = hc_dlopen ("cygOpenCL-1.dll", RTLD_NOW);
   #else
   ocl->lib = hc_dlopen ("libOpenCL.so", RTLD_NOW);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -294,7 +294,7 @@ void SetConsoleWindowSize (const int x)
 }
 #endif
 
-#if defined (__linux__)
+#if defined (__linux__) || defined (__CYGWIN__)
 static struct termios savemodes;
 static int havemodes = 0;
 


### PR DESCRIPTION
set_cpu_affinity was if'd out since cygwin has no cpu_set_t or pthreads_setaffinity_np support.

Still doesn't quite work(OpenCL kernels don't even run) but at least it gets to that point.