### PR TITLE
Only lock loopback and pot files while actually writing to them.

### DIFF
--- a/src/loopback.c
+++ b/src/loopback.c
@@ -112,15 +112,6 @@ int loopback_write_open (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  if (lock_file (fp) == -1)
-  {
-    fclose (fp);
-
-    event_log_error (hashcat_ctx, "%s: %s", loopback_ctx->filename, strerror (errno));
-
-    return -1;
-  }
-
   loopback_ctx->fp = fp;
 
   loopback_ctx->unused = true;
@@ -165,9 +156,13 @@ void loopback_write_append (hashcat_ctx_t *hashcat_ctx, const u8 *plain_ptr, con
 
   loopback_format_plain (hashcat_ctx, plain_ptr, plain_len);
 
+  lock_file (fp);
+
   fwrite (EOL, strlen (EOL), 1, fp);
 
   fflush (fp);
+
+  unlock_file (fp);
 
   loopback_ctx->unused = false;
 }

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -184,15 +184,6 @@ int potfile_write_open (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  if (lock_file (fp) == -1)
-  {
-    fclose (fp);
-
-    event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
-
-    return -1;
-  }
-
   potfile_ctx->fp = fp;
 
   return 0;
@@ -260,9 +251,13 @@ void potfile_write_append (hashcat_ctx_t *hashcat_ctx, const char *out_buf, u8 *
 
   tmp_buf[tmp_len] = 0;
 
+  lock_file (potfile_ctx->fp);
+
   fprintf (potfile_ctx->fp, "%s" EOL, tmp_buf);
 
   fflush (potfile_ctx->fp);
+
+  unlock_file (potfile_ctx->fp);
 }
 
 int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)


### PR DESCRIPTION
Closes #893.