### PR TITLE
Few more fixes.

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -17,6 +17,7 @@
 #elif defined (_WIN32) || defined (_WIN64)
 #define _WIN 1
 #define WIN 1
+#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L //hack to get ctime_r working
 #else
 #error Your Operating System is not supported or detected
 #endif

--- a/include/event.h
+++ b/include/event.h
@@ -14,13 +14,19 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
 #define EVENT(id)              event_call ((id), hashcat_ctx, NULL,  0)
 #define EVENT_DATA(id,buf,len) event_call ((id), hashcat_ctx, (buf), (len))
 
-size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
-size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
 int  event_ctx_init         (hashcat_ctx_t *hashcat_ctx);
 void event_ctx_destroy      (hashcat_ctx_t *hashcat_ctx);

--- a/src/event.c
+++ b/src/event.c
@@ -8,8 +8,6 @@
 #include "thread.h"
 #include "event.h"
 
-static int event_log (const char *fmt, va_list ap, char *s, const size_t sz) __attribute__ ((format (printf, 1, 0)));
-
 void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, const size_t len)
 {
   event_ctx_t *event_ctx = hashcat_ctx->event_ctx;
@@ -55,6 +53,7 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
   }
 }
 
+__attribute__ ((format (printf, 1, 0)))
 static int event_log (const char *fmt, va_list ap, char *s, const size_t sz)
 {
   return vsnprintf (s, sz, fmt, ap);

--- a/src/status.c
+++ b/src/status.c
@@ -844,7 +844,9 @@ char *status_get_time_started_absolute (const hashcat_ctx_t *hashcat_ctx)
 
   const time_t time_start = status_ctx->runtime_start;
 
-  char *start = ctime (&time_start);
+  char buf;
+
+  char *start = ctime_r (&time_start, &buf);
 
   const size_t start_len = strlen (start);
 
@@ -934,7 +936,9 @@ char *status_get_time_estimated_absolute (const hashcat_ctx_t *hashcat_ctx)
 
   now += sec_etc;
 
-  char *etc = ctime (&now);
+  char buf;
+
+  char *etc = ctime_r (&now, &buf);
 
   const size_t etc_len = strlen (etc);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -70,8 +70,10 @@ void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const 
   if (user_options->show        == true) return;
   if (user_options->left        == true) return;
 
-  event_log_info_nn (hashcat_ctx, "Started: %s", ctime (&proc_start));
-  event_log_info_nn (hashcat_ctx, "Stopped: %s", ctime (&proc_stop));
+  char start_buf, stop_buf;
+
+  event_log_info_nn (hashcat_ctx, "Started: %s", ctime_r (&proc_start, &start_buf));
+  event_log_info_nn (hashcat_ctx, "Stopped: %s", ctime_r (&proc_stop, &stop_buf));
 }
 
 int setup_console ()


### PR DESCRIPTION
It compiles so I assume it works fine. Interestingly cppcheck complains about ctime_r but not ctime when it should complain about both.

I tried avoiding defining _POSIX_THREAD_SAFE_FUNCTIONS directly but the only other way is to define _POSIX_C_SOURCE which defines ANSI stdio as well.