### PR TITLE
Thread safety fixes.

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -17,6 +17,7 @@
 #elif defined (_WIN32) || defined (_WIN64)
 #define _WIN 1
 #define WIN 1
+#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L //for *time_r functions
 #else
 #error Your Operating System is not supported or detected
 #endif

--- a/include/event.h
+++ b/include/event.h
@@ -14,13 +14,19 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
 #define EVENT(id)              event_call ((id), hashcat_ctx, NULL,  0)
 #define EVENT_DATA(id,buf,len) event_call ((id), hashcat_ctx, (buf), (len))
 
-size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (gnu_printf, 2, 3)))
+size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (gnu_printf, 2, 3)))
+size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
-size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+__attribute__ ((format (printf, 2, 3)))
+size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (gnu_printf, 2, 3)))
+size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
+__attribute__ ((format (gnu_printf, 2, 3)))
+size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
 int  event_ctx_init         (hashcat_ctx_t *hashcat_ctx);
 void event_ctx_destroy      (hashcat_ctx_t *hashcat_ctx);

--- a/src/combinator.c
+++ b/src/combinator.c
@@ -53,14 +53,14 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if ((fp1 = fopen (dictfile1, "rb")) == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %s", dictfile1, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", dictfile1);
 
       return -1;
     }
 
     if (hc_stat (dictfile1, &tmp_stat) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %s", dictfile1, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", dictfile1);
 
       fclose (fp1);
 
@@ -78,7 +78,7 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if ((fp2 = fopen (dictfile2, "rb")) == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", dictfile2);
 
       fclose (fp1);
 
@@ -87,7 +87,7 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if (hc_stat (dictfile2, &tmp_stat) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", dictfile2);
 
       fclose (fp1);
       fclose (fp2);

--- a/src/cpu_crc32.c
+++ b/src/cpu_crc32.c
@@ -85,7 +85,7 @@ int cpu_crc32 (hashcat_ctx_t *hashcat_ctx, const char *filename, u8 keytab[64])
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", filename);
 
     return (-1);
   }

--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -118,7 +118,7 @@ int debugfile_init (hashcat_ctx_t *hashcat_ctx)
     {
       fclose (fp);
 
-      event_log_error (hashcat_ctx, "%s: %s", debugfile_ctx->filename, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", debugfile_ctx->filename);
 
       return -1;
     }

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -53,7 +53,7 @@ int dictstat_init (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", dictstat_ctx->filename);
 
     return -1;
   }
@@ -121,7 +121,7 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", dictstat_ctx->filename);
 
     return -1;
   }
@@ -130,7 +130,7 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
   {
     fclose (fp);
 
-    event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", dictstat_ctx->filename);
 
     return -1;
   }

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -323,7 +323,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
     if (fd == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %s", dictfile, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", dictfile);
 
       return -1;
     }
@@ -340,7 +340,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
         if (combs_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %s", combinator_ctx->dict2, strerror (errno));
+          event_log_error (hashcat_ctx, "%s: %m", combinator_ctx->dict2);
 
           fclose (fd);
 
@@ -357,7 +357,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
         if (combs_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %s", dictfilec, strerror (errno));
+          event_log_error (hashcat_ctx, "%s: %m", dictfilec);
 
           fclose (fd);
 

--- a/src/event.c
+++ b/src/event.c
@@ -8,8 +8,6 @@
 #include "thread.h"
 #include "event.h"
 
-static int event_log (const char *fmt, va_list ap, char *s, const size_t sz) __attribute__ ((format (printf, 1, 0)));
-
 void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, const size_t len)
 {
   event_ctx_t *event_ctx = hashcat_ctx->event_ctx;
@@ -55,6 +53,7 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
   }
 }
 
+__attribute__ ((format (gnu_printf, 1, 0)))
 static int event_log (const char *fmt, va_list ap, char *s, const size_t sz)
 {
   return vsnprintf (s, sz, fmt, ap);

--- a/src/folder.c
+++ b/src/folder.c
@@ -280,7 +280,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   if (getcwd (cwd, HCBUFSIZ_TINY - 1) == NULL)
   {
-    event_log_error (hashcat_ctx, "getcwd(): %s", strerror (errno));
+    event_log_error (hashcat_ctx, "getcwd(): %m");
 
     return -1;
   }
@@ -317,7 +317,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
   This causes invalid error out if install_folder (/usr/local/bin) does not exist
   if (resolved_install_folder == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", resolved_install_folder, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", resolved_install_folder);
 
     return -1;
   }
@@ -325,7 +325,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   if (resolved_exec_path == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", resolved_exec_path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", resolved_exec_path);
 
     return -1;
   }
@@ -414,7 +414,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   if (realpath (cpath, cpath_real) == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", cpath, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", cpath);
 
     return -1;
   }

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -140,7 +140,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", new_hashfile);
 
     return -1;
   }
@@ -149,7 +149,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
   {
     fclose (fp);
 
-    event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", new_hashfile);
 
     return -1;
   }
@@ -215,7 +215,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
   if (rename (hashfile, old_hashfile) != 0)
   {
-    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %s", hashfile, old_hashfile, strerror (errno));
+    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %m", hashfile, old_hashfile);
 
     return -1;
   }
@@ -224,7 +224,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
   if (rename (new_hashfile, hashfile) != 0)
   {
-    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %s", new_hashfile, hashfile, strerror (errno));
+    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %m", new_hashfile, hashfile);
 
     return -1;
   }
@@ -480,7 +480,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
         if (hc_stat (hashes->hashfile, &st) == -1)
         {
-          event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
+          event_log_error (hashcat_ctx, "%s: %m", hashes->hashfile);
 
           return -1;
         }
@@ -502,7 +502,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
       if ((fp = fopen (hashfile, "rb")) == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %s", hashfile, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", hashfile);
 
         return -1;
       }
@@ -705,7 +705,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           if (fp == NULL)
           {
-            event_log_error (hashcat_ctx, "%s: %s", hash_buf, strerror (errno));
+            event_log_error (hashcat_ctx, "%s: %m", hash_buf);
 
             return -1;
           }
@@ -813,7 +813,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
       if ((fp = fopen (hashfile, "rb")) == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %s", hashfile, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", hashfile);
 
         return -1;
       }

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -111,7 +111,7 @@ static int hm_SYSFS_get_fan_speed_current (hashcat_ctx_t *hashcat_ctx, const int
 
   if (fd_cur == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path_cur, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path_cur);
 
     return -1;
   }
@@ -133,7 +133,7 @@ static int hm_SYSFS_get_fan_speed_current (hashcat_ctx_t *hashcat_ctx, const int
 
   if (fd_max == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path_max, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path_max);
 
     return -1;
   }
@@ -186,7 +186,7 @@ static int hm_SYSFS_set_fan_control (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path);
 
     return -1;
   }
@@ -218,7 +218,7 @@ static int hm_SYSFS_set_fan_speed_target (hashcat_ctx_t *hashcat_ctx, const int 
 
   if (fd_max == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path_max, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path_max);
 
     return -1;
   }
@@ -249,7 +249,7 @@ static int hm_SYSFS_set_fan_speed_target (hashcat_ctx_t *hashcat_ctx, const int 
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path);
 
     return -1;
   }
@@ -280,7 +280,7 @@ static int hm_SYSFS_get_temperature_current (hashcat_ctx_t *hashcat_ctx, const i
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path);
 
     return -1;
   }
@@ -321,7 +321,7 @@ static int hm_SYSFS_get_pp_dpm_sclk (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path);
 
     return -1;
   }
@@ -374,7 +374,7 @@ static int hm_SYSFS_get_pp_dpm_mclk (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path);
 
     return -1;
   }
@@ -427,7 +427,7 @@ static int hm_SYSFS_get_pp_dpm_pcie (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path);
 
     return -1;
   }
@@ -481,7 +481,7 @@ static int hm_SYSFS_set_power_dpm_force_performance_level (hashcat_ctx_t *hashca
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", path);
 
     return -1;
   }

--- a/src/induct.c
+++ b/src/induct.c
@@ -65,14 +65,14 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (rename (root_directory, root_directory_mv) != 0)
         {
-          event_log_error (hashcat_ctx, "Rename directory %s to %s: %s", root_directory, root_directory_mv, strerror (errno));
+          event_log_error (hashcat_ctx, "Rename directory %s to %s: %m", root_directory, root_directory_mv);
 
           return -1;
         }
       }
       else
       {
-        event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", root_directory);
 
         return -1;
       }
@@ -80,7 +80,7 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if (hc_mkdir (root_directory, 0700) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", root_directory);
 
       return -1;
     }
@@ -126,7 +126,7 @@ void induct_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
     }
     else
     {
-      event_log_error (hashcat_ctx, "%s: %s", induct_ctx->root_directory, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", induct_ctx->root_directory);
 
       //return -1;
     }

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -53,7 +53,7 @@ void logfile_append (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", logfile_ctx->logfile, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", logfile_ctx->logfile);
 
     return;
   }
@@ -96,7 +96,7 @@ int logfile_init (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", logfile_ctx->logfile, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", logfile_ctx->logfile);
 
     return -1;
   }

--- a/src/loopback.c
+++ b/src/loopback.c
@@ -107,7 +107,7 @@ int loopback_write_open (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", loopback_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", loopback_ctx->filename);
 
     return -1;
   }

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -656,7 +656,7 @@ static int sp_setup_tbl (hashcat_ctx_t *hashcat_ctx)
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", hcstat, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", hcstat);
 
     return -1;
   }
@@ -1202,7 +1202,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
             if (hc_stat (arg, &file_stat) == -1)
             {
-              event_log_error (hashcat_ctx, "%s: %s", arg, strerror (errno));
+              event_log_error (hashcat_ctx, "%s: %m", arg);
 
               return -1;
             }
@@ -1213,7 +1213,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
               if (mask_fp == NULL)
               {
-                event_log_error (hashcat_ctx, "%s: %s", arg, strerror (errno));
+                event_log_error (hashcat_ctx, "%s: %m", arg);
 
                 return -1;
               }
@@ -1295,7 +1295,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (mask_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %s", arg, strerror (errno));
+          event_log_error (hashcat_ctx, "%s: %m", arg);
 
           return -1;
         }
@@ -1358,7 +1358,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (mask_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %s", arg, strerror (errno));
+          event_log_error (hashcat_ctx, "%s: %m", arg);
 
           return -1;
         }

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -89,7 +89,7 @@ static int ocl_check_dri (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 
   if (fd_dri == NULL)
   {
-    event_log_error (hashcat_ctx, "Can not access %s: %s", dri_card0_path, strerror (errno));
+    event_log_error (hashcat_ctx, "Can not access %s: %m", dri_card0_path);
     event_log_error (hashcat_ctx, "This causes some drivers to crash when OpenCL is used!");
     event_log_error (hashcat_ctx, "Usually it's enough to add your user account to the \"video\" group to fix this problem:");
     event_log_error (hashcat_ctx, "$ sudo usermod -a -G video $LOGNAME");
@@ -308,7 +308,7 @@ static int read_kernel_binary (hashcat_ctx_t *hashcat_ctx, const char *kernel_fi
 
     if (num_read != (size_t) st.st_size)
     {
-      event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", kernel_file);
 
       return -1;
     }
@@ -324,7 +324,7 @@ static int read_kernel_binary (hashcat_ctx_t *hashcat_ctx, const char *kernel_fi
   }
   else
   {
-    event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", kernel_file);
 
     return -1;
   }
@@ -340,7 +340,7 @@ static int write_kernel_binary (hashcat_ctx_t *hashcat_ctx, char *kernel_file, c
 
     if (fp == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", kernel_file);
 
       return -1;
     }
@@ -349,7 +349,7 @@ static int write_kernel_binary (hashcat_ctx_t *hashcat_ctx, char *kernel_file, c
     {
       fclose (fp);
 
-      event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", kernel_file);
 
       return -1;
     }
@@ -3627,7 +3627,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     if (chdir (folder_config->cpath_real) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %s", folder_config->cpath_real, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", folder_config->cpath_real);
 
       return -1;
     }
@@ -3671,7 +3671,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (fd == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %s", files_names[i], strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", files_names[i]);
 
         return -1;
       }
@@ -3684,7 +3684,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (n != 1)
       {
-        event_log_error (hashcat_ctx, "%s: %s", files_names[i], strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", files_names[i]);
 
         return -1;
       }
@@ -3723,7 +3723,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_stat (source_file, &sst) == -1)
       {
-        event_log_error (hashcat_ctx, "%s: %s", source_file, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", source_file);
 
         return -1;
       }
@@ -3931,7 +3931,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_stat (source_file, &sst) == -1)
       {
-        event_log_error (hashcat_ctx, "%s: %s", source_file, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", source_file);
 
         return -1;
       }
@@ -4073,7 +4073,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_stat (source_file, &sst) == -1)
       {
-        event_log_error (hashcat_ctx, "%s: %s", source_file, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", source_file);
 
         return -1;
       }
@@ -4197,7 +4197,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     if (chdir (folder_config->cwd) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %s", folder_config->cwd, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", folder_config->cwd);
 
       return -1;
     }

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -310,7 +310,7 @@ int outfile_write_open (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", outfile_ctx->filename);
 
     return -1;
   }
@@ -319,7 +319,7 @@ int outfile_write_open (hashcat_ctx_t *hashcat_ctx)
   {
     fclose (fp);
 
-    event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", outfile_ctx->filename);
 
     return -1;
   }

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -364,7 +364,7 @@ int outcheck_ctx_init (hashcat_ctx_t *hashcat_ctx)
   {
     if (hc_mkdir (outcheck_ctx->root_directory, 0700) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %s", outcheck_ctx->root_directory, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", outcheck_ctx->root_directory);
 
       return -1;
     }
@@ -394,7 +394,7 @@ void outcheck_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
     }
     else
     {
-      event_log_error (hashcat_ctx, "%s: %s", outcheck_ctx->root_directory, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", outcheck_ctx->root_directory);
 
       //return -1;
     }

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -150,7 +150,7 @@ int potfile_read_open (hashcat_ctx_t *hashcat_ctx)
 
   if (potfile_ctx->fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", potfile_ctx->filename);
 
     return -1;
   }
@@ -179,7 +179,7 @@ int potfile_write_open (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", potfile_ctx->filename);
 
     return -1;
   }

--- a/src/restore.c
+++ b/src/restore.c
@@ -145,7 +145,7 @@ static int init_restore (hashcat_ctx_t *hashcat_ctx)
 
   if (getcwd (rd->cwd, 255) == NULL)
   {
-    event_log_error (hashcat_ctx, "getcwd(): %s", strerror (errno));
+    event_log_error (hashcat_ctx, "getcwd(): %m");
 
     return -1;
   }
@@ -165,7 +165,7 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "Restore file '%s': %s", eff_restore_file, strerror (errno));
+    event_log_error (hashcat_ctx, "Restore file '%s': %m", eff_restore_file);
 
     return -1;
   }
@@ -244,14 +244,14 @@ static int write_restore (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", new_restore_file, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", new_restore_file);
 
     return -1;
   }
 
   if (setvbuf (fp, NULL, _IONBF, 0))
   {
-    event_log_error (hashcat_ctx, "setvbuf file '%s': %s", new_restore_file, strerror (errno));
+    event_log_error (hashcat_ctx, "setvbuf file '%s': %m", new_restore_file);
 
     fclose (fp);
 
@@ -299,13 +299,13 @@ int cycle_restore (hashcat_ctx_t *hashcat_ctx)
   {
     if (unlink (eff_restore_file))
     {
-      event_log_warning (hashcat_ctx, "Unlink file '%s': %s", eff_restore_file, strerror (errno));
+      event_log_warning (hashcat_ctx, "Unlink file '%s': %m", eff_restore_file);
     }
   }
 
   if (rename (new_restore_file, eff_restore_file))
   {
-    event_log_warning (hashcat_ctx, "Rename file '%s' to '%s': %s", new_restore_file, eff_restore_file, strerror (errno));
+    event_log_warning (hashcat_ctx, "Rename file '%s' to '%s': %m", new_restore_file, eff_restore_file);
   }
 
   return 0;

--- a/src/rp.c
+++ b/src/rp.c
@@ -752,7 +752,7 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
 
     if ((fp = fopen (rp_file, "rb")) == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %s", rp_file, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", rp_file);
 
       return -1;
     }

--- a/src/status.c
+++ b/src/status.c
@@ -844,7 +844,9 @@ char *status_get_time_started_absolute (const hashcat_ctx_t *hashcat_ctx)
 
   const time_t time_start = status_ctx->runtime_start;
 
-  char *start = ctime (&time_start);
+  char buf;
+
+  char *start = ctime_r (&time_start, &buf);
 
   const size_t start_len = strlen (start);
 
@@ -934,7 +936,9 @@ char *status_get_time_estimated_absolute (const hashcat_ctx_t *hashcat_ctx)
 
   now += sec_etc;
 
-  char *etc = ctime (&now);
+  char buf;
+
+  char *etc = ctime_r (&now, &buf);
 
   const size_t etc_len = strlen (etc);
 

--- a/src/stdout.c
+++ b/src/stdout.c
@@ -69,7 +69,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
 
     if (fp == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %s", filename, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", filename);
 
       return -1;
     }
@@ -78,7 +78,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
     {
       fclose (fp);
 
-      event_log_error (hashcat_ctx, "%s: %s", filename, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", filename);
 
       return -1;
     }

--- a/src/straight.c
+++ b/src/straight.c
@@ -69,7 +69,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       if (fd == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %s", straight_ctx->dict, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", straight_ctx->dict);
 
         return -1;
       }
@@ -97,7 +97,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       if (fd == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %s", combinator_ctx->dict1, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", combinator_ctx->dict1);
 
         return -1;
       }
@@ -112,7 +112,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       if (fd == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %s", combinator_ctx->dict2, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", combinator_ctx->dict2);
 
         return -1;
       }
@@ -151,7 +151,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
     if (fd == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %s", straight_ctx->dict, strerror (errno));
+      event_log_error (hashcat_ctx, "%s: %m", straight_ctx->dict);
 
       return -1;
     }
@@ -272,7 +272,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (hc_stat (l0_filename, &l0_stat) == -1)
         {
-          event_log_error (hashcat_ctx, "%s: %s", l0_filename, strerror (errno));
+          event_log_error (hashcat_ctx, "%s: %m", l0_filename);
 
           return -1;
         }
@@ -295,7 +295,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
               if (hc_stat (l1_filename, &l1_stat) == -1)
               {
-                event_log_error (hashcat_ctx, "%s: %s", l1_filename, strerror (errno));
+                event_log_error (hashcat_ctx, "%s: %m", l1_filename);
 
                 return -1;
               }
@@ -345,7 +345,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_stat (l0_filename, &l0_stat) == -1)
       {
-        event_log_error (hashcat_ctx, "%s: %s", l0_filename, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", l0_filename);
 
         return -1;
       }
@@ -368,7 +368,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
             if (hc_stat (l1_filename, &l1_stat) == -1)
             {
-              event_log_error (hashcat_ctx, "%s: %s", l1_filename, strerror (errno));
+              event_log_error (hashcat_ctx, "%s: %m", l1_filename);
 
               return -1;
             }
@@ -409,7 +409,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_stat (l0_filename, &l0_stat) == -1)
       {
-        event_log_error (hashcat_ctx, "%s: %s", l0_filename, strerror (errno));
+        event_log_error (hashcat_ctx, "%s: %m", l0_filename);
 
         return -1;
       }
@@ -432,7 +432,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
             if (hc_stat (l1_filename, &l1_stat) == -1)
             {
-              event_log_error (hashcat_ctx, "%s: %s", l1_filename, strerror (errno));
+              event_log_error (hashcat_ctx, "%s: %m", l1_filename);
 
               return -1;
             }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -70,8 +70,10 @@ void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const 
   if (user_options->show        == true) return;
   if (user_options->left        == true) return;
 
-  event_log_info_nn (hashcat_ctx, "Started: %s", ctime (&proc_start));
-  event_log_info_nn (hashcat_ctx, "Stopped: %s", ctime (&proc_stop));
+  char start_buf, stop_buf;
+
+  event_log_info_nn (hashcat_ctx, "Started: %s", ctime_r (&proc_start, &start_buf));
+  event_log_info_nn (hashcat_ctx, "Stopped: %s", ctime_r (&proc_stop, &stop_buf));
 }
 
 int setup_console ()

--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -75,7 +75,7 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %s", tuning_db_file, strerror (errno));
+    event_log_error (hashcat_ctx, "%s: %m", tuning_db_file);
 
     return -1;
   }


### PR DESCRIPTION
First commit removes strerror, which is not thread safe. At least not under linux. %m is a GNU extension and as such, the attribute had to be changed to gnu_printf. Otherwise MinGW threw warnings.

I left two functions as normal printf because of MinGW stupidity( PRIu64 getting evaluated to %u and whatnot).

Second commit changed ctime to ctime_r. Pretty straight forward. The define also exposes gmtime_r in MinGW.