### PR TITLE
Only apply gnu_printf to MinGW

### DIFF
--- a/include/event.h
+++ b/include/event.h
@@ -14,18 +14,24 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
 #define EVENT(id)              event_call ((id), hashcat_ctx, NULL,  0)
 #define EVENT_DATA(id,buf,len) event_call ((id), hashcat_ctx, (buf), (len))
 
+#if defined (__MINGW32__)
+#define EVENT_PRINTF __attribute__ ((format (gnu_printf, 2, 3)))
+#else
+#define EVENT_PRINTF __attribute__ ((format (printf, 2, 3)))
+#endif
+
 __attribute__ ((format (printf, 2, 3)))
 size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-__attribute__ ((format (gnu_printf, 2, 3)))
+EVENT_PRINTF
 size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-__attribute__ ((format (gnu_printf, 2, 3)))
+EVENT_PRINTF
 size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
 __attribute__ ((format (printf, 2, 3)))
 size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-__attribute__ ((format (gnu_printf, 2, 3)))
+EVENT_PRINTF
 size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-__attribute__ ((format (gnu_printf, 2, 3)))
+EVENT_PRINTF
 size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
 int  event_ctx_init         (hashcat_ctx_t *hashcat_ctx);

--- a/src/event.c
+++ b/src/event.c
@@ -53,7 +53,7 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
   }
 }
 
-__attribute__ ((format (gnu_printf, 1, 0)))
+__attribute__ ((format (printf, 1, 0)))
 static int event_log (const char *fmt, va_list ap, char *s, const size_t sz)
 {
   return vsnprintf (s, sz, fmt, ap);


### PR DESCRIPTION
Needs verification before being pulled. No problems with MinGW or Linux but I cannot test OS X or FreeBSD so I have no idea if %m is supported by them or not.

Ideally test by invoking one of the functions. For example

./hashcat -a 2 -m ?? hashfile.txt filenotfound.dict

@matrix ?