### PR TITLE
extend global CFLAGS and LDFLAGS to aid distro packaging

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -101,7 +101,7 @@ BINARY_NATIVE           := $(PROG_NAME)
 ## General compiler and linker options
 ##
 
-CFLAGS                  := -pipe -std=c99 -Iinclude/ -IOpenCL/
+CFLAGS                  += -pipe -std=c99 -Iinclude/ -IOpenCL/
 CFLAGS                  += -W
 CFLAGS                  += -Wall
 CFLAGS                  += -Wextra
@@ -137,7 +137,7 @@ CFLAGS                  += -ftrapv
 
 #CFLAGS                  += -Wstack-usage=524288
 
-LFLAGS                  :=
+LFLAGS                  := $(LDFLAGS)
 
 ifndef DEBUG
 CFLAGS                  += -O2


### PR DESCRIPTION
This preserves globally defined CFLAGS and LDFLAGS and simply
extends those variables to aid distro based packaging toolchains
and predefined distro wide defaults like SSP, relro etc.

this re-fixes 7f8aaf74302816d03fbff62dab5c987d498acdde after it was
somehow undone ;)