### PR TITLE
respect ports tree CFLAGS and LFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -177,10 +177,12 @@ LFLAGS_NATIVE           += -lpthread -ldl
 endif # Linux
 
 ifeq ($(UNAME),FreeBSD)
+ifndef PORTNAME
 CFLAGS_NATIVE           := $(CFLAGS)
-CFLAGS_NATIVE           += -I$(OPENCL_HEADERS_KHRONOS)/
-CFLAGS_NATIVE           += -march=native
 LFLAGS_NATIVE           := $(LFLAGS)
+CFLAGS_NATIVE           += -march=native
+endif
+CFLAGS_NATIVE           += -I$(OPENCL_HEADERS_KHRONOS)/
 LFLAGS_NATIVE           += -lpthread
 endif # FreeBSD
 


### PR DESCRIPTION
FreeBSD ports need to respect flags passed down by the build system.
This enables FreeBSD hashcat port to use upstream hashcat source code
patch-free.