### PR TITLE
respect ports tree CFLAGS and LFLAGS  step 2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -179,11 +179,11 @@ endif # Linux
 ifeq ($(UNAME),FreeBSD)
 ifndef PORTNAME
 CFLAGS_NATIVE           := $(CFLAGS)
-LFLAGS_NATIVE           := $(LFLAGS)
-CFLAGS_NATIVE           += -march=native
-endif
 CFLAGS_NATIVE           += -I$(OPENCL_HEADERS_KHRONOS)/
+CFLAGS_NATIVE           += -march=native
+LFLAGS_NATIVE           := $(LFLAGS)
 LFLAGS_NATIVE           += -lpthread
+endif
 endif # FreeBSD
 
 ifeq ($(UNAME),Darwin)


### PR DESCRIPTION
It's actually less confusing to let the port set
the other two options as well, so just move the whole
block under ifdef PORTNAME.

Sorry about the back-to-back thing. The port works 100% patch-free now.
