### PR TITLE
-m 11600 = 7-Zip: added support for parsing $7z$1... and $7z$2... hashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,4 +1,9 @@
 * changes v3.30 -> v3.xx:
+##
+## Features
+##
+
+- Added support for parsing 7-Zip hashes with LZMA/LZMA2 compression indicator set to a non-zero value
 
 ##
 ## Workarounds


### PR DESCRIPTION
Recently, 7z2hashcat.pl was updated to generate also $7z$1 and $7z$2 "hashes" (see https://github.com/philsmd/7z2hashcat/issues/4). This compression indicator field tells us if the data was uncompressed (" $7z$0"), LZMA compressed ("$7z$1") or LZMA2 compressed ("$7z$2").

This commit only allows the parsing of such hashes (some may or may currently not crack because hashcat doesn't do the LZMA/LZMA2 decompression step for the time being).

There is still some work to do to support LZMA/LZMA2 compressed data (e.g. if the data was first compressed and afterwards encrypted... where the CRC32 - the hash - was generted from the decrypt-and-decompressed data).

This can be implemented via a hook and will probably be discussed in a separate github issue.

For now, we should just allow both formats, since their is still the possibility (even for .7z files compressed via LZMA and LZMA2) that they can be cracked (because that worked beforehand too ;) ... i.e. with the AES CBC attack etc).
Thanks