### PR TITLE
log topid/subid should use u32 everywhere 

### DIFF
--- a/src/logfile.c
+++ b/src/logfile.c
@@ -11,15 +11,15 @@
 #include "locking.h"
 #include "shared.h"
 
-static int logfile_generate_id (void)
+static u32 logfile_generate_id (void)
 {
-  const int n = rand ();
+  const u32 n = (u32) rand ();
 
   time_t t;
 
   time (&t);
 
-  return t + n;
+  return (u32) t + n;
 }
 
 void logfile_generate_topid (hashcat_ctx_t *hashcat_ctx)
@@ -28,9 +28,9 @@ void logfile_generate_topid (hashcat_ctx_t *hashcat_ctx)
 
   if (logfile_ctx->enabled == false) return;
 
-  const int id = logfile_generate_id ();
+  const u32 id = logfile_generate_id ();
 
-  snprintf (logfile_ctx->topid, 1 + 16, "TOP%08x", (u32) id);
+  snprintf (logfile_ctx->topid, 1 + 16, "TOP%08x", id);
 }
 
 void logfile_generate_subid (hashcat_ctx_t *hashcat_ctx)
@@ -39,9 +39,9 @@ void logfile_generate_subid (hashcat_ctx_t *hashcat_ctx)
 
   if (logfile_ctx->enabled == false) return;
 
-  const int id = logfile_generate_id ();
+  const u32 id = logfile_generate_id ();
 
-  snprintf (logfile_ctx->subid, 1 + 16, "SUB%08x", (u32) id);
+  snprintf (logfile_ctx->subid, 1 + 16, "SUB%08x", id);
 }
 
 void logfile_append (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)


### PR DESCRIPTION
For the ids we do not need signed integers.
This changes should make sure that we use unsigneds in general when dealing with ids (both top and sub ids for the logfile).

Thank you