### PR TITLE
fixes #980: combinator attack needs special formula for max pass length

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -18,6 +18,12 @@
 
 - Workaround added for AMDGPU-Pro OpenCL runtime: AES encrypt and decrypt Invertkey function was calculated wrong in certain cases
 
+##
+## Bugs
+##
+
+- Fixed a problem with maximal password length with the combinator attack
+
 * changes v3.20 -> v3.30:
 
 ##

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -84,9 +84,20 @@ int build_plain (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pl
       memcpy (plain_ptr, comb_buf, comb_len);
     }
 
+    int pw_max_combi;
+
+    if (hashconfig->pw_max < PW_DICTMAX)
+    {
+      pw_max_combi = hashconfig->pw_max;
+    }
+    else
+    {
+      pw_max_combi = PW_MAX;
+    }
+
     plain_len += comb_len;
 
-    if (plain_len > (int) hashconfig->pw_max) plain_len = (int) hashconfig->pw_max;
+    if (plain_len > pw_max_combi) plain_len = pw_max_combi;
   }
   else if (user_options->attack_mode == ATTACK_MODE_BF)
   {


### PR DESCRIPTION
This fix should deal with the problem mentioned in #980 (i.e. the problem where the output was truncated whenever the output of the combinator attack was greater than PW_DICTMAX).

I suggest to deal with this problem with a fixed formula that recognizes whenever the hashconfig->pw_max variable was set to a (much) lower value compared to PW_DICTMAX, in that case hashconfig->pw_max is the real max (also for the combination). Otherwise, the max should simply be PW_MAX

Thank you