### PR TITLE
fix for previous commit: added obj/lzma_sdk/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ hashcat.dll
 kernels/**
 lib/*.a
 obj/*.o
+obj/lzma_sdk/.o
 include/CL


### PR DESCRIPTION
We need an additional .lock files for the obj/lzma_sdk/ folder such that git doesn't think it is empty.
This fixes the problem introduced with previous commit (my commit: https://github.com/hashcat/hashcat/pull/986/commits/6fe0173a79fa9afcaf74bd2385a85c93f92df5bc).

Thanks