### PR TITLE
.gitignore: added/fixed the wildcards for obj/lzma_sdk/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ hashcat.dll
 kernels/**
 lib/*.a
 obj/*.o
-obj/lzma_sdk/.o
+obj/lzma_sdk/*.o
 include/CL


### PR DESCRIPTION
We need to ignore all *.o files within the obj/lzma_sdk/ folder, not just the file ".o".
This error was actually just introduced by a typo.