### PR TITLE
hook code: refactored the hook salt to be part of the hash_t struct

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -365,7 +365,6 @@ typedef enum opts_type
   OPTS_TYPE_HOOK12            = (1 << 26),
   OPTS_TYPE_HOOK23            = (1 << 27),
   OPTS_TYPE_BINARY_HASHFILE   = (1 << 28),
-  OPTS_TYPE_HOOK_SALT         = (1 << 29),
 
 } opts_type_t;
 
@@ -675,8 +674,6 @@ typedef struct hashinfo
   user_t *user;
   char   *orighash;
 
-  void   *hook_salt; // additional salt info only used by the hook (host)
-
 } hashinfo_t;
 
 typedef struct hash
@@ -684,6 +681,7 @@ typedef struct hash
   void       *digest;
   salt_t     *salt;
   void       *esalt;
+  void       *hook_salt; // additional salt info only used by the hook (host)
   int         cracked;
   hashinfo_t *hash_info;
   char       *pw_buf;
@@ -732,6 +730,8 @@ typedef struct hashes
 
   void   *esalts_buf;
 
+  void   *hook_salts_buf;
+
   u32     hashes_cnt_orig;
   u32     hashes_cnt;
   hash_t *hashes_buf;
@@ -762,6 +762,7 @@ struct hashconfig
 
   u32   is_salted;
   u32   esalt_size;
+  u32   hook_salt_size;
   u32   tmp_size;
   u32   hook_size;
 

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -26,22 +26,24 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
   status_ctx_t   *status_ctx   = hashcat_ctx->status_ctx;
   user_options_t *user_options = hashcat_ctx->user_options;
 
-  u32  dgst_size  = hashconfig->dgst_size;
-  u32  is_salted  = hashconfig->is_salted;
-  u32  esalt_size = hashconfig->esalt_size;
-  u32  hash_mode  = hashconfig->hash_mode;
-  char separator  = hashconfig->separator;
+  u32  dgst_size      = hashconfig->dgst_size;
+  u32  is_salted      = hashconfig->is_salted;
+  u32  esalt_size     = hashconfig->esalt_size;
+  u32  hook_salt_size = hashconfig->hook_salt_size;
+  u32  hash_mode      = hashconfig->hash_mode;
+  char separator      = hashconfig->separator;
 
   char *root_directory      = outcheck_ctx->root_directory;
   u32   outfile_check_timer = user_options->outfile_check_timer;
 
   // buffers
-  hash_t hash_buf = { 0, 0, 0, 0, 0, NULL, 0 };
+  hash_t hash_buf = { 0, 0, 0, 0, 0, 0, NULL, 0 };
 
   hash_buf.digest = hcmalloc (dgst_size);
 
-  if (is_salted)  hash_buf.salt =  (salt_t *) hcmalloc (sizeof (salt_t));
-  if (esalt_size) hash_buf.esalt = (void   *) hcmalloc (esalt_size);
+  if (is_salted)      hash_buf.salt      = (salt_t *) hcmalloc (sizeof (salt_t));
+  if (esalt_size)     hash_buf.esalt     = (void   *) hcmalloc (esalt_size);
+  if (hook_salt_size) hash_buf.hook_salt = (void   *) hcmalloc (hook_salt_size);
 
   u32 digest_buf[64] = { 0 };
 
@@ -293,6 +295,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
   }
 
   hcfree (hash_buf.esalt);
+  hcfree (hash_buf.hook_salt);
 
   hcfree (hash_buf.salt);
 

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -290,6 +290,7 @@ int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
   hash_buf.digest    = hcmalloc (hashconfig->dgst_size);
   hash_buf.salt      = NULL;
   hash_buf.esalt     = NULL;
+  hash_buf.hook_salt = NULL;
   hash_buf.hash_info = NULL;
   hash_buf.cracked   = 0;
 
@@ -301,6 +302,11 @@ int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
   if (hashconfig->esalt_size)
   {
     hash_buf.esalt = hcmalloc (hashconfig->esalt_size);
+  }
+
+  if (hashconfig->hook_salt_size)
+  {
+    hash_buf.hook_salt = hcmalloc (hashconfig->hook_salt_size);
   }
 
   // this is usually detected by weak-hash-check
@@ -363,6 +369,11 @@ int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
     if (hashconfig->esalt_size)
     {
       memset (hash_buf.esalt, 0, hashconfig->esalt_size);
+    }
+
+    if (hashconfig->hook_salt_size)
+    {
+      memset (hash_buf.hook_salt, 0, hashconfig->hook_salt_size);
     }
 
     hash_t *found = NULL;
@@ -487,6 +498,11 @@ int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
   if (hashconfig->esalt_size)
   {
     hcfree (hash_buf.esalt);
+  }
+
+  if (hashconfig->hook_salt_size)
+  {
+    hcfree (hash_buf.hook_salt);
   }
 
   if (hashconfig->is_salted)


### PR DESCRIPTION
This is just some cosmetic changes to refactor hook_salt into hash_t directly (it doesn't use the hashinfo struct anymore).

Thanks