### PR TITLE
-m 11600: additional check within the parser to avoid loading hashes that produce too many false positives

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -11331,11 +11331,14 @@ int seven_zip_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_
     seven_zip->padding_check_full = false;
   }
 
-  if (data_type > 2)
+  if (data_type != 0x80)
   {
-    if (margin < 4) // we can't be sure about too many false positives
+    if (data_type > 2)
     {
-      return (PARSER_SALT_VALUE);
+      if (margin < 4) // we can't be sure about too many false positives
+      {
+        return (PARSER_SALT_VALUE);
+      }
     }
   }
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -11331,6 +11331,14 @@ int seven_zip_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_
     seven_zip->padding_check_full = false;
   }
 
+  if (data_type > 2)
+  {
+    if (margin < 4) // we can't be sure about too many false positives
+    {
+      return (PARSER_SALT_VALUE);
+    }
+  }
+
   // real salt
 
   salt->salt_buf[0] = seven_zip->data_buf[0];


### PR DESCRIPTION
This is just an additional safety check. We shouldn't allow to load hashes that can't be verified with at least some minimum of reliability.

Thanks