### PR TITLE
docs update: mention the event_log () changes within the technical section

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -35,6 +35,7 @@
 
 - Building: Split native compilation into two dedicated targets: "hashcat_static" and "hashcat_shared", default is "hashcat_static"
 - Building: Removed the use of RPATH on linker level
+- Events: Improved the maximum event message handling. event_log () will now also internally make sure that the message is properly terminated
 
 * changes v3.20 -> v3.30:
 


### PR DESCRIPTION
This is just a documentation/changes update for the technically interested people out there.

It just mentions that there were some updates with event_log () and that event_log () now also makes sure that the strings are terminated (internally).

Thank you very much