### PR TITLE
fix for #996: for pwdump format both halves of LM need to have the username info

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -915,22 +915,38 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           hlfmt_user (hashcat_ctx, hashlist_format, line_buf, line_len, &user_buf, &user_len);
 
-          user_t **user = &hashes_buf[hashes_cnt].hash_info->user;
+          // special case:
+          // both hash_t need to have the username info if the pwdump format is used (i.e. we have 2 hashes for 3000, both with same user)
 
-          *user = (user_t *) hcmalloc (sizeof (user_t));
+          u32 hashes_per_user = 1;
 
-          user_t *user_ptr = *user;
-
-          if (user_buf != NULL)
+          if (hashconfig->hash_mode == 3000) // the following conditions should be true if (hashlist_format == HLFMT_PWDUMP)
           {
-            user_ptr->user_name = hcstrdup (user_buf);
-          }
-          else
-          {
-            user_ptr->user_name = hcstrdup ("");
+            if (hash_len == 32)
+            {
+              hashes_per_user = 2;
+            }
           }
 
-          user_ptr->user_len = user_len;
+          for (u32 i = 0; i < hashes_per_user; i++)
+          {
+            user_t **user = &hashes_buf[hashes_cnt + i].hash_info->user;
+
+            *user = (user_t *) hcmalloc (sizeof (user_t));
+
+            user_t *user_ptr = *user;
+
+            if (user_buf != NULL)
+            {
+              user_ptr->user_name = hcstrdup (user_buf);
+            }
+            else
+            {
+              user_ptr->user_name = hcstrdup ("");
+            }
+
+            user_ptr->user_len = user_len;
+          }
         }
 
         if (hashconfig->opts_type & OPTS_TYPE_HASH_COPY)


### PR DESCRIPTION
This should fix issue #996 where in case of a pwdump file and a combination of --show and --username arguments, hashcat was showing a segfault.

This should fix the crash by making sure that the username information is connected to both halves of the NT part (2 hashes, same username).
Thx