### PR TITLE
fixes #963: show all user's hashes if --show/--left was specified

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -6,6 +6,7 @@
 
 - Added support for parsing 7-Zip hashes with LZMA/LZMA2 compression indicator set to a non-zero value
 - Added support for decompressing LZMA1/LZMA2 data for -m 11600 = 7-Zip to validate the CRC
+- Added support for showing all user names with --show and --left if --username was specified
 
 ##
 ## Algorithms

--- a/include/potfile.h
+++ b/include/potfile.h
@@ -26,4 +26,7 @@ void potfile_destroy          (hashcat_ctx_t *hashcat_ctx);
 int  potfile_handle_show      (hashcat_ctx_t *hashcat_ctx);
 int  potfile_handle_left      (hashcat_ctx_t *hashcat_ctx);
 
+void potfile_update_hash      (hashcat_ctx_t *hashcat_ctx, hash_t *found, char *line_pw_buf, int line_pw_len);
+void potfile_update_hashes    (hashcat_ctx_t *hashcat_ctx, hash_t *found, hash_t *hashes_buf, u32 hashes_cnt, int (*compar) (const void *, const void *, void *), char *line_pw_buf, int line_pw_len);
+
 #endif // _POTFILE_H

--- a/include/types.h
+++ b/include/types.h
@@ -1244,6 +1244,8 @@ typedef struct potfile_ctx
 {
   bool     enabled;
 
+  bool     keep_all_usernames;
+
   FILE    *fp;
   char    *filename;
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1068,6 +1068,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
   hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   hashes_t       *hashes       = hashcat_ctx->hashes;
   user_options_t *user_options = hashcat_ctx->user_options;
+  potfile_ctx_t  *potfile_ctx  = hashcat_ctx->potfile_ctx;
 
   hash_t *hashes_buf = hashes->hashes_buf;
   u32     hashes_cnt = hashes->hashes_cnt;
@@ -1082,7 +1083,11 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
   for (u32 hashes_pos = 1; hashes_pos < hashes_cnt; hashes_pos++)
   {
-    if (hashconfig->is_salted)
+    if (potfile_ctx->keep_all_usernames == true)
+    {
+      // do not sort, because we need to keep all hashes in this particular case
+    }
+    else if (hashconfig->is_salted)
     {
       if (sort_by_salt (hashes_buf[hashes_pos].salt, hashes_buf[hashes_pos - 1].salt) == 0)
       {

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -312,7 +312,6 @@ int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
 {
   const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const hashes_t       *hashes       = hashcat_ctx->hashes;
-  const user_options_t *user_options = hashcat_ctx->user_options;
   const potfile_ctx_t  *potfile_ctx  = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return 0;


### PR DESCRIPTION
This commit adds the feature requested in #963, i.e. whenever --username is combined with --show or --left, the hashes shouldn't be uniqued and all user's hashes should be within the output.

Thank you very much