### PR TITLE
Restore strerror as %m is unsupported by the BSDs

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -53,6 +53,7 @@
 - OpenCL Kernel: Renumbered hash-mode 7600 to 4521
 - OpenCL Device: Do a check on available constant memory size and abort if it's less than 64kB
 - Sessions: Move out handling of multiple instance from restore file into separate pidfile
+- Threads: Restored strerror as %m is unsupported by the BSDs
 - Wordlists: Disable dictstat handling for hash-mode 3000 as it virtually creates words in the wordlist which is not the case for other modes
 - WPA: Changed format for outfile and potfile from essid:mac1:mac2 to hash:essid
 - WPA: Changed format for outfile_check from essid:mac1:mac2 to hash

--- a/include/event.h
+++ b/include/event.h
@@ -14,24 +14,18 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
 #define EVENT(id)              event_call ((id), hashcat_ctx, NULL,  0)
 #define EVENT_DATA(id,buf,len) event_call ((id), hashcat_ctx, (buf), (len))
 
-#if defined (__MINGW32__)
-#define EVENT_PRINTF __attribute__ ((format (gnu_printf, 2, 3)))
-#else
-#define EVENT_PRINTF __attribute__ ((format (printf, 2, 3)))
-#endif
-
 __attribute__ ((format (printf, 2, 3)))
 size_t event_log_info_nn    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-EVENT_PRINTF
+__attribute__ ((format (printf, 2, 3)))
 size_t event_log_warning_nn (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-EVENT_PRINTF
+__attribute__ ((format (printf, 2, 3)))
 size_t event_log_error_nn   (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
 __attribute__ ((format (printf, 2, 3)))
 size_t event_log_info       (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-EVENT_PRINTF
+__attribute__ ((format (printf, 2, 3)))
 size_t event_log_warning    (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
-EVENT_PRINTF
+__attribute__ ((format (printf, 2, 3)))
 size_t event_log_error      (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...);
 
 int  event_ctx_init         (hashcat_ctx_t *hashcat_ctx);

--- a/src/combinator.c
+++ b/src/combinator.c
@@ -66,14 +66,14 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if ((fp1 = fopen (dictfile1, "rb")) == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %m", dictfile1);
+      event_log_error (hashcat_ctx, "%s: %s", dictfile1, strerror (errno));
 
       return -1;
     }
 
     if ((fp2 = fopen (dictfile2, "rb")) == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %m", dictfile2);
+      event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
 
       return -1;
     }

--- a/src/cpu_crc32.c
+++ b/src/cpu_crc32.c
@@ -97,7 +97,7 @@ int cpu_crc32 (hashcat_ctx_t *hashcat_ctx, const char *filename, u8 keytab[64])
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", filename);
+    event_log_error (hashcat_ctx, "%s: %s", filename, strerror (errno));
 
     return (-1);
   }

--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -119,7 +119,7 @@ int debugfile_init (hashcat_ctx_t *hashcat_ctx)
     {
       fclose (fp);
 
-      event_log_error (hashcat_ctx, "%s: %m", debugfile_ctx->filename);
+      event_log_error (hashcat_ctx, "%s: %s", debugfile_ctx->filename, strerror (errno));
 
       return -1;
     }

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -112,7 +112,7 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", dictstat_ctx->filename);
+    event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
 
     return -1;
   }
@@ -121,7 +121,7 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
   {
     fclose (fp);
 
-    event_log_error (hashcat_ctx, "%s: %m", dictstat_ctx->filename);
+    event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
 
     return -1;
   }

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -323,7 +323,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
     if (fd == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %m", dictfile);
+      event_log_error (hashcat_ctx, "%s: %s", dictfile, strerror (errno));
 
       return -1;
     }
@@ -340,7 +340,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
         if (combs_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %m", combinator_ctx->dict2);
+          event_log_error (hashcat_ctx, "%s: %s", combinator_ctx->dict2, strerror (errno));
 
           fclose (fd);
 
@@ -357,7 +357,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
         if (combs_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %m", dictfilec);
+          event_log_error (hashcat_ctx, "%s: %s", dictfilec, strerror (errno));
 
           fclose (fd);
 

--- a/src/event.c
+++ b/src/event.c
@@ -58,11 +58,7 @@ static int event_log (const char *fmt, va_list ap, char *s, const size_t sz)
 {
   size_t length;
 
-#if defined (__MINGW32__)
-  length = __mingw_vsnprintf (s, sz, fmt, ap);
-#else
   length = vsnprintf (s, sz, fmt, ap);
-#endif
   length = MIN (length, sz);
 
   s[length] = 0;

--- a/src/folder.c
+++ b/src/folder.c
@@ -278,7 +278,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   if (getcwd (cwd, HCBUFSIZ_TINY - 1) == NULL)
   {
-    event_log_error (hashcat_ctx, "getcwd(): %m");
+    event_log_error (hashcat_ctx, "getcwd(): %s", strerror (errno));
 
     return -1;
   }
@@ -315,7 +315,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
   This causes invalid error out if install_folder (/usr/local/bin) does not exist
   if (resolved_install_folder == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", resolved_install_folder);
+    event_log_error (hashcat_ctx, "%s: %s", resolved_install_folder, strerror (errno));
 
     return -1;
   }
@@ -323,7 +323,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   if (resolved_exec_path == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", resolved_exec_path);
+    event_log_error (hashcat_ctx, "%s: %s", resolved_exec_path, strerror (errno));
 
     return -1;
   }
@@ -412,7 +412,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   if (realpath (cpath, cpath_real) == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", cpath);
+    event_log_error (hashcat_ctx, "%s: %s", cpath, strerror (errno));
 
     return -1;
   }

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -134,7 +134,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", new_hashfile);
+    event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
 
     return -1;
   }
@@ -143,7 +143,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
   {
     fclose (fp);
 
-    event_log_error (hashcat_ctx, "%s: %m", new_hashfile);
+    event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
 
     return -1;
   }
@@ -209,7 +209,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
   if (rename (hashfile, old_hashfile) != 0)
   {
-    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %m", hashfile, old_hashfile);
+    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %s", hashfile, old_hashfile, strerror (errno));
 
     return -1;
   }
@@ -218,7 +218,7 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
   if (rename (new_hashfile, hashfile) != 0)
   {
-    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %m", new_hashfile, hashfile);
+    event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %s", new_hashfile, hashfile, strerror (errno));
 
     return -1;
   }
@@ -472,7 +472,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
         if (hc_stat (hashes->hashfile, &st) == -1)
         {
-          event_log_error (hashcat_ctx, "%s: %m", hashes->hashfile);
+          event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
 
           return -1;
         }
@@ -485,7 +485,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
         if (hc_stat (hashes->hashfile, &st) == -1)
         {
-          event_log_error (hashcat_ctx, "%s: %m", hashes->hashfile);
+          event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
 
           return -1;
         }
@@ -507,7 +507,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
       if ((fp = fopen (hashfile, "rb")) == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %m", hashfile);
+        event_log_error (hashcat_ctx, "%s: %s", hashfile, strerror (errno));
 
         return -1;
       }
@@ -726,7 +726,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           if (fp == NULL)
           {
-            event_log_error (hashcat_ctx, "%s: %m", hash_buf);
+            event_log_error (hashcat_ctx, "%s: %s", hash_buf, strerror (errno));
 
             return -1;
           }
@@ -864,7 +864,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
       if ((fp = fopen (hashfile, "rb")) == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %m", hashfile);
+        event_log_error (hashcat_ctx, "%s: %s", hashfile, strerror (errno));
 
         return -1;
       }

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -109,7 +109,7 @@ static int hm_SYSFS_get_fan_speed_current (hashcat_ctx_t *hashcat_ctx, const int
 
   if (fd_cur == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path_cur);
+    event_log_error (hashcat_ctx, "%s: %s", path_cur, strerror (errno));
 
     return -1;
   }
@@ -131,7 +131,7 @@ static int hm_SYSFS_get_fan_speed_current (hashcat_ctx_t *hashcat_ctx, const int
 
   if (fd_max == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path_max);
+    event_log_error (hashcat_ctx, "%s: %s", path_max, strerror (errno));
 
     return -1;
   }
@@ -184,7 +184,7 @@ static int hm_SYSFS_set_fan_control (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path);
+    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
 
     return -1;
   }
@@ -216,7 +216,7 @@ static int hm_SYSFS_set_fan_speed_target (hashcat_ctx_t *hashcat_ctx, const int 
 
   if (fd_max == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path_max);
+    event_log_error (hashcat_ctx, "%s: %s", path_max, strerror (errno));
 
     return -1;
   }
@@ -247,7 +247,7 @@ static int hm_SYSFS_set_fan_speed_target (hashcat_ctx_t *hashcat_ctx, const int 
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path);
+    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
 
     return -1;
   }
@@ -278,7 +278,7 @@ static int hm_SYSFS_get_temperature_current (hashcat_ctx_t *hashcat_ctx, const i
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path);
+    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
 
     return -1;
   }
@@ -319,7 +319,7 @@ static int hm_SYSFS_get_pp_dpm_sclk (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path);
+    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
 
     return -1;
   }
@@ -372,7 +372,7 @@ static int hm_SYSFS_get_pp_dpm_mclk (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path);
+    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
 
     return -1;
   }
@@ -425,7 +425,7 @@ static int hm_SYSFS_get_pp_dpm_pcie (hashcat_ctx_t *hashcat_ctx, const int devic
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path);
+    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
 
     return -1;
   }
@@ -479,7 +479,7 @@ static int hm_SYSFS_set_power_dpm_force_performance_level (hashcat_ctx_t *hashca
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", path);
+    event_log_error (hashcat_ctx, "%s: %s", path, strerror (errno));
 
     return -1;
   }

--- a/src/induct.c
+++ b/src/induct.c
@@ -66,7 +66,7 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (rename (root_directory, root_directory_mv) != 0)
         {
-          event_log_error (hashcat_ctx, "Rename directory %s to %s: %m", root_directory, root_directory_mv);
+          event_log_error (hashcat_ctx, "Rename directory %s to %s: %s", root_directory, root_directory_mv, strerror (errno));
 
           return -1;
         }
@@ -75,7 +75,7 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
       }
       else
       {
-        event_log_error (hashcat_ctx, "%s: %m", root_directory);
+        event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
 
         return -1;
       }
@@ -83,7 +83,7 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if (hc_mkdir (root_directory, 0700) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %m", root_directory);
+      event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
 
       return -1;
     }
@@ -129,7 +129,7 @@ void induct_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
     }
     else
     {
-      event_log_error (hashcat_ctx, "%s: %m", induct_ctx->root_directory);
+      event_log_error (hashcat_ctx, "%s: %s", induct_ctx->root_directory, strerror (errno));
 
       //return -1;
     }

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -54,7 +54,7 @@ void logfile_append (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", logfile_ctx->logfile);
+    event_log_error (hashcat_ctx, "%s: %s", logfile_ctx->logfile, strerror (errno));
 
     return;
   }

--- a/src/loopback.c
+++ b/src/loopback.c
@@ -108,7 +108,7 @@ int loopback_write_open (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", loopback_ctx->filename);
+    event_log_error (hashcat_ctx, "%s: %s", loopback_ctx->filename, strerror (errno));
 
     return -1;
   }

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -656,7 +656,7 @@ static int sp_setup_tbl (hashcat_ctx_t *hashcat_ctx)
 
   if (fd == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", hcstat);
+    event_log_error (hashcat_ctx, "%s: %s", hcstat, strerror (errno));
 
     return -1;
   }
@@ -1262,7 +1262,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
               if (mask_fp == NULL)
               {
-                event_log_error (hashcat_ctx, "%s: %m", arg);
+                event_log_error (hashcat_ctx, "%s: %s", arg, strerror (errno));
 
                 return -1;
               }
@@ -1355,7 +1355,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (mask_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %m", arg);
+          event_log_error (hashcat_ctx, "%s: %s", arg, strerror (errno));
 
           return -1;
         }
@@ -1429,7 +1429,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (mask_fp == NULL)
         {
-          event_log_error (hashcat_ctx, "%s: %m", arg);
+          event_log_error (hashcat_ctx, "%s: %s", arg, strerror (errno));
 
           return -1;
         }

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -306,7 +306,7 @@ static int read_kernel_binary (hashcat_ctx_t *hashcat_ctx, const char *kernel_fi
 
     if (num_read != (size_t) st.st_size)
     {
-      event_log_error (hashcat_ctx, "%s: %m", kernel_file);
+      event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
 
       return -1;
     }
@@ -322,7 +322,7 @@ static int read_kernel_binary (hashcat_ctx_t *hashcat_ctx, const char *kernel_fi
   }
   else
   {
-    event_log_error (hashcat_ctx, "%s: %m", kernel_file);
+    event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
 
     return -1;
   }
@@ -338,7 +338,7 @@ static int write_kernel_binary (hashcat_ctx_t *hashcat_ctx, char *kernel_file, c
 
     if (fp == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %m", kernel_file);
+      event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
 
       return -1;
     }
@@ -347,7 +347,7 @@ static int write_kernel_binary (hashcat_ctx_t *hashcat_ctx, char *kernel_file, c
     {
       fclose (fp);
 
-      event_log_error (hashcat_ctx, "%s: %m", kernel_file);
+      event_log_error (hashcat_ctx, "%s: %s", kernel_file, strerror (errno));
 
       return -1;
     }
@@ -3772,7 +3772,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     if (chdir (folder_config->cpath_real) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %m", folder_config->cpath_real);
+      event_log_error (hashcat_ctx, "%s: %s", folder_config->cpath_real, strerror (errno));
 
       return -1;
     }
@@ -3814,7 +3814,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_read (files_names[i]) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", files_names[i]);
+        event_log_error (hashcat_ctx, "%s: %s", files_names[i], strerror (errno));
 
         return -1;
       }
@@ -3851,7 +3851,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_read (source_file) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", source_file);
+        event_log_error (hashcat_ctx, "%s: %s", source_file, strerror (errno));
 
         return -1;
       }
@@ -4052,7 +4052,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_read (source_file) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", source_file);
+        event_log_error (hashcat_ctx, "%s: %s", source_file, strerror (errno));
 
         return -1;
       }
@@ -4191,7 +4191,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_read (source_file) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", source_file);
+        event_log_error (hashcat_ctx, "%s: %s", source_file, strerror (errno));
 
         return -1;
       }
@@ -4314,7 +4314,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     if (chdir (folder_config->cwd) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %m", folder_config->cwd);
+      event_log_error (hashcat_ctx, "%s: %s", folder_config->cwd, strerror (errno));
 
       return -1;
     }

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -315,7 +315,7 @@ int outfile_write_open (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", outfile_ctx->filename);
+    event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
 
     return -1;
   }
@@ -324,7 +324,7 @@ int outfile_write_open (hashcat_ctx_t *hashcat_ctx)
   {
     fclose (fp);
 
-    event_log_error (hashcat_ctx, "%s: %m", outfile_ctx->filename);
+    event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
 
     return -1;
   }

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -77,7 +77,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
           if (hc_stat (root_directory, &outfile_check_stat) == -1)
           {
-            event_log_error (hashcat_ctx, "%s: %m", root_directory);
+            event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
 
             return -1;
           }
@@ -331,7 +331,7 @@ int outcheck_ctx_init (hashcat_ctx_t *hashcat_ctx)
   {
     if (hc_mkdir (outcheck_ctx->root_directory, 0700) == -1)
     {
-      event_log_error (hashcat_ctx, "%s: %m", outcheck_ctx->root_directory);
+      event_log_error (hashcat_ctx, "%s: %s", outcheck_ctx->root_directory, strerror (errno));
 
       return -1;
     }
@@ -359,7 +359,7 @@ void outcheck_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
     }
     else
     {
-      event_log_error (hashcat_ctx, "%s: %m", outcheck_ctx->root_directory);
+      event_log_error (hashcat_ctx, "%s: %s", outcheck_ctx->root_directory, strerror (errno));
 
       //return -1;
     }

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -118,7 +118,7 @@ static int write_pidfile (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", pidfile_filename);
+    event_log_error (hashcat_ctx, "%s: %s", pidfile_filename, strerror (errno));
 
     return -1;
   }

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -154,7 +154,7 @@ int potfile_read_open (hashcat_ctx_t *hashcat_ctx)
 
   if (potfile_ctx->fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", potfile_ctx->filename);
+    event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
 
     return -1;
   }
@@ -183,7 +183,7 @@ int potfile_write_open (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", potfile_ctx->filename);
+    event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
 
     return -1;
   }

--- a/src/restore.c
+++ b/src/restore.c
@@ -35,7 +35,7 @@ static int init_restore (hashcat_ctx_t *hashcat_ctx)
 
   if (getcwd (rd->cwd, 255) == NULL)
   {
-    event_log_error (hashcat_ctx, "getcwd(): %m");
+    event_log_error (hashcat_ctx, "getcwd(): %s", strerror (errno));
 
     return -1;
   }
@@ -55,7 +55,7 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "Restore file '%s': %m", eff_restore_file);
+    event_log_error (hashcat_ctx, "Restore file '%s': %s", eff_restore_file, strerror (errno));
 
     return -1;
   }
@@ -134,14 +134,14 @@ static int write_restore (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", new_restore_file);
+    event_log_error (hashcat_ctx, "%s: %s", new_restore_file, strerror (errno));
 
     return -1;
   }
 
   if (setvbuf (fp, NULL, _IONBF, 0))
   {
-    event_log_error (hashcat_ctx, "setvbuf file '%s': %m", new_restore_file);
+    event_log_error (hashcat_ctx, "setvbuf file '%s': %s", new_restore_file, strerror (errno));
 
     fclose (fp);
 
@@ -187,13 +187,13 @@ int cycle_restore (hashcat_ctx_t *hashcat_ctx)
   {
     if (unlink (eff_restore_file) == -1)
     {
-      event_log_warning (hashcat_ctx, "Unlink file '%s': %m", eff_restore_file);
+      event_log_warning (hashcat_ctx, "Unlink file '%s': %s", eff_restore_file, strerror (errno));
     }
   }
 
   if (rename (new_restore_file, eff_restore_file) == -1)
   {
-    event_log_warning (hashcat_ctx, "Rename file '%s' to '%s': %m", new_restore_file, eff_restore_file);
+    event_log_warning (hashcat_ctx, "Rename file '%s' to '%s': %s", new_restore_file, eff_restore_file, strerror (errno));
   }
 
   return 0;

--- a/src/rp.c
+++ b/src/rp.c
@@ -733,7 +733,7 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
 
     if ((fp = fopen (rp_file, "rb")) == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %m", rp_file);
+      event_log_error (hashcat_ctx, "%s: %s", rp_file, strerror (errno));
 
       return -1;
     }

--- a/src/stdout.c
+++ b/src/stdout.c
@@ -69,7 +69,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
 
     if (fp == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %m", filename);
+      event_log_error (hashcat_ctx, "%s: %s", filename, strerror (errno));
 
       return -1;
     }
@@ -78,7 +78,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
     {
       fclose (fp);
 
-      event_log_error (hashcat_ctx, "%s: %m", filename);
+      event_log_error (hashcat_ctx, "%s: %s", filename, strerror (errno));
 
       return -1;
     }

--- a/src/straight.c
+++ b/src/straight.c
@@ -69,7 +69,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       if (fd == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %m", straight_ctx->dict);
+        event_log_error (hashcat_ctx, "%s: %s", straight_ctx->dict, strerror (errno));
 
         return -1;
       }
@@ -97,7 +97,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       if (fd == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %m", combinator_ctx->dict1);
+        event_log_error (hashcat_ctx, "%s: %s", combinator_ctx->dict1, strerror (errno));
 
         return -1;
       }
@@ -112,7 +112,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       if (fd == NULL)
       {
-        event_log_error (hashcat_ctx, "%s: %m", combinator_ctx->dict2);
+        event_log_error (hashcat_ctx, "%s: %s", combinator_ctx->dict2, strerror (errno));
 
         return -1;
       }
@@ -151,7 +151,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
     if (fd == NULL)
     {
-      event_log_error (hashcat_ctx, "%s: %m", straight_ctx->dict);
+      event_log_error (hashcat_ctx, "%s: %s", straight_ctx->dict, strerror (errno));
 
       return -1;
     }
@@ -286,7 +286,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
               if (hc_path_read (l1_filename) == false)
               {
-                event_log_error (hashcat_ctx, "%s: %m", l1_filename);
+                event_log_error (hashcat_ctx, "%s: %s", l1_filename, strerror (errno));
 
                 return -1;
               }
@@ -350,7 +350,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
             if (hc_path_read (l1_filename) == false)
             {
-              event_log_error (hashcat_ctx, "%s: %m", l1_filename);
+              event_log_error (hashcat_ctx, "%s: %s", l1_filename, strerror (errno));
 
               return -1;
             }
@@ -405,7 +405,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
             if (hc_path_read (l1_filename) == false)
             {
-              event_log_error (hashcat_ctx, "%s: %m", l1_filename);
+              event_log_error (hashcat_ctx, "%s: %s", l1_filename, strerror (errno));
 
               return -1;
             }

--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -76,7 +76,7 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
   if (fp == NULL)
   {
-    event_log_error (hashcat_ctx, "%s: %m", tuning_db_file);
+    event_log_error (hashcat_ctx, "%s: %s", tuning_db_file, strerror (errno));
 
     return -1;
   }

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1277,42 +1277,42 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
   if (hc_path_read (folder_config->cwd) == false)
   {
-    event_log_error (hashcat_ctx, "%s: %m", folder_config->cwd);
+    event_log_error (hashcat_ctx, "%s: %s", folder_config->cwd, strerror (errno));
 
     return -1;
   }
 
   if (hc_path_read (folder_config->install_dir) == false)
   {
-    event_log_error (hashcat_ctx, "%s: %m", folder_config->install_dir);
+    event_log_error (hashcat_ctx, "%s: %s", folder_config->install_dir, strerror (errno));
 
     return -1;
   }
 
   if (hc_path_read (folder_config->profile_dir) == false)
   {
-    event_log_error (hashcat_ctx, "%s: %m", folder_config->profile_dir);
+    event_log_error (hashcat_ctx, "%s: %s", folder_config->profile_dir, strerror (errno));
 
     return -1;
   }
 
   if (hc_path_write (folder_config->session_dir) == false)
   {
-    event_log_error (hashcat_ctx, "%s: %m", folder_config->session_dir);
+    event_log_error (hashcat_ctx, "%s: %s", folder_config->session_dir, strerror (errno));
 
     return -1;
   }
 
   if (hc_path_read (folder_config->shared_dir) == false)
   {
-    event_log_error (hashcat_ctx, "%s: %m", folder_config->shared_dir);
+    event_log_error (hashcat_ctx, "%s: %s", folder_config->shared_dir, strerror (errno));
 
     return -1;
   }
 
   if (hc_path_read (folder_config->cpath_real) == false)
   {
-    event_log_error (hashcat_ctx, "%s: %m", folder_config->cpath_real);
+    event_log_error (hashcat_ctx, "%s: %s", folder_config->cpath_real, strerror (errno));
 
     return -1;
   }
@@ -1325,7 +1325,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_read (user_options_extra->hc_hash) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", user_options_extra->hc_hash);
+        event_log_error (hashcat_ctx, "%s: %s", user_options_extra->hc_hash, strerror (errno));
 
         return -1;
       }
@@ -1342,7 +1342,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_exist (wlfile) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", wlfile);
+        event_log_error (hashcat_ctx, "%s: %s", wlfile, strerror (errno));
 
         return -1;
       }
@@ -1354,7 +1354,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_exist (rp_file) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", rp_file);
+        event_log_error (hashcat_ctx, "%s: %s", rp_file, strerror (errno));
 
         return -1;
       }
@@ -1371,14 +1371,14 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_read (dictfile1) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", dictfile1);
+        event_log_error (hashcat_ctx, "%s: %s", dictfile1, strerror (errno));
 
         return -1;
       }
 
       if (hc_path_read (dictfile2) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", dictfile2);
+        event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
 
         return -1;
       }
@@ -1396,7 +1396,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
       {
         if (hc_path_read (maskfile) == false)
         {
-          event_log_error (hashcat_ctx, "%s: %m", maskfile);
+          event_log_error (hashcat_ctx, "%s: %s", maskfile, strerror (errno));
 
           return -1;
         }
@@ -1415,7 +1415,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_exist (wlfile) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", wlfile);
+        event_log_error (hashcat_ctx, "%s: %s", wlfile, strerror (errno));
 
         return -1;
       }
@@ -1426,7 +1426,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
       {
         if (hc_path_read (maskfile) == false)
         {
-          event_log_error (hashcat_ctx, "%s: %m", maskfile);
+          event_log_error (hashcat_ctx, "%s: %s", maskfile, strerror (errno));
 
           return -1;
         }
@@ -1445,7 +1445,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_exist (wlfile) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", wlfile);
+        event_log_error (hashcat_ctx, "%s: %s", wlfile, strerror (errno));
 
         return -1;
       }
@@ -1456,7 +1456,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
       {
         if (hc_path_read (maskfile) == false)
         {
-          event_log_error (hashcat_ctx, "%s: %m", maskfile);
+          event_log_error (hashcat_ctx, "%s: %s", maskfile, strerror (errno));
 
           return -1;
         }
@@ -1472,7 +1472,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_write (logfile_ctx->logfile) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", logfile_ctx->logfile);
+        event_log_error (hashcat_ctx, "%s: %s", logfile_ctx->logfile, strerror (errno));
 
         return -1;
       }
@@ -1481,7 +1481,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_create (logfile_ctx->logfile) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", logfile_ctx->logfile);
+        event_log_error (hashcat_ctx, "%s: %s", logfile_ctx->logfile, strerror (errno));
 
         return -1;
       }
@@ -1513,7 +1513,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_write (outfile_ctx->filename) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", outfile_ctx->filename);
+        event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
 
         return -1;
       }
@@ -1522,7 +1522,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_create (outfile_ctx->filename) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", outfile_ctx->filename);
+        event_log_error (hashcat_ctx, "%s: %s", outfile_ctx->filename, strerror (errno));
 
         return -1;
       }
@@ -1597,7 +1597,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
   {
     if (hc_path_write (pidfile_ctx->filename) == false)
     {
-      event_log_error (hashcat_ctx, "%s: %m", pidfile_ctx->filename);
+      event_log_error (hashcat_ctx, "%s: %s", pidfile_ctx->filename, strerror (errno));
 
       return -1;
     }
@@ -1606,7 +1606,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
   {
     if (hc_path_create (pidfile_ctx->filename) == false)
     {
-      event_log_error (hashcat_ctx, "%s: %m", pidfile_ctx->filename);
+      event_log_error (hashcat_ctx, "%s: %s", pidfile_ctx->filename, strerror (errno));
 
       return -1;
     }
@@ -1620,7 +1620,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_write (potfile_ctx->filename) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", potfile_ctx->filename);
+        event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
 
         return -1;
       }
@@ -1629,7 +1629,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_create (potfile_ctx->filename) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", potfile_ctx->filename);
+        event_log_error (hashcat_ctx, "%s: %s", potfile_ctx->filename, strerror (errno));
 
         return -1;
       }
@@ -1644,7 +1644,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_write (dictstat_ctx->filename) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", dictstat_ctx->filename);
+        event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
 
         return -1;
       }
@@ -1653,7 +1653,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_create (dictstat_ctx->filename) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %m", dictstat_ctx->filename);
+        event_log_error (hashcat_ctx, "%s: %s", dictstat_ctx->filename, strerror (errno));
 
         return -1;
       }


### PR DESCRIPTION
The BSDs just print m instead of the actual error message. Benefit
is not worth the cost.

Most of the usages of %m are reporting an error, not a warning. Thread safety doesn't really matter at that point. Some Linux and Windows specific usages were kept.