### PR TITLE
Disable glob file under Cygwin

### DIFF
--- a/src/win_file_globbing.mk
+++ b/src/win_file_globbing.mk
@@ -98,7 +98,7 @@ endif
 ## win native
 ##
 
-IS_WIN_BUILD_NATIVE := $(filter CYGWIN,$(UNAME))$(filter MSYS2,$(UNAME))
+IS_WIN_BUILD_NATIVE := $(filter MSYS2,$(UNAME))
 
 ifneq (,$(IS_WIN_BUILD_NATIVE))
 


### PR DESCRIPTION
Cygwin is fully capable of generating MinGW or native binaries. No
need to restrict it. Also removed a bug where the glob file would
be applied to native cygwin builds, causing a failed compile.

All of that should also apply to MSYS2 but I'll leave it since I
have not tested it.