### PR TITLE
Add NVML and NVAPI support to Cygwin. Disable file globbing.

### DIFF
--- a/include/ext_nvapi.h
+++ b/include/ext_nvapi.h
@@ -12,8 +12,8 @@
 
 #define NVAPI_INTERFACE extern NvAPI_Status
 
-typedef unsigned long NvU32;
-typedef   signed long NvS32;
+typedef unsigned int NvU32;
+typedef   signed int NvS32;
 
 #define NV_DECLARE_HANDLE(name) struct name##__ { int unused; }; typedef struct name##__ *name
 

--- a/include/hwmon.h
+++ b/include/hwmon.h
@@ -4,6 +4,9 @@
  */
 
 #include <errno.h>
+#if defined (__CYGWIN__)
+#include <sys/cygwin.h>
+#endif
 
 #ifndef _HWMON_H
 #define _HWMON_H

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -2884,6 +2884,10 @@ int opencl_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
           #if defined (_WIN)
           need_nvapi = true;
           #endif
+
+          #if defined (__CYGWIN__)
+          need_nvapi = true;
+          #endif
         }
       }
 

--- a/src/win_file_globbing.mk
+++ b/src/win_file_globbing.mk
@@ -98,7 +98,7 @@ endif
 ## win native
 ##
 
-IS_WIN_BUILD_NATIVE := $(filter CYGWIN,$(UNAME))$(filter MSYS2,$(UNAME))
+IS_WIN_BUILD_NATIVE := $(filter MSYS2,$(UNAME))
 
 ifneq (,$(IS_WIN_BUILD_NATIVE))
 


### PR DESCRIPTION
Runtime tested. The NVML/NVAPI stuff ehaves the same as a MinGW build.

Typedef was changed as long is 64-bits under Cygwin.