### PR TITLE
make install error on MacOS Sierra

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,11 @@ UNAME                   := $(shell uname -s)
 # we need to strip the windows version number to be able to build hashcat on cygwin hosts
 UNAME                   := $(patsubst CYGWIN_NT-%,CYGWIN,$(UNAME))
 
+##
+## Detect Operating System version
+## 
+OSVERSION		:= $(shell uname -r|cut -d. -f1)
+
 # same for msys
 UNAME                   := $(patsubst MSYS_NT-%,MSYS2,$(UNAME))
 UNAME                   := $(patsubst MINGW32_NT-%,MSYS2,$(UNAME))
@@ -85,11 +90,18 @@ FIND                    := find
 INSTALL                 := install
 RM                      := rm
 SED                     := sed
-
+SEDOPS			:= -i
 ifeq ($(UNAME),Darwin)
 CC                      := clang
+ifeq ($(OSVERSION),16)
+SED			:= sed
+SEDOPS			:= -i ""
+else
 SED                     := gsed
 endif
+endif
+
+
 
 ifeq ($(UNAME),FreeBSD)
 CC                      := cc
@@ -353,9 +365,9 @@ install_docs:
 	$(FIND) masks/    -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
 	$(FIND) rules/    -type d -exec $(INSTALL) -m 755 -d    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
 	$(FIND) rules/    -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(SED) -i 's/\.\/hashcat/hashcat/'                      $(DESTDIR)$(DOCUMENT_FOLDER)/example0.sh
-	$(SED) -i 's/\.\/hashcat/hashcat/'                      $(DESTDIR)$(DOCUMENT_FOLDER)/example400.sh
-	$(SED) -i 's/\.\/hashcat/hashcat/'                      $(DESTDIR)$(DOCUMENT_FOLDER)/example500.sh
+	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'			$(DESTDIR)$(DOCUMENT_FOLDER)/example0.sh
+	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'                   $(DESTDIR)$(DOCUMENT_FOLDER)/example400.sh
+	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'                  	$(DESTDIR)$(DOCUMENT_FOLDER)/example500.sh
 
 install_shared:
 	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(SHARED_FOLDER)

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,6 +91,7 @@ INSTALL                 := install
 RM                      := rm
 SED                     := sed
 SEDOPS			:= -i
+
 ifeq ($(UNAME),Darwin)
 CC                      := clang
 ifeq ($(OSVERSION),16)
@@ -100,8 +101,6 @@ else
 SED                     := gsed
 endif
 endif
-
-
 
 ifeq ($(UNAME),FreeBSD)
 CC                      := cc
@@ -365,9 +364,9 @@ install_docs:
 	$(FIND) masks/    -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
 	$(FIND) rules/    -type d -exec $(INSTALL) -m 755 -d    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
 	$(FIND) rules/    -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'			$(DESTDIR)$(DOCUMENT_FOLDER)/example0.sh
-	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'                   $(DESTDIR)$(DOCUMENT_FOLDER)/example400.sh
-	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'                  	$(DESTDIR)$(DOCUMENT_FOLDER)/example500.sh
+	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'		$(DESTDIR)$(DOCUMENT_FOLDER)/example0.sh
+	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'		$(DESTDIR)$(DOCUMENT_FOLDER)/example400.sh
+	$(SED) $(SEDOPS) 's/\.\/hashcat/hashcat/'		$(DESTDIR)$(DOCUMENT_FOLDER)/example500.sh
 
 install_shared:
 	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(SHARED_FOLDER)


### PR DESCRIPTION
macOS Sierra does not uses gsed, but sed. Makefile set gsed for all Darwin based OSes.

1. Added OS Version on Makefile validation for Darwin platform.
    If OS type is Darwin and OS Version is 16, sed is command is used instead of gsed. 
2. Added SEDOPS variable in order to construct the correct options syntax depending on the system who executes the sed command. 
    On macOS's sed command, -i option needs to explicitly set at least an empty string as a parametre. 