### PR TITLE
readme: added appveyor badges to README.md #1032

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Please refer to the [Hashcat Wiki](https://hashcat.net/wiki/) and the output of 
 
 ### Building ###
 
-[![Hashcat Build status](https://travis-ci.org/hashcat/hashcat.svg?branch=master)](https://travis-ci.org/hashcat/hashcat)
-
 Refer to [BUILD.md](BUILD.md) for instructions on how to build **hashcat** from source.
+
+Tests:  
+
+Travis | Appveyor
+------ | --------
+[![Hashcat Travis Build status](https://travis-ci.org/hashcat/hashcat.svg?branch=master)](https://travis-ci.org/hashcat/hashcat) | [![Hashcat Appveyor Build status](https://ci.appveyor.com/api/projects/status/github/hashcat/hashcat?branch=master&svg=true)](https://ci.appveyor.com/api/projects/status/github/hashcat/hashcat?branch=master&svg=true)
 
 ### Contributing ###
 


### PR DESCRIPTION
This just adds the appveyor badges to README.md (see the list of things to do for #1032).

Thanks