### PR TITLE
Fix more cppcheck warnings

### DIFF
--- a/src/combinator.c
+++ b/src/combinator.c
@@ -75,6 +75,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
     {
       event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
 
+      fclose (fp1);
+
       return -1;
     }
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -256,8 +256,6 @@ char **scan_directory (const char *path)
 
   files[num_files] = NULL;
 
-  num_files++;
-
   hcfree (tmp_path);
 
   return (files);

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -573,8 +573,8 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
    * load hashes, part II: allocate required memory, set pointers
    */
 
-  hash_t *hashes_buf     = NULL;
-  void   *digests_buf    = NULL;
+  hash_t *hashes_buf;
+  void   *digests_buf;
   salt_t *salts_buf      = NULL;
   void   *esalts_buf     = NULL;
   void   *hook_salts_buf = NULL;
@@ -758,7 +758,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           while (!feof (fp))
           {
-            const int nread = fread (in, sizeof (hccapx_t), 1, fp);
+            const size_t nread = fread (in, sizeof (hccapx_t), 1, fp);
 
             if (nread == 0) break;
 

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -571,6 +571,8 @@ static int nvml_init (hashcat_ctx_t *hashcat_ctx)
 
     fread (nvml_winpath, 100, 1, nvml_lib);
 
+    fclose (nvml_lib);
+
     ssize_t size = cygwin_conv_path (CCP_WIN_A_TO_POSIX | CCP_PROC_CYGDRIVE, nvml_winpath, NULL, 0);
 
     if (size > 0)

--- a/src/interface.c
+++ b/src/interface.c
@@ -12275,9 +12275,6 @@ int axcrypt_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UN
 
   if (salt_len != 32) return (PARSER_SALT_LENGTH);
 
-  /* Skip '*' */
-  wrapped_key_pos++;
-
   u32 wrapped_key_len = input_len - 11 - 1 - wrapping_rounds_len - 1 - salt_len - 1;
 
   if (wrapped_key_len != 48) return (PARSER_SALT_LENGTH);
@@ -13120,8 +13117,6 @@ int zip2_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UNUSE
 
   u32 param7_len = param8_pos - param7_pos;
 
-  param8_pos++;
-
   const u32 type  = atoll ((const char *) param0_pos);
   const u32 mode  = atoll ((const char *) param1_pos);
   const u32 magic = atoll ((const char *) param2_pos);
@@ -13428,7 +13423,7 @@ int luks_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UNUSE
 
   struct luks_phdr hdr;
 
-  const int nread = fread (&hdr, sizeof (hdr), 1, fp);
+  const size_t nread = fread (&hdr, sizeof (hdr), 1, fp);
 
   if (nread != 1) return (PARSER_LUKS_FILE_SIZE);
 
@@ -13637,23 +13632,23 @@ int luks_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UNUSE
 
   const u32 keyMaterialOffset = byte_swap_32 (hdr.keyblock[keyslot_idx].keyMaterialOffset);
 
-  const int rc_seek1 = fseek (fp, keyMaterialOffset * 512, SEEK_SET);
+  const int rc_seek1 = fseeko (fp, keyMaterialOffset * 512, SEEK_SET);
 
   if (rc_seek1 == -1) return (PARSER_LUKS_FILE_SIZE);
 
-  const int nread2 = fread (luks->af_src_buf, keyBytes, stripes, fp);
+  const size_t nread2 = fread (luks->af_src_buf, keyBytes, stripes, fp);
 
-  if (nread2 != (int) stripes) return (PARSER_LUKS_FILE_SIZE);
+  if (nread2 != stripes) return (PARSER_LUKS_FILE_SIZE);
 
   // finally, copy some encrypted payload data for entropy check
 
   const u32 payloadOffset = byte_swap_32 (hdr.payloadOffset);
 
-  const int rc_seek2 = fseek (fp, payloadOffset * 512, SEEK_SET);
+  const int rc_seek2 = fseeko (fp, payloadOffset * 512, SEEK_SET);
 
   if (rc_seek2 == -1) return (PARSER_LUKS_FILE_SIZE);
 
-  const int nread3 = fread (luks->ct_buf, sizeof (u32), 128, fp);
+  const size_t nread3 = fread (luks->ct_buf, sizeof (u32), 128, fp);
 
   if (nread3 != 128) return (PARSER_LUKS_FILE_SIZE);
 
@@ -14728,7 +14723,7 @@ int check_old_hccap (const char *hashfile)
 
   u32 signature;
 
-  const int nread = fread (&signature, sizeof (u32), 1, fp);
+  const size_t nread = fread (&signature, sizeof (u32), 1, fp);
 
   if (nread != 1) return -1;
 

--- a/src/straight.c
+++ b/src/straight.c
@@ -272,7 +272,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (hc_path_is_directory (l0_filename) == true)
         {
-          char **dictionary_files = NULL;
+          char **dictionary_files;
 
           dictionary_files = scan_directory (l0_filename);
 
@@ -336,7 +336,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_is_directory (l0_filename) == true)
       {
-        char **dictionary_files = NULL;
+        char **dictionary_files;
 
         dictionary_files = scan_directory (l0_filename);
 
@@ -391,7 +391,7 @@ int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_path_is_directory (l0_filename) == true)
       {
-        char **dictionary_files = NULL;
+        char **dictionary_files;
 
         dictionary_files = scan_directory (l0_filename);
 


### PR DESCRIPTION
Please verify the changes. I'm a little unsure about the variable++ removals. cppcheck complains that the variable's assigned value goes unused.