### PR TITLE
travis test: see if w/ this approach the correct submodule version is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+# disable the default submodule logic (it doesn't respect our "opencl12" branch dependency of the OpenCL-Headers)
+git:
+  submodules: false
+before_install:
+  - git submodule update --init --recursive
+
 os:
   - linux
   - osx


### PR DESCRIPTION
It seems that travis doesn't respect our submodule HEAD for the OpenCL-Headers.

I hope that with this approach the correct revision/branch is used.

Thank you