### PR TITLE
travis test: workaround undefined _WIN32 with a sed fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# this is a workaround because some OpenCL headers cause problems with older gcc compilers (undefined macro: _WIN32)
+before_install:
+ - sed -i 's/if _WIN32/if defined (_WIN32)/' deps/OpenCL-Headers/CL/cl_platform.h
 os:
   - linux
   - osx


### PR DESCRIPTION
This should fix some warnings that only seem to appear with older gcc/clang compilers.
But the root of the problem is that the #if #elsif etc do miss the defined () check.

Thank you