### PR TITLE
appveyor: fixed the link to the appveyor project

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Tests:
 
 Travis | Appveyor
 ------ | --------
-[![Hashcat Travis Build status](https://travis-ci.org/hashcat/hashcat.svg?branch=master)](https://travis-ci.org/hashcat/hashcat) | [![Hashcat Appveyor Build status](https://ci.appveyor.com/api/projects/status/github/hashcat/hashcat?branch=master&svg=true)](https://ci.appveyor.com/api/projects/status/github/hashcat/hashcat?branch=master&svg=true)
+[![Hashcat Travis Build status](https://travis-ci.org/hashcat/hashcat.svg?branch=master)](https://travis-ci.org/hashcat/hashcat) | [![Hashcat Appveyor Build status](https://ci.appveyor.com/api/projects/status/github/hashcat/hashcat?branch=master&svg=true)](https://ci.appveyor.com/project/jsteube/hashcat)
 
 ### Contributing ###
 


### PR DESCRIPTION
The link for appveyor within README.md was not correct... we need to use this one: https://ci.appveyor.com/project/jsteube/hashcat

Thank you