### PR TITLE
fix: we should initialize the aes_key in seven_zip_hook_func ()

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -14124,7 +14124,7 @@ void seven_zip_hook_func (hc_device_param_t *device_param, hashes_t *hashes, con
 
     // init AES
 
-    AES_KEY aes_key;
+    AES_KEY aes_key = { 0 };
     AES_set_decrypt_key (ukey, 256, &aes_key);
 
     AES_KEY aes_key_copied;


### PR DESCRIPTION
To avoid uninitialize memory and/or compiler warnings, I hereby suggest that we initialize the aes_key used within the 7-Zip hook function.

Thank you