### PR TITLE
fix: initialize the hc_stat_t structs before using/modifying them

### DIFF
--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1565,8 +1565,8 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
     char *outfile = outfile_ctx->filename;
 
-    hc_stat_t tmpstat_outfile;
-    hc_stat_t tmpstat_hashfile;
+    hc_stat_t tmpstat_outfile  = { 0 };
+    hc_stat_t tmpstat_hashfile = { 0 };
 
     FILE *tmp_outfile_fp = fopen (outfile, "r");
 


### PR DESCRIPTION
We need to initialize hc_stat_t because otherwise some fields (we are not interested in) could be uninitialized.
Thank you