### PR TITLE
mem problem in OpenCL device management: free () the platforms string

### DIFF
--- a/src/opencl.c
+++ b/src/opencl.c
@@ -192,6 +192,8 @@ static int setup_opencl_platforms_filter (hashcat_ctx_t *hashcat_ctx, const char
       {
         event_log_error (hashcat_ctx, "Invalid OpenCL platform %d specified", platform);
 
+        hcfree (platforms);
+
         return -1;
       }
 


### PR DESCRIPTION
This additional free () is needed to avoid a memory leak whenever the platform specified was not allowed.
Thank you