### PR TITLE
outfile check: out_files variable should be freed (also) in case of an error

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -64,6 +64,7 @@
 - Helper: Added functions to check existence, type, read- and write-permissions and rewrite sources to use them instead of stat()
 - Hardware Monitor: Fixed several memory leaks when no hardware monitor sensor is found
 - OpenCL Device Management: Fixed several memory leaks when initialization of a device/platform failed
+- Outfile Check: Fixed a memory leak for failed outfile reads
 - OpenCL Header: Updated CL_* errorcode to OpenCL 1.2 standard
 - OpenCL Runtime: Updated AMDGPU-Pro driver version check, do warn if version 16.60 is detected which is known to be broken
 - OpenCL Kernel: Renumbered hash-mode 7600 to 4521

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -79,6 +79,8 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
           {
             event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
 
+            hcfree (out_files);
+
             return -1;
           }
 


### PR DESCRIPTION
To avoid a memory leak, we need to free () the memory used for the out_files variable (also) in case of an error.

Thank you