### PR TITLE
added additional memory leak checks within the rule engine

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -66,6 +66,7 @@
 - Hardware Monitor: Fixed several memory leaks when no hardware monitor sensor is found
 - OpenCL Device Management: Fixed several memory leaks when initialization of a device/platform failed
 - Outfile Check: Fixed a memory leak for failed outfile reads
+- Rule Engine: Fixed several memory leaks when loading of rules failed
 - OpenCL Header: Updated CL_* errorcode to OpenCL 1.2 standard
 - OpenCL Runtime: Updated AMDGPU-Pro driver version check, do warn if version 16.60 is detected which is known to be broken
 - OpenCL Kernel: Renumbered hash-mode 7600 to 4521

--- a/src/rp.c
+++ b/src/rp.c
@@ -735,6 +735,8 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
     {
       event_log_error (hashcat_ctx, "%s: %s", rp_file, strerror (errno));
 
+      hcfree (rule_buf);
+
       return -1;
     }
 
@@ -835,15 +837,17 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
 
   hcfree (repeats);
 
+  hcfree (all_kernel_rules_cnt);
+  hcfree (all_kernel_rules_buf);
+
   if (kernel_rules_cnt == 0)
   {
     event_log_error (hashcat_ctx, "No valid rules left");
 
+    hcfree (kernel_rules_buf);
+
     return -1;
   }
-
-  hcfree (all_kernel_rules_cnt);
-  hcfree (all_kernel_rules_buf);
 
   *out_cnt = kernel_rules_cnt;
   *out_buf = kernel_rules_buf;


### PR DESCRIPTION
Some additional free()s are required in case of errors within the rule engine.

Thank you