### PR TITLE
-m 11400 = SIP digest authentication (MD5): added bound checks in parser

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -77,6 +77,7 @@
 - OpenCL Device: Do a check on available constant memory size and abort if it's less than 64kB
 - File Reads: Improved error detection on file reads, especially when getting the file stats
 - File Locking: Improved error detection on file locks
+- Hash Parsing: Added additional bound checks for the SIP digest authentication (MD5) parser (-m 11400)
 - Sessions: Move out handling of multiple instance from restore file into separate pidfile
 - Threads: Restored strerror as %m is unsupported by the BSDs
 - Wordlists: Fixed memory leak in case access a file in a wordlist folder fails

--- a/src/interface.c
+++ b/src/interface.c
@@ -10998,6 +10998,13 @@ int sip_auth_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_U
 
   u32 md5_max_len = 4 * 64;
 
+  u32 total_length = method_len + 1 + URI_prefix_len + URI_prefix_len + URI_resource_len + URI_suffix_len + URI_suffix_len;
+
+  if (URI_prefix_len) total_length++;
+  if (URI_suffix_len) total_length++;
+
+  if (total_length > md5_max_len) return (PARSER_SALT_LENGTH);
+
   u32 md5_remaining_len = md5_max_len;
 
   u32 tmp_md5_buf[64] = { 0 };


### PR DESCRIPTION
Within the parser for -m 11400 = SIP digest authentication (MD5) we should perform a initial check to make sure that the buffer is large enough to hold all data (i.e. that it can't ever overflow).

Thank you