### PR TITLE
rule engine: 2 more possibly memory leaks (see previous commits)

### DIFF
--- a/src/rp.c
+++ b/src/rp.c
@@ -735,6 +735,9 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
     {
       event_log_error (hashcat_ctx, "%s: %s", rp_file, strerror (errno));
 
+      hcfree (all_kernel_rules_cnt);
+      hcfree (all_kernel_rules_buf);
+
       hcfree (rule_buf);
 
       return -1;


### PR DESCRIPTION
These additional 2 buffers:

1. all_kernel_rules_cnt
2. all_kernel_rules_buf

also need to be freed in case of an error within the rule engine.

Thank you