### PR TITLE
outfile check: also out_info variable needs to be freed

### DIFF
--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -80,6 +80,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
             event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
 
             hcfree (out_files);
+            hcfree (out_info);
 
             return -1;
           }


### PR DESCRIPTION
An additional free () is needed in case of an error within the outfile check.

Thx