### PR TITLE
mp: memory checks added to avoid leaks

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -68,6 +68,7 @@
 - Hardware Monitor: Fixed several memory leaks in case no hardware monitor sensor is found
 - Hardware Monitor: Fixed several memory leaks in case hash-file writing (caused by --remove) failed
 - Mask Increment: Fixed memory leak in case mask_append() fails
+- Mask Checks: Added additional memory cleanups after parsing/verifying masks
 - OpenCL Device Management: Fixed several memory leaks in case initialization of an OpenCL device or platform failed
 - Outfile Check: Fixed a memory leak for failed outfile reads
 - Rule Engine: Fixed several memory leaks in case loading of rules failed

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -976,12 +976,9 @@ static int mask_append (hashcat_ctx_t *hashcat_ctx, const char *mask, const char
 
       const int rc = mask_append_final (hashcat_ctx, mask_truncated);
 
-      if (rc == -1)
-      {
-        hcfree (mask_truncated);
+      hcfree (mask_truncated);
 
-        return -1;
-      }
+      if (rc == -1) return -1;
     }
   }
   else
@@ -996,9 +993,9 @@ static int mask_append (hashcat_ctx_t *hashcat_ctx, const char *mask, const char
 
       const int rc = mask_append_final (hashcat_ctx, prepend_mask);
 
-      if (rc == -1) return -1;
-
       hcfree (prepend_mask);
+
+      if (rc == -1) return -1;
     }
     else
     {


### PR DESCRIPTION
This additional cleanups (frees) are needed to avoid memory leaks.

Thx