### PR TITLE
file locking: for windows we need to just return 0

### DIFF
--- a/src/locking.c
+++ b/src/locking.c
@@ -55,6 +55,8 @@ int lock_file (MAYBE_UNUSED FILE *fp)
 int unlock_file (MAYBE_UNUSED FILE *fp)
 {
   // we should put windows specific code here
+
+  return 0;
 }
 
 #endif // F_SETLKW


### PR DESCRIPTION
If we do not return anything, the compiler gives a warning.

We do not yet use file locking/unlocking for windows.

Thx