### PR TITLE
if fstat () fails we shouldn't forget to close the file

### DIFF
--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -142,7 +142,12 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
               hc_stat_t outfile_stat;
 
-              if (hc_fstat (fileno (fp), &outfile_stat)) continue;
+              if (hc_fstat (fileno (fp), &outfile_stat))
+              {
+                close (fp);
+
+                continue;
+              }
 
               if (outfile_stat.st_ctime > out_info[j].ctime)
               {


### PR DESCRIPTION
an fclose () was missing and therefore the memory occupied by the fp variable could lead to a memory leak.
Thanks