### PR TITLE
if fstat () fails we shouldn't forget to close the file

### DIFF
--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -144,7 +144,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
               if (hc_fstat (fileno (fp), &outfile_stat))
               {
-                close (fp);
+                fclose (fp);
 
                 continue;
               }


### PR DESCRIPTION
fclose () not close () like in perl

;)