### PR TITLE
keyfiles: for VeraCrypt/TrueCrypt keyfiles we need to free the memory

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -84,6 +84,7 @@
 - File Locking: Improved error detection on file locks
 - Hash Parsing: Added additional bound checks for the SIP digest authentication (MD5) parser (-m 11400)
 - Hash Parsing: Make sure that all files are correctly closed whenever a hash file parsing error occurs
+- Keyfile handling: Make sure that the memory is cleanly freed whenever a VeraCrypt/TrueCrypt keyfile fails to load
 - Sessions: Move out handling of multiple instance from restore file into separate pidfile
 - Threads: Restored strerror as %m is unsupported by the BSDs
 - Wordlists: Fixed memory leak in case access a file in a wordlist folder fails

--- a/src/interface.c
+++ b/src/interface.c
@@ -22506,7 +22506,12 @@ int hashconfig_general_defaults (hashcat_ctx_t *hashcat_ctx)
     {
       const int rc_crc32 = cpu_crc32 (hashcat_ctx, keyfile, (u8 *) keyfile_buf);
 
-      if (rc_crc32 == -1) return -1;
+      if (rc_crc32 == -1)
+      {
+        free (keyfiles);
+
+        return -1;
+      }
 
     } while ((keyfile = strtok_r (NULL, ",", &saveptr)) != NULL);
 


### PR DESCRIPTION
In case of errors reading the keyfiles (for VeraCrypt/TrueCrypt), we need to free () the memory cleanly.

Thanks