### PR TITLE
-m 13100 = Kerberos 5 TGS-REP: parser failed to correctly verify the hash

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -51,6 +51,7 @@
 - Fixed string not null terminated while reading maskfiles
 - Fixed pointer to local outside scope in case -j or -k is used
 - Fixed pointer to local outside scope in case --markov-hcstat is not used
+- Fixed a problem within the Kerberos 5 TGS-REP (-m 13100) hash parser
 
 ##
 ## Technical

--- a/src/interface.c
+++ b/src/interface.c
@@ -12186,10 +12186,10 @@ int krb5tgs_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UN
 
     data_pos = (u8 *) strchr ((const char *) account_pos, '*');
 
+    if (data_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+
     /* Skip '*' */
     data_pos++;
-
-    if (data_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 
     u32 account_len = data_pos - account_pos + 1;
 


### PR DESCRIPTION
The technical explanation of this problem is that we need to first check for the NULL pointer until we advanced within the hash buffer. Otherwise we could risk making a NULL-pointer dereference,

Thank you