### PR TITLE
minor: check return value of hc_stat () and use fclose () in case of error

### DIFF
--- a/src/opencl.c
+++ b/src/opencl.c
@@ -306,7 +306,12 @@ static int read_kernel_binary (hashcat_ctx_t *hashcat_ctx, const char *kernel_fi
   {
     hc_stat_t st;
 
-    hc_stat (kernel_file, &st);
+    if (hc_stat (kernel_file, &st))
+    {
+      fclose (fp);
+
+      return -1;
+    }
 
     char *buf = (char *) hcmalloc (st.st_size + 1);
 


### PR DESCRIPTION
We should always check if hc_stat () succeeds. In case of an error, we should close all file handles and return/exit.

Thank you