### PR TITLE
fix our usage of strtok_r (), it was not 100% correct

### DIFF
--- a/src/affinity.c
+++ b/src/affinity.c
@@ -63,7 +63,7 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 
   char *devices = hcstrdup (user_options->cpu_affinity);
 
-  char *saveptr = NULL;
+  char *saveptr;
 
   char *next = strtok_r (devices, ",", &saveptr);
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -5114,6 +5114,8 @@ int ikepsk_md5_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE
 
   char *saveptr;
 
+  if (input_buf == NULL) return (PARSER_HASH_VALUE);
+
   in_off[0] = (u8 *) strtok_r ((char *) input_buf, ":", &saveptr);
 
   if (in_off[0] == NULL) return (PARSER_SEPARATOR_UNMATCHED);
@@ -5199,6 +5201,8 @@ int ikepsk_sha1_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYB
   size_t in_len[9] = { 0 };
 
   char *saveptr;
+
+  if (input_buf == NULL) return (PARSER_HASH_VALUE);
 
   in_off[0] = (u8 *) strtok_r ((char *) input_buf, ":", &saveptr);
 
@@ -22510,6 +22514,13 @@ int hashconfig_general_defaults (hashcat_ctx_t *hashcat_ctx)
     char *saveptr;
 
     char *keyfile = strtok_r (keyfiles, ",", &saveptr);
+
+    if (keyfile == NULL)
+    {
+      free (keyfiles);
+
+      return -1;
+    }
 
     do
     {

--- a/src/interface.c
+++ b/src/interface.c
@@ -5112,7 +5112,7 @@ int ikepsk_md5_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE
 
   size_t in_len[9] = { 0 };
 
-  char *saveptr = NULL;
+  char *saveptr;
 
   in_off[0] = (u8 *) strtok_r ((char *) input_buf, ":", &saveptr);
 
@@ -5198,7 +5198,7 @@ int ikepsk_sha1_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYB
 
   size_t in_len[9] = { 0 };
 
-  char *saveptr = NULL;
+  char *saveptr;
 
   in_off[0] = (u8 *) strtok_r ((char *) input_buf, ":", &saveptr);
 
@@ -22507,7 +22507,7 @@ int hashconfig_general_defaults (hashcat_ctx_t *hashcat_ctx)
 
     char *keyfiles = hcstrdup (tcvc_keyfiles);
 
-    char *saveptr = NULL;
+    char *saveptr;
 
     char *keyfile = strtok_r (keyfiles, ",", &saveptr);
 

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -180,7 +180,7 @@ static int setup_opencl_platforms_filter (hashcat_ctx_t *hashcat_ctx, const char
   {
     char *platforms = hcstrdup (opencl_platforms);
 
-    char *saveptr = NULL;
+    char *saveptr;
 
     char *next = strtok_r (platforms, ",", &saveptr);
 
@@ -221,7 +221,7 @@ static int setup_devices_filter (hashcat_ctx_t *hashcat_ctx, const char *opencl_
   {
     char *devices = hcstrdup (opencl_devices);
 
-    char *saveptr = NULL;
+    char *saveptr;
 
     char *next = strtok_r (devices, ",", &saveptr);
 
@@ -262,7 +262,7 @@ static int setup_device_types_filter (hashcat_ctx_t *hashcat_ctx, const char *op
   {
     char *device_types = hcstrdup (opencl_device_types);
 
-    char *saveptr = NULL;
+    char *saveptr;
 
     char *next = strtok_r (device_types, ",", &saveptr);
 

--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -119,7 +119,7 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
     int token_cnt = 0;
 
-    char *saveptr = NULL;
+    char *saveptr;
 
     char *next = strtok_r (line_buf, "\t ", &saveptr);
 


### PR DESCRIPTION
This should fix the warning messages that we get around the usage of strtok_r ().

How to use it correctly:
1. see https://linux.die.net/man/3/strtok_r
2. see http://stackoverflow.com/a/15961298

Thanks