### PR TITLE
dead code: here we do not need to check for NULL

### DIFF
--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -119,8 +119,6 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
     int token_cnt = 0;
 
-    if (line_buf == NULL) continue;
-
     char *saveptr;
 
     char *next = strtok_r (line_buf, "\t ", &saveptr);


### PR DESCRIPTION
This is just a cosmetic fix... the check is irrelevant since line_buf can't be NULL here.

We can omit this check for NULL at that specific location.

Thx