### PR TITLE
dead code: hash_len is always > 0 at this location

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -725,13 +725,6 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
         if (hashconfig->hash_mode == 2500)
         {
-          if (hash_len == 0)
-          {
-            event_log_error (hashcat_ctx, "hccapx file not specified");
-
-            return -1;
-          }
-
           hashlist_mode = HL_MODE_FILE;
 
           hashes->hashlist_mode = hashlist_mode;


### PR DESCRIPTION
The check for hash_len == 0 makes no sense at this location in the source code because we already checked that beforehand (we call this dead code).

Thank you