### PR TITLE
minor: use 2 distinct return value to avoid dead code detections

### DIFF
--- a/src/opencl.c
+++ b/src/opencl.c
@@ -4314,9 +4314,9 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
         {
           char *build_log = (char *) hcmalloc (build_log_size + 1);
 
-          CL_rc = hc_clGetProgramBuildInfo (hashcat_ctx, device_param->program_amp, device_param->device, CL_PROGRAM_BUILD_LOG, build_log_size, build_log, NULL);
+          int CL_rc_build_info = hc_clGetProgramBuildInfo (hashcat_ctx, device_param->program_amp, device_param->device, CL_PROGRAM_BUILD_LOG, build_log_size, build_log, NULL);
 
-          if (CL_rc == -1) return -1;
+          if (CL_rc_build_info == -1) return -1;
 
           puts (build_log);
 


### PR DESCRIPTION
This should avoid (or let's say work around) a problem where it seems that the following code is dead code.

Thanks