### PR TITLE
Remove defined macros in favor of preprocessor defaults

### DIFF
--- a/include/affinity.h
+++ b/include/affinity.h
@@ -22,9 +22,9 @@
 #include <mach/thread_policy.h>
 #endif // __APPLE__
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #include <windows.h>
-#endif // _WIN
+#endif // __WIN32__
 
 int set_cpu_affinity (hashcat_ctx_t *hashcat_ctx);
 

--- a/include/common.h
+++ b/include/common.h
@@ -8,22 +8,17 @@
 
 #define PROGNAME "hashcat"
 
-#if   defined (__linux__) || defined (__CYGWIN__)
+#if defined (__unix__) || defined (__APPLE__) || defined (__FreeBSD___) 
 #define _POSIX
-#elif defined (__APPLE__)
-#define _POSIX
-#elif defined (__FreeBSD__)
-#define _POSIX
-#elif defined (_WIN32) || defined (_WIN64)
-#define _WIN 1
-#define WIN 1
-#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L //for *time_r functions
-#else
-#error Your Operating System is not supported or detected
 #endif
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+
+//needed for *time_r functions in MinGW.
+#ifndef _POSIX_THREAD_SAFE_FUNCTIONS
+#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L
 #endif
 
 #define _FILE_OFFSET_BITS 64
@@ -48,9 +43,9 @@
 #define HC_API_CALL
 #endif
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #define WIN32_LEAN_AND_MEAN
-#endif
+#endif // __WIN32__
 
 /* The C++ standard denies redefinition of keywords,
 but this is nededed for VS compiler which doesn't have inline keyword but has __inline
@@ -84,10 +79,10 @@ but this is nededed for VS compiler which doesn't have inline keyword but has __
 #define BLOCK_SIZE          64
 #define EXPECTED_ITERATIONS 10000
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #define EOL "\r\n"
 #else
 #define EOL "\n"
-#endif
+#endif // __WIN32__
 
 #endif // _COMMON_H

--- a/include/dynloader.h
+++ b/include/dynloader.h
@@ -15,11 +15,11 @@
 #endif // __APPLE__
 #endif // _POSIX
 
-#ifdef _WIN
+#if defined (__WIN32__)
 #include <windows.h>
-#endif
+#endif // __WIN32__
 
-#ifdef _WIN
+#if defined (__WIN32__)
 HMODULE hc_dlopen  (LPCSTR lpLibFileName);
 BOOL    hc_dlclose (HMODULE hLibModule);
 FARPROC hc_dlsym   (HMODULE hModule, LPCSTR lpProcName);
@@ -27,7 +27,7 @@ FARPROC hc_dlsym   (HMODULE hModule, LPCSTR lpProcName);
 void *hc_dlopen  (const char *fileName, int flag);
 int   hc_dlclose (void *handle);
 void *hc_dlsym   (void *module, const char *symbol);
-#endif
+#endif // __WIN32__
 
 #define HC_LOAD_FUNC2(ptr,name,type,var,libname,noerr) \
   ptr->name = (type) hc_dlsym (ptr->var, #name); \

--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -9,9 +9,9 @@
 #include <string.h>
 #include <stdlib.h>
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #include <windows.h>
-#endif // _WIN
+#endif // __WIN32__
 
 /**
  * Declarations from adl_sdk.h and subheaders
@@ -45,19 +45,19 @@ typedef struct AdapterInfo
   char strDisplayName[ADL_MAX_PATH];
   int  iPresent;
 
-  #if defined (_WIN32) || defined (_WIN64)
+  #if defined (__WIN32__) || defined (__CYGWIN__)
   int  iExist;
   char strDriverPath[ADL_MAX_PATH];
   char strDriverPathExt[ADL_MAX_PATH];
   char strPNPString[ADL_MAX_PATH];
   int  iOSDisplayIndex;
-  #endif /* (_WIN32) || (_WIN64) */
+  #endif
 
   #if defined (__linux__)
   int  iXScreenNum;
   int  iDrvIndex;
   char strXScreenConfigName[ADL_MAX_PATH];
-  #endif /* (__linux__) */
+  #endif // __linux__
 } AdapterInfo, *LPAdapterInfo;
 
 typedef struct ADLThermalControllerInfo
@@ -250,9 +250,9 @@ typedef struct ADLOD6PowerControlInfo
   int iExtMask;
 } ADLOD6PowerControlInfo;
 
-#if defined (__MSC_VER)
+#if   defined (__MSC_VER)
 #define ADL_API_CALL __cdecl
-#elif defined (_WIN32) || defined (__WIN32__)
+#elif defined (__WIN32__)
 #define ADL_API_CALL __stdcall
 #else
 #define ADL_API_CALL
@@ -308,11 +308,11 @@ typedef int (ADL_API_CALL *ADL_OVERDRIVE6_TARGETTEMPERATUREDATA_GET) (int, int *
 typedef int (ADL_API_CALL *ADL_OVERDRIVE6_TARGETTEMPERATURERANGEINFO_GET) (int, ADLOD6ParameterRange *);
 typedef int (ADL_API_CALL *ADL_OVERDRIVE6_FANSPEED_RESET) (int);
 
-#if defined (_POSIX)
-typedef void *ADL_LIB;
-#else
+#if defined (__WIN32__)
 typedef HINSTANCE ADL_LIB;
-#endif
+#else
+typedef void *ADL_LIB;
+#endif // __WIN32__
 
 typedef struct hm_adl_lib
 {

--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -11,23 +11,9 @@
 
 #if defined (__APPLE__)
 #include <OpenCL/cl.h>
-#endif
-
-#if defined (_WIN)
+#else
 #include <CL/cl.h>
-#endif
-
-#if defined (__linux__)
-#include <CL/cl.h>
-#endif
-
-#if defined (__FreeBSD__)
-#include <CL/cl.h>
-#endif
-
-#if defined (__CYGWIN__)
-#include <CL/cl.h>
-#endif
+#endif // __APPLE__
 
 // NVIDIA extras
 
@@ -82,11 +68,11 @@ typedef cl_int           (CL_API_CALL *OCL_CLRELEASEPROGRAM)          (cl_progra
 typedef cl_int           (CL_API_CALL *OCL_CLSETKERNELARG)            (cl_kernel, cl_uint, size_t, const void *);
 typedef cl_int           (CL_API_CALL *OCL_CLWAITFOREVENTS)           (cl_uint, const cl_event *);
 
-#if defined (_POSIX)
-typedef void *OCL_LIB;
-#else
+#if defined (__WIN32__)
 typedef HINSTANCE OCL_LIB;
-#endif
+#else
+typedef void *OCL_LIB;
+#endif // __WIN32__
 
 typedef struct hc_opencl_lib
 {

--- a/include/ext_nvapi.h
+++ b/include/ext_nvapi.h
@@ -217,11 +217,11 @@ NVAPI_INTERFACE NvAPI_GPU_GetBusSlotId (NvPhysicalGpuHandle hPhysicalGpu, NvU32 
 
 typedef NvPhysicalGpuHandle HM_ADAPTER_NVAPI;
 
-#if defined(_WIN32) || defined(__WIN32__)
+#if defined (__WIN32__)
 #define NVAPI_API_CALL __stdcall
 #else
 #define NVAPI_API_CALL
-#endif
+#endif // __WIN32__
 
 typedef int *(*NVAPI_API_CALL NVAPI_QUERYINTERFACE) (unsigned int);
 typedef int (*NVAPI_API_CALL NVAPI_INITIALIZE) (void);
@@ -235,11 +235,11 @@ typedef int (*NVAPI_API_CALL NVAPI_GPU_RESTORECOOLERSETTINGS) (NvPhysicalGpuHand
 typedef int (*NVAPI_API_CALL NVAPI_GPU_GETBUSID) (NvPhysicalGpuHandle, NvU32 *);
 typedef int (*NVAPI_API_CALL NVAPI_GPU_GETBUSSLOTID) (NvPhysicalGpuHandle, NvU32 *);
 
-#if defined (_POSIX)
-typedef void *NVAPI_LIB;
-#else
+#if defined (__WIN32__)
 typedef HINSTANCE NVAPI_LIB;
-#endif
+#else
+typedef void *NVAPI_LIB;
+#endif // __WIN32__
 
 typedef struct hm_nvapi_lib
 {

--- a/include/ext_nvml.h
+++ b/include/ext_nvml.h
@@ -168,11 +168,11 @@ typedef enum nvmlGom_enum
 
 typedef nvmlDevice_t HM_ADAPTER_NVML;
 
-#if defined(_WIN32) || defined(__WIN32__)
+#if defined (__WIN32__)
 #define NVML_API_CALL __stdcall
 #else
 #define NVML_API_CALL
-#endif
+#endif // __WIN32__
 
 typedef const char * (*NVML_API_CALL NVML_ERROR_STRING) (nvmlReturn_t);
 typedef int (*NVML_API_CALL NVML_INIT) (void);
@@ -197,11 +197,11 @@ typedef nvmlReturn_t (*NVML_API_CALL NVML_DEVICE_SET_POWERMANAGEMENTLIMIT) (nvml
 typedef nvmlReturn_t (*NVML_API_CALL NVML_DEVICE_GET_POWERMANAGEMENTLIMIT) (nvmlDevice_t, unsigned int *);
 typedef nvmlReturn_t (*NVML_API_CALL NVML_DEVICE_GET_PCIINFO) (nvmlDevice_t, nvmlPciInfo_t *);
 
-#if defined (_POSIX)
-typedef void *NVML_LIB;
-#else
+#if defined (__WIN32__)
 typedef HINSTANCE NVML_LIB;
-#endif
+#else
+typedef void *NVML_LIB;
+#endif // __WIN32__
 
 typedef struct hm_nvml_lib
 {

--- a/include/ext_xnvctrl.h
+++ b/include/ext_xnvctrl.h
@@ -61,21 +61,21 @@ typedef int   (*XCLOSEDISPLAY) (void *);
 
 typedef int HM_ADAPTER_XNVCTRL;
 
-#if defined(_WIN32) || defined(__WIN32__)
+#if defined(__WIN32__)
 #define XNVCTRL_API_CALL __stdcall
 #else
 #define XNVCTRL_API_CALL
-#endif
+#endif // __WIN32__
 
 typedef int  (*XNVCTRL_API_CALL XNVCTRLQUERYTARGETCOUNT)     (void *, int, int *);
 typedef int  (*XNVCTRL_API_CALL XNVCTRLQUERYTARGETATTRIBUTE) (void *, int, int, unsigned int, unsigned int, int *);
 typedef void (*XNVCTRL_API_CALL XNVCTRLSETTARGETATTRIBUTE)   (void *, int, int, unsigned int, unsigned int, int);
 
-#if defined (_POSIX)
-typedef void *XNVCTRL_LIB;
-#else
+#if defined (__WIN32__)
 typedef HINSTANCE XNVCTRL_LIB;
-#endif
+#else
+typedef void *XNVCTRL_LIB;
+#endif // __WIN32__
 
 typedef struct hm_xnvctrl_lib
 {

--- a/include/folder.h
+++ b/include/folder.h
@@ -13,16 +13,16 @@
 #if defined (_POSIX)
 #include <sys/types.h>
 #include <pwd.h>
-#endif
+#endif // _POSIX_
 
 #if defined (__APPLE__)
 #include <mach-o/dyld.h>
 #endif // __APPLE__
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #include <windows.h>
 #include <direct.h>
-#endif
+#endif // __WIN32__
 
 #define DOT_HASHCAT     ".hashcat"
 #define SESSIONS_FOLDER "sessions"

--- a/include/hwmon.h
+++ b/include/hwmon.h
@@ -6,7 +6,7 @@
 #include <errno.h>
 #if defined (__CYGWIN__)
 #include <sys/cygwin.h>
-#endif
+#endif // __CYGWIN__
 
 #ifndef _HWMON_H
 #define _HWMON_H

--- a/include/pidfile.h
+++ b/include/pidfile.h
@@ -13,12 +13,10 @@
 #if defined (_POSIX)
 #include <sys/types.h>
 #include <sys/stat.h>
-#endif // _POSIX
-
-#if defined (_WIN)
+#else
 #include <windows.h>
 #include <psapi.h>
-#endif // _WIN
+#endif // _POSIX
 
 void unlink_pidfile (hashcat_ctx_t *hashcat_ctx);
 

--- a/include/restore.h
+++ b/include/restore.h
@@ -13,12 +13,10 @@
 #if defined (_POSIX)
 #include <sys/types.h>
 #include <sys/stat.h>
-#endif // _POSIX
-
-#if defined (_WIN)
+#else
 #include <windows.h>
 #include <psapi.h>
-#endif // _WIN
+#endif // _POSIX
 
 #define RESTORE_VERSION_MIN 340
 #define RESTORE_VERSION_CUR 340

--- a/include/sort_r.h
+++ b/include/sort_r.h
@@ -28,10 +28,10 @@ Slightly modified to work with hashcat to no falsly detect _SORT_R_LINUX with mi
      defined __FreeBSD__ || defined __DragonFly__)
 #  define _SORT_R_BSD
 #  define _SORT_R_INLINE inline
-#elif (defined __linux__) || defined (__CYGWIN__)
+#elif (defined __unix__)
 #  define _SORT_R_LINUX
 #  define _SORT_R_INLINE inline
-#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
+#elif (defined __WIN32__)
 #  define _SORT_R_WINDOWS
 #  define _SORT_R_INLINE __inline
 #else

--- a/include/terminal.h
+++ b/include/terminal.h
@@ -19,9 +19,9 @@
 #endif // __APPLE__
 #endif // _POSIX
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #include <windows.h>
-#endif // _WIN
+#endif // __WIN32__
 
 void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag);
 void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const time_t proc_stop);
@@ -33,9 +33,9 @@ void clear_prompt (void);
 
 void *thread_keypress (void *p);
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 void SetConsoleWindowSize (const int x);
-#endif
+#endif // __WIN32__
 
 int tty_break(void);
 int tty_getchar(void);

--- a/include/thread.h
+++ b/include/thread.h
@@ -11,12 +11,11 @@
 #if defined (_POSIX)
 #include <pthread.h>
 #include <semaphore.h>
-#endif // _POSIX
-#if defined (_WIN)
+#else
 #include <windows.h>
-#endif // _WIN
+#endif // _POSIX
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 
 #define hc_thread_create(t,f,a)     t = CreateThread (NULL, 0, (LPTHREAD_START_ROUTINE) &f, a, 0, NULL)
 #define hc_thread_wait(n,a)         for (u32 i = 0; i < n; i++) WaitForSingleObject ((a)[i], INFINITE)
@@ -27,7 +26,7 @@
 #define hc_thread_mutex_init(m)     InitializeCriticalSection (&m)
 #define hc_thread_mutex_delete(m)   DeleteCriticalSection     (&m)
 
-#elif defined (_POSIX)
+#else
 
 #define hc_thread_create(t,f,a)     pthread_create (&t, NULL, f, a)
 #define hc_thread_wait(n,a)         for (u32 i = 0; i < n; i++) pthread_join ((a)[i], NULL)
@@ -41,7 +40,7 @@
 #endif
 
 /*
-#if defined (_WIN)
+#if defined (__WIN32__)
 
 BOOL WINAPI sigHandler_default (DWORD sig);
 BOOL WINAPI sigHandler_benchmark (DWORD sig);

--- a/include/types.h
+++ b/include/types.h
@@ -17,7 +17,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #include <windows.h>
 #if defined (_BASETSD_H)
 #else
@@ -30,7 +30,7 @@ typedef INT16  int16_t;
 typedef INT32  int32_t;
 typedef INT64  int64_t;
 #endif
-#endif // _WIN
+#endif // __WIN32__
 
 typedef uint8_t  u8;
 typedef uint16_t u16;
@@ -39,35 +39,33 @@ typedef uint64_t u64;
 
 // timer
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 typedef LARGE_INTEGER     hc_timer_t;
-#elif defined (_POSIX)
+#else
 typedef struct timeval    hc_timer_t;
-#endif
+#endif // WIN32
 
 // thread
 
 #if defined (_POSIX)
 #include <pthread.h>
-#endif
+#endif // _POSIX
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 typedef HANDLE            hc_thread_t;
 typedef CRITICAL_SECTION  hc_thread_mutex_t;
-#elif defined (_POSIX)
+#else
 typedef pthread_t         hc_thread_t;
 typedef pthread_mutex_t   hc_thread_mutex_t;
-#endif
+#endif // __WIN32__
 
 // stat
 
-#if defined (_POSIX)
-typedef struct stat hc_stat_t;
-#endif
-
-#if defined (_WIN)
+#if defined (__WIN32__)
 typedef struct _stat64 hc_stat_t;
-#endif
+#else
+typedef struct stat hc_stat_t;
+#endif // __WIN32__
 
 // enums
 
@@ -1208,7 +1206,7 @@ typedef struct dictstat_ctx
   size_t cnt;
   #else
   u32    cnt;
-  #endif
+  #endif // _POSIX
 
 } dictstat_ctx_t;
 

--- a/src/affinity.c
+++ b/src/affinity.c
@@ -54,12 +54,12 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->cpu_affinity == NULL) return 0;
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   DWORD_PTR aff_mask = 0;
   #else
   cpu_set_t cpuset;
   CPU_ZERO (&cpuset);
-  #endif
+  #endif // __WIN32__
 
   char *devices = hcstrdup (user_options->cpu_affinity);
 
@@ -75,11 +75,11 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 
     if (cpu_id == 0)
     {
-      #if defined (_WIN)
+      #if defined (__WIN32__)
       aff_mask = 0;
       #else
       CPU_ZERO (&cpuset);
-      #endif
+      #endif // __WIN32__
 
       break;
     }
@@ -93,17 +93,17 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
       return -1;
     }
 
-    #if defined (_WIN)
+    #if defined (__WIN32__)
     aff_mask |= 1u << (cpu_id - 1);
     #else
     CPU_SET ((cpu_id - 1), &cpuset);
-    #endif
+    #endif // __WIN32__
 
   } while ((next = strtok_r (NULL, ",", &saveptr)) != NULL);
 
   hcfree (devices);
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
 
   SetProcessAffinityMask (GetCurrentProcess (), aff_mask);
 
@@ -125,8 +125,8 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  #endif
+  #endif // __WIN32__
 
   return 0;
-#endif
+#endif // __CYGWIN__
 }

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -16,7 +16,7 @@ int sort_by_dictstat (const void *s1, const void *s2)
   dictstat_t *d1 = (dictstat_t *) s1;
   dictstat_t *d2 = (dictstat_t *) s2;
 
-  #if defined (__linux__) || defined (__CYGWIN__)
+  #if defined (__unix__)
   d2->stat.st_atim = d1->stat.st_atim;
   #else
   d2->stat.st_atime = d1->stat.st_atime;

--- a/src/dynloader.c
+++ b/src/dynloader.c
@@ -6,7 +6,7 @@
 #include "common.h"
 #include "dynloader.h"
 
-#ifdef _WIN
+#if defined (__WIN32__)
 
 HMODULE hc_dlopen (LPCSTR lpLibFileName)
 {
@@ -40,4 +40,4 @@ void *hc_dlsym (void *module, const char *symbol)
   return dlsym (module, symbol);
 }
 
-#endif
+#endif // __WIN32__

--- a/src/folder.c
+++ b/src/folder.c
@@ -10,10 +10,6 @@
 #include "shared.h"
 #include "folder.h"
 
-#if defined (__APPLE__)
-#include "event.h"
-#endif
-
 int sort_by_stringptr (const void *p1, const void *p2)
 {
   const char **s1 = (const char **) p1;
@@ -24,7 +20,7 @@ int sort_by_stringptr (const void *p1, const void *p2)
 
 static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 {
-  #if defined (__linux__) || defined (__CYGWIN__)
+  #if defined (__unix__)
 
   char *tmp;
 
@@ -36,7 +32,7 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   if (len == -1) return -1;
 
-  #elif defined (_WIN)
+  #elif defined (__WIN32__)
 
   const DWORD len = GetModuleFileName (NULL, exec_path, exec_path_sz - 1);
 
@@ -107,7 +103,7 @@ static void get_session_dir (char *session_dir, const char *profile_dir)
 {
   snprintf (session_dir, HCBUFSIZ_TINY - 1, "%s/%s", profile_dir, SESSIONS_FOLDER);
 }
-#endif
+#endif // _POSIX
 
 int count_dictionaries (char **dictionary_files)
 {
@@ -304,7 +300,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
     return -1;
   }
 
-  #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined (__CYGWIN__)
+  #if defined (_POSIX)
 
   static const char SLASH[] = "/";
 
@@ -407,7 +403,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   char *cpath;
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
 
   hc_asprintf (&cpath, "%s\\OpenCL\\", shared_dir);
 
@@ -442,7 +438,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
     return -1;
   }
 
-  #endif
+  #endif // __WIN32__
 
   hcfree (cpath);
 
@@ -456,7 +452,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
     putenv (tmp);
   }
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
 
   naive_replace (cpath_real, '\\', '/');
 
@@ -467,7 +463,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   naive_escape (cpath_real, PATH_MAX,  ' ', '\\');
 
-  #endif
+  #endif // __WIN32__
 
   /**
    * kernel cache, we need to make sure folder exist
@@ -508,9 +504,9 @@ void folder_config_destroy (hashcat_ctx_t *hashcat_ctx)
 
 int hc_mkdir (const char *name, MAYBE_UNUSED const int mode)
 {
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   return _mkdir (name);
   #else
   return mkdir (name, mode);
-  #endif
+  #endif // __WIN32__
 }

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -551,7 +551,7 @@ static int nvml_init (hashcat_ctx_t *hashcat_ctx)
 
   memset (nvml, 0, sizeof (NVML_PTR));
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   nvml->lib = hc_dlopen ("nvml.dll");
 
   if (!nvml->lib)
@@ -642,7 +642,7 @@ static int nvml_init (hashcat_ctx_t *hashcat_ctx)
 
   #elif defined (_POSIX)
   nvml->lib = hc_dlopen ("libnvidia-ml.so", RTLD_NOW);
-  #endif
+  #endif // _POSIX
 
   if (!nvml->lib)
   {
@@ -1142,13 +1142,13 @@ static int nvapi_init (hashcat_ctx_t *hashcat_ctx)
 
   memset (nvapi, 0, sizeof (NVAPI_PTR));
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
 
-  #if defined (_WIN64)
+  #if defined (__WIN64__)
   nvapi->lib = hc_dlopen ("nvapi64.dll");
   #else
   nvapi->lib = hc_dlopen ("nvapi.dll");
-  #endif
+  #endif // __WIN64__
 
   #else
 
@@ -1158,13 +1158,13 @@ static int nvapi_init (hashcat_ctx_t *hashcat_ctx)
   nvapi->lib = hc_dlopen ("nvapi64.dll", RTLD_NOW);
   #else
   nvapi->lib = hc_dlopen ("nvapi.dll", RTLD_NOW);
-  #endif
+  #endif // __x86_64__
 
   #else
   nvapi->lib = hc_dlopen ("nvapi.so", RTLD_NOW); // uhm yes, but .. yeah
-  #endif
+  #endif // __CYGWIN__
 
-  #endif
+  #endif // __WIN32__
 
   if (!nvapi->lib)
   {
@@ -1415,12 +1415,12 @@ static int xnvctrl_init (hashcat_ctx_t *hashcat_ctx)
 
   memset (xnvctrl, 0, sizeof (XNVCTRL_PTR));
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
 
   // unsupport platform?
   return -1;
 
-  #elif defined (_POSIX)
+  #else
 
   xnvctrl->lib_x11 = dlopen ("libX11.so", RTLD_LAZY);
 
@@ -1451,7 +1451,7 @@ static int xnvctrl_init (hashcat_ctx_t *hashcat_ctx)
 
   return 0;
 
-  #endif
+  #endif // // __WIN32__
 }
 
 static void xnvctrl_close (hashcat_ctx_t *hashcat_ctx)
@@ -1474,7 +1474,7 @@ static void xnvctrl_close (hashcat_ctx_t *hashcat_ctx)
       dlclose (xnvctrl->lib_xnvctrl);
     }
 
-    #endif
+    #endif // _POSIX
 
     hcfree (xnvctrl);
   }
@@ -1766,16 +1766,16 @@ static int adl_init (hashcat_ctx_t *hashcat_ctx)
 
   memset (adl, 0, sizeof (ADL_PTR));
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   adl->lib = hc_dlopen ("atiadlxx.dll");
 
   if (!adl->lib)
   {
     adl->lib = hc_dlopen ("atiadlxy.dll");
   }
-  #elif defined (_POSIX)
+  #else
   adl->lib = hc_dlopen ("libatiadlxx.so", RTLD_NOW);
-  #endif
+  #endif // __WIN32__
 
   if (!adl->lib)
   {

--- a/src/main.c
+++ b/src/main.c
@@ -20,13 +20,13 @@
 #include "interface.h"
 #include "event.h"
 
-#if defined(__MINGW64__) || defined(__MINGW32__)
+#if defined(__MINGW32__)
 int _dowildcard = -1;
 #endif
 
 static void main_log_clear_line (MAYBE_UNUSED const int prev_len, MAYBE_UNUSED FILE *fp)
 {
-  #if defined (_WIN)
+  #if defined (__WIN32__)
 
   fputc ('\r', fp);
 
@@ -41,7 +41,7 @@ static void main_log_clear_line (MAYBE_UNUSED const int prev_len, MAYBE_UNUSED F
 
   printf ("\033[2K\r");
 
-  #endif
+  #endif // __WIN32__
 }
 
 static void main_log (hashcat_ctx_t *hashcat_ctx, FILE *fp, const int loglevel)
@@ -72,7 +72,7 @@ static void main_log (hashcat_ctx_t *hashcat_ctx, FILE *fp, const int loglevel)
 
   // color stuff pre
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   HANDLE hConsole = GetStdHandle (STD_OUTPUT_HANDLE);
 
   CONSOLE_SCREEN_BUFFER_INFO con_info;
@@ -98,7 +98,7 @@ static void main_log (hashcat_ctx_t *hashcat_ctx, FILE *fp, const int loglevel)
     case LOGLEVEL_WARNING: fwrite ("\033[33m", 5, 1, fp); break;
     case LOGLEVEL_ERROR:   fwrite ("\033[31m", 5, 1, fp); break;
   }
-  #endif
+  #endif // __WIN32__
 
   // finally, print
 
@@ -106,7 +106,7 @@ static void main_log (hashcat_ctx_t *hashcat_ctx, FILE *fp, const int loglevel)
 
   // color stuff post
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   switch (loglevel)
   {
     case LOGLEVEL_INFO:                                              break;
@@ -120,7 +120,7 @@ static void main_log (hashcat_ctx_t *hashcat_ctx, FILE *fp, const int loglevel)
     case LOGLEVEL_WARNING: fwrite ("\033[0m", 4, 1, fp); break;
     case LOGLEVEL_ERROR:   fwrite ("\033[0m", 4, 1, fp); break;
   }
-  #endif
+  #endif // __WIN32__
 
   // eventual newline
 

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -31,7 +31,7 @@ static const char dri_card0_path[] = "/dev/dri/card0";
 
 static const char drm_card0_vendor_path[] = "/sys/class/drm/card0/device/vendor";
 static const char drm_card0_driver_path[] = "/sys/class/drm/card0/device/driver";
-#endif
+#endif // __linux__
 
 static const u32 full01 = 0x01010101;
 static const u32 full80 = 0x80808080;
@@ -390,9 +390,9 @@ int ocl_init (hashcat_ctx_t *hashcat_ctx)
 
   memset (ocl, 0, sizeof (OCL_PTR));
 
-  #if   defined(_WIN)
+  #if   defined (__WIN32__)
   ocl->lib = hc_dlopen ("OpenCL");
-  #elif defined(__APPLE__)
+  #elif defined (__APPLE__)
   ocl->lib = hc_dlopen ("/System/Library/Frameworks/OpenCL.framework/OpenCL", RTLD_NOW);
   #elif defined (__CYGWIN__)
   ocl->lib = hc_dlopen ("opencl.dll", RTLD_NOW);
@@ -402,7 +402,7 @@ int ocl_init (hashcat_ctx_t *hashcat_ctx)
   ocl->lib = hc_dlopen ("libOpenCL.so", RTLD_NOW);
 
   if (ocl->lib == NULL) ocl->lib = hc_dlopen ("libOpenCL.so.1", RTLD_NOW);
-  #endif
+  #endif // __WIN32__
 
   if (ocl->lib == NULL)
   {
@@ -410,17 +410,17 @@ int ocl_init (hashcat_ctx_t *hashcat_ctx)
     event_log_error (hashcat_ctx, NULL);
     event_log_error (hashcat_ctx, "You're probably missing the OpenCL runtime and driver installation");
 
-    #if defined (__linux__)
+    #if   defined (__linux__)
     event_log_error (hashcat_ctx, "* AMD users on Linux require \"AMDGPU-Pro Driver\" (16.40 or later)");
-    #elif defined (_WIN)
+    #elif defined (__WIN32__)
     event_log_error (hashcat_ctx, "* AMD users on Windows require \"AMD Radeon Software Crimson Edition\" (15.12 or later)");
     #endif
 
     event_log_error (hashcat_ctx, "* Intel CPU users require \"OpenCL Runtime for Intel Core and Intel Xeon Processors\" (16.1.1 or later)");
 
-    #if defined (__linux__)
+    #if   defined (__linux__)
     event_log_error (hashcat_ctx, "* Intel GPU on Linux users require \"OpenCL 2.0 GPU Driver Package for Linux\" (2.0 or later)");
-    #elif defined (_WIN)
+    #elif defined (__WIN32__)
     event_log_error (hashcat_ctx, "* Intel GPU on Windows users require \"OpenCL Driver for Intel Iris and Intel HD Graphics\"");
     #endif
 
@@ -1801,14 +1801,14 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
   {
     hc_timer_set (&device_param->timer_speed);
   }
-  #endif
+  #endif // _POSIX
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   if (device_param->timer_speed.QuadPart == 0)
   {
     hc_timer_set (&device_param->timer_speed);
   }
-  #endif
+  #endif // __WIN32__
 
   // find higest password length, this is for optimization stuff
 
@@ -2250,17 +2250,17 @@ int opencl_ctx_init (hashcat_ctx_t *hashcat_ctx)
     event_log_error (hashcat_ctx, NULL);
     event_log_error (hashcat_ctx, "You're probably missing the OpenCL runtime installation");
 
-    #if defined (__linux__)
+    #if   defined (__linux__)
     event_log_error (hashcat_ctx, "* AMD users on Linux require \"AMDGPU-Pro Driver\" (16.40 or later)");
-    #elif defined (_WIN)
+    #elif defined (__WIN32__)
     event_log_error (hashcat_ctx, "* AMD users on Windows require \"AMD Radeon Software Crimson Edition\" (15.12 or later)");
     #endif
 
     event_log_error (hashcat_ctx, "* Intel CPU users require \"OpenCL Runtime for Intel Core and Intel Xeon Processors\" (16.1.1 or later)");
 
-    #if defined (__linux__)
+    #if   defined (__linux__)
     event_log_error (hashcat_ctx, "* Intel GPU on Linux users require \"OpenCL 2.0 GPU Driver Package for Linux\" (2.0 or later)");
-    #elif defined (_WIN)
+    #elif defined (__WIN32__)
     event_log_error (hashcat_ctx, "* Intel GPU on Windows users require \"OpenCL Driver for Intel Iris and Intel HD Graphics\"");
     #endif
 
@@ -2271,9 +2271,9 @@ int opencl_ctx_init (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  if (opencl_platforms_filter != (u32) -1)
+  if (opencl_platforms_filter != -1u)
   {
-    u32 platform_cnt_mask = ~(((u32) -1 >> platforms_cnt) << platforms_cnt);
+    u32 platform_cnt_mask = ~(( -1u >> platforms_cnt) << platforms_cnt);
 
     if (opencl_platforms_filter > platform_cnt_mask)
     {
@@ -2927,11 +2927,7 @@ int opencl_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
           need_xnvctrl = true;
           #endif
 
-          #if defined (_WIN)
-          need_nvapi = true;
-          #endif
-
-          #if defined (__CYGWIN__)
+          #if defined (__WIN32__) || defined (__CYGWIN__)
           need_nvapi = true;
           #endif
         }
@@ -3056,7 +3052,7 @@ int opencl_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
               if (atoi (device_param->driver_version) == 2236) amd_warn = true;
               // AMDGPU-Pro Driver 16.60 is known to be broken
               if (atoi (device_param->driver_version) == 2264) amd_warn = true;
-              #elif defined (_WIN)
+              #elif defined (__WIN32__)
               // AMD Radeon Software 14.9 and higher, should be updated to 15.12
               if (atoi (device_param->driver_version) >= 1573) amd_warn = false;
               #else
@@ -3829,11 +3825,11 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     char build_opts[1024] = { 0 };
 
-    #if defined (_WIN)
+    #if defined (__WIN32__)
     snprintf (build_opts, sizeof (build_opts) - 1, "-I \"%s\"", folder_config->cpath_real);
     #else
     snprintf (build_opts, sizeof (build_opts) - 1, "-I %s", folder_config->cpath_real);
-    #endif
+    #endif // __WIN32__
 
     // include check
     // this test needs to be done manually because of osx opencl runtime

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -57,7 +57,7 @@ static int check_running_process (hashcat_ctx_t *hashcat_ctx)
 
     hcfree (pidbin);
 
-    #elif defined (_WIN)
+    #elif defined (__WIN32__)
 
     HANDLE hProcess = OpenProcess (PROCESS_ALL_ACCESS, FALSE, pd->pid);
 
@@ -88,7 +88,7 @@ static int check_running_process (hashcat_ctx_t *hashcat_ctx)
     hcfree (pidbin);
     hcfree (pidbin2);
 
-    #endif
+    #endif // _POSIX
   }
 
   hcfree (pd);
@@ -108,11 +108,11 @@ static int init_pidfile (hashcat_ctx_t *hashcat_ctx)
 
   if (rc == -1) return -1;
 
-  #if defined (_POSIX)
-  pd->pid = getpid ();
-  #elif defined (_WIN)
+  #if   defined (__WIN32__)
   pd->pid = GetCurrentProcessId ();
-  #endif
+  #else
+  pd->pid = getpid ();
+  #endif // __WIN32__
 
   return 0;
 }

--- a/src/restore.c
+++ b/src/restore.c
@@ -11,7 +11,7 @@
 #include "shared.h"
 #include "restore.h"
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 static void fsync (int fd)
 {
   HANDLE h = (HANDLE) _get_osfhandle (fd);

--- a/src/shared.c
+++ b/src/shared.c
@@ -108,19 +108,7 @@ void hc_asprintf (char **strp, const char *fmt, ...)
   va_end (args);
 }
 
-#if defined (_POSIX)
-int hc_stat (const char *pathname, hc_stat_t *buf)
-{
-  return stat (pathname, buf);
-}
-
-int hc_fstat (int fd, hc_stat_t *buf)
-{
-  return fstat (fd, buf);
-}
-#endif
-
-#if defined (_WIN)
+#if defined (__WIN32__)
 int hc_stat (const char *pathname, hc_stat_t *buf)
 {
   return stat64 (pathname, buf);
@@ -130,33 +118,43 @@ int hc_fstat (int fd, hc_stat_t *buf)
 {
   return fstat64 (fd, buf);
 }
-#endif
+#else
+int hc_stat (const char *pathname, hc_stat_t *buf)
+{
+  return stat (pathname, buf);
+}
+
+int hc_fstat (int fd, hc_stat_t *buf)
+{
+  return fstat (fd, buf);
+}
+#endif // __WIN32__
 
 void hc_sleep_msec (const u32 msec)
 {
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   Sleep (msec);
   #else
   usleep (msec * 1000);
-  #endif
+  #endif // __WIN32__
 }
 
 void hc_sleep (const u32 sec)
 {
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   Sleep (sec * 1000);
   #else
   sleep (sec);
-  #endif
+  #endif // __WIN32__
 }
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 #define __WINDOWS__
-#endif
+#endif // __WIN32__
 #include "sort_r.h"
-#if defined (_WIN)
+#if defined (__WIN32__)
 #undef __WINDOWS__
-#endif
+#endif // __WIN32__
 
 void hc_qsort_r (void *base, size_t nmemb, size_t size, int (*compar) (const void *, const void *, void *), void *arg)
 {

--- a/src/status.c
+++ b/src/status.c
@@ -878,21 +878,21 @@ char *status_get_time_started_relative (const hashcat_ctx_t *hashcat_ctx)
 
   const time_t time_start = status_ctx->runtime_start;
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   __time64_t sec_run = time_now - time_start;
   #else
   time_t sec_run = time_now - time_start;
-  #endif
+  #endif // __WIN32__
 
   struct tm *tmp;
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   tmp = _gmtime64 (&sec_run);
   #else
   struct tm tm;
 
   tmp = gmtime_r (&sec_run, &tm);
-  #endif
+  #endif // __WIN32__
 
   char *display_run = (char *) malloc (HCBUFSIZ_TINY);
 
@@ -906,11 +906,11 @@ char *status_get_time_estimated_absolute (const hashcat_ctx_t *hashcat_ctx)
   const status_ctx_t         *status_ctx         = hashcat_ctx->status_ctx;
   const user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   __time64_t sec_etc = 0;
   #else
   time_t sec_etc = 0;
-  #endif
+  #endif // __WIN32__
 
   if ((user_options_extra->wordlist_mode == WL_MODE_FILE) || (user_options_extra->wordlist_mode == WL_MODE_MASK))
   {
@@ -964,11 +964,11 @@ char *status_get_time_estimated_relative (const hashcat_ctx_t *hashcat_ctx)
   const user_options_t       *user_options       = hashcat_ctx->user_options;
   const user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   __time64_t sec_etc = 0;
   #else
   time_t sec_etc = 0;
-  #endif
+  #endif // __WIN32__
 
   if ((user_options_extra->wordlist_mode == WL_MODE_FILE) || (user_options_extra->wordlist_mode == WL_MODE_MASK))
   {
@@ -993,22 +993,22 @@ char *status_get_time_estimated_relative (const hashcat_ctx_t *hashcat_ctx)
   }
 
   // we need this check to avoid integer overflow
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   if (sec_etc > 100000000)
   {
     sec_etc = 100000000;
   }
-  #endif
+  #endif // __WIN32__
 
   struct tm *tmp;
 
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   tmp = _gmtime64 (&sec_etc);
   #else
   struct tm tm;
 
   tmp = gmtime_r (&sec_etc, &tm);
-  #endif
+  #endif // __WIN32__
 
   char *display = (char *) malloc (HCBUFSIZ_TINY);
 
@@ -1022,21 +1022,21 @@ char *status_get_time_estimated_relative (const hashcat_ctx_t *hashcat_ctx)
 
     if (runtime_left > 0)
     {
-      #if defined (_WIN)
+      #if defined (__WIN32__)
       __time64_t sec_left = runtime_left;
       #else
       time_t sec_left = runtime_left;
-      #endif
+      #endif // __WIN32__
 
       struct tm *tmp_left;
 
-      #if defined (_WIN)
+      #if defined (__WIN32__)
       tmp_left = _gmtime64 (&sec_left);
       #else
       struct tm tm_left;
 
       tmp_left = gmtime_r (&sec_left, &tm_left);
-      #endif
+      #endif // __WIN32__
 
       char *display_left = (char *) malloc (HCBUFSIZ_TINY);
 

--- a/src/stdout.c
+++ b/src/stdout.c
@@ -40,7 +40,7 @@ static void out_push (out_t *out, const u8 *pw_buf, const int pw_len)
 
   out->len += pw_len + 2;
 
-  #endif
+  #endif // _POSIX
 
   if (out->len >= BUFSIZ - 100)
   {

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -84,7 +84,7 @@ void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const 
 
 int setup_console ()
 {
-  #if defined (_WIN)
+  #if defined (__WIN32__)
   SetConsoleWindowSize (132);
 
   if (_setmode (_fileno (stdin), _O_BINARY) == -1)
@@ -107,7 +107,7 @@ int setup_console ()
 
     return -1;
   }
-  #endif
+  #endif // __WIN32__
 
   return 0;
 }
@@ -156,7 +156,7 @@ static void keypress (hashcat_ctx_t *hashcat_ctx)
     //https://github.com/hashcat/hashcat/issues/302
     //#if defined (_POSIX)
     //if (ch != '\n')
-    //#endif
+    //#endif // _POSIX
 
     hc_thread_mutex_lock (status_ctx->mux_display);
 
@@ -259,7 +259,7 @@ static void keypress (hashcat_ctx_t *hashcat_ctx)
     //https://github.com/hashcat/hashcat/issues/302
     //#if defined (_POSIX)
     //if (ch != '\n')
-    //#endif
+    //#endif // _POSIX
 
     hc_thread_mutex_unlock (status_ctx->mux_display);
   }
@@ -276,7 +276,7 @@ void *thread_keypress (void *p)
   return NULL;
 }
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 void SetConsoleWindowSize (const int x)
 {
   HANDLE h = GetStdHandle (STD_OUTPUT_HANDLE);
@@ -300,9 +300,9 @@ void SetConsoleWindowSize (const int x)
 
   if (!SetConsoleWindowInfo (h, TRUE, sr)) return;
 }
-#endif
+#endif // __WIN32__
 
-#if defined (__linux__) || defined (__CYGWIN__)
+#if defined (__unix__)
 static struct termios savemodes;
 static int havemodes = 0;
 
@@ -400,7 +400,7 @@ int tty_fix()
 }
 #endif
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 static DWORD saveMode = 0;
 
 int tty_break()
@@ -461,7 +461,7 @@ int tty_fix()
 
   return 0;
 }
-#endif
+#endif // __WIN32__
 
 void opencl_info (hashcat_ctx_t *hashcat_ctx)
 {

--- a/src/thread.c
+++ b/src/thread.c
@@ -12,7 +12,7 @@
 #include "thread.h"
 
 /*
-#if defined (_WIN)
+#if defined (__WIN32__)
 
 BOOL WINAPI sigHandler_default (DWORD sig)
 {

--- a/src/timer.c
+++ b/src/timer.c
@@ -7,7 +7,7 @@
 #include "types.h"
 #include "timer.h"
 
-#if defined (_WIN)
+#if defined (__WIN32__)
 
 inline void hc_timer_set (hc_timer_t *a)
 {
@@ -27,7 +27,7 @@ inline double hc_timer_get (hc_timer_t a)
   return (double) ((double) (hr_tmp.QuadPart - a.QuadPart) / (double) (hr_freq.QuadPart / 1000));
 }
 
-#elif defined(_POSIX)
+#else
 
 inline void hc_timer_set (hc_timer_t* a)
 {
@@ -43,4 +43,4 @@ inline double hc_timer_get (hc_timer_t a)
   return (double) (((hr_tmp.tv_sec - (a).tv_sec) * 1000) + ((double) (hr_tmp.tv_usec - (a).tv_usec) / 1000));
 }
 
-#endif
+#endif // __WIN32__

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1624,7 +1624,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
       tmpstat_hashfile.st_blksize = 0;
       tmpstat_hashfile.st_blocks  = 0;
-      #endif
+      #endif // _POSIX
 
       if (memcmp (&tmpstat_outfile, &tmpstat_hashfile, sizeof (hc_stat_t)) == 0)
       {

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -297,7 +297,7 @@ u64 count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile)
   #if defined (_POSIX)
   d.stat.st_blksize = 0;
   d.stat.st_blocks  = 0;
-  #endif
+  #endif // _POSIX
 
   if (d.stat.st_size == 0) return 0;
 


### PR DESCRIPTION
2nd attempt.

Kept _POSIX since __unix__ is not defined on BSDs. Also added support for ADL on Cygwin. Totally untested(no hardware) but should work.