### PR TITLE
cpu MD5: use smaller than (<) instead of != to make coverity happy

### DIFF
--- a/src/cpu_md5.c
+++ b/src/cpu_md5.c
@@ -167,11 +167,11 @@ void md5_complete_no_limit (u32 digest[4], u32 *plain, u32 plain_len)
      * final block
      */
 
-    // set 0x80 if neeeded
+    // set 0x80 if needed
 
     if (cur_len >= 0)
     {
-      if (cur_len != block_total_len)
+      if (copy_len < block_total_len)
       {
         block_ptr[copy_len] = (char) 0x80;
       }


### PR DESCRIPTION
It seems that coverity does not understand the limit within the cpu MD5 hashing correctly... this way we should guarantee that we never overflow the block buffer.

Thanks