### PR TITLE
tainted string fix: check some lower/upper bounds of the strings

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -71,6 +71,26 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
+  // we only use these 2 checks to avoid "tainted string" warnings
+
+  if (rd->argc < 1)
+  {
+    event_log_error (hashcat_ctx, "Unusual low number of arguments (argc) within the restore file %s", eff_restore_file);
+
+    fclose (fp);
+
+    return -1;
+  }
+
+  if (rd->argc > 250) // some upper bound check is always good (with some dirs/dicts it could be a large string)
+  {
+    event_log_error (hashcat_ctx, "Unusual high number of arguments (argc) within the restore file %s", eff_restore_file);
+
+    fclose (fp);
+
+    return -1;
+  }
+
   rd->argv = (char **) hccalloc (rd->argc, sizeof (char *));
 
   char *buf = (char *) hcmalloc (HCBUFSIZ_LARGE);

--- a/src/shared.c
+++ b/src/shared.c
@@ -260,7 +260,19 @@ void setup_environment_variables ()
 
     snprintf (display, sizeof (display) - 1, "DISPLAY=%s", compute);
 
-    putenv (display);
+    // we only use this check to avoid "tainted string" warnings
+
+    u32 display_len_max = sizeof (display);
+
+    u32 display_len = strnlen (display, display_len_max);
+
+    if (display_len > 0) // should be always true
+    {
+      if (display_len < display_len_max) // some upper bound is always good
+      {
+        putenv (display);
+      }
+    }
   }
   else
   {


### PR DESCRIPTION
This is just a test if the tainted string problems of the compiler/coverity will vanish by adding these few checks.

Thank you