### PR TITLE
tainted string: maybe strdup () helps us out

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -256,6 +256,10 @@ void setup_environment_variables ()
 
   if (compute)
   {
+    // fix for coverity "TAINTED_STRING" issue (using the environment variable directly could be "dangerous")
+
+    compute = strdup (compute);
+
     static char display[100];
 
     u32 compute_len_max = sizeof (display);
@@ -273,6 +277,8 @@ void setup_environment_variables ()
         putenv (display);
       }
     }
+
+    free (compute);
   }
   else
   {


### PR DESCRIPTION
This is just a test if we can get rid of the TAINTED STRING warning of coverity around the getenv () function.

Thanks