### PR TITLE
use putenv () with the COMPUTE environment as it was before

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -260,19 +260,7 @@ void setup_environment_variables ()
 
     snprintf (display, sizeof (display) - 1, "DISPLAY=%s", compute);
 
-    // we only use this check to avoid "tainted string" warnings
-
-    u32 display_len_max = sizeof (display);
-
-    u32 display_len = strnlen (display, display_len_max);
-
-    if (display_len > 0) // should be always true
-    {
-      if (display_len < display_len_max) // some upper bound is always good
-      {
-        putenv (display);
-      }
-    }
+    putenv (display);
   }
   else
   {


### PR DESCRIPTION
revert the tainted string changes around the getenv () / putenv () function calls

Thanks