### PR TITLE
add autoconf/automake supports

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,21 +8,29 @@ environment:
       CYG_SETUP: setup-x86_64.exe
       BASH: C:\cygwin64\bin\bash
       CC: gcc
+      DOCUMENT_FOLDER: /usr/local/share/doc/hashcat/
+      SHARED_FOLDER: /usr/local/share/hashcat/
     - CYG_ROOT: C:\cygwin
       CYG_CACHE: C:\cygwin\var\cache\setup
       CYG_SETUP: setup-x86.exe
       BASH: C:\cygwin\bin\bash
       CC: gcc
+      DOCUMENT_FOLDER: /usr/local/share/doc/hashcat/
+      SHARED_FOLDER: /usr/local/share/hashcat/
     - MSYSTEM: MINGW64
       MSYS_CACHE: C:\msys64\var\cache\pacman\pkg
       KERNEL_CACHE: C:\msys64\usr\local\bin\OpenCL\
       BASH: C:\msys64\usr\bin\bash
       CC: gcc
+      DOCUMENT_FOLDER: /bin/
+      SHARED_FOLDER: /bin/
     - MSYSTEM: MINGW32
       MSYS_CACHE: C:\msys64\var\cache\pacman\pkg
       KERNEL_CACHE: C:\msys64\usr\local\bin\OpenCL\
       BASH: C:\msys64\usr\bin\bash
       CC: gcc
+      DOCUMENT_FOLDER: /bin/
+      SHARED_FOLDER: /bin/
 
 # if we have too many commits at the same time, we might need to download more than just the last commit for appveyor to succeed
 # otherwise we get the error: "fatal: reference is not a tree <commit>"
@@ -42,7 +50,8 @@ install:
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
 
 build_script:
-  - if defined BASH (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && git submodule update --init && make install")
+  - if defined CYG_ROOT (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && git submodule update --init && ./autogen.sh && ./configure --enable-static --disable-shared --disable-debug CPPFLAGS=-I$(pwd)/deps/OpenCL-Headers/ && make install")
+  - if defined MSYSTEM (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && git submodule update --init && ./autogen.sh && ./configure --enable-static --disable-shared --disable-debug --bindir=/bin/ --datarootdir=/bin/ --docdir=/bin/ --includedir=/bin/ --libdir=/bin/ CPPFLAGS=-I$(pwd)/deps/OpenCL-Headers/ && make SHARED_FOLDER=$(cygpath %SHARED_FOLDER%) install")
 
 test_script:
   # some file globbing tests
@@ -54,11 +63,11 @@ test_script:
         mkdir $env:KERNEL_CACHE 2>&1 | out-null
       }
 
-      & $env:BASH -lc "hashcat.exe -m 0 --show $env:DOCUMENT_FOLDER/*file_not_found.hash" 2>&1 | out-null
+      & $env:BASH -lc "hashcat.exe -m 0 --show $env:DOCUMENT_FOLDER/examples/*file_not_found.hash" 2>&1 | out-null
 
       if ($LastExitCode -eq 0)
       {
         throw "test failed"
       }
 
-      & $env:BASH -lc "hashcat.exe -m 0 --show $env:DOCUMENT_FOLDER/*ple0.hash"
+      & $env:BASH -lc "hashcat.exe -m 0 --show $env:DOCUMENT_FOLDER/examples/*ple0.hash"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 os:
   - linux
   - osx
@@ -14,4 +15,4 @@ matrix:
       dist: trusty
       compiler: clang
 script:
-  - make
+  - ./autogen.sh && ./configure --enable-static --disable-shared --disable-debug CPPFLAGS=-I$(pwd)/deps/OpenCL-Headers/ && make && sudo make install

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,98 @@
+
+INSTALL_FOLDER          ?= $(bindir)
+LIBRARY_FOLDER          ?= $(libdir)
+SHARED_FOLDER           ?= $(datadir)/@PACKAGE@/
+DOCUMENT_FOLDER         ?= $(docdir)
+
+SUBDIRS= src
+
+examplesdir = $(DOCUMENT_FOLDER)/examples
+
+examples_DATA = \
+	$(top_srcdir)/example.dict \
+	$(top_srcdir)/example0.hash \
+	$(top_srcdir)/example400.hash \
+	$(top_srcdir)/example500.hash \
+	$(top_srcdir)/example0.sh \
+	$(top_srcdir)/example400.sh \
+	$(top_srcdir)/example500.sh \
+	$(NULL)
+
+DOC_FILES= \
+    $(top_srcdir)/charsets/* \
+    $(top_srcdir)/docs/* \
+    $(top_srcdir)/extra/* \
+    $(top_srcdir)/include/* \
+    $(top_srcdir)/masks/* \
+    $(top_srcdir)/OpenCL/* \
+    $(top_srcdir)/rules/* \
+    $(top_srcdir)/tools/* \
+    ChangeLo* \
+    $(NULL)
+
+EXTRA_DIST=autogen.sh autoclean.sh AUTHORS README.md \
+	$(DOC_FILES) $(examples_DATA) \
+	$(NULL)
+
+uninstall-local:
+	chmod -R u+w '$(DESTDIR)$(DOCUMENT_FOLDER)'
+	rm -rf '$(DESTDIR)$(DOCUMENT_FOLDER)'
+#.PHONY: install-examples-source
+
+FIND=find
+
+install-data-local: install-examples-source $(top_srcdir)/OpenCL/*
+	mkdir -p "$(DESTDIR)$(SHARED_FOLDER)/OpenCL/"
+	$(INSTALL_DATA) $(top_srcdir)/OpenCL/*       "$(DESTDIR)$(SHARED_FOLDER)/OpenCL/"
+	$(INSTALL_DATA) $(top_srcdir)/hashcat.hcstat "$(DESTDIR)$(SHARED_FOLDER)/"
+	$(INSTALL_DATA) $(top_srcdir)/hashcat.hctune "$(DESTDIR)$(SHARED_FOLDER)/"
+
+install-examples-source:
+	cd $(top_srcdir)/ ; \
+	for d in \
+		docs \
+		charsets \
+		masks \
+		rules \
+		extra; do \
+		$(MKDIR_P) "$(DESTDIR)$(DOCUMENT_FOLDER)/$$d"; \
+		$(FIND) "$$d" -type d -exec $(INSTALL) -m 755 -d    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \; ; \
+		$(FIND) "$$d" -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \; ; \
+	done && \
+	chmod 755 '$(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion/hashcat.sh' && \
+	echo Done \
+	$(NULL)
+
+
+ChangeLog: .git
+	if test -d $(srcdir)/.git; then                         \
+	  if test -f $(srcdir)/.last-cl-gen; then               \
+        git log --no-merges --date-order --date=short       \
+          $$(cat $(srcdir)/.last-cl-gen)..                  \
+          | sed -e  '/^commit.*$$/d'                        \
+          | awk '/^Author/ {sub(/\\$$/,""); getline t; print $$0 t; next}; 1' \
+          | sed -e 's/^Author: //g'                         \
+          | sed -e 's/>Date:   \([0-9]*-[0-9]*-[0-9]*\)/>\t\1/g' \
+          | sed -e 's/^\(.*\) \(\)\t\(.*\)/\3    \1    \2/g' \
+          > ChangeLog.tmp;                                  \
+      else                                                  \
+        git log --no-merges --date-order --date=short       \
+          | sed -e  '/^commit.*$$/d'                        \
+          | awk '/^Author/ {sub(/\\$$/,""); getline t; print $$0 t; next}; 1' \
+          | sed -e 's/^Author: //g'                         \
+          | sed -e 's/>Date:   \([0-9]*-[0-9]*-[0-9]*\)/>\t\1/g' \
+          | sed -e 's/^\(.*\) \(\)\t\(.*\)/\3    \1    \2/g' \
+          > ChangeLog.tmp;                                  \
+      fi;                                                   \
+	  touch ChangeLog                                       \
+	    && git rev-list -n 1 HEAD >.last-cl-gen.tmp         \
+        && (echo; cat $(srcdir)/ChangeLog) >>ChangeLog.tmp  \
+        && mv -f ChangeLog.tmp $(srcdir)/ChangeLog          \
+        && mv -f .last-cl-gen.tmp $(srcdir)/.last-cl-gen    \
+        && rm -f ChangeLog.tmp;                             \
+    fi
+	if test -d $(srcdir)/.hg; then                          \
+        hg log --template changelog > ChangeLog;            \
+        touch $(srcdir)/.last-cl-gen;                       \
+    fi
+

--- a/autoclean.sh
+++ b/autoclean.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+chmod 755 $0 autogen.sh config.guess config.rpath config.status config.sub configure depcomp install-sh missing
+
+make clean
+make distclean
+
+rm -f *.o
+
+rm -f config.log
+rm -f config.status
+rm -f config.h
+rm -f Makefile
+rm -rf ./autom4te.cache/
+rm -f gmon.out
+
+#rm -f ./src/Makefile.in
+#rm -f ./Makefile.in

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+./autoclean.sh
+
+rm -f configure
+
+rm -f Makefile.in
+
+rm -f config.guess
+rm -f config.sub
+rm -f install-sh
+rm -f missing
+rm -f depcomp
+
+if [ 0 = 1 ]; then
+autoscan
+else
+
+touch NEWS
+touch README
+touch AUTHORS
+touch ChangeLog
+touch config.h.in
+touch install-sh
+
+libtoolize --force --copy --install --automake
+aclocal
+automake -a -c
+autoconf
+# run twice to get rid of 'ltmain.sh not found'
+autoreconf -f -i -Wall,no-obsolete
+autoreconf -f -i -Wall,no-obsolete
+
+#./configure --enable-static --enable-shared --disable-debug
+./configure --enable-static --disable-shared --disable-debug
+
+#make clean
+make ChangeLog
+
+#make
+#make check
+#make -C doc/latex/
+make dist-gzip
+
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,237 @@
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+
+AC_PREREQ([2.68])
+AC_INIT([hashcat], [3.3.0], [atom@hashcat.net])
+AC_CONFIG_SRCDIR([src/tuningdb.c])
+AC_CONFIG_HEADERS([config.h])
+AM_INIT_AUTOMAKE([-Wall subdir-objects])
+
+#magic for conditional check in Makefile:
+MK=''; AC_SUBST(MK)
+SED=sed
+
+# Checks for programs.
+AM_PROG_AR
+AC_PROG_CXX
+AC_PROG_AWK
+AC_PROG_CC
+AC_PROG_CC_STDC
+AC_PROG_INSTALL
+
+# Checks for libraries.
+LT_INIT([shared static])
+
+app_cv_link_all_option="-Wl,--whole-archive"
+app_cv_no_link_all_option="-Wl,--no-whole-archive"
+app_cv_platform_type="Unix"
+
+AC_CACHE_CHECK([type of operating system we're going to host on],
+               [app_cv_os_type],
+[case $host in
+  *-*-aix*)
+    app_cv_os_type="AIX"
+    ;;
+  *-*-irix*)
+    app_cv_os_type="IRIX"
+    ;;
+  *-*-cygwin*)
+    app_cv_os_type="Cygwin"
+    ;;
+  *-*-darwin*)
+    app_cv_link_all_option="-Wl,-all_load"
+    app_cv_no_link_all_option="-Wl,-noall_load"
+    app_cv_os_type="Darwin"
+    ;;
+  *-*-minix*)
+    app_cv_link_all_option="-Wl,-all_load"
+    app_cv_no_link_all_option="-Wl,-noall_load"
+    app_cv_os_type="Minix"
+    ;;
+  *-*-freebsd*)
+    app_cv_os_type="FreeBSD"
+    ;;
+  *-*-kfreebsd-gnu)
+    app_cv_os_type="GNU/kFreeBSD"
+    ;;
+  *-*-openbsd*)
+    app_cv_os_type="OpenBSD"
+    ;;
+  *-*-netbsd*)
+    app_cv_os_type="NetBSD"
+    ;;
+  *-*-dragonfly*)
+    app_cv_os_type="DragonFly"
+    ;;
+  *-*-hpux*)
+    app_cv_os_type="HP-UX"
+    ;;
+  *-*-interix*)
+    app_cv_os_type="Interix"
+    ;;
+  *-*-linux*)
+    app_cv_os_type="Linux"
+    ;;
+  *-*-gnu*)
+    app_cv_os_type="GNU"
+    ;;
+  *-*-solaris*)
+    app_cv_link_all_option="-Wl,-z,allextract"
+    app_cv_no_link_all_option="-Wl,-z,defaultextract"
+    app_cv_os_type="SunOS"
+    ;;
+  *-*-auroraux*)
+    app_cv_link_all_option="-Wl,-z,allextract"
+    app_cv_link_all_option="-Wl,-z,defaultextract"
+    app_cv_os_type="AuroraUX"
+    ;;
+  *-*-win32*)
+    app_cv_os_type="Win32"
+    app_cv_platform_type="Win32"
+    ;;
+  *-*-mingw*)
+    app_cv_os_type="MingW"
+    app_cv_platform_type="Win32"
+    ;;
+  *-*-haiku*)
+    app_cv_os_type="Haiku"
+    ;;
+  *-unknown-eabi*)
+    app_cv_os_type="Freestanding"
+    ;;
+  *-unknown-elf*)
+    app_cv_os_type="Freestanding"
+    ;;
+  *)
+    app_cv_link_all_option=""
+    app_cv_no_link_all_option=""
+    app_cv_os_type="Unknown"
+    app_cv_platform_type="Unknown"
+    ;;
+esac])
+
+AC_CACHE_CHECK([type of operating system we're going to target],
+               [app_cv_target_os_type],
+[case $target in
+  *-*-aix*)
+    app_cv_target_os_type="AIX" ;;
+  *-*-irix*)
+    app_cv_target_os_type="IRIX" ;;
+  *-*-cygwin*)
+    app_cv_target_os_type="Cygwin" ;;
+  *-*-darwin*)
+    app_cv_target_os_type="Darwin" ;;
+  *-*-minix*)
+    app_cv_target_os_type="Minix" ;;
+  *-*-freebsd*)
+    app_cv_target_os_type="FreeBSD" ;;
+  *-*-kfreebsd-gnu)
+    app_cv_target_os_type="GNU/kFreeBSD" ;;
+  *-*-openbsd*)
+    app_cv_target_os_type="OpenBSD" ;;
+  *-*-netbsd*)
+    app_cv_target_os_type="NetBSD" ;;
+  *-*-dragonfly*)
+    app_cv_target_os_type="DragonFly" ;;
+  *-*-hpux*)
+    app_cv_target_os_type="HP-UX" ;;
+  *-*-interix*)
+    app_cv_target_os_type="Interix" ;;
+  *-*-linux*)
+    app_cv_target_os_type="Linux" ;;
+  *-*-gnu*)
+    app_cv_target_os_type="GNU" ;;
+  *-*-solaris*)
+    app_cv_target_os_type="SunOS" ;;
+  *-*-auroraux*)
+    app_cv_target_os_type="AuroraUX" ;;
+  *-*-win32*)
+    app_cv_target_os_type="Win32" ;;
+  *-*-mingw*)
+    app_cv_target_os_type="MingW" ;;
+  *-*-haiku*)
+    app_cv_target_os_type="Haiku" ;;
+  *-*-rtems*)
+    app_cv_target_os_type="RTEMS" ;;
+  *-*-nacl*)
+    app_cv_target_os_type="NativeClient" ;;
+  *-unknown-eabi*)
+    app_cv_target_os_type="Freestanding" ;;
+  *)
+    app_cv_target_os_type="Unknown" ;;
+esac])
+
+if test "$app_cv_os_type" = "MingW" ; then
+  AC_CHECK_HEADERS([windows.h psapi.h])
+  AC_CHECK_LIB(psapi, [main], [LIBPSAPI=-lpsapi])
+  AC_SUBST(LIBPSAPI)
+  #AC_CHECK_LIB(shlwapi, PathIsDirectory, [LIBSHLWAPI=-lshlwapi])
+  #AC_SUBST(LIBSHLWAPI)
+fi
+
+# Checks for libraries.
+# FIXME: Replace `main' with a function in `-ldl':
+AC_CHECK_LIB([dl], [main])
+# FIXME: Replace `main' with a function in `-lpthread':
+AC_CHECK_LIB([pthread], [main])
+
+# debug
+AC_ARG_ENABLE([debug],
+	AS_HELP_STRING([--enable-debug],[Compile the debug version (default: disabled)]),
+	[enable_debug=$enableval],
+	[enable_debug=no])
+AM_CONDITIONAL([DEBUG], [test $enable_debug = "yes"])
+AM_COND_IF(DEBUG,
+    AC_DEFINE(DEBUG, 1, [Define to 0 if this is a release build]),
+    AC_DEFINE(DEBUG, 0, [Define to 1 or higher if this is a debug build]))
+if test "x$enable_debug" = "xyes"; then
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+  changequote([,])
+  dnl add -O0 only if GCC or ICC is used
+  if test "$GCC" = "yes" || test "$ICC" = "yes"; then
+    CFLAGS="$CFLAGS -O0"
+    CXXFLAGS="$CXXFLAGS -O0"
+  fi
+else
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-g//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-g//g'`
+  changequote([,])
+fi
+
+# Checks for header files.
+AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h mach/mach.h stddef.h stdint.h stdlib.h string.h sys/ioctl.h sys/time.h termios.h unistd.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_CHECK_HEADER_STDBOOL
+AC_C_INLINE
+AC_TYPE_INT16_T
+AC_TYPE_INT32_T
+AC_TYPE_INT64_T
+AC_TYPE_INT8_T
+AC_TYPE_OFF_T
+AC_TYPE_SIZE_T
+AC_TYPE_SSIZE_T
+AC_CHECK_MEMBERS([struct stat.st_blksize])
+AC_STRUCT_ST_BLOCKS
+AC_CHECK_MEMBERS([struct stat.st_rdev])
+AC_TYPE_UID_T
+AC_TYPE_UINT16_T
+AC_TYPE_UINT32_T
+AC_TYPE_UINT64_T
+AC_TYPE_UINT8_T
+AC_CHECK_TYPES([ptrdiff_t])
+
+# Checks for library functions.
+AC_FUNC_FSEEKO
+AC_FUNC_MALLOC
+AC_FUNC_REALLOC
+AC_CHECK_FUNCS([getcwd gettimeofday memmove memset mkdir putenv realpath rmdir select strchr strdup strerror strrchr strstr])
+
+AC_CONFIG_FILES([Makefile
+                 src/Makefile
+                 src/libhashcat.pc
+                 ])
+AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,0 +1,147 @@
+
+INSTALL_FOLDER          ?= $(bindir)
+LIBRARY_FOLDER          ?= $(libdir)
+SHARED_FOLDER           ?= $(datadir)/@PACKAGE@/
+DOCUMENT_FOLDER         ?= $(docdir)
+
+AM_LDFLAGS=
+AM_CFLAGS=
+EXTRA_DIST=
+
+if DEBUG
+# use "valgrind --tool=memcheck --leak-check=yes" to check memory leak
+DEFS+=-DDEBUG=1
+AM_CFLAGS+=-g  -Werror# -Wall
+
+else
+AM_CFLAGS+=-O3 -Werror# -Wall
+endif
+
+AM_CFLAGS+= \
+    -I$(top_srcdir)/src/ \
+    -I$(top_srcdir)/OpenCL/ \
+    -I$(top_srcdir)/include/ \
+    -I$(top_srcdir)/include/lzma_sdk/ \
+    -I$(top_builddir)/include/ \
+    -I$(top_builddir)/include/lzma_sdk/ \
+    $(NULL)
+
+AM_LDFLAGS += \
+    -L$(top_builddir)/src/ \
+    $(NULL)
+
+DEFS+= \
+    `getconf LFS_CFLAGS` \
+    `getconf LFS64_CFLAGS` \
+    -D_GNU_SOURCE \
+    -D_FILE_OFFSET_BITS=64 \
+    -DHAVE_MMAP64=1 \
+    $(NULL)
+
+libhashcat_la_LDFLAGS=
+libhashcat_la_CPPFLAGS=
+
+include_HEADERS = \
+    $(top_srcdir)/include/hashcat.h \
+    $(NULL)
+
+EXTRA_DIST += libhashcat.pc.in
+
+pkgconfigdir = $(LIBRARY_FOLDER)/pkgconfig
+pkgconfig_DATA = libhashcat.pc
+
+#BUILT_SOURCES = $(top_builddir)/src/xmllex.c
+#CLEANFILES = $(top_builddir)/src/xmllex.c
+#nodist_program_SOURCES = $(top_builddir)/src/xmllex.c
+#$(top_builddir)/src/xmllex.c: $(top_srcdir)/src/xmllex.l $(top_srcdir)/src/xmldecl.h
+#	$(LEX) -o $@ $(top_srcdir)/src/xmllex.l
+
+lib_LTLIBRARIES=libhashcat.la
+libhashcat_la_SOURCES= \
+    affinity.c \
+    autotune.c \
+    benchmark.c \
+    bitmap.c \
+    bitops.c \
+    combinator.c \
+    common.c \
+    convert.c \
+    cpt.c \
+    cpu_aes.c \
+    cpu_crc32.c \
+    cpu_des.c \
+    cpu_md4.c \
+    cpu_md5.c \
+    cpu_sha1.c \
+    cpu_sha256.c \
+    debugfile.c \
+    dictstat.c \
+    dispatch.c \
+    dynloader.c \
+    event.c \
+    ext_ADL.c \
+    ext_nvapi.c \
+    ext_nvml.c \
+    ext_OpenCL.c \
+    ext_sysfs.c \
+    ext_xnvctrl.c \
+    ext_lzma.c \
+    lzma_sdk/Alloc.c \
+    lzma_sdk/Lzma2Dec.c \
+    lzma_sdk/LzmaDec.c \
+    filehandling.c \
+    folder.c \
+    hashcat.c \
+    hashes.c \
+    hlfmt.c \
+    hwmon.c \
+    induct.c \
+    interface.c \
+    locking.c \
+    logfile.c \
+    loopback.c \
+    memory.c \
+    monitor.c \
+    mpsp.c \
+    opencl.c \
+    outfile_check.c \
+    outfile.c \
+    pidfile.c \
+    potfile.c \
+    restore.c \
+    rp.c \
+    rp_cpu.c \
+    rp_kernel_on_cpu.c \
+    shared.c \
+    status.c \
+    stdout.c \
+    straight.c \
+    terminal.c \
+    thread.c \
+    timer.c \
+    tuningdb.c \
+    usage.c \
+    user_options.c \
+    weak_hash.c \
+    wordlist.c \
+    $(NULL)
+
+bin_PROGRAMS=hashcat
+
+hashcat_SOURCES= \
+    main.c \
+    $(NULL)
+
+hashcat_LDADD = -lhashcat -lm $(LIBPSAPI)
+
+COMPTIME = $(shell date +%s)
+
+@MK@GITNUMTMP=$(shell cd "$(top_srcdir)"; echo $$(git describe --tags|sed -r 's|v?(.+)|\1|'|sed 's|-|+|g'); cd - > /dev/null )
+#@MK@GITNUMTMP=$(shell cd "$(top_srcdir)"; A=$$(git show | head -n 1 | awk '{print $$2}'); echo $${A:0:7}; cd - > /dev/null )
+@MK@ifeq ($(GITNUMTMP),)
+@MK@else
+VERSION_TAG="${GITNUMTMP}"
+@MK@endif
+
+hashcat_CFLAGS = $(AM_CFLAGS) -DCOMPTIME=$(COMPTIME) -DVERSION_TAG=\"$(VERSION_TAG)\" -DINSTALL_FOLDER=\"$(INSTALL_FOLDER)\" -DSHARED_FOLDER=\"$(SHARED_FOLDER)\" -DDOCUMENT_FOLDER=\"$(DOCUMENT_FOLDER)\"
+hashcat_LDFLAGS = $(AM_LDFLAGS)

--- a/src/libhashcat.pc.in
+++ b/src/libhashcat.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libhashcat
+URL: https://github.com/hashcat/hashcat.git
+Description: Library for password recovery
+Version: @PACKAGE_VERSION@
+Requires: 
+Libs: -L${libdir} -lhashcat
+Cflags: -I${includedir}


### PR DESCRIPTION
The Makefiles are handled by autoconf/automake, so

* the software can be cross compiled without specify 32 bit or 64 bit version.
* the release file can be generated with command
    make dist-gzip
* tested in Ubuntu