### PR TITLE
tests: fixed timeout values

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -100,6 +100,7 @@
 - Wordlists: Fixed memory leak in case access a file in a wordlist folder fails
 - WPA: Changed format for outfile and potfile from essid:mac1:mac2 to hash:mac_ap:mac_sta:essid
 - WPA: Changed format for outfile_check from essid:mac1:mac2 to hash
+- Tests: Fixed the timeout status code value and increased the runtime to 400 seconds
 
 * changes v3.20 -> v3.30:
 

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -24,7 +24,7 @@ NEVER_CRACK="11600 14900"
 
 SLOW_ALGOS="400 500 501 1600 1800 2100 2500 3200 5200 5800 6211 6212 6213 6221 6222 6223 6231 6232 6233 6241 6242 6243 6251 6261 6271 6281 6300 6400 6500 6600 6700 6800 7100 7200 7400 7900 8200 8800 8900 9000 9100 9200 9300 9400 9500 9600 10000 10300 10500 10700 10900 11300 11600 11900 12000 12100 12200 12300 12400 12500 12800 12900 13000 13200 13400 13600 14600 14700 14800"
 
-OPTS="--quiet --force --potfile-disable --runtime 200 --gpu-temp-disable --weak-hash-threshold=0"
+OPTS="--quiet --force --potfile-disable --runtime 400 --gpu-temp-disable --weak-hash-threshold=0"
 
 OUTD="test_$(date +%s)"
 
@@ -357,7 +357,7 @@ function status()
         fi
 
         ;;
-      2)
+      4)
         echo "timeout reached, cmdline : ${CMD}" &>> ${OUTD}/logfull.txt
         ((e_to++))
 


### PR DESCRIPTION
This commit only affects the tests (specifically the tools/test.sh file).

The exit code value (see docs/status_codes.txt) changed recently, but test.sh was not updated yet. This PR should fix that and increase the runtime to 400 seconds.

Thanks