### PR TITLE
fix rule 'i' in host mode in case pos = length

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -45,13 +45,14 @@
 - Fixed a problem within the Kerberos 5 TGS-REP (-m 13100) hash parser
 - Fixed clEnqueueNDRangeKernel(): CL_UNKNOWN_ERROR caused by an invalid work-item count during weak-hash-check
 - Fixed cracking of PeopleSoft Token (-m 13500) if salt length + password length is >= 128 byte
-- Fixed cracking of Plaintext (-m 99999) in case MD4 was used in a previous session 
+- Fixed cracking of Plaintext (-m 99999) in case MD4 was used in a previous session
 - Fixed DEScrypt cracking in BF mode in case the hashlist contains more than 16 times the same salt
 - Fixed duplicate detection for WPA handshakes with the same ESSID
 - Fixed nvapi datatype definition for NvS32 and NvU32
 - Fixed pointer to local outside scope in case -j or -k is used
 - Fixed pointer to local outside scope in case --markov-hcstat is not used
 - Fixed rule 'O' (RULE_OP_MANGLE_OMIT) in host mode in case the offset + length parameter equals the length of the input word
+- Fixed rule 'i' (RULE_OP_MANGLE_INSERT) in host mode in case the offset + length parameter equals the length of the input word
 - Fixed string not null terminated inside workaround for checking drm driver path
 - Fixed string not null terminated while reading maskfiles
 - Fixed truncation of password after position 32 with the combinator attack

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -52,7 +52,7 @@
 - Fixed pointer to local outside scope in case -j or -k is used
 - Fixed pointer to local outside scope in case --markov-hcstat is not used
 - Fixed rule 'O' (RULE_OP_MANGLE_OMIT) in host mode in case the offset + length parameter equals the length of the input word
-- Fixed rule 'i' (RULE_OP_MANGLE_INSERT) in host mode in case the offset + length parameter equals the length of the input word
+- Fixed rule 'i' (RULE_OP_MANGLE_INSERT) in host mode in case the offset parameter equals the length of the input word
 - Fixed string not null terminated inside workaround for checking drm driver path
 - Fixed string not null terminated while reading maskfiles
 - Fixed truncation of password after position 32 with the combinator attack

--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -213,7 +213,7 @@ static int mangle_omit (char arr[BLOCK_SIZE], int arr_len, int upos, int ulen)
 
 static int mangle_insert (char arr[BLOCK_SIZE], int arr_len, int upos, char c)
 {
-  if (upos >= arr_len) return (arr_len);
+  if (upos > arr_len) return (arr_len);
 
   if ((arr_len + 1) >= BLOCK_SIZE) return (arr_len);
 


### PR DESCRIPTION
close #1144 

to test:

```
$ echo -n 1 | ./hashcat --stdout -j 'i1u'
1u
```