### PR TITLE
osx: we need to have some volatile vars for the overflow checks

### DIFF
--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -815,7 +815,9 @@ static int sp_get_sum (u32 start, u32 stop, cs_t *root_css_buf, u64 *result)
 
   for (i = start; i < stop; i++)
   {
-    if (overflow_check_u64_mul (sum, root_css_buf[i].cs_len) == false) return -1;
+    volatile const u64 cs_len = (const u64) root_css_buf[i].cs_len; // temporary hack needed for OSX
+
+    if (overflow_check_u64_mul (sum, cs_len) == false) return -1;
 
     sum *= root_css_buf[i].cs_len;
   }

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -305,13 +305,17 @@ int count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile, u64
 
       if (user_options_extra->attack_kern == ATTACK_KERN_STRAIGHT)
       {
-        if (overflow_check_u64_mul (keyspace, straight_ctx->kernel_rules_cnt) == false) return -1;
+        volatile const u64 kernel_rules_cnt = (const u64) straight_ctx->kernel_rules_cnt; // temporary hack needed for OSX
+
+        if (overflow_check_u64_mul (keyspace, kernel_rules_cnt) == false) return -1;
 
         keyspace *= straight_ctx->kernel_rules_cnt;
       }
       else if (user_options_extra->attack_kern == ATTACK_KERN_COMBI)
       {
-        if (overflow_check_u64_mul (keyspace, combinator_ctx->combs_cnt) == false) return -1;
+        volatile const u64 combs_cnt = (const u64) combinator_ctx->combs_cnt; // temporary hack needed for OSX
+
+        if (overflow_check_u64_mul (keyspace, combs_cnt) == false) return -1;
 
         keyspace *= combinator_ctx->combs_cnt;
       }
@@ -378,13 +382,17 @@ int count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile, u64
       {
         if (user_options_extra->attack_kern == ATTACK_KERN_STRAIGHT)
         {
-          if (overflow_check_u64_add (cnt, straight_ctx->kernel_rules_cnt) == false) return -1;
+          volatile const u64 kernel_rules_cnt = (const u64) straight_ctx->kernel_rules_cnt; // temporary hack needed for OSX
+
+          if (overflow_check_u64_add (cnt, kernel_rules_cnt) == false) return -1;
 
           cnt += straight_ctx->kernel_rules_cnt;
         }
         else if (user_options_extra->attack_kern == ATTACK_KERN_COMBI)
         {
-          if (overflow_check_u64_add (cnt, combinator_ctx->combs_cnt) == false) return -1;
+          volatile const u64 combs_cnt = (const u64) combinator_ctx->combs_cnt; // temporary hack needed for OSX
+
+          if (overflow_check_u64_add (cnt, combs_cnt) == false) return -1;
 
           cnt += combinator_ctx->combs_cnt;
         }


### PR DESCRIPTION
For some strange reasons the OSX clang compiler forces us to have some volatile variables before each overflow_check_* () function call.

This shouldn't affect the performance at all.
I think this (temporarily) hack is acceptable... I don't think there is any better solution for now.

Thanks

--

P.S.: the problem only happens with -O2 (optimizations turned on, level 2), but we can't really touch this setting, nor can we make sure the user doesn't change it to -O2 manually.