### PR TITLE
fixes #1153: incorrect error message while combining --keyspace with custom charset

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,3 +1,11 @@
+* changes v3.40 -> ?:
+
+##
+## Bugs
+##
+
+- Fixed a problem where --keyspace combined with custom charsets incorrectly displayed an error message
+
 * changes v3.30 -> v3.40:
 
 ##

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -820,9 +820,12 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
 
     if (user_options->hc_argc < 2)
     {
-      event_log_error (hashcat_ctx, "You need to specify a mask if you specify a custom-charset");
+      if (user_options->keyspace == false) // special case, we do not need a hash file
+      {
+        event_log_error (hashcat_ctx, "You need to specify a mask if you specify a custom-charset");
 
-      return -1;
+        return -1;
+      }
     }
   }
 

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -820,7 +820,7 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
 
     if (user_options->hc_argc < 2)
     {
-      if (user_options->keyspace == false) // special case, we do not need a hash file
+      if (user_options->keyspace == false) // --keyspace would be a special case, i.e. we do not need a hash file
       {
         event_log_error (hashcat_ctx, "You need to specify a mask if you specify a custom-charset");
 


### PR DESCRIPTION
This sanity check was too greedy... --keyspace is special and does not need a hash file, therefore we do not need to check for at least 2 command line arguments.
Thx