### PR TITLE
min pass length init: typo fixed

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -5,6 +5,7 @@
 ##
 
 - Fixed a problem where --keyspace combined with custom charsets incorrectly displayed an error message
+- Fixed a typo that resulted in the minimum password length not being correctly initialized
 
 * changes v3.30 -> v3.40:
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -22491,7 +22491,7 @@ int hashconfig_init (hashcat_ctx_t *hashcat_ctx)
 
   // pw_min
 
-  hashconfig->pw_max = PW_MIN;
+  hashconfig->pw_min = PW_MIN;
 
   switch (hashconfig->hash_mode)
   {


### PR DESCRIPTION
As far as I can tell, this problem/bug didn't have any side effects. It just was confusing and wrong.
The good thing is that pw_max was correctly set (overridden) afterwards and the pw_min should initialized anyway to 0 by the compiler.

Thank you