### PR TITLE
Some cleanups

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -30,6 +30,10 @@
 #define _FILE_OFFSET_BITS 64
 #endif
 
+#ifndef _FORTIFY_SOURCE
+#define _FORTIFY_SOURCE 2
+#endif
+
 #define NOMINMAX 1
 
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))

--- a/include/common.h
+++ b/include/common.h
@@ -22,7 +22,7 @@
 
 // needed for *time_r functions under MinGW
 #ifndef _POSIX_THREAD_SAFE_FUNCTIONS
-#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L
+#define _POSIX_THREAD_SAFE_FUNCTIONS 200809L
 #endif
 
 // needed for 64-bit off_t on 32-bit OSes

--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -11,21 +11,7 @@
 
 #if defined (__APPLE__)
 #include <OpenCL/cl.h>
-#endif
-
-#if defined (_WIN)
-#include <CL/cl.h>
-#endif
-
-#if defined (__linux__)
-#include <CL/cl.h>
-#endif
-
-#if defined (__FreeBSD__)
-#include <CL/cl.h>
-#endif
-
-#if defined (__CYGWIN__)
+#else
 #include <CL/cl.h>
 #endif
 

--- a/include/pidfile.h
+++ b/include/pidfile.h
@@ -13,9 +13,6 @@
 #if defined (_WIN)
 #include <windows.h>
 #include <psapi.h>
-#else
-#include <sys/types.h>
-#include <sys/stat.h>
 #endif // _WIN
 
 int pidfile_ctx_init (hashcat_ctx_t *hashcat_ctx);

--- a/include/restore.h
+++ b/include/restore.h
@@ -13,9 +13,6 @@
 #if defined (_WIN)
 #include <windows.h>
 #include <psapi.h>
-#else
-#include <sys/types.h>
-#include <sys/stat.h>
 #endif // _WIN
 
 #define RESTORE_VERSION_MIN 340

--- a/src/Makefile
+++ b/src/Makefile
@@ -121,7 +121,7 @@ VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+
 ## General compiler and linker options
 ##
 
-CFLAGS                  += -pipe -std=c99 -Iinclude/ -Iinclude/lzma_sdk/ -IOpenCL/
+CFLAGS                  += -pipe -std=gnu99 -Iinclude/ -Iinclude/lzma_sdk/ -IOpenCL/
 
 ifeq ($(PRODUCTION),0)
 CFLAGS                  += -W

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -16,11 +16,7 @@ int sort_by_dictstat (const void *s1, const void *s2)
   dictstat_t *d1 = (dictstat_t *) s1;
   dictstat_t *d2 = (dictstat_t *) s2;
 
-  #if defined (__linux__) || defined (__CYGWIN__)
-  d2->stat.st_atim = d1->stat.st_atim;
-  #else
   d2->stat.st_atime = d1->stat.st_atime;
-  #endif
 
   return memcmp (&d1->stat, &d2->stat, sizeof (struct stat));
 }


### PR DESCRIPTION
First is true since kernel 2.6 apparently.

The fourth should have no effect. Doesn't hurt since _GNU_SOURCE defines that version for other stuff.

The fifth - c99 causes no problems although in theory it should. I'm guessing _GNU_SOURCE overrides c99.