### PR TITLE
fixes #1160: parsing/displaying -m 7000 = Fortigate hashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -6,6 +6,7 @@
 
 - Fixed a problem where --keyspace combined with custom charsets incorrectly displayed an error message
 - Fixed a typo that resulted in the minimum password length not being correctly initialized
+- Fixed a problem with parsing and displaying -m 7000 = Fortigate (FortiOS) hashes
 
 * changes v3.30 -> v3.40:
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -14054,7 +14054,7 @@ int fortigate_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_
 
   int decoded_len = base64_decode (base64_to_int, (const u8 *) hash_pos, DISPLAY_LEN_MAX_7000 - 3, tmp_buf);
 
-  if (decoded_len != 32 + 1) return (PARSER_HASH_LENGTH);
+  if (decoded_len != 32) return (PARSER_HASH_LENGTH);
 
   /**
    * store data
@@ -16219,7 +16219,7 @@ int ascii_digest (hashcat_ctx_t *hashcat_ctx, char *out_buf, const size_t out_le
 
     // base64 encode (salt + SHA1)
 
-    base64_encode (int_to_base64, (const u8 *) tmp_buf, 12 + 20 + 1, (u8 *) ptr_plain);
+    base64_encode (int_to_base64, (const u8 *) tmp_buf, 12 + 20, (u8 *) ptr_plain);
 
     ptr_plain[44] = 0;
 

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -5492,7 +5492,7 @@ sub gen_hash
 
     my $hash = sha1 ($salt_bin . $word_buf . $FORTIGATE_MAGIC);
 
-    $hash = encode_base64 ($salt_bin . $hash . "\x00");
+    $hash = encode_base64 ($salt_bin . $hash);
     $hash =~ s/[\r\n]//g;
 
     $tmp_hash = sprintf ("%s%s", $FORTIGATE_SIGNATURE, $hash);


### PR DESCRIPTION
It seems that due to some bug in hashcat-legacy (see https://github.com/hashcat/hashcat-legacy/blob/master/src/engine.c#L2193 ), we didn't implement the parsing/generation of -m 7000 = Fortigate (FortiOS) hashes correctly.

Jtr seems to also have some example hashes that seem to confirm that there was a bug (in both hashcat-legacy and hashcat, since we ported it from hashcat-legacy): see https://github.com/magnumripper/JohnTheRipper/blob/9737dea214b5e52e87fd5775acadc7839d0fcdee/src/FGT_fmt_plug.c#L78-L80

Thank you

This should fix #1160 