### PR TITLE
fixes #1162: visual indication if checkpoint quit is enabled

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -6,6 +6,7 @@
 
 - WPA cracking: Added support for WPA/WPA2 handshake AP nonce automatic error correction
 - WPA cracking: Added parameter --nonce-error-corrections to configure range of error correction
+- Added visual indicator to the status screen to indicate if the checkpoint quit feature is enabled
 
 ##
 ## Improvements

--- a/src/status.c
+++ b/src/status.c
@@ -29,7 +29,7 @@ static const char ST_0007[] = "Quit";
 static const char ST_0008[] = "Bypass";
 static const char ST_0009[] = "Aborted (Checkpoint)";
 static const char ST_0010[] = "Aborted (Runtime)";
-static const char ST_9998[] = "Running (Checkpoint Quit requested)";
+static const char ST_0011[] = "Running (Checkpoint Quit requested)";
 static const char ST_9999[] = "Unknown! Bug!";
 
 static const char UNITS[7] = { ' ', 'k', 'M', 'G', 'T', 'P', 'E' };
@@ -203,7 +203,7 @@ char *status_get_status_string (const hashcat_ctx_t *hashcat_ctx)
   {
     if (status_ctx->checkpoint_shutdown == true)
     {
-      return ((char *) ST_9998);
+      return ((char *) ST_0011);
     }
   }
 

--- a/src/status.c
+++ b/src/status.c
@@ -29,6 +29,7 @@ static const char ST_0007[] = "Quit";
 static const char ST_0008[] = "Bypass";
 static const char ST_0009[] = "Aborted (Checkpoint)";
 static const char ST_0010[] = "Aborted (Runtime)";
+static const char ST_9998[] = "Running (Checkpoint Quit requested)";
 static const char ST_9999[] = "Unknown! Bug!";
 
 static const char UNITS[7] = { ' ', 'k', 'M', 'G', 'T', 'P', 'E' };
@@ -195,6 +196,16 @@ char *status_get_status_string (const hashcat_ctx_t *hashcat_ctx)
   const status_ctx_t *status_ctx = hashcat_ctx->status_ctx;
 
   const int devices_status = status_ctx->devices_status;
+
+  // special case: running but checkpoint quit requested
+
+  if (devices_status == STATUS_RUNNING)
+  {
+    if (status_ctx->checkpoint_shutdown == true)
+    {
+      return ((char *) ST_9998);
+    }
+  }
 
   switch (devices_status)
   {


### PR DESCRIPTION
This implements the feature request within issue #1162.

Whenever the user enables the Checkpoint Quit feature, the status screen should have a visual indication to show whether the feature is currently enabled or not.

Thank you