### PR TITLE
remove: do not remove hashes unless --remove was specified

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -504,11 +504,14 @@ static int outer_loop (hashcat_ctx_t *hashcat_ctx)
 
   if (status_ctx->devices_status == STATUS_CRACKED)
   {
-    if (hashes->digests_saved != hashes->digests_done)
+    if (user_options->remove == true)
     {
-      const int rc = save_hash (hashcat_ctx);
+      if (hashes->digests_saved != hashes->digests_done)
+      {
+        const int rc = save_hash (hashcat_ctx);
 
-      if (rc == -1) return -1;
+        if (rc == -1) return -1;
+      }
     }
 
     EVENT (EVENT_POTFILE_ALL_CRACKED);
@@ -690,11 +693,14 @@ static int outer_loop (hashcat_ctx_t *hashcat_ctx)
 
   if (status_ctx->devices_status == STATUS_CRACKED)
   {
-    if (hashes->digests_saved != hashes->digests_done)
+    if (user_options->remove == true)
     {
-      const int rc = save_hash (hashcat_ctx);
+      if (hashes->digests_saved != hashes->digests_done)
+      {
+        const int rc = save_hash (hashcat_ctx);
 
-      if (rc == -1) return -1;
+        if (rc == -1) return -1;
+      }
     }
 
     EVENT (EVENT_WEAK_HASH_ALL_CRACKED);


### PR DESCRIPTION
We should never call save_hash () unless the user specified --remove.

This commit prevents hashcat to empty/clear/remove hash lists if the user didn't specify --remove.

Thank you