### PR TITLE
fixes #1199: introduce special bit (8) in message_pair (HCCAPX) to indicate if replay counter match

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -6,6 +6,7 @@
 
 - WPA cracking: Added support for WPA/WPA2 handshake AP nonce automatic error correction
 - WPA cracking: Added parameter --nonce-error-corrections to configure range of error correction
+- WPA cracking: Added support for a special bit (bit 8) of the message_pair that indicates if replay counters did match
 - Added visual indicator to the status screen to indicate if the checkpoint quit feature is enabled
 
 ##

--- a/src/interface.c
+++ b/src/interface.c
@@ -2785,6 +2785,8 @@ int wpa_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UNUSED
   memcpy (wpa->orig_nonce_ap,  in.nonce_ap,  32);
   memcpy (wpa->orig_nonce_sta, in.nonce_sta, 32);
 
+  in.message_pair &= 0x7f; // ignore the highest bit (it is used to indicate if the replay counters did match)
+
   if (wpa->message_pair_chgd == true)
   {
     if (wpa->message_pair != in.message_pair) return (PARSER_HCCAPX_MESSAGE_PAIR);


### PR DESCRIPTION
For -m 2500 = WPA/WPA2 there was some recent suggestion/issue #1199 that we should introduce a special bit within the message_pair value which indicates if the matching was done considering the replay counter.

For the time being we just ignore this special bit. In the future, we could add some further logic.

3th party tools might already use this bit and therefore we need to ignore it.

Thanks