### PR TITLE
fix for previous commit: make sure that we do not override the hccapx structure values

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -2785,6 +2785,8 @@ int wpa_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UNUSED
   memcpy (wpa->orig_nonce_ap,  in.nonce_ap,  32);
   memcpy (wpa->orig_nonce_sta, in.nonce_sta, 32);
 
+  u8 message_pair_orig = in.message_pair;
+
   in.message_pair &= 0x7f; // ignore the highest bit (it is used to indicate if the replay counters did match)
 
   if (wpa->message_pair_chgd == true)
@@ -2792,9 +2794,9 @@ int wpa_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UNUSED
     if (wpa->message_pair != in.message_pair) return (PARSER_HCCAPX_MESSAGE_PAIR);
   }
 
-  wpa->message_pair = in.message_pair;
+  wpa->message_pair = message_pair_orig;
 
-  if ((wpa->message_pair == MESSAGE_PAIR_M32E3) || (wpa->message_pair == MESSAGE_PAIR_M34E3))
+  if ((in.message_pair == MESSAGE_PAIR_M32E3) || (in.message_pair == MESSAGE_PAIR_M34E3))
   {
     wpa->nonce_error_corrections = 0;
   }


### PR DESCRIPTION
This commit makes sure that we do not change any values within the hccapx files themself.
We should only change the values needed while parsing.

Thanks