### PR TITLE
Fix compilation error on macOs (missing iconv linking)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -212,6 +212,7 @@ CFLAGS_NATIVE           := $(CFLAGS)
 LFLAGS_NATIVE           := $(LFLAGS)
 LFLAGS_NATIVE           += -framework OpenCL
 LFLAGS_NATIVE           += -lpthread
+LFLAGS_NATIVE           += -liconv
 endif # Darwin
 
 ifeq ($(UNAME),CYGWIN)


### PR DESCRIPTION
This PR fixes a compilation error on macOs due to a missing LDFLAG to link libiconv.