### PR TITLE
Add support for rule: eX

### DIFF
--- a/OpenCL/inc_rp.cl
+++ b/OpenCL/inc_rp.cl
@@ -2454,7 +2454,7 @@ inline u32 rule_op_mangle_dupeblock_last (const u32 p0, const u32 p1, u32 buf0[4
   return out_len;
 }
 
-inline u32 rule_op_mangle_title (const u32 p0, const u32 p1, u32 buf0[4], u32 buf1[4], const u32 in_len)
+inline u32 rule_op_mangle_title_sep (const u32 p0, const u32 p1, u32 buf0[4], u32 buf1[4], const u32 in_len)
 {
   buf0[0] |= (generate_cmask (buf0[0]));
   buf0[1] |= (generate_cmask (buf0[1]));
@@ -2468,7 +2468,7 @@ inline u32 rule_op_mangle_title (const u32 p0, const u32 p1, u32 buf0[4], u32 bu
   u32 tib40[4];
   u32 tib41[4];
 
-  const uchar4 tmp0 = (uchar4) (' ');
+  const uchar4 tmp0 = (uchar4) (p0);
   const uchar4 tmp1 = (uchar4) (0x00);
   const uchar4 tmp2 = (uchar4) (0xff);
 
@@ -2542,7 +2542,8 @@ inline u32 apply_rule (const u32 name, const u32 p0, const u32 p1, u32 buf0[4], 
     case RULE_OP_MANGLE_REPLACE_NM1:      out_len = rule_op_mangle_replace_nm1      (p0, p1, buf0, buf1, out_len); break;
     case RULE_OP_MANGLE_DUPEBLOCK_FIRST:  out_len = rule_op_mangle_dupeblock_first  (p0, p1, buf0, buf1, out_len); break;
     case RULE_OP_MANGLE_DUPEBLOCK_LAST:   out_len = rule_op_mangle_dupeblock_last   (p0, p1, buf0, buf1, out_len); break;
-    case RULE_OP_MANGLE_TITLE:            out_len = rule_op_mangle_title            (p0, p1, buf0, buf1, out_len); break;
+    case RULE_OP_MANGLE_TITLE_SEP:        out_len = rule_op_mangle_title_sep        (p0, p1, buf0, buf1, out_len); break;
+    case RULE_OP_MANGLE_TITLE:            out_len = rule_op_mangle_title_sep        (' ', p1, buf0, buf1, out_len); break;
   }
 
   return out_len;

--- a/OpenCL/inc_rp.h
+++ b/OpenCL/inc_rp.h
@@ -32,6 +32,7 @@
 #define RULE_OP_MANGLE_DUPECHAR_FIRST   'z'
 #define RULE_OP_MANGLE_DUPECHAR_LAST    'Z'
 #define RULE_OP_MANGLE_DUPECHAR_ALL     'q'
+#define RULE_OP_MANGLE_TITLE_SEP        'e'
 
 #define RULE_OP_REJECT_LESS             '<'
 #define RULE_OP_REJECT_GREATER          '>'

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -12,6 +12,7 @@
 
 - Wordlist encoding: Support added for internal convert from and to user-defined encoding during runtime
 - Wordlist encoding: Added parameters --encoding-from and --encoding-to to configure wordlist encoding handling
+- Rules: Support added for rule 'eX'
 
 ##
 ## Improvements

--- a/docs/rules.txt
+++ b/docs/rules.txt
@@ -38,6 +38,7 @@
 #define RULE_OP_MANGLE_DUPEBLOCK_FIRST  'y' // duplicates first n characters
 #define RULE_OP_MANGLE_DUPEBLOCK_LAST   'Y' // duplicates last n characters
 #define RULE_OP_MANGLE_TITLE            'E' // lowercase everything then upper case the first letter and every letter after a space
+#define RULE_OP_MANGLE_TITLE_SEP        'e' // lowercase everything then upper case the first letter and every letter after char X
 
 /* With -j or -k only */
 

--- a/include/types.h
+++ b/include/types.h
@@ -280,6 +280,7 @@ typedef enum rule_functions
   RULE_OP_MANGLE_EXTRACT_MEMORY  = 'X',
   RULE_OP_MANGLE_APPEND_MEMORY   = '4',
   RULE_OP_MANGLE_PREPEND_MEMORY  = '6',
+  RULE_OP_MANGLE_TITLE_SEP       = 'e',
 
   RULE_OP_MEMORIZE_WORD          = 'M',
 

--- a/src/rp.c
+++ b/src/rp.c
@@ -58,7 +58,8 @@ static const char grp_op_chr[] =
 {
   RULE_OP_MANGLE_APPEND,
   RULE_OP_MANGLE_PREPEND,
-  RULE_OP_MANGLE_PURGECHAR
+  RULE_OP_MANGLE_PURGECHAR,
+  RULE_OP_MANGLE_TITLE_SEP
 };
 
 static const char grp_op_chr_chr[] =
@@ -444,6 +445,11 @@ int cpu_rule_to_kernel_rule (char *rule_buf, u32 rule_len, kernel_rule_t *rule)
         SET_NAME (rule, rule_buf[rule_pos]);
         break;
 
+      case RULE_OP_MANGLE_TITLE_SEP:
+        SET_NAME (rule, rule_buf[rule_pos]);
+        SET_P0   (rule, rule_buf[rule_pos]);
+        break;
+
       default:
         return -1;
     }
@@ -660,6 +666,11 @@ int kernel_rule_to_cpu_rule (char *rule_buf, kernel_rule_t *rule)
 
       case RULE_OP_MANGLE_TITLE:
         rule_buf[rule_pos] = rule_cmd;
+        break;
+
+      case RULE_OP_MANGLE_TITLE_SEP:
+        rule_buf[rule_pos] = rule_cmd;
+        GET_P0 (rule);
         break;
 
       case 0:

--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -431,7 +431,7 @@ static int mangle_chr_decr (char arr[BLOCK_SIZE], int arr_len, int upos)
   return (arr_len);
 }
 
-static int mangle_title (char arr[BLOCK_SIZE], int arr_len)
+static int mangle_title_sep (char arr[BLOCK_SIZE], int arr_len, char c)
 {
   int upper_next = 1;
 
@@ -439,7 +439,7 @@ static int mangle_title (char arr[BLOCK_SIZE], int arr_len)
 
   for (pos = 0; pos < arr_len; pos++)
   {
-    if (arr[pos] == ' ')
+    if (arr[pos] == c)
     {
       upper_next = 1;
 
@@ -702,8 +702,13 @@ int _old_apply_rule (char *rule, int rule_len, char in[BLOCK_SIZE], int in_len, 
         if ((upos >= 1) && ((upos + 0) < out_len)) mangle_overstrike (out, out_len, upos, out[upos - 1]);
         break;
 
+      case RULE_OP_MANGLE_TITLE_SEP:
+        NEXT_RULEPOS (rule_pos);
+        out_len = mangle_title_sep (out, out_len, rule[rule_pos]);
+        break;
+
       case RULE_OP_MANGLE_TITLE:
-        out_len = mangle_title (out, out_len);
+        out_len = mangle_title_sep (out, out_len, ' ');
         break;
 
       case RULE_OP_MANGLE_EXTRACT_MEMORY:

--- a/src/rp_kernel_on_cpu.c
+++ b/src/rp_kernel_on_cpu.c
@@ -2393,7 +2393,7 @@ static u32 rule_op_mangle_dupeblock_last (MAYBE_UNUSED const u32 p0, MAYBE_UNUSE
   return out_len;
 }
 
-static u32 rule_op_mangle_title (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED u32 buf0[4], MAYBE_UNUSED u32 buf1[4], const u32 in_len)
+static u32 rule_op_mangle_title_sep (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED u32 buf0[4], MAYBE_UNUSED u32 buf1[4], const u32 in_len)
 {
   buf0[0] |= (generate_cmask (buf0[0]));
   buf0[1] |= (generate_cmask (buf0[1]));
@@ -2405,6 +2405,8 @@ static u32 rule_op_mangle_title (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u
   buf1[3] |= (generate_cmask (buf1[3]));
 
   buf0[0] &= ~(0x00000020 & generate_cmask (buf0[0]));
+
+  const u8 tmp2 = (u8) p0;
 
   for (u32 i = 0; i < in_len; i++)
   {
@@ -2479,35 +2481,35 @@ static u32 rule_op_mangle_title (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u
 
     if (i < 3)
     {
-      if (tmp0   == ' ') buf0[0]   &= tmp1  ;
+      if (tmp0   == tmp2) buf0[0]   &= tmp1  ;
     }
     else if (i < 7)
     {
-      if (tmp0   == ' ') buf0[1]   &= tmp1  ;
+      if (tmp0   == tmp2) buf0[1]   &= tmp1  ;
     }
     else if (i < 11)
     {
-      if (tmp0   == ' ') buf0[2]   &= tmp1  ;
+      if (tmp0   == tmp2) buf0[2]   &= tmp1  ;
     }
     else if (i < 15)
     {
-      if (tmp0   == ' ') buf0[3]   &= tmp1  ;
+      if (tmp0   == tmp2) buf0[3]   &= tmp1  ;
     }
     else if (i < 19)
     {
-      if (tmp0   == ' ') buf1[0]   &= tmp1  ;
+      if (tmp0   == tmp2) buf1[0]   &= tmp1  ;
     }
     else if (i < 23)
     {
-      if (tmp0   == ' ') buf1[1]   &= tmp1  ;
+      if (tmp0   == tmp2) buf1[1]   &= tmp1  ;
     }
     else if (i < 27)
     {
-      if (tmp0   == ' ') buf1[2]   &= tmp1  ;
+      if (tmp0   == tmp2) buf1[2]   &= tmp1  ;
     }
     else if (i < 31)
     {
-      if (tmp0   == ' ') buf1[3]   &= tmp1  ;
+      if (tmp0   == tmp2) buf1[3]   &= tmp1  ;
     }
   }
 
@@ -2559,7 +2561,8 @@ u32 apply_rule (const u32 name, const u32 p0, const u32 p1, u32 buf0[4], u32 buf
     case RULE_OP_MANGLE_REPLACE_NM1:      out_len = rule_op_mangle_replace_nm1      (p0, p1, buf0, buf1, out_len); break;
     case RULE_OP_MANGLE_DUPEBLOCK_FIRST:  out_len = rule_op_mangle_dupeblock_first  (p0, p1, buf0, buf1, out_len); break;
     case RULE_OP_MANGLE_DUPEBLOCK_LAST:   out_len = rule_op_mangle_dupeblock_last   (p0, p1, buf0, buf1, out_len); break;
-    case RULE_OP_MANGLE_TITLE:            out_len = rule_op_mangle_title            (p0, p1, buf0, buf1, out_len); break;
+    case RULE_OP_MANGLE_TITLE_SEP:        out_len = rule_op_mangle_title_sep        (p0, p1, buf0, buf1, out_len); break;
+    case RULE_OP_MANGLE_TITLE:            out_len = rule_op_mangle_title_sep        (' ', p1, buf0, buf1, out_len); break;
   }
 
   return out_len;


### PR DESCRIPTION
```
$ cat /tmp/in
ab-bcd-cef
abc
ab cd ef
-ab
 ab

$ ./hashcat --stdout -j 'e-' /tmp/in
Ab-Bcd-Cef
Abc
Ab cd ef
-Ab
 ab
```

I've tested:

1- using 'e-' with -j switch:  `./hashcat --stdout -j 'e-' /tmp/in`.
2- using 'e-' with -r switch: `./hashcat --stdout -r <(echo 'e-') /tmp/in`
3- using 'e-' to crack hash: 
```
$ ./hashcat --quiet -r <(echo 'e-') /tmp/h /tmp/in
ff46c8192da24c9d1b30fb90b7461ec2:Ab-Bcd-Cef
```
Closes #1231