### PR TITLE
Add support for rule position 'p'

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Wordlist encoding: Support added for internal convert from and to user-defined encoding during runtime
 - Wordlist encoding: Added parameters --encoding-from and --encoding-to to configure wordlist encoding handling
 - Rules: Support added for rule 'eX'
+- Rules: Support added for position 'p' in host mode (using -j or -k)
 
 ##
 ## Improvements

--- a/docs/rules.txt
+++ b/docs/rules.txt
@@ -56,4 +56,4 @@
 #define RULE_OP_REJECT_EQUAL_AT         '=' // reject plains that do not contain char X at position N
 #define RULE_OP_REJECT_CONTAINS         '%' // reject plains that contain char X less than N times
 #define RULE_OP_REJECT_MEMORY           'Q' // reject plains that match the plain saved (see M), i.e. if unchanged
-
+#define RULE_LAST_REJECTED_SAVED_POS    'p' // position of the character last found with '/' or '%'

--- a/include/types.h
+++ b/include/types.h
@@ -293,6 +293,7 @@ typedef enum rule_functions
   RULE_OP_REJECT_EQUAL_AT        = '=',
   RULE_OP_REJECT_CONTAINS        = '%',
   RULE_OP_REJECT_MEMORY          = 'Q',
+  RULE_LAST_REJECTED_SAVED_POS   = 'p',
 
   RULE_OP_MANGLE_SWITCH_FIRST    = 'k',
   RULE_OP_MANGLE_SWITCH_LAST     = 'K',


### PR DESCRIPTION
The loop condition in `RULE_OP_REJECT_CONTAINS` was changed to be compatible with JtR. 

```
echo 'remember' | ./hashcat --stdout -j '/e op3'
r3member

echo 'remember' |  ./hashcat --stdout -j '%2m ip!'
reme!mber

echo 'remember' |  ./hashcat --stdout -j '%3e op3 %2e op3 /e op3'
r3m3mb3r
```

Using `p` without using `/` or `%` before it, would result in an invalid rule.
E.g. `echo 'remember' |  ./hashcat --stdout -j 'op3'` will return empty response with exit status 1.

This may not close #1035. I thought it's nice to have.