### PR TITLE
fixes #1239: remove AES padding attack for 7zip since we can't guarantee that the padding is always zero

### DIFF
--- a/include/interface.h
+++ b/include/interface.h
@@ -808,11 +808,6 @@ typedef struct seven_zip_hook_salt
   char coder_attributes[5 + 1];
   u8   coder_attributes_len;
 
-  u32 margin;
-
-  bool padding_check_full;
-  bool padding_check_fast;
-
   int aes_len; // pre-computed length of the maximal (subset of) data we need for AES-CBC
 
 } seven_zip_hook_salt_t;


### PR DESCRIPTION
As discussed already within issue #1239 this has very little performance impact (since 7zip has a default  cost of 19 = 2^19 iterations), i.e. the more significant cost is the computation performed via the kernel and not the verify code (the hook).

Thanks also to @magnumripper for reporting this problem. I am still interested in stats on how rare such an archive is (or even just a way how these files are generated). If somebody knows, please let us know... but we decided here to better be safe than sorry and avoid false negatives.
Thx