### PR TITLE
Fix for Periodic Status Leak

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -37,6 +37,7 @@
 
 - Fixed a missing type specifier in a function declaration of the RACF kernel
 - Fixed a condition that caused a hybrid attack using a maskfile to not select all wordlists from a wordlist folder
+- Fixed a memory leak that is present when a user is periodically printing hashcat status (using --status-timer)
 
 ##
 ## Technical

--- a/include/status.h
+++ b/include/status.h
@@ -91,4 +91,6 @@ void        status_progress_reset                 (hashcat_ctx_t *hashcat_ctx);
 int         status_ctx_init                       (hashcat_ctx_t *hashcat_ctx);
 void        status_ctx_destroy                    (hashcat_ctx_t *hashcat_ctx);
 
+void        status_status_destroy                 (hashcat_status_t *status_ctx);
+
 #endif // _STATUS_H

--- a/src/main.c
+++ b/src/main.c
@@ -717,6 +717,9 @@ static void main_monitor_status_refresh (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx
 {
   const user_options_t       *user_options       = hashcat_ctx->user_options;
   const user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
+  const status_ctx_t         *status_ctx         = hashcat_ctx->status_ctx;
+
+  if (status_ctx->accessible == false) return;
 
   if ((user_options_extra->wordlist_mode == WL_MODE_FILE) || (user_options_extra->wordlist_mode == WL_MODE_MASK))
   {

--- a/src/memory.c
+++ b/src/memory.c
@@ -73,4 +73,5 @@ void hcfree (void *ptr)
   if (ptr == NULL) return;
 
   free (ptr);
+  ptr = NULL;
 }

--- a/src/status.c
+++ b/src/status.c
@@ -1809,25 +1809,24 @@ void status_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
 
 void status_status_destroy (hashcat_status_t *status_ctx)
 {
-  if (NULL == status_ctx)
-    return;
+  if (NULL == status_ctx) return;
 
-  hcfree(status_ctx->session);
-  hcfree(status_ctx->time_estimated_absolute);
-  hcfree(status_ctx->time_estimated_relative);
-  hcfree(status_ctx->time_started_absolute);
-  hcfree(status_ctx->time_started_relative);
-  hcfree(status_ctx->speed_sec_all);
-  hcfree(status_ctx->guess_base);
-  hcfree(status_ctx->guess_mod);
-  hcfree(status_ctx->guess_charset);
-  hcfree(status_ctx->cpt);
+  hcfree (status_ctx->session);
+  hcfree (status_ctx->time_estimated_absolute);
+  hcfree (status_ctx->time_estimated_relative);
+  hcfree (status_ctx->time_started_absolute);
+  hcfree (status_ctx->time_started_relative);
+  hcfree (status_ctx->speed_sec_all);
+  hcfree (status_ctx->guess_base);
+  hcfree (status_ctx->guess_mod);
+  hcfree (status_ctx->guess_charset);
+  hcfree (status_ctx->cpt);
 
   for (int device_id = 0; device_id < status_ctx->device_info_cnt; device_id++)
   {
     device_info_t *device_info = status_ctx->device_info_buf + device_id;
-    hcfree(device_info->speed_sec_dev);
-    hcfree(device_info->guess_candidates_dev);
-    hcfree(device_info->hwmon_dev);
+    hcfree (device_info->speed_sec_dev);
+    hcfree (device_info->guess_candidates_dev);
+    hcfree (device_info->hwmon_dev);
   }
 }

--- a/src/status.c
+++ b/src/status.c
@@ -1806,3 +1806,28 @@ void status_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
 
   memset (status_ctx, 0, sizeof (status_ctx_t));
 }
+
+void status_status_destroy (hashcat_status_t *status_ctx)
+{
+  if (NULL == status_ctx)
+    return;
+
+  hcfree(status_ctx->session);
+  hcfree(status_ctx->time_estimated_absolute);
+  hcfree(status_ctx->time_estimated_relative);
+  hcfree(status_ctx->time_started_absolute);
+  hcfree(status_ctx->time_started_relative);
+  hcfree(status_ctx->speed_sec_all);
+  hcfree(status_ctx->guess_base);
+  hcfree(status_ctx->guess_mod);
+  hcfree(status_ctx->guess_charset);
+  hcfree(status_ctx->cpt);
+
+  for (int device_id = 0; device_id < status_ctx->device_info_cnt; device_id++)
+  {
+    device_info_t *device_info = status_ctx->device_info_buf + device_id;
+    hcfree(device_info->speed_sec_dev);
+    hcfree(device_info->guess_candidates_dev);
+    hcfree(device_info->hwmon_dev);
+  }
+}

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -692,6 +692,7 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
 
   fflush (stdout);
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }
 
@@ -1105,6 +1106,7 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }
 
@@ -1134,6 +1136,7 @@ void status_benchmark_machine_readable (hashcat_ctx_t *hashcat_ctx)
     event_log_info (hashcat_ctx, "%d:%u:%d:%d:%.2f:%" PRIu64, device_id + 1, hash_mode, device_info->corespeed_dev, device_info->memoryspeed_dev, device_info->exec_msec_dev, (u64) (device_info->hashes_msec_dev_benchmark * 1000));
   }
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }
 
@@ -1178,6 +1181,7 @@ void status_benchmark (hashcat_ctx_t *hashcat_ctx)
       hashcat_status->speed_sec_all);
   }
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }
 
@@ -1203,6 +1207,7 @@ void status_speed_machine_readable (hashcat_ctx_t *hashcat_ctx)
     event_log_info (hashcat_ctx, "%d:%" PRIu64, device_id + 1, (u64) (device_info->hashes_msec_dev_benchmark * 1000));
   }
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }
 
@@ -1247,6 +1252,7 @@ void status_speed (hashcat_ctx_t *hashcat_ctx)
       hashcat_status->speed_sec_all);
   }
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }
 
@@ -1272,6 +1278,7 @@ void status_progress_machine_readable (hashcat_ctx_t *hashcat_ctx)
     event_log_info (hashcat_ctx, "%d:%d:%0.2f", device_id + 1, device_info->progress_dev, device_info->runtime_msec_dev);
   }
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }
 
@@ -1319,5 +1326,6 @@ void status_progress (hashcat_ctx_t *hashcat_ctx)
       device_info->runtime_msec_dev);
   }
 
+  status_status_destroy (hashcat_status);
   hcfree (hashcat_status);
 }


### PR DESCRIPTION
This fixes #1254 by freeing some of the contents within `hashcat_status_t`.

Valgrind Before: https://gist.github.com/tankbusta/8ad06e98bed01ca7a3399dd76945ec72
Valgrind After: https://gist.github.com/tankbusta/02640f63705626a22549d8688e94a5b4