### PR TITLE
Add support for rejection rule _N

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -18,6 +18,7 @@
 - Rules: Support added for rule 'eX'
 - Rules: Support added for position 'p' in host mode (using -j or -k)
 - 7-Zip cracking: increased max. data length to 320k and removed AES padding attack to avoid false negatives
+- Rules: Support added for rejection rule '_N' in host mode
 
 ##
 ## Workarounds

--- a/docs/rules.txt
+++ b/docs/rules.txt
@@ -49,6 +49,7 @@
 
 #define RULE_OP_REJECT_LESS             '<' // reject plains of length greater than N
 #define RULE_OP_REJECT_GREATER          '>' // reject plains of length less than N
+#define RULE_OP_REJECT_EQUAL            '_' // reject plains of length not equal to N
 #define RULE_OP_REJECT_CONTAIN          '!' // reject plains that contain char X
 #define RULE_OP_REJECT_NOT_CONTAIN      '/' // reject plains that do not contain char X
 #define RULE_OP_REJECT_EQUAL_FIRST      '(' // reject plains that do not contain char X at first position

--- a/include/types.h
+++ b/include/types.h
@@ -286,6 +286,7 @@ typedef enum rule_functions
 
   RULE_OP_REJECT_LESS            = '<',
   RULE_OP_REJECT_GREATER         = '>',
+  RULE_OP_REJECT_EQUAL           = '_',
   RULE_OP_REJECT_CONTAIN         = '!',
   RULE_OP_REJECT_NOT_CONTAIN     = '/',
   RULE_OP_REJECT_EQUAL_FIRST     = '(',

--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -766,6 +766,12 @@ int _old_apply_rule (char *rule, int rule_len, char in[BLOCK_SIZE], int in_len, 
         if (out_len < upos) return (RULE_RC_REJECT_ERROR);
         break;
 
+      case RULE_OP_REJECT_EQUAL:
+        NEXT_RULEPOS (rule_pos);
+        NEXT_RPTOI (rule, rule_pos, upos);
+        if (out_len != upos) return (RULE_RC_REJECT_ERROR);
+        break;
+
       case RULE_OP_REJECT_CONTAIN:
         NEXT_RULEPOS (rule_pos);
         if (strchr (out, rule[rule_pos]) != NULL) return (RULE_RC_REJECT_ERROR);

--- a/tools/rules-test-cases.yaml
+++ b/tools/rules-test-cases.yaml
@@ -499,6 +499,18 @@ uMl6:
     ab
     abc
 
+_2:
+  mode: 1
+  input: |
+    a
+    ab
+    abc
+    123456790abcdefghijklmnopqrstuvw
+    123456790abcdefghijklmnopqrstuvwx
+
+  expected_output: |
+    ab
+
 '!a':
   mode: 1
   input: |


### PR DESCRIPTION
Ported from JtR.

Example: `_2`

input:

```
a
ab
abc
```
output:

```
ab
```