### PR TITLE
Allow OpenCL devices to be destroyed

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -1216,8 +1216,8 @@ int hashcat_session_destroy (hashcat_ctx_t *hashcat_ctx)
   induct_ctx_destroy         (hashcat_ctx);
   logfile_destroy            (hashcat_ctx);
   loopback_destroy           (hashcat_ctx);
-  opencl_ctx_destroy         (hashcat_ctx);
   opencl_ctx_devices_destroy (hashcat_ctx);
+  opencl_ctx_destroy         (hashcat_ctx);
   outcheck_ctx_destroy       (hashcat_ctx);
   outfile_destroy            (hashcat_ctx);
   pidfile_ctx_destroy        (hashcat_ctx);


### PR DESCRIPTION
OpenCL devices need to be destroyed before the memset in `opencl_ctx_destroy` to allow hashcat to properly free some allocations.

Shouldn't there also be the following free's within `opencl_ctx_destroy`? The macOS leak detector is flagging these when using hashcat as a library during multiple sessions. 

```
hcfree (opencl_ctx->ocl);
hcfree (opencl_ctx->platforms_vendor);
hcfree (opencl_ctx->platforms_name);
hcfree (opencl_ctx->platforms_version);
hcfree (opencl_ctx->platforms_skipped);
```