### PR TITLE
test: fixed tests for -m 2410 in combinator mode

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -674,7 +674,9 @@ function attack_1()
 
     offset=14
 
-    if   [ ${hash_type} -eq  2500 ]; then
+    if   [ ${hash_type} -eq  2410 ]; then
+      offset=11
+    elif [ ${hash_type} -eq  2500 ]; then
       offset=7
     elif [ ${hash_type} -eq  5800 ]; then
       offset=6


### PR DESCRIPTION
The test.sh wasn't up to date with the newest password length changes in test.pl and hashcat (see 8c89ed94). Therefore, some errors were shown within the tests (combinator mode only).

This should update the lenght limit and fix the errors.

Thx