### PR TITLE
fixes 1306: every permanent chdir () needs to update the folder_config

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -20,6 +20,7 @@
 ##
 
 - Fixed a parser error for mode -m 9820 = MS Office <= 2003 $3, SHA1 + RC4, collider #2
+- Fixed a problem with changed current working directory, for instance by using --restore together with --remove
 
 ##
 ## Improvements


### PR DESCRIPTION
As mentioned within the issue #1306 the path to the hash file used by --remove needs to be updated/fixed whenever we use --restore (in this case we accomplish that by updating the folder_config with the updated chdir () folder).

We should keep in mind that this is indeed the only instance of a permanent chdir () for now that I was able to find, but in general the folder_config needs to be updated every time there is a permanent chdir ().

Thx