### PR TITLE
fixes #1314: do not use the defines INSTALL_FOLDER/SHARED_FOLDER but the values from folder config

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -158,20 +158,17 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
      * updated folders
      */
 
-    const char *install_folder = NULL;
-    const char *shared_folder  = NULL;
+    // copy the paths of INSTALL_FOLDER and SHARED_FOLDER from the folder config:
 
-    #if defined (INSTALL_FOLDER)
-    install_folder = INSTALL_FOLDER;
-    #endif
-
-    #if defined (SHARED_FOLDER)
-    shared_folder = SHARED_FOLDER;
-    #endif
+    char *install_folder = hcstrdup (folder_config->install_dir);
+    char *shared_folder  = hcstrdup (folder_config->shared_dir);
 
     folder_config_destroy (hashcat_ctx);
 
     const int rc_folder_config_init = folder_config_init (hashcat_ctx, install_folder, shared_folder);
+
+    hcfree (install_folder);
+    hcfree (shared_folder);
 
     if (rc_folder_config_init == -1) return -1;
 


### PR DESCRIPTION
As mentioned here https://github.com/hashcat/hashcat/issues/1314#issuecomment-321524050 the INSTALL_FOLDER and SHARED_FOLDER values are not available in src/restore.c because the src/Makefile did only define (-D) them within src/main.c

The other problem mentioned within #1314 will be fixed with a second commit (since it is unrelated, as discussed). We need to set some values to NULL in addition to the hcfree (x) calls.

Thx