### PR TITLE
fixed double-free problem if OpenCL/ folder is missing (and e.g. shar…

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -21,6 +21,7 @@
 
 - Fixed a parser error for mode -m 9820 = MS Office <= 2003 $3, SHA1 + RC4, collider #2
 - Fixed a problem with changed current working directory, for instance by using --restore together with --remove
+- Fixed a memory problem that occured when the OpenCL folder was not found and e.g. the shared and session folder were the same
 
 ##
 ## Improvements

--- a/src/folder.c
+++ b/src/folder.c
@@ -435,9 +435,31 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
     hcfree (cwd);
 
     hcfree (shared_dir);
+
+    // Attention: since hcfree () doesn't set the pointer to NULL, we need to do it externally such that
+    // we prevent double-freeing the same memory address (this happens if e.g. profile_dir == session_dir)
+
+    if (profile_dir == shared_dir) profile_dir = NULL;
+    if (session_dir == shared_dir) session_dir = NULL;
+
+    shared_dir = NULL;
+
+
     hcfree (profile_dir);
-    hcfree (cpath_real);
+
+    if (session_dir == profile_dir) session_dir = NULL;
+
+    profile_dir = NULL;
+
+
     hcfree (session_dir);
+
+    session_dir = NULL;
+
+
+    hcfree (cpath_real);
+
+    cpath_real = NULL;
 
     return -1;
   }


### PR DESCRIPTION
This pr fixes the double-free problem that we found here #1314 by accident.
If at least 2 of session folder, shared folder or profile_dir are the same we might free () the same address multiple times.

These additional checks prevent the double-freeing.
This can be tested by  just moving the OpenCL folder to a different path before starting hashcat (e.g. mv OpenCL/ OpenCL2/ , of course you shouldn't forget to move the folder back after testing).

Thx