### PR TITLE
formatting: remove tabs in tools/package_bin.sh

### DIFF
--- a/tools/package_bin.sh
+++ b/tools/package_bin.sh
@@ -24,8 +24,8 @@ cp -r $IN/masks                         $OUT/
 cp -r $IN/rules                         $OUT/
 cp -r $IN/extra                         $OUT/
 cp    $IN/example.dict                  $OUT/
-cp    $IN/example[0123456789]*.hash	$OUT/
-cp    $IN/example[0123456789]*.cmd	$OUT/
+cp    $IN/example[0123456789]*.hash     $OUT/
+cp    $IN/example[0123456789]*.cmd      $OUT/
 cp -r $IN/OpenCL                        $OUT/
 
 # since for the binary distribution we still use .bin, we need to rewrite the commands


### PR DESCRIPTION
This is just a minor formatting change that makes the shell script more readable.

Thanks