### PR TITLE
fix time/date estimated if very large

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -23,6 +23,7 @@
 - Fixed a problem with changed current working directory, for instance by using --restore together with --remove
 - Fixed a memory problem that occured when the OpenCL folder was not found and e.g. the shared and session folder were the same
 - Fixed the version number used in the restore file header
+- Fixed the estimated time value whenever the value is very large and overflows
 
 ##
 ## Improvements

--- a/include/status.h
+++ b/include/status.h
@@ -47,6 +47,11 @@ double      status_get_msec_paused                (const hashcat_ctx_t *hashcat_
 double      status_get_msec_real                  (const hashcat_ctx_t *hashcat_ctx);
 char       *status_get_time_started_absolute      (const hashcat_ctx_t *hashcat_ctx);
 char       *status_get_time_started_relative      (const hashcat_ctx_t *hashcat_ctx);
+#if defined (_WIN)
+__time64_t  status_get_sec_etc                    (const hashcat_ctx_t *hashcat_ctx);
+#else
+time_t      status_get_sec_etc                    (const hashcat_ctx_t *hashcat_ctx);
+#endif
 char       *status_get_time_estimated_absolute    (const hashcat_ctx_t *hashcat_ctx);
 char       *status_get_time_estimated_relative    (const hashcat_ctx_t *hashcat_ctx);
 u64         status_get_restore_point              (const hashcat_ctx_t *hashcat_ctx);


### PR DESCRIPTION
There was a recent bug report on the hashcat forum (https://hashcat.net/forum/thread-6774.html) that made me wonder if there is some kind of upper limit of the date displayed...

and indeed there was a fixed value
```
if (sec_etc > 100000000)
```
(this value converted from seconds to years is about 3 years).

This pull request tries to fix this hardcoded value with calls of the overflow_check_u64_add () function.
Furthermore, I've refactored some code into a new function called status_get_sec_etc ().

Thanks