### PR TITLE
fixed the usage of getopt_* ()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -23,6 +23,7 @@
 - Fixed a problem with changed current working directory, for instance by using --restore together with --remove
 - Fixed a memory problem that occured when the OpenCL folder was not found and e.g. the shared and session folder were the same
 - Fixed the version number used in the restore file header
+- Fixed the parsing of command line options. It doesn't show two times the same error about an invalid option anymore.
 
 ##
 ## Improvements

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -248,7 +248,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
 
   option_index = 0;
 
-  while (((c = getopt_long (argc, argv, short_options, long_options, &option_index)) != -1) && optopt == 0)
+  while ((c = getopt_long (argc, argv, short_options, long_options, &option_index)) != -1)
   {
     switch (c)
     {
@@ -291,14 +291,18 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
 
         return -1;
       }
+
+      break;
+
+      case '?':
+      {
+        event_log_error (hashcat_ctx, "Invalid argument specified.");
+
+        return -1;
+      }
+
+      break;
     }
-  }
-
-  if (optopt != 0)
-  {
-    event_log_error (hashcat_ctx, "Invalid argument specified.");
-
-    return -1;
   }
 
   optind = 1;
@@ -306,7 +310,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
 
   option_index = 0;
 
-  while (((c = getopt_long (argc, argv, short_options, long_options, &option_index)) != -1) && optopt == 0)
+  while ((c = getopt_long (argc, argv, short_options, long_options, &option_index)) != -1)
   {
     switch (c)
     {
@@ -416,21 +420,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_CUSTOM_CHARSET_2:          user_options->custom_charset_2          = optarg;         break;
       case IDX_CUSTOM_CHARSET_3:          user_options->custom_charset_3          = optarg;         break;
       case IDX_CUSTOM_CHARSET_4:          user_options->custom_charset_4          = optarg;         break;
-
-      default:
-      {
-        event_log_error (hashcat_ctx, "Invalid argument specified.");
-
-        return -1;
-      }
     }
-  }
-
-  if (optopt != 0)
-  {
-    event_log_error (hashcat_ctx, "Invalid argument specified.");
-
-    return -1;
   }
 
   user_options->hc_bin = argv[0];


### PR DESCRIPTION
When I did try to run hashcat with an incorrect command line option like this:

```
$ ./hashcat --aninvalidoption
```
... I do get a sequence of 2 times the same error message:
```
$ ./hashcat --aninvalidoption
./hashcat: unrecognized option '--aninvalidoption'
./hashcat: unrecognized option '--aninvalidoption'
Invalid argument specified.

```

This commit fixes the usage of getopt_long () by also catching the error case '?' and showing the error message immidiately  (and only once).
Thanks