### PR TITLE
reformatting; replaced some tabs with spaces

### DIFF
--- a/OpenCL/m00500.cl
+++ b/OpenCL/m00500.cl
@@ -92,7 +92,7 @@ __kernel void m00500_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   int pl;
 
-	for (pl = pw_len; pl > 16; pl -= 16)
+  for (pl = pw_len; pl > 16; pl -= 16)
   {
     md5_update (&md5_ctx, final, 16);
   }
@@ -103,11 +103,11 @@ __kernel void m00500_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   /* Then something really weird... */
 
-	for (int i = pw_len; i != 0; i >>= 1)
+  for (int i = pw_len; i != 0; i >>= 1)
   {
     u32 t[16] = { 0 };
 
-		if (i & 1)
+    if (i & 1)
     {
       t[0] = 0;
     }
@@ -184,32 +184,32 @@ __kernel void m00500_loop (__global pw_t *pws, __global const kernel_rule_t *rul
 
     md5_init (&md5_ctx);
 
-		if (j & 1)
+    if (j & 1)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, w, pw_len);
     }
-		else
+    else
     {
-			md5_update (&md5_ctx, digest, 16);
-    }
-
-		if (j % 3)
-    {
-			md5_update (&md5_ctx, s, salt_len);
+      md5_update (&md5_ctx, digest, 16);
     }
 
-		if (j % 7)
+    if (j % 3)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, s, salt_len);
     }
 
-		if (j & 1)
+    if (j % 7)
     {
-			md5_update (&md5_ctx, digest, 16);
+      md5_update (&md5_ctx, w, pw_len);
     }
-		else
+
+    if (j & 1)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, digest, 16);
+    }
+    else
+    {
+      md5_update (&md5_ctx, w, pw_len);
     }
 
     md5_final (&md5_ctx);

--- a/OpenCL/m01600.cl
+++ b/OpenCL/m01600.cl
@@ -94,7 +94,7 @@ __kernel void m01600_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   int pl;
 
-	for (pl = pw_len; pl > 16; pl -= 16)
+  for (pl = pw_len; pl > 16; pl -= 16)
   {
     md5_update (&md5_ctx, final, 16);
   }
@@ -105,11 +105,11 @@ __kernel void m01600_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   /* Then something really weird... */
 
-	for (int i = pw_len; i != 0; i >>= 1)
+  for (int i = pw_len; i != 0; i >>= 1)
   {
     u32 t[16] = { 0 };
 
-		if (i & 1)
+    if (i & 1)
     {
       t[0] = 0;
     }
@@ -186,32 +186,32 @@ __kernel void m01600_loop (__global pw_t *pws, __global const kernel_rule_t *rul
 
     md5_init (&md5_ctx);
 
-		if (j & 1)
+    if (j & 1)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, w, pw_len);
     }
-		else
+    else
     {
-			md5_update (&md5_ctx, digest, 16);
-    }
-
-		if (j % 3)
-    {
-			md5_update (&md5_ctx, s, salt_len);
+      md5_update (&md5_ctx, digest, 16);
     }
 
-		if (j % 7)
+    if (j % 3)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, s, salt_len);
     }
 
-		if (j & 1)
+    if (j % 7)
     {
-			md5_update (&md5_ctx, digest, 16);
+      md5_update (&md5_ctx, w, pw_len);
     }
-		else
+
+    if (j & 1)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, digest, 16);
+    }
+    else
+    {
+      md5_update (&md5_ctx, w, pw_len);
     }
 
     md5_final (&md5_ctx);

--- a/OpenCL/m01800.cl
+++ b/OpenCL/m01800.cl
@@ -104,7 +104,7 @@ __kernel void m01800_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   int pl;
 
-	for (pl = pw_len; pl > 64; pl -= 64)
+  for (pl = pw_len; pl > 64; pl -= 64)
   {
     sha512_update (&ctx, final, 64);
   }
@@ -183,7 +183,7 @@ __kernel void m01800_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   int idx;
 
-	for (pl = pw_len, idx = 0; pl > 64; pl -= 64, idx += 16)
+  for (pl = pw_len, idx = 0; pl > 64; pl -= 64, idx += 16)
   {
     p_final[idx +  0] = final[ 0];
     p_final[idx +  1] = final[ 1];
@@ -257,7 +257,7 @@ __kernel void m01800_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   u32 s_final[64] = { 0 };
 
-	for (pl = salt_len, idx = 0; pl > 64; pl -= 64, idx += 16)
+  for (pl = salt_len, idx = 0; pl > 64; pl -= 64, idx += 16)
   {
     s_final[idx +  0] = final[ 0];
     s_final[idx +  1] = final[ 1];
@@ -332,32 +332,32 @@ __kernel void m01800_loop (__global pw_t *pws, __global const kernel_rule_t *rul
 
     sha512_init (&ctx);
 
-		if (j & 1)
+    if (j & 1)
     {
-			sha512_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+      sha512_update_global (&ctx, tmps[gid].p_bytes, pw_len);
     }
-		else
+    else
     {
-			sha512_update (&ctx, alt_result, 64);
-    }
-
-		if (j % 3)
-    {
-			sha512_update_global (&ctx, tmps[gid].s_bytes, salt_len);
+      sha512_update (&ctx, alt_result, 64);
     }
 
-		if (j % 7)
+    if (j % 3)
     {
-			sha512_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+      sha512_update_global (&ctx, tmps[gid].s_bytes, salt_len);
     }
 
-		if (j & 1)
+    if (j % 7)
     {
-			sha512_update (&ctx, alt_result, 64);
+      sha512_update_global (&ctx, tmps[gid].p_bytes, pw_len);
     }
-		else
+
+    if (j & 1)
     {
-			sha512_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+      sha512_update (&ctx, alt_result, 64);
+    }
+    else
+    {
+      sha512_update_global (&ctx, tmps[gid].p_bytes, pw_len);
     }
 
     sha512_final (&ctx);

--- a/OpenCL/m06300.cl
+++ b/OpenCL/m06300.cl
@@ -84,7 +84,7 @@ __kernel void m06300_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   int pl;
 
-	for (pl = pw_len; pl > 16; pl -= 16)
+  for (pl = pw_len; pl > 16; pl -= 16)
   {
     md5_update (&md5_ctx, final, 16);
   }
@@ -95,11 +95,11 @@ __kernel void m06300_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   /* Then something really weird... */
 
-	for (int i = pw_len; i != 0; i >>= 1)
+  for (int i = pw_len; i != 0; i >>= 1)
   {
     u32 t[16] = { 0 };
 
-		if (i & 1)
+    if (i & 1)
     {
       t[0] = 0;
     }
@@ -176,32 +176,32 @@ __kernel void m06300_loop (__global pw_t *pws, __global const kernel_rule_t *rul
 
     md5_init (&md5_ctx);
 
-		if (j & 1)
+    if (j & 1)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, w, pw_len);
     }
-		else
+    else
     {
-			md5_update (&md5_ctx, digest, 16);
-    }
-
-		if (j % 3)
-    {
-			md5_update (&md5_ctx, s, salt_len);
+      md5_update (&md5_ctx, digest, 16);
     }
 
-		if (j % 7)
+    if (j % 3)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, s, salt_len);
     }
 
-		if (j & 1)
+    if (j % 7)
     {
-			md5_update (&md5_ctx, digest, 16);
+      md5_update (&md5_ctx, w, pw_len);
     }
-		else
+
+    if (j & 1)
     {
-			md5_update (&md5_ctx, w, pw_len);
+      md5_update (&md5_ctx, digest, 16);
+    }
+    else
+    {
+      md5_update (&md5_ctx, w, pw_len);
     }
 
     md5_final (&md5_ctx);

--- a/OpenCL/m07400.cl
+++ b/OpenCL/m07400.cl
@@ -96,7 +96,7 @@ __kernel void m07400_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   int pl;
 
-	for (pl = pw_len; pl > 32; pl -= 32)
+  for (pl = pw_len; pl > 32; pl -= 32)
   {
     sha256_update (&ctx, final, 32);
   }
@@ -167,7 +167,7 @@ __kernel void m07400_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   int idx;
 
-	for (pl = pw_len, idx = 0; pl > 32; pl -= 32, idx += 8)
+  for (pl = pw_len, idx = 0; pl > 32; pl -= 32, idx += 8)
   {
     p_final[idx + 0] = final[0];
     p_final[idx + 1] = final[1];
@@ -225,7 +225,7 @@ __kernel void m07400_init (__global pw_t *pws, __global const kernel_rule_t *rul
 
   u32 s_final[64] = { 0 };
 
-	for (pl = salt_len, idx = 0; pl > 32; pl -= 32, idx += 8)
+  for (pl = salt_len, idx = 0; pl > 32; pl -= 32, idx += 8)
   {
     s_final[idx + 0] = final[0];
     s_final[idx + 1] = final[1];
@@ -288,32 +288,32 @@ __kernel void m07400_loop (__global pw_t *pws, __global const kernel_rule_t *rul
 
     sha256_init (&ctx);
 
-		if (j & 1)
+    if (j & 1)
     {
-			sha256_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+      sha256_update_global (&ctx, tmps[gid].p_bytes, pw_len);
     }
-		else
+    else
     {
-			sha256_update (&ctx, alt_result, 32);
-    }
-
-		if (j % 3)
-    {
-			sha256_update_global (&ctx, tmps[gid].s_bytes, salt_len);
+      sha256_update (&ctx, alt_result, 32);
     }
 
-		if (j % 7)
+    if (j % 3)
     {
-			sha256_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+      sha256_update_global (&ctx, tmps[gid].s_bytes, salt_len);
     }
 
-		if (j & 1)
+    if (j % 7)
     {
-			sha256_update (&ctx, alt_result, 32);
+      sha256_update_global (&ctx, tmps[gid].p_bytes, pw_len);
     }
-		else
+
+    if (j & 1)
     {
-			sha256_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+      sha256_update (&ctx, alt_result, 32);
+    }
+    else
+    {
+      sha256_update_global (&ctx, tmps[gid].p_bytes, pw_len);
     }
 
     sha256_final (&ctx);

--- a/include/ext_nvml.h
+++ b/include/ext_nvml.h
@@ -55,9 +55,9 @@ typedef enum nvmlReturn_enum {
 } nvmlReturn_t;
 
 typedef enum nvmlClockType_enum {
-	NVML_CLOCK_GRAPHICS = 0,
-	NVML_CLOCK_SM = 1,
-	NVML_CLOCK_MEM = 2
+  NVML_CLOCK_GRAPHICS = 0,
+  NVML_CLOCK_SM = 1,
+  NVML_CLOCK_MEM = 2
 } nvmlClockType_t;
 
 typedef enum nvmlTemperatureThresholds_enum


### PR DESCRIPTION
This PR just makes some minor changes to the source code format... it replaces some tabs with spaces because this is what the other parts of the source code do too and furthermore the README.md says:
```
5. Uses 2-spaces as indentation
```

Thanks