### PR TITLE
use an overflow check instead of a hard coded max. value for ETA

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -25,6 +25,7 @@
 - Fixed a memory problem that occured when the OpenCL folder was not found and e.g. the shared and session folder were the same
 - Fixed the version number used in the restore file header
 - Fixed the parsing of command line options. It doesn't show two times the same error about an invalid option anymore.
+- Fixed the estimated time value whenever the value is very large and overflows
 
 ##
 ## Improvements

--- a/include/shared.h
+++ b/include/shared.h
@@ -62,4 +62,8 @@ void hc_string_trim_leading (char *s);
 size_t hc_fread (void *ptr, size_t size, size_t nmemb, FILE *stream);
 void   hc_fwrite (const void *ptr, size_t size, size_t nmemb, FILE *stream);
 
+void       hc_time   (hc_time_t *t);
+struct tm *hc_gmtime (hc_time_t *t);
+char      *hc_ctime  (hc_time_t *t, char *buf, MAYBE_UNUSED size_t buf_size);
+
 #endif // _SHARED_H

--- a/include/status.h
+++ b/include/status.h
@@ -47,6 +47,7 @@ double      status_get_msec_paused                (const hashcat_ctx_t *hashcat_
 double      status_get_msec_real                  (const hashcat_ctx_t *hashcat_ctx);
 char       *status_get_time_started_absolute      (const hashcat_ctx_t *hashcat_ctx);
 char       *status_get_time_started_relative      (const hashcat_ctx_t *hashcat_ctx);
+hc_time_t   status_get_sec_etc                    (const hashcat_ctx_t *hashcat_ctx);
 char       *status_get_time_estimated_absolute    (const hashcat_ctx_t *hashcat_ctx);
 char       *status_get_time_estimated_relative    (const hashcat_ctx_t *hashcat_ctx);
 u64         status_get_restore_point              (const hashcat_ctx_t *hashcat_ctx);

--- a/include/types.h
+++ b/include/types.h
@@ -43,6 +43,14 @@ typedef uint16_t u16;
 typedef uint32_t u32;
 typedef uint64_t u64;
 
+// time
+
+#if defined (_WIN)
+typedef __time64_t        hc_time_t;
+#else
+typedef time_t            hc_time_t;
+#endif
+
 // timer
 
 #if defined (_WIN)

--- a/src/shared.c
+++ b/src/shared.c
@@ -441,3 +441,40 @@ void hc_fwrite (const void *ptr, size_t size, size_t nmemb, FILE *stream)
 
   if (rc == 0) rc = 0;
 }
+
+
+void hc_time (hc_time_t *t)
+{
+  #if defined (_WIN)
+  _time64 (t);
+  #else
+  time (t);
+  #endif
+}
+
+struct tm *hc_gmtime (hc_time_t *t)
+{
+  #if defined (_WIN)
+  return _gmtime64 (t);
+  #else
+  return gmtime (t);
+  #endif
+}
+
+char *hc_ctime (hc_time_t *t, char *buf, MAYBE_UNUSED size_t buf_size)
+{
+  char *etc = NULL;
+
+  #if defined (_WIN)
+  etc = _ctime64 (t);
+
+  if (etc != NULL)
+  {
+    snprintf (buf, buf_size, "%s", etc);
+  }
+  #else
+  etc = ctime_r (t, buf); // buf should have room for at least 26 bytes
+  #endif
+
+  return etc;
+}


### PR DESCRIPTION
There was a recent bug report on the hashcat forum (https://hashcat.net/forum/thread-6774.html) that made me wonder if there is some kind of upper limit of the date displayed...

and indeed there was a fixed value
```
if (sec_etc > 100000000)
```
(this value converted from seconds to years is about 3 years).

This pull request tries to fix this hardcoded value with calls of the overflow_check_u64_add () function.
Furthermore, I've refactored some code into a new function called status_get_sec_etc ().

This commit also introduces a new hashcat specific type called hc_time_t and some time-specific function which use this new type (the idea is to convert all time_t into hc_time_t soon).
Thanks