### PR TITLE
replace all time_t/__time64_t with hc_time_t and all related functions

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -34,6 +34,12 @@
 - OpenCL Runtime: Updated AMD ROCm driver version check, warn if version < 1.1
 - WPA cracking: Improved nonce-error-corrections mode to use a both positive and negative corrections
 
+##
+## Technical
+##
+
+- Time: added new type for time measurements hc_time_t and related functions to force the use of 64 bit times
+
 * changes v3.5.0 -> v3.6.0:
 
 ##

--- a/include/shared.h
+++ b/include/shared.h
@@ -62,8 +62,8 @@ void hc_string_trim_leading (char *s);
 size_t hc_fread (void *ptr, size_t size, size_t nmemb, FILE *stream);
 void   hc_fwrite (const void *ptr, size_t size, size_t nmemb, FILE *stream);
 
-void       hc_time   (hc_time_t *t);
-struct tm *hc_gmtime (hc_time_t *t);
-char      *hc_ctime  (hc_time_t *t, char *buf, MAYBE_UNUSED size_t buf_size);
+hc_time_t  hc_time   (hc_time_t *t);
+struct tm *hc_gmtime (const hc_time_t *t, MAYBE_UNUSED struct tm *result);
+char      *hc_ctime  (const hc_time_t *t, char *buf, MAYBE_UNUSED const size_t buf_size);
 
 #endif // _SHARED_H

--- a/include/terminal.h
+++ b/include/terminal.h
@@ -22,7 +22,7 @@
 #endif // _WIN
 
 void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag);
-void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const time_t proc_stop);
+void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const hc_time_t proc_start, const hc_time_t proc_stop);
 
 int setup_console (void);
 

--- a/include/types.h
+++ b/include/types.h
@@ -760,9 +760,9 @@ typedef struct hash
 
 typedef struct outfile_data
 {
-  char   *file_name;
-  off_t   seek;
-  time_t ctime;
+  char      *file_name;
+  off_t      seek;
+  hc_time_t  ctime;
 
 } outfile_data_t;
 
@@ -889,8 +889,8 @@ typedef struct bs_word
 
 typedef struct cpt
 {
-  u32    cracked;
-  time_t timestamp;
+  u32       cracked;
+  hc_time_t timestamp;
 
 } cpt_t;
 
@@ -1694,10 +1694,10 @@ typedef struct cpt_ctx
 {
   bool enabled;
 
-  cpt_t  *cpt_buf;
-  int     cpt_pos;
-  time_t  cpt_start;
-  u64     cpt_total;
+  cpt_t     *cpt_buf;
+  int        cpt_pos;
+  hc_time_t  cpt_start;
+  u64        cpt_total;
 
 } cpt_ctx_t;
 
@@ -1839,8 +1839,8 @@ typedef struct status_ctx
    * timer
    */
 
-  time_t  runtime_start;
-  time_t  runtime_stop;
+  hc_time_t runtime_start;
+  hc_time_t runtime_stop;
 
   hc_timer_t timer_running;     // timer on current dict
   hc_timer_t timer_paused;      // timer on current dict
@@ -1880,7 +1880,7 @@ typedef struct cache_generate
   u64 cnt;
   u64 cnt2;
 
-  time_t runtime;
+  hc_time_t runtime;
 
 } cache_generate_t;
 

--- a/src/cpt.c
+++ b/src/cpt.c
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "memory.h"
 #include "cpt.h"
+#include "shared.h"
 
 int cpt_ctx_init (hashcat_ctx_t *hashcat_ctx)
 {
@@ -28,7 +29,7 @@ int cpt_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
   cpt_ctx->cpt_total = 0;
   cpt_ctx->cpt_pos   = 0;
-  cpt_ctx->cpt_start = time (NULL);
+  cpt_ctx->cpt_start = hc_time (NULL);
 
   return 0;
 }
@@ -54,5 +55,5 @@ void cpt_ctx_reset (hashcat_ctx_t *hashcat_ctx)
 
   cpt_ctx->cpt_total = 0;
   cpt_ctx->cpt_pos   = 0;
-  cpt_ctx->cpt_start = time (NULL);
+  cpt_ctx->cpt_start = hc_time (NULL);
 }

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -210,9 +210,9 @@ static int inner2_loop (hashcat_ctx_t *hashcat_ctx)
 
   hc_timer_set (&status_ctx->timer_running);
 
-  time_t runtime_start;
+  hc_time_t runtime_start;
 
-  time (&runtime_start);
+  hc_time (&runtime_start);
 
   status_ctx->runtime_start = runtime_start;
 
@@ -266,9 +266,9 @@ static int inner2_loop (hashcat_ctx_t *hashcat_ctx)
 
   // update some timer
 
-  time_t runtime_stop;
+  hc_time_t runtime_stop;
 
-  time (&runtime_stop);
+  hc_time (&runtime_stop);
 
   status_ctx->runtime_stop = runtime_stop;
 
@@ -1132,7 +1132,7 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
 
   // start logfile entry
 
-  const time_t proc_start = time (NULL);
+  const hc_time_t proc_start = hc_time (NULL);
 
   logfile_generate_topid (hashcat_ctx);
 
@@ -1203,7 +1203,7 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
 
   // final logfile entry
 
-  const time_t proc_stop = time (NULL);
+  const hc_time_t proc_stop = hc_time (NULL);
 
   logfile_top_uint (proc_start);
   logfile_top_uint (proc_stop);

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -388,7 +388,7 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, 
     {
       hc_thread_mutex_lock (status_ctx->mux_display);
 
-      cpt_ctx->cpt_buf[cpt_ctx->cpt_pos].timestamp = time (NULL);
+      cpt_ctx->cpt_buf[cpt_ctx->cpt_pos].timestamp = hc_time (NULL);
       cpt_ctx->cpt_buf[cpt_ctx->cpt_pos].cracked   = cpt_cracked;
 
       cpt_ctx->cpt_pos++;
@@ -911,8 +911,8 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
       char *line_buf = (char *) hcmalloc (HCBUFSIZ_LARGE);
 
-      time_t prev = 0;
-      time_t now  = 0;
+      hc_time_t prev = 0;
+      hc_time_t now  = 0;
 
       while (!feof (fp))
       {
@@ -1072,11 +1072,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
           hashes_cnt++;
         }
 
-        time (&now);
+        hc_time (&now);
 
         if ((now - prev) == 0) continue;
 
-        time (&prev);
+        hc_time (&prev);
 
         hashlist_parse_t hashlist_parse;
 

--- a/src/induct.c
+++ b/src/induct.c
@@ -68,7 +68,7 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
       {
         char *root_directory_mv;
 
-        hc_asprintf (&root_directory_mv, "%s/%s.induct.%d", folder_config->session_dir, user_options->session, (int) time (NULL));
+        hc_asprintf (&root_directory_mv, "%s/%s.induct.%d", folder_config->session_dir, user_options->session, (int) hc_time (NULL));
 
         if (rename (root_directory, root_directory_mv) != 0)
         {

--- a/src/loopback.c
+++ b/src/loopback.c
@@ -96,9 +96,9 @@ int loopback_write_open (hashcat_ctx_t *hashcat_ctx)
 
   if (induct_ctx->enabled == false) return 0;
 
-  time_t now;
+  hc_time_t now;
 
-  time (&now);
+  hc_time (&now);
 
   const u32 random_num = get_random_num (0, 9999);
 

--- a/src/main.c
+++ b/src/main.c
@@ -786,21 +786,12 @@ static void main_wordlist_cache_generate (MAYBE_UNUSED hashcat_ctx_t *hashcat_ct
   {
     char *runtime = (char *) malloc (HCBUFSIZ_TINY);
 
-    #if defined (_WIN)
-    __time64_t runtime_sec = cache_generate->runtime;
-    #else
-    time_t runtime_sec = cache_generate->runtime;
-    #endif
+    const hc_time_t runtime_sec = cache_generate->runtime;
 
     struct tm *tmp;
+    struct tm  tm;
 
-    #if defined (_WIN)
-    tmp = _gmtime64 (&runtime_sec);
-    #else
-    struct tm tm;
-
-    tmp = gmtime_r (&runtime_sec, &tm);
-    #endif
+    tmp = hc_gmtime (&runtime_sec, &tm);
 
     format_timer_display (tmp, runtime, HCBUFSIZ_TINY);
 
@@ -969,7 +960,7 @@ int main (int argc, char **argv)
 
   setup_console ();
 
-  const time_t proc_start = time (NULL);
+  const hc_time_t proc_start = hc_time (NULL);
 
   // hashcat main context
 
@@ -1060,7 +1051,7 @@ int main (int argc, char **argv)
 
   // finished with hashcat, clean up
 
-  const time_t proc_stop = time (NULL);
+  const hc_time_t proc_stop = hc_time (NULL);
 
   goodbye_screen (hashcat_ctx, proc_start, proc_stop);
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -30,9 +30,9 @@ int get_runtime_left (const hashcat_ctx_t *hashcat_ctx)
     msec_paused += msec_paused_tmp;
   }
 
-  time_t runtime_cur;
+  hc_time_t runtime_cur;
 
-  time (&runtime_cur);
+  hc_time (&runtime_cur);
 
   const int runtime_left = (int) (status_ctx->runtime_start
                                 + user_options->runtime
@@ -116,9 +116,9 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
 
   // timer
 
-  time_t last_temp_check_time;
+  hc_time_t last_temp_check_time;
 
-  time (&last_temp_check_time);
+  hc_time (&last_temp_check_time);
 
   u32 slowdown_warnings    = 0;
   u32 performance_warnings = 0;
@@ -168,9 +168,9 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
     {
       hc_thread_mutex_lock (status_ctx->mux_hwmon);
 
-      time_t temp_check_time;
+      hc_time_t temp_check_time;
 
-      time (&temp_check_time);
+      hc_time (&temp_check_time);
 
       u32 Ta = temp_check_time - last_temp_check_time; // set Ta = sleep_time; is not good enough (see --remove etc)
 

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -51,7 +51,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
   char **out_files = NULL;
 
-  time_t folder_mtime = 0;
+  hc_time_t folder_mtime = 0;
 
   int out_cnt = 0;
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -357,9 +357,9 @@ void setup_seeding (const bool rp_gen_seed_chgd, const u32 rp_gen_seed)
   }
   else
   {
-    time_t ts;
+    hc_time_t ts;
 
-    time (&ts);
+    hc_time (&ts);
 
     srand (ts);
   }
@@ -443,25 +443,25 @@ void hc_fwrite (const void *ptr, size_t size, size_t nmemb, FILE *stream)
 }
 
 
-void hc_time (hc_time_t *t)
+hc_time_t hc_time (hc_time_t *t)
 {
   #if defined (_WIN)
-  _time64 (t);
+  return _time64 (t);
   #else
-  time (t);
+  return time (t);
   #endif
 }
 
-struct tm *hc_gmtime (hc_time_t *t)
+struct tm *hc_gmtime (const hc_time_t *t, MAYBE_UNUSED struct tm *result)
 {
   #if defined (_WIN)
   return _gmtime64 (t);
   #else
-  return gmtime (t);
+  return gmtime_r (t, result);
   #endif
 }
 
-char *hc_ctime (hc_time_t *t, char *buf, MAYBE_UNUSED size_t buf_size)
+char *hc_ctime (const hc_time_t *t, char *buf, MAYBE_UNUSED const size_t buf_size)
 {
   char *etc = NULL;
 

--- a/src/status.c
+++ b/src/status.c
@@ -938,11 +938,11 @@ char *status_get_time_started_absolute (const hashcat_ctx_t *hashcat_ctx)
 {
   const status_ctx_t *status_ctx = hashcat_ctx->status_ctx;
 
-  const time_t time_start = status_ctx->runtime_start;
+  const hc_time_t time_start = status_ctx->runtime_start;
 
   char buf[32] = { 0 };
 
-  char *start = ctime_r (&time_start, buf);
+  char *start = hc_ctime (&time_start, buf, 32);
 
   const size_t start_len = strlen (start);
 
@@ -956,27 +956,18 @@ char *status_get_time_started_relative (const hashcat_ctx_t *hashcat_ctx)
 {
   const status_ctx_t *status_ctx = hashcat_ctx->status_ctx;
 
-  time_t time_now;
+  hc_time_t time_now;
 
-  time (&time_now);
+  hc_time (&time_now);
 
-  const time_t time_start = status_ctx->runtime_start;
+  const hc_time_t time_start = status_ctx->runtime_start;
 
-  #if defined (_WIN)
-  __time64_t sec_run = time_now - time_start;
-  #else
-  time_t sec_run = time_now - time_start;
-  #endif
+  hc_time_t sec_run = time_now - time_start;
 
   struct tm *tmp;
+  struct tm  tm;
 
-  #if defined (_WIN)
-  tmp = _gmtime64 (&sec_run);
-  #else
-  struct tm tm;
-
-  tmp = gmtime_r (&sec_run, &tm);
-  #endif
+  tmp = hc_gmtime (&sec_run, &tm);
 
   char *display_run = (char *) malloc (HCBUFSIZ_TINY);
 
@@ -1058,7 +1049,10 @@ char *status_get_time_estimated_relative (const hashcat_ctx_t *hashcat_ctx)
 
   hc_time_t sec_etc = status_get_sec_etc (hashcat_ctx);
 
-  struct tm *tmp = hc_gmtime (&sec_etc);
+  struct tm *tmp;
+  struct tm  tm;
+
+  tmp = hc_gmtime (&sec_etc, &tm);
 
   if (tmp == NULL)
   {
@@ -1080,8 +1074,9 @@ char *status_get_time_estimated_relative (const hashcat_ctx_t *hashcat_ctx)
       hc_time_t sec_left = runtime_left;
 
       struct tm *tmp_left;
+      struct tm  tm_left;
 
-      tmp_left = hc_gmtime (&sec_left);
+      tmp_left = hc_gmtime (&sec_left, &tm_left);
 
       char *display_left = (char *) malloc (HCBUFSIZ_TINY);
 
@@ -1472,14 +1467,14 @@ int status_get_cpt_cur_min (const hashcat_ctx_t *hashcat_ctx)
 
   if (status_ctx->accessible == false) return 0;
 
-  const time_t now = time (NULL);
+  const hc_time_t now = hc_time (NULL);
 
   int cpt_cur_min = 0;
 
   for (int i = 0; i < CPT_CACHE; i++)
   {
-    const u32    cracked   = cpt_ctx->cpt_buf[i].cracked;
-    const time_t timestamp = cpt_ctx->cpt_buf[i].timestamp;
+    const u32       cracked   = cpt_ctx->cpt_buf[i].cracked;
+    const hc_time_t timestamp = cpt_ctx->cpt_buf[i].timestamp;
 
     if ((timestamp + 60) > now)
     {
@@ -1497,14 +1492,14 @@ int status_get_cpt_cur_hour (const hashcat_ctx_t *hashcat_ctx)
 
   if (status_ctx->accessible == false) return 0;
 
-  const time_t now = time (NULL);
+  const hc_time_t now = hc_time (NULL);
 
   int cpt_cur_hour = 0;
 
   for (int i = 0; i < CPT_CACHE; i++)
   {
-    const u32    cracked   = cpt_ctx->cpt_buf[i].cracked;
-    const time_t timestamp = cpt_ctx->cpt_buf[i].timestamp;
+    const u32       cracked   = cpt_ctx->cpt_buf[i].cracked;
+    const hc_time_t timestamp = cpt_ctx->cpt_buf[i].timestamp;
 
     if ((timestamp + 3600) > now)
     {
@@ -1522,14 +1517,14 @@ int status_get_cpt_cur_day (const hashcat_ctx_t *hashcat_ctx)
 
   if (status_ctx->accessible == false) return 0;
 
-  const time_t now = time (NULL);
+  const hc_time_t now = hc_time (NULL);
 
   int cpt_cur_day = 0;
 
   for (int i = 0; i < CPT_CACHE; i++)
   {
-    const u32    cracked   = cpt_ctx->cpt_buf[i].cracked;
-    const time_t timestamp = cpt_ctx->cpt_buf[i].timestamp;
+    const u32       cracked   = cpt_ctx->cpt_buf[i].cracked;
+    const hc_time_t timestamp = cpt_ctx->cpt_buf[i].timestamp;
 
     if ((timestamp + 86400) > now)
     {
@@ -1577,7 +1572,7 @@ char *status_get_cpt (const hashcat_ctx_t *hashcat_ctx)
 {
   const cpt_ctx_t *cpt_ctx = hashcat_ctx->cpt_ctx;
 
-  const time_t now = time (NULL);
+  const hc_time_t now = hc_time (NULL);
 
   char *cpt = (char *) malloc (HCBUFSIZ_TINY);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -76,7 +76,7 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
   }
 }
 
-void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const time_t proc_stop)
+void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const hc_time_t proc_start, const hc_time_t proc_stop)
 {
   const user_options_t *user_options = hashcat_ctx->user_options;
 
@@ -89,8 +89,8 @@ void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const 
   char start_buf[32]; memset (start_buf, 0, sizeof (start_buf));
   char stop_buf[32];  memset (start_buf, 0, sizeof (stop_buf));
 
-  event_log_info_nn (hashcat_ctx, "Started: %s", ctime_r (&proc_start, start_buf));
-  event_log_info_nn (hashcat_ctx, "Stopped: %s", ctime_r (&proc_stop,  stop_buf));
+  event_log_info_nn (hashcat_ctx, "Started: %s", hc_ctime (&proc_start, start_buf, 32));
+  event_log_info_nn (hashcat_ctx, "Stopped: %s", hc_ctime (&proc_stop,  stop_buf, 32));
 }
 
 int setup_console ()

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -355,12 +355,12 @@ int count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile, u64
     }
   }
 
-  time_t rt_start;
+  hc_time_t rt_start;
 
-  time (&rt_start);
+  hc_time (&rt_start);
 
-  time_t now  = 0;
-  time_t prev = 0;
+  hc_time_t now  = 0;
+  hc_time_t prev = 0;
 
   u64 comp = 0;
   u64 cnt  = 0;
@@ -444,11 +444,11 @@ int count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile, u64
       }
     }
 
-    time (&now);
+    hc_time (&now);
 
     if ((now - prev) == 0) continue;
 
-    time (&prev);
+    hc_time (&prev);
 
     double percent = ((double) comp / (double) d.stat.st_size) * 100;
 
@@ -466,9 +466,9 @@ int count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile, u64
     }
   }
 
-  time_t rt_stop;
+  hc_time_t rt_stop;
 
-  time (&rt_stop);
+  hc_time (&rt_stop);
 
   cache_generate_t cache_generate;
 


### PR DESCRIPTION
This commit replaces all instances of time_t or the 64-bit windows version of it (__time64_t) with the new hashcat-specific time format hc_time_t.

It also uses the new functions hc_time (), hc_ctime (), hc_gmtime ().

Thanks