### PR TITLE
fixes #1278: allow the '#' character within the username of DCC2 hashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -26,6 +26,7 @@
 - Fixed the version number used in the restore file header
 - Fixed the parsing of command line options. It doesn't show two times the same error about an invalid option anymore.
 - Fixed the estimated time value whenever the value is very large and overflows
+- Fixed the parsing of DCC2 hashes by allowing the "#" character within the user name
 
 ##
 ## Improvements

--- a/src/interface.c
+++ b/src/interface.c
@@ -3063,7 +3063,9 @@ int dcc2_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UNUSE
 
   salt_pos++;
 
-  u8 *digest_pos = (u8 *) strchr ((const char *) salt_pos, '#');
+  // search last '#' from the end since the username can consist of a '#' too
+
+  u8 *digest_pos = (u8 *) strrchr ((const char *) salt_pos, '#');
 
   if (digest_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 


### PR DESCRIPTION
By searching for the last "#" character within the hash instead of the next "#" character, we can allow also user names which do have this character.

The problem was that the parsing failed (with error message "Hash-encoding exception") whenever the user name consisted of the "#" char (see #1278).

Thanks