### PR TITLE
fixes #1313: keep/print the original salt for descrypt hashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -26,6 +26,7 @@
 - Fixed the version number used in the restore file header
 - Fixed the parsing of command line options. It doesn't show two times the same error about an invalid option anymore.
 - Fixed the estimated time value whenever the value is very large and overflows
+- Fixed the parsing of descrypt hashes if the hashes do have non-standard characters within the salt
 
 ##
 ## Improvements

--- a/src/interface.c
+++ b/src/interface.c
@@ -3784,7 +3784,13 @@ int descrypt_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_U
   salt->salt_buf[0] = itoa64_to_int (input_buf[0])
                     | itoa64_to_int (input_buf[1]) << 6;
 
-  salt->salt_len = 2;
+  // we need to add 2 additional bytes (the salt sign) such that the salt sorting algorithm
+  // doesn't eliminate salts that are identical but have different salt signs
+
+  salt->salt_buf[0] |= input_buf[0] << 16
+                    |  input_buf[1] << 24;
+
+  salt->salt_len = 4; // actually it is only 2 (but we need to add the original salt_sign to it)
 
   u8 tmp_buf[100] = { 0 };
 


### PR DESCRIPTION
As mentioned within the github issue #1313 if some descrypt hashes used non-standard character within the salt the conversion sometimes lead to removing some salts because they were seen as identical.

This commit adds the original salt to the salt buffer such that the salt-sorting-algorithm doesn't eliminate them anymore and hence the output doesn't look corrupted (it seemed like hashcat would somehow modify the hashes sometimes, as seen in the example of #1313)

Thx