### PR TITLE
fixes #1338: hexify also all password of format $HEX[]

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -26,6 +26,7 @@
 - Fixed an invalid progress value in status view if words from the base wordlist get rejected because of length
 - Fixed a parser error for mode -m 9820 = MS Office <= 2003 $3, SHA1 + RC4, collider #2
 - Fixed a problem with changed current working directory, for instance by using --restore together with --remove
+- Fixed a problem with the conversion to the $HEX[] format: convert/hexify also all passwords of the format $HEX[]
 - Fixed the calculation of device_name_chksum; should be done for each iteration
 - Fixed the estimated time value whenever the value is very large and overflows
 - Fixed the parsing of command line options. It doesn't show two times the same error about an invalid option anymore

--- a/src/convert.c
+++ b/src/convert.c
@@ -152,6 +152,19 @@ bool need_hexify (const u8 *buf, const int len, const char separator, bool alway
     }
   }
 
+  // also test if the password is of the format $HEX[]:
+
+  if (rc == false)
+  {
+    if ((len & 1) == 0)
+    {
+      if (is_hexify (buf, len))
+      {
+        rc = true;
+      }
+    }
+  }
+
   return rc;
 }
 


### PR DESCRIPTION
The problem as described in #1338 could be that in very rare situation whenever the raw password was indeed starting with $HEX[ and ending with ] (and in between has only hex chars 0-9a-fA-F, the length is a multiple of 2), hashcat didn't convert it to $HEX[244845585b       5d] (i.e. hexify ($pass) where $pass is "$HEX[...]").

This could lead to a misinterpretation of the string because hashcat (if the plain was loaded again) would decode it as $HEX[] even if it was a raw password (and contain the literal sequence of bytes "$HEX[" and "]" at the end).

I suggest that in such a situation (very rare) we need to hexify the password again to avoid any confusion.

The user can always turn this behaviour of by using --outfile-autohex-disable.

Thx