### PR TITLE
fixes show output of -m 9710, -m 9810 and -m 10410

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -33,6 +33,7 @@
 - Fixed the parsing of command line options. It doesn't show two times the same error about an invalid option anymore
 - Fixed the parsing of DCC2 hashes by allowing the "#" character within the user name
 - Fixed the parsing of descrypt hashes if the hashes do have non-standard characters within the salt
+- Fixed the output of --show when used together with the collider modes -m 9710, 9810 or 10410
 - Fixed the version number used in the restore file header
 
 ##

--- a/src/convert.c
+++ b/src/convert.c
@@ -97,6 +97,12 @@ bool is_hexify (const u8 *buf, const int len)
 {
   if (len < 6) return false; // $HEX[] = 6
 
+  // length of the hex string must be a multiple of 2
+  // and the length of "$HEX[]" is 6 (also an even length)
+  // Therefore the overall length must be an even number:
+
+  if ((len & 1) == 1) return false;
+
   if (buf[0]       != '$') return (false);
   if (buf[1]       != 'H') return (false);
   if (buf[2]       != 'E') return (false);
@@ -156,12 +162,9 @@ bool need_hexify (const u8 *buf, const int len, const char separator, bool alway
 
   if (rc == false)
   {
-    if ((len & 1) == 0)
+    if (is_hexify (buf, len))
     {
-      if (is_hexify (buf, len))
-      {
-        rc = true;
-      }
+      rc = true;
     }
   }
 


### PR DESCRIPTION
The problem that lead to this PR was first reported here: https://hashcat.net/forum/thread-6813.html : 

Whenever the user used --show together with -m 9710 (or 9810 or 10410) the output was not correct and therefore could not be loaded by -m 9720 (or 9820 or 10420 respecively).

This commit fixes the output of --show s.t. whenever a collider mode was used the output (the hash to be loaded with the next mode) is always in hex (but without the "$HEX[" prefix and "]" suffix).

Thank you