### PR TITLE
Fix overflow in mangle_dupechar_last function

### DIFF
--- a/OpenCL/inc_rp.cl
+++ b/OpenCL/inc_rp.cl
@@ -503,6 +503,7 @@ static int mangle_dupechar_last (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8
 {
   const int out_len = len + p0;
 
+  if (len     ==                0) return (len);
   if (out_len >= RP_PASSWORD_SIZE) return (len);
 
   const u8 c = buf[len - 1];

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -41,6 +41,7 @@
 - Fixed the output of --show when used together with the collider modes -m 9710, 9810 or 10410
 - Fixed the use of --veracrypt-pim option. It was completely ignored without showing an error
 - Fixed the version number used in the restore file header
+- Fixed overflow in mangle_dupechar_last function
 
 ##
 ## Improvements

--- a/src/rp_kernel_on_cpu.c
+++ b/src/rp_kernel_on_cpu.c
@@ -528,6 +528,7 @@ static int mangle_dupechar_last (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8
 {
   const int out_len = len + p0;
 
+  if (len     ==                0) return (len);
   if (out_len >= RP_PASSWORD_SIZE) return (len);
 
   const u8 c = buf[len - 1];


### PR DESCRIPTION
The problematic line is here: https://github.com/hashcat/hashcat/blob/master/src/rp_kernel_on_cpu.c#L533
when `len` is zero (e.g. rule "]Z1" applied on "a").

To check set DEBUG to 2 and run:

```
$ cat /tmp/2
a

$ ./hashcat --stdout -r <(echo ]Z1) /tmp/2
=================================================================
==99299==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x70000052c42f at pc 0x00010bdcf1e9 bp 0x70000052bde0 sp 0x70000052bdd8
READ of size 1 at 0x70000052c42f thread T15
```