### PR TITLE
Change benchmark mode output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -438,8 +438,7 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     {
       char *hash_type = strhashtype (hashconfig->hash_mode); // not a bug
 
-      event_log_info (hashcat_ctx, "Hashtype: %s", hash_type);
-      event_log_info (hashcat_ctx, "Hashmode: %d", hashconfig->hash_mode);
+      event_log_info (hashcat_ctx, "Hashtype: %s, -m %d", hash_type, hashconfig->hash_mode);
       event_log_info (hashcat_ctx, NULL);
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -438,7 +438,7 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     {
       char *hash_type = strhashtype (hashconfig->hash_mode); // not a bug
 
-      event_log_info (hashcat_ctx, "Hashtype: %s, -m %d", hash_type, hashconfig->hash_mode);
+      event_log_info (hashcat_ctx, "%d - Hashtype: %s", hashconfig->hash_mode, hash_type);
       event_log_info (hashcat_ctx, NULL);
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -438,7 +438,7 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     {
       char *hash_type = strhashtype (hashconfig->hash_mode); // not a bug
 
-      event_log_info (hashcat_ctx, "%d - Hashtype: %s", hashconfig->hash_mode, hash_type);
+      event_log_info (hashcat_ctx, "Hashtype: %d - %s", hashconfig->hash_mode, hash_type);
       event_log_info (hashcat_ctx, NULL);
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -438,7 +438,7 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     {
       char *hash_type = strhashtype (hashconfig->hash_mode); // not a bug
 
-      event_log_info (hashcat_ctx, "Hashtype: %d - %s", hashconfig->hash_mode, hash_type);
+      event_log_info (hashcat_ctx, "Hashmode: %d - %s", hashconfig->hash_mode, hash_type);
       event_log_info (hashcat_ctx, NULL);
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -439,6 +439,7 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
       char *hash_type = strhashtype (hashconfig->hash_mode); // not a bug
 
       event_log_info (hashcat_ctx, "Hashtype: %s", hash_type);
+      event_log_info (hashcat_ctx, "Hashmode: %d", hashconfig->hash_mode);
       event_log_info (hashcat_ctx, NULL);
     }
   }
@@ -527,9 +528,6 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
 
   event_log_info (hashcat_ctx, NULL);
 
-  #if defined (DEBUG)
-  if (user_options->benchmark == true) event_log_info (hashcat_ctx, "Hashmode: %d", hashconfig->hash_mode);
-  #endif
 }
 
 static void main_opencl_session_pre (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const void *buf, MAYBE_UNUSED const size_t len)


### PR DESCRIPTION
Changed the output for benchmark mode to include the hashmode version number along with the name. Mode number was available with DEBUG = 1 already but I've removed that requirement and reformatted the output to include the mode number in the 'Hashmode:' line before the name of the algorithm.