### PR TITLE
Use stat64 for all platforms except cygwin.

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -75,10 +75,10 @@ typedef pthread_mutex_t   hc_thread_mutex_t;
 
 // stat
 
-#if defined (_WIN)
-typedef struct _stat64 hc_stat_t;
+#if defined (__CYGWIN__)
+typedef struct stat   hc_stat_t;
 #else
-typedef struct stat hc_stat_t;
+typedef struct stat64 hc_stat_t;
 #endif
 
 // enums

--- a/src/shared.c
+++ b/src/shared.c
@@ -151,17 +151,7 @@ void hc_asprintf (char **strp, const char *fmt, ...)
   va_end (args);
 }
 
-#if defined (_WIN)
-int hc_stat (const char *pathname, hc_stat_t *buf)
-{
-  return stat64 (pathname, buf);
-}
-
-int hc_fstat (int fd, hc_stat_t *buf)
-{
-  return fstat64 (fd, buf);
-}
-#else
+#if defined (__CYGWIN__)
 int hc_stat (const char *pathname, hc_stat_t *buf)
 {
   return stat (pathname, buf);
@@ -170,6 +160,16 @@ int hc_stat (const char *pathname, hc_stat_t *buf)
 int hc_fstat (int fd, hc_stat_t *buf)
 {
   return fstat (fd, buf);
+}
+#else
+int hc_stat (const char *pathname, hc_stat_t *buf)
+{
+  return stat64 (pathname, buf);
+}
+
+int hc_fstat (int fd, hc_stat_t *buf)
+{
+  return fstat64 (fd, buf);
 }
 #endif
 


### PR DESCRIPTION
MinGW as well as the other major platforms support using stat64 directly. Not cygwin though.

Tested on Cygwin, Linux, and MinGW. No idea about FreeBSD or OS X. A quick google search shows that they work.