### PR TITLE
fixed problem with cached word lists (dictstat2): nanoseconds must be considered/ignored too

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -35,6 +35,7 @@
 - Fixed a parser error in multiple modes not checking for return code, resulting in negative memory index writes
 - Fixed a problem with changed current working directory, for instance by using --restore together with --remove
 - Fixed a problem with the conversion to the $HEX[] format: convert/hexify also all passwords of the format $HEX[]
+- Fixed the dictstat lookup if nanoseconds are used in timestamps for the cached files
 - Fixed the calculation of device_name_chksum; should be done for each iteration
 - Fixed the estimated time value whenever the value is very large and overflows
 - Fixed the parsing of command line options. It doesn't show two times the same error about an invalid option anymore

--- a/include/common.h
+++ b/include/common.h
@@ -75,6 +75,20 @@ but this is nededed for VS compiler which doesn't have inline keyword but has __
 
 #define MAYBE_UNUSED __attribute__((unused))
 
+/* Check if we also need to use/set the nanoseconds for the file stats:
+The linux manual says that the only valid way to check for nanosecond resolution is to follow this rule:
+"The nanosecond components of each timestamp are available via names of the form st_atim.tv_nsec
+if the _BSD_SOURCE or _SVID_SOURCE feature test macro is defined"
+*/
+
+#if defined (_BSD_SOURCE)
+#define WITH_NANOSECONDS_IN_STAT 1
+#endif
+
+#if defined (_SVID_SOURCE)
+#define WITH_NANOSECONDS_IN_STAT 1
+#endif
+
 // config section
 // do not try to simply change this, it will not work
 

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -19,6 +19,10 @@ int sort_by_dictstat (const void *s1, const void *s2)
 
   d2->stat.st_atime = d1->stat.st_atime;
 
+  #if defined (WITH_NANOSECONDS_IN_STAT)
+  d2->stat.st_atim.tv_nsec = d1->stat.st_atim.tv_nsec;
+  #endif
+
   const int rc_from = strcmp (d1->encoding_from, d2->encoding_from);
 
   if (rc_from != 0) return rc_from;

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -293,6 +293,10 @@ int count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile, u64
   d.stat.st_rdev    = 0;
   d.stat.st_atime   = 0;
 
+  #if defined (WITH_NANOSECONDS_IN_STAT)
+  d.stat.st_atim.tv_nsec = 0;
+  #endif
+
   #if defined (_POSIX)
   d.stat.st_blksize = 0;
   d.stat.st_blocks  = 0;


### PR DESCRIPTION
I tried to reproduce the problem mentioned here: https://github.com/hashcat/hashcat/issues/1356#issuecomment-330819324 a while ago and saw that the dictstat/dictstat2 files contain some "random" (not cleared) bytes.
After digging a little bit, I discovered that the dictstat only cleared the atim.tv_sec (the seconds), but it didn't clear the full access time (including the atim.tv_nsec)...
Therefore the bytes I saw where actually the nanoseconds that made it into the dictstat file (even if the whole access time should be ignored for good reasons).

Also have a look at this: "man 2 stat"  (http://man7.org/linux/man-pages/man2/stat.2.html) where it says that for compatability reasons there is a mapping like this: #define st_atime st_atim.tv_sec
This means, that whenever we set st_atime, we only set the seconds (but the nanoseconds remain untouched).

Furthermore, the manual says that the only way to check for nanoseconds time resolution in the stat struct is to use the macros  _BSD_SOURCE  or  _SVID_SOURCE. Therefore my suggestion is to use this rule to test for nanoseconds and if nanoseconds resolution was detected we should set/ignore the nanoseconds too (this is exactly what this patch tries to do).

Thank you very much