### PR TITLE
fixed the nanosecond access time problem, also working on macos now

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -75,18 +75,21 @@ but this is nededed for VS compiler which doesn't have inline keyword but has __
 
 #define MAYBE_UNUSED __attribute__((unused))
 
-/* Check if we also need to use/set the nanoseconds for the file stats:
-The linux manual says that the only valid way to check for nanosecond resolution is to follow this rule:
-"The nanosecond components of each timestamp are available via names of the form st_atim.tv_nsec
-if the _BSD_SOURCE or _SVID_SOURCE feature test macro is defined"
-*/
+/*
+ * Check if the system uses nanoseconds for file timestamps.
+ * In case the system uses nanoseconds we set some custom macros here,
+ * e.g. the (nanosecond) access time macros for dictstat
+ */
 
-#if defined (_BSD_SOURCE)
-#define WITH_NANOSECONDS_IN_STAT 1
+#if defined (__linux__)
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,5,48)
+#define STAT_NANOSECONDS_ACCESS_TIME st_atim.tv_nsec
+#endif
 #endif
 
-#if defined (_SVID_SOURCE)
-#define WITH_NANOSECONDS_IN_STAT 1
+#if defined (__APPLE__)
+#define STAT_NANOSECONDS_ACCESS_TIME st_atimespec.tv_nsec
 #endif
 
 // config section

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -19,8 +19,8 @@ int sort_by_dictstat (const void *s1, const void *s2)
 
   d2->stat.st_atime = d1->stat.st_atime;
 
-  #if defined (WITH_NANOSECONDS_IN_STAT)
-  d2->stat.st_atim.tv_nsec = d1->stat.st_atim.tv_nsec;
+  #if defined (STAT_NANOSECONDS_ACCESS_TIME)
+  d2->stat.STAT_NANOSECONDS_ACCESS_TIME = d1->stat.STAT_NANOSECONDS_ACCESS_TIME;
   #endif
 
   const int rc_from = strcmp (d1->encoding_from, d2->encoding_from);

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -293,8 +293,8 @@ int count_words (hashcat_ctx_t *hashcat_ctx, FILE *fd, const char *dictfile, u64
   d.stat.st_rdev    = 0;
   d.stat.st_atime   = 0;
 
-  #if defined (WITH_NANOSECONDS_IN_STAT)
-  d.stat.st_atim.tv_nsec = 0;
+  #if defined (STAT_NANOSECONDS_ACCESS_TIME)
+  d.stat.STAT_NANOSECONDS_ACCESS_TIME = 0;
   #endif
 
   #if defined (_POSIX)


### PR DESCRIPTION
After testing the recently merged dictstat fix (https://github.com/hashcat/hashcat/pull/1378) on several system, I found out that it doesn't wok on all linux systems.
I came to the conclusion that testing for the _BSD_SOURCE or _SVID_SOURCE macros is not sufficient/reliable. For instance, here we can see: http://man7.org/linux/man-pages/man7/feature_test_macros.7.html, that _BSD_SOURCE is deprecated and shouldn't be used any longer.

I think the only reasonable fix is to switch to kernel version checks (the linux manual says that all kernels greater or equal to 2.5.48, see man 2 stat, use nanosecond time resolutions).

This patch was also tested on macos (where a slightly different timespec field is needed: st_atimespec.tv_nsec).

As mentioned, I've tested this fix now on several systems (including macos) and it seems to work correctly (yes, I even hexdumped the dicstat2 to be sure) on all tested systems.

Thank you very much