### PR TITLE
remove trusty matrix expansion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,5 @@ language: c
 compiler:
   - clang
   - gcc
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      compiler: gcc
-    - os: linux
-      dist: trusty
-      compiler: clang
 script:
   - make


### PR DESCRIPTION
trusty is now the travis `linux` default