### PR TITLE
show/left: improved the performance by using a tree and linked node structure

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -67,6 +67,7 @@
 - Startup: Show some attack-specific optimizer constraints on start, eg: minimum and maximum support password- and salt-length
 - Startup: Check and abort session if outfile and wordlist point to the same file
 - WPA cracking: Improved nonce-error-corrections mode to use a both positive and negative corrections
+- Show cracks: Improved the performance of --show/--left if used together with --username
 
 ##
 ## Technical

--- a/include/potfile.h
+++ b/include/potfile.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <errno.h>
+#include <search.h>
 
 #define INCR_POT 1000
 
@@ -23,7 +24,7 @@ void potfile_destroy          (hashcat_ctx_t *hashcat_ctx);
 int  potfile_handle_show      (hashcat_ctx_t *hashcat_ctx);
 int  potfile_handle_left      (hashcat_ctx_t *hashcat_ctx);
 
-void potfile_update_hash      (hashcat_ctx_t *hashcat_ctx, hash_t *found, char *line_pw_buf, int line_pw_len);
-void potfile_update_hashes    (hashcat_ctx_t *hashcat_ctx, hash_t *found, hash_t *hashes_buf, u32 hashes_cnt, int (*compar) (const void *, const void *, void *), char *line_pw_buf, int line_pw_len);
+void potfile_update_hash      (hashcat_ctx_t *hashcat_ctx, hash_t *found,  char *line_pw_buf, int line_pw_len);
+void potfile_update_hashes    (hashcat_ctx_t *hashcat_ctx, hash_t *search, char *line_pw_buf, int line_pw_len, pot_tree_entry_t *tree);
 
 #endif // _POTFILE_H

--- a/include/types.h
+++ b/include/types.h
@@ -1335,6 +1335,39 @@ typedef struct potfile_ctx
 
 } potfile_ctx_t;
 
+// this is a linked list structure of all the hashes with the same "key" (hash or hash + salt)
+
+typedef struct pot_hash_node
+{
+  hash_t *hash_buf;
+
+  struct pot_hash_node *next;
+
+} pot_hash_node_t;
+
+// Attention: this is only used when --show and --username are used together
+// there could be multiple entries for each identical hash+salt combination
+// (e.g. same hashes, but different user names... we want to print all of them!)
+// that is why we use a linked list here
+
+typedef struct pot_tree_entry
+{
+  hash_t *key;
+
+  // the hashconfig is required to distinguish between salted and non-salted hashes and to make sure
+  // we compare the correct dgst_pos0...dgst_pos3
+  hashconfig_t *hashconfig;
+
+  pot_hash_node_t *nodes; // linked list
+
+  // the following field is just an extra optimization for this structure:
+
+  pot_hash_node_t *last_node; // this is just one special node (the last one) within the root node called "nodes"
+
+  // the extra field "last_node" makes it possible to insert new nodes even faster
+
+} pot_tree_entry_t;
+
 typedef struct restore_data
 {
   int  version;


### PR DESCRIPTION
This new combination of 2 alternative structures (binary tree + linked list) and the use of tsearch () / tfind () should make the speed of --show/--left much faster.

Thanks