### PR TITLE
show/left: improve speed of --show/--left again by using a single malloc/free

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -1352,9 +1352,7 @@ typedef struct pot_hash_node
 
 typedef struct pot_tree_entry
 {
-  hash_t *key;
-
-  pot_hash_node_t *nodes; // head of the linked list
+  pot_hash_node_t *nodes; // head of the linked list (under the field "hash_buf" it contains the sorting keys)
 
   // the hashconfig is required to distinguish between salted and non-salted hashes and to make sure
   // we compare the correct dgst_pos0...dgst_pos3


### PR DESCRIPTION
This additional change to the tree+linked list improvement for --show/--left makes sure that we reduce the number of mallocs/frees even more (it allocates all the memory needed at the very beginning and frees all of it at the very end).

Furthermore, I use a little extra hack/trick here to reduce some memory usage. Since the linked list nodes contain the "key" information (salt+hash), we do not need to store them separately. We just need to look at the first node's hash_buf field. (this will reduce the memory needed by 8 bytes per hash, in addition to the previous 8 byte improvement).

Thanks