### PR TITLE
Replace PRIu64 with ju. Less verbose.

### DIFF
--- a/include/logfile.h
+++ b/include/logfile.h
@@ -16,8 +16,8 @@
 
 #define logfile_top_msg(msg)                               logfile_append (hashcat_ctx, "%s\t%s",                  logfile_ctx->topid,                     (msg));
 #define logfile_sub_msg(msg)                               logfile_append (hashcat_ctx, "%s\t%s\t%s",              logfile_ctx->topid, logfile_ctx->subid, (msg));
-#define logfile_top_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%" PRIu64 "",     logfile_ctx->topid,                     (var), (u64)   (val));
-#define logfile_sub_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%s\t%" PRIu64 "", logfile_ctx->topid, logfile_ctx->subid, (var), (u64)   (val));
+#define logfile_top_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%ju",     logfile_ctx->topid,                     (var), (u64)   (val));
+#define logfile_sub_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%s\t%ju", logfile_ctx->topid, logfile_ctx->subid, (var), (u64)   (val));
 #define logfile_top_var_uint(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%u",              logfile_ctx->topid,                     (var), (u32)   (val));
 #define logfile_sub_var_uint(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%s\t%u",          logfile_ctx->topid, logfile_ctx->subid, (var), (u32)   (val));
 #define logfile_top_var_char(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%c",              logfile_ctx->topid,                     (var), (char)  (val));

--- a/src/main.c
+++ b/src/main.c
@@ -344,7 +344,7 @@ static void main_calculated_words_base (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx,
 
   if (user_options->keyspace == false) return;
 
-  event_log_info (hashcat_ctx, "%" PRIu64 "", status_ctx->words_base);
+  event_log_info (hashcat_ctx, "%ju", status_ctx->words_base);
 }
 
 static void main_potfile_remove_parse_pre (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const void *buf, MAYBE_UNUSED const size_t len)
@@ -775,9 +775,9 @@ static void main_wordlist_cache_hit (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MA
 
   event_log_info (hashcat_ctx, "Dictionary cache hit:");
   event_log_info (hashcat_ctx, "* Filename..: %s", cache_hit->dictfile);
-  event_log_info (hashcat_ctx, "* Passwords.: %" PRIu64, cache_hit->cached_cnt);
-  event_log_info (hashcat_ctx, "* Bytes.....: %" PRId64, cache_hit->stat.st_size);
-  event_log_info (hashcat_ctx, "* Keyspace..: %" PRIu64, cache_hit->keyspace);
+  event_log_info (hashcat_ctx, "* Passwords.: %ju", cache_hit->cached_cnt);
+  event_log_info (hashcat_ctx, "* Bytes.....: %ju", cache_hit->stat.st_size);
+  event_log_info (hashcat_ctx, "* Keyspace..: %ju", cache_hit->keyspace);
   event_log_info (hashcat_ctx, NULL);
 }
 
@@ -791,7 +791,7 @@ static void main_wordlist_cache_generate (MAYBE_UNUSED hashcat_ctx_t *hashcat_ct
 
   if (cache_generate->percent < 100)
   {
-    event_log_info_nn (hashcat_ctx, "Dictionary cache building %s: %" PRIu64 " bytes (%.2f%%)", cache_generate->dictfile, cache_generate->comp, cache_generate->percent);
+    event_log_info_nn (hashcat_ctx, "Dictionary cache building %s: %ju bytes (%.2f%%)", cache_generate->dictfile, cache_generate->comp, cache_generate->percent);
   }
   else
   {
@@ -808,9 +808,9 @@ static void main_wordlist_cache_generate (MAYBE_UNUSED hashcat_ctx_t *hashcat_ct
 
     event_log_info (hashcat_ctx, "Dictionary cache built:");
     event_log_info (hashcat_ctx, "* Filename..: %s", cache_generate->dictfile);
-    event_log_info (hashcat_ctx, "* Passwords.: %" PRIu64, cache_generate->cnt2);
-    event_log_info (hashcat_ctx, "* Bytes.....: %" PRId64, cache_generate->comp);
-    event_log_info (hashcat_ctx, "* Keyspace..: %" PRIu64, cache_generate->cnt);
+    event_log_info (hashcat_ctx, "* Passwords.: %ju", cache_generate->cnt2);
+    event_log_info (hashcat_ctx, "* Bytes.....: %ju", cache_generate->comp);
+    event_log_info (hashcat_ctx, "* Keyspace..: %ju", cache_generate->cnt);
     event_log_info (hashcat_ctx, "* Runtime...: %s", runtime);
     event_log_info (hashcat_ctx, NULL);
 

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -4453,7 +4453,7 @@ int opencl_session_begin (hashcat_ctx_t *hashcat_ctx)
         }
         else if ((opencl_ctx->force_jit_compilation == 8900) || (opencl_ctx->force_jit_compilation == 15700))
         {
-          hc_asprintf (&build_opts_update,"%s -DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%u -DSCRYPT_TMP_ELEM=%" PRIu64, build_opts, hashes->salts_buf[0].scrypt_N, hashes->salts_buf[0].scrypt_r, hashes->salts_buf[0].scrypt_p, 1u << scrypt_tmto_final, (u64) scrypt_tmp_size / 16);
+          hc_asprintf (&build_opts_update,"%s -DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%u -DSCRYPT_TMP_ELEM=%ju", build_opts, hashes->salts_buf[0].scrypt_N, hashes->salts_buf[0].scrypt_r, hashes->salts_buf[0].scrypt_p, 1u << scrypt_tmto_final, (u64) scrypt_tmp_size / 16);
         }
         else
         {

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -491,7 +491,7 @@ int outfile_write (hashcat_ctx_t *hashcat_ctx, const char *out_buf, const unsign
 
   if (outfile_ctx->outfile_format & OUTFILE_FMT_CRACKPOS)
   {
-    tmp_len += snprintf (tmp_buf + tmp_len, HCBUFSIZ_LARGE - tmp_len, "%" PRIu64, crackpos);
+    tmp_len += snprintf (tmp_buf + tmp_len, HCBUFSIZ_LARGE - tmp_len, "%ju", crackpos);
   }
 
   tmp_buf[tmp_len] = 0;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -666,7 +666,7 @@ void opencl_info (hashcat_ctx_t *hashcat_ctx)
       event_log_info (hashcat_ctx, "    Version        : %s", device_version);
       event_log_info (hashcat_ctx, "    Processor(s)   : %u", device_processors);
       event_log_info (hashcat_ctx, "    Clock          : %u", device_maxclock_frequency);
-      event_log_info (hashcat_ctx, "    Memory         : %" PRIu64 "/%" PRIu64 " MB allocatable", device_maxmem_alloc / 1024 / 1024, device_global_mem / 1024 / 1024);
+      event_log_info (hashcat_ctx, "    Memory         : %ju/%ju MB allocatable", device_maxmem_alloc / 1024 / 1024, device_global_mem / 1024 / 1024);
       event_log_info (hashcat_ctx, "    OpenCL Version : %s", device_opencl_version);
       event_log_info (hashcat_ctx, "    Driver Version : %s", driver_version);
       event_log_info (hashcat_ctx, NULL);
@@ -724,7 +724,7 @@ void opencl_info_compact (hashcat_ctx_t *hashcat_ctx)
 
       if (device_param->skipped == false)
       {
-        event_log_info (hashcat_ctx, "* Device #%u: %s, %" PRIu64 "/%" PRIu64 " MB allocatable, %uMCU",
+        event_log_info (hashcat_ctx, "* Device #%u: %s, %ju/%ju MB allocatable, %uMCU",
                   devices_idx + 1,
                   device_name,
                   device_maxmem_alloc / 1024 / 1024,
@@ -768,7 +768,7 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
 
     if (device_info->skipped_dev == true) continue;
 
-    printf ("%" PRIu64 "\t", (u64) (device_info->hashes_msec_dev * 1000));
+    printf ("%ju\t", (u64) (device_info->hashes_msec_dev * 1000));
 
     // that 1\t is for backward compatibility
     printf ("1000\t");
@@ -785,9 +785,9 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
     printf ("%f\t", device_info->exec_msec_dev);
   }
 
-  printf ("CURKU\t%" PRIu64 "\t", hashcat_status->restore_point);
+  printf ("CURKU\t%ju\t", hashcat_status->restore_point);
 
-  printf ("PROGRESS\t%" PRIu64 "\t%" PRIu64 "\t", hashcat_status->progress_cur_relative_skip, hashcat_status->progress_end_relative_skip);
+  printf ("PROGRESS\t%ju\t%ju\t", hashcat_status->progress_cur_relative_skip, hashcat_status->progress_end_relative_skip);
 
   printf ("RECHASH\t%d\t%d\t", hashcat_status->digests_done, hashcat_status->digests_cnt);
 
@@ -811,7 +811,7 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
-  printf ("REJECTED\t%" PRIu64 "\t", hashcat_status->progress_rejected);
+  printf ("REJECTED\t%ju\t", hashcat_status->progress_rejected);
 
   hc_fwrite (EOL, strlen (EOL), 1, stdout);
 
@@ -1200,19 +1200,19 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     case PROGRESS_MODE_KEYSPACE_KNOWN:
 
       event_log_info (hashcat_ctx,
-        "Progress.........: %" PRIu64 "/%" PRIu64 " (%.02f%%)",
+        "Progress.........: %ju/%ju (%.02f%%)",
         hashcat_status->progress_cur_relative_skip,
         hashcat_status->progress_end_relative_skip,
         hashcat_status->progress_finished_percent);
 
       event_log_info (hashcat_ctx,
-        "Rejected.........: %" PRIu64 "/%" PRIu64 " (%.02f%%)",
+        "Rejected.........: %ju/%ju (%.02f%%)",
         hashcat_status->progress_rejected,
         hashcat_status->progress_cur_relative_skip,
         hashcat_status->progress_rejected_percent);
 
       event_log_info (hashcat_ctx,
-        "Restore.Point....: %" PRIu64 "/%" PRIu64 " (%.02f%%)",
+        "Restore.Point....: %ju/%ju (%.02f%%)",
         hashcat_status->restore_point,
         hashcat_status->restore_total,
         hashcat_status->restore_percent);
@@ -1222,15 +1222,15 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     case PROGRESS_MODE_KEYSPACE_UNKNOWN:
 
       event_log_info (hashcat_ctx,
-        "Progress.........: %" PRIu64,
+        "Progress.........: %ju",
         hashcat_status->progress_cur_relative_skip);
 
       event_log_info (hashcat_ctx,
-        "Rejected.........: %" PRIu64,
+        "Rejected.........: %ju",
         hashcat_status->progress_rejected);
 
       event_log_info (hashcat_ctx,
-        "Restore.Point....: %" PRIu64,
+        "Restore.Point....: %ju",
         hashcat_status->restore_point);
 
       break;
@@ -1293,7 +1293,7 @@ void status_benchmark_machine_readable (hashcat_ctx_t *hashcat_ctx)
 
     if (device_info->skipped_dev == true) continue;
 
-    event_log_info (hashcat_ctx, "%d:%u:%d:%d:%.2f:%" PRIu64, device_id + 1, hash_mode, device_info->corespeed_dev, device_info->memoryspeed_dev, device_info->exec_msec_dev, (u64) (device_info->hashes_msec_dev_benchmark * 1000));
+    event_log_info (hashcat_ctx, "%d:%u:%d:%d:%.2f:%ju", device_id + 1, hash_mode, device_info->corespeed_dev, device_info->memoryspeed_dev, device_info->exec_msec_dev, (u64) (device_info->hashes_msec_dev_benchmark * 1000));
   }
 
   status_status_destroy (hashcat_ctx, hashcat_status);
@@ -1366,7 +1366,7 @@ void status_speed_machine_readable (hashcat_ctx_t *hashcat_ctx)
 
     if (device_info->skipped_dev == true) continue;
 
-    event_log_info (hashcat_ctx, "%d:%" PRIu64, device_id + 1, (u64) (device_info->hashes_msec_dev_benchmark * 1000));
+    event_log_info (hashcat_ctx, "%d:%ju", device_id + 1, (u64) (device_info->hashes_msec_dev_benchmark * 1000));
   }
 
   status_status_destroy (hashcat_ctx, hashcat_status);


### PR DESCRIPTION
Tested with MinGW (the poster child for compiler issues). cppcheck will argue the format is wrong, (uint64_t vs. uintmax_t) but they're equivalent, even on 32-bit.