### PR TITLE
fixes #1403: fixed extraction of the version number for archives without .git dir

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -46,6 +46,7 @@
 - Fixed the parsing of descrypt hashes if the hashes do have non-standard characters within the salt
 - Fixed the use of --veracrypt-pim option. It was completely ignored without showing an error
 - Fixed the version number used in the restore file header
+- Fixed the version number extraction for github releases which do not including the .git directory
 
 ##
 ## Improvements

--- a/src/Makefile
+++ b/src/Makefile
@@ -122,8 +122,12 @@ WIN_ICONV_64             := /opt/win-iconv-64
 
 COMPTIME                := $(shell date +%s)
 
+# the following variable value will be automatically replaced by the "git archive" command
+# (which is automatically run for every github release)
+# the value will be something like this: "tag: vX.Y.Z, refs/pull/Y/head"
+
 VERSION_EXPORT          := $Format:%D$
-#VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+ || echo "$(VERSION_EXPORT)"|cut -d, -f2|$(SED) -r 's|.* (\w+/)?([^ ]+)|\2|')
+#VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+ || echo "$(VERSION_EXPORT)" | $(SED) 's/.*: v\([\.0-9]*\),.*/v\1/')
 VERSION_TAG             := 4.0.0-rc6
 
 ##


### PR DESCRIPTION
This commit fixes #1403. The main problem was that gsed or sed under apple does not support the extended regex option (-r).

Furthermore, the sed command didn't seem to extract the correct version number at all.

I've tested this patch under linux and a macOS system and both seem to generate the correct output now.

Thanks