### PR TITLE
Switch debug to -Og

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -180,10 +180,10 @@ CFLAGS                  += -O2
 LFLAGS                  += -s
 else
 ifeq ($(DEBUG),1)
-CFLAGS                  += -DDEBUG -g -ggdb
+CFLAGS                  += -DDEBUG -Og -ggdb
 else
 ifeq ($(DEBUG),2)
-CFLAGS                  += -DDEBUG -g -ggdb
+CFLAGS                  += -DDEBUG -Og -ggdb
 CFLAGS                  += -fsanitize=address -fno-omit-frame-pointer
 endif
 endif


### PR DESCRIPTION
Og provides a more realistic debugging experience compared to -g (which uses the highly inefficient O0)