### PR TITLE
fixes #1412: sed for VERSION_EXPORT fixed compilation problem

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -127,7 +127,7 @@ COMPTIME                := $(shell date +%s)
 # the value will be something like this: "tag: vX.Y.Z, refs/pull/Y/head"
 
 VERSION_EXPORT          := $Format:%D$
-VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+ || echo "$(VERSION_EXPORT)" | $(SED) 's/.*: v\([\.0-9]*\),.*/v\1/')
+VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+ || echo "$(VERSION_EXPORT)" | $(SED) 's/.*: v\([\.0-9]*\).*/v\1/')
 
 ##
 ## General compiler and linker options


### PR DESCRIPTION
This pull request fixes the compilation problem (that does not only affect mac, but all compilations that only use the source archive, without the .git directory) reported in #1412.

The explanation of the problem is https://github.com/hashcat/hashcat/issues/1412#issuecomment-340182983 and https://github.com/hashcat/hashcat/issues/1412#issuecomment-340184040

since the format of the VERSION_EXPORT changed, we can no longer search for the "," in the output and therefore the sed expression failed.
The new suggested expression does not look for a matching "," it only looks for ": " + version number (including dots)
The match stops after no more number+dots is found.

Therefore I think this more flexible expression should work in both cases (if we have "HEAD -> master, tag: v4.0.0" or also if we have something like " tag: v4.0.0, refs#0000/head")

Thanks