### PR TITLE
partially fix compile for musl

### DIFF
--- a/include/affinity.h
+++ b/include/affinity.h
@@ -11,9 +11,6 @@
 
 #if defined (_POSIX)
 #include <pthread.h>
-#if defined (__linux__)
-#include <sys/sysctl.h>
-#endif // __linux__
 #endif // _POSIX
 
 #if defined (__APPLE__)


### PR DESCRIPTION
last issue is that musl has no qsort_r. not sure how to fix that.