### PR TITLE
cosmetic: updated comment about VERSION_EXPORT

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -125,7 +125,7 @@ COMPTIME                := $(shell date +%s)
 
 # the following variable value will be automatically replaced by the "git archive" command
 # (which is automatically run for every github release)
-# the value will be something like this: "tag: vX.Y.Z, refs/pull/Y/head"
+# the value will be something like this: "tag: vX.Y.Z, refs/pull/K/head" or "HEAD -> master, tag: vX.Y.Z"
 
 VERSION_EXPORT          := $Format:%D$
 VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+ || echo "$(VERSION_EXPORT)" | $(SED) 's/.*: v\([\.0-9]*\).*/v\1/')


### PR DESCRIPTION
As @ilovezfs pointed out correctly here: https://github.com/hashcat/hashcat/pull/1413#commitcomment-25252447 , we forgot to update the comment about the different formats that the VERSION_EXPORT variable could hold. This small cosmetic fix makes sure that both formats that we saw so far are mentioned.

Thx
