### PR TITLE
fix #1435: --show/--left hash parsing fixed for hashes with long salts

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,3 +1,11 @@
+* changes v4.0.1 -> xxx:
+
+##
+## Bugs
+##
+
+- Fixed a hash parsing problem when using --show/--left together with hashes with long salts that require pure kernels
+
 * changes v4.0.0 -> v4.0.1:
 
 ##

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -329,6 +329,8 @@ void generate_source_kernel_filename (const u32 attack_exec, const u32 attack_ke
         snprintf (source_file, 255, "%s/OpenCL/m%05d_a1-optimized.cl", shared_dir, (int) kern_type);
       else if (attack_kern == ATTACK_KERN_BF)
         snprintf (source_file, 255, "%s/OpenCL/m%05d_a3-optimized.cl", shared_dir, (int) kern_type);
+      else if (attack_kern == ATTACK_KERN_NONE)
+        snprintf (source_file, 255, "%s/OpenCL/m%05d_a0-optimized.cl", shared_dir, (int) kern_type);
     }
     else
     {
@@ -345,6 +347,8 @@ void generate_source_kernel_filename (const u32 attack_exec, const u32 attack_ke
         snprintf (source_file, 255, "%s/OpenCL/m%05d_a1.cl", shared_dir, (int) kern_type);
       else if (attack_kern == ATTACK_KERN_BF)
         snprintf (source_file, 255, "%s/OpenCL/m%05d_a3.cl", shared_dir, (int) kern_type);
+      else if (attack_kern == ATTACK_KERN_NONE)
+        snprintf (source_file, 255, "%s/OpenCL/m%05d_a0.cl", shared_dir, (int) kern_type);
     }
     else
     {
@@ -365,6 +369,8 @@ void generate_cached_kernel_filename (const u32 attack_exec, const u32 attack_ke
         snprintf (cached_file, 255, "%s/kernels/m%05d_a1-optimized.%s.kernel", profile_dir, (int) kern_type, device_name_chksum);
       else if (attack_kern == ATTACK_KERN_BF)
         snprintf (cached_file, 255, "%s/kernels/m%05d_a3-optimized.%s.kernel", profile_dir, (int) kern_type, device_name_chksum);
+      else if (attack_kern == ATTACK_KERN_NONE)
+        snprintf (cached_file, 255, "%s/kernels/m%05d_a0-optimized.%s.kernel", profile_dir, (int) kern_type, device_name_chksum);
     }
     else
     {
@@ -381,6 +387,8 @@ void generate_cached_kernel_filename (const u32 attack_exec, const u32 attack_ke
         snprintf (cached_file, 255, "%s/kernels/m%05d_a1.%s.kernel", profile_dir, (int) kern_type, device_name_chksum);
       else if (attack_kern == ATTACK_KERN_BF)
         snprintf (cached_file, 255, "%s/kernels/m%05d_a3.%s.kernel", profile_dir, (int) kern_type, device_name_chksum);
+      else if (attack_kern == ATTACK_KERN_NONE)
+        snprintf (cached_file, 255, "%s/kernels/m%05d_a0.%s.kernel", profile_dir, (int) kern_type, device_name_chksum);
     }
     else
     {


### PR DESCRIPTION
As described here #1435, whenever --show/--left was used with hashes that had a long salt (and therefore would require a pure - not-optimized - kernel), hashcat showed an error messages that the hash/salt was not correct (salt-length exception).

The problem is that --show/--left use a special attack mode and therefore the lookup for the correct kernels source file failed.

Technically speaking, we just missed the ATTACK_KERN_NONE case in the function that checks if pure/optimized kernels are present.

I think my suggested fix is acceptable. Alternatively, we could add an additional special-case handling for the case when --show/--left is being used, but I think it isn't worth the extra code. This fix/hack should always work

Thx