### PR TITLE
always include the error message even if hash is long

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -15,6 +15,12 @@
 * changes v4.0.0 -> v4.0.1:
 
 ##
+## Improvements
+##
+
+- Changed the maximum length of the substring of a hash shown whenever the parser found a problem while parsing the hash
+
+##
 ## Bugs
 ##
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1036,9 +1036,9 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+              char *tmp_line_buf;
 
-              snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+              hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
@@ -1058,9 +1058,9 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+              char *tmp_line_buf;
 
-              snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+              hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
@@ -1082,9 +1082,9 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+              char *tmp_line_buf;
 
-              snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+              hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
@@ -1107,9 +1107,9 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           if (parser_status < PARSER_GLOBAL_ZERO)
           {
-            char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+            char *tmp_line_buf;
 
-            snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+            hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
             compress_terminal_line_length (tmp_line_buf, 38, 32);
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -14,6 +14,7 @@
 #include "filehandling.h"
 #include "hlfmt.h"
 #include "interface.h"
+#include "terminal.h"
 #include "logfile.h"
 #include "loopback.h"
 #include "mpsp.h"
@@ -1035,7 +1036,15 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, line_buf, strparser (parser_status));
+              char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+
+              snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+
+              compress_terminal_line_length (tmp_line_buf, 38, 32);
+
+              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+
+              hcfree (tmp_line_buf);
 
               continue;
             }
@@ -1049,7 +1058,15 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, line_buf, strparser (parser_status));
+              char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+
+              snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+
+              compress_terminal_line_length (tmp_line_buf, 38, 32);
+
+              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+
+              hcfree (tmp_line_buf);
 
               continue;
             }
@@ -1065,7 +1082,15 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, line_buf, strparser (parser_status));
+              char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+
+              snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+
+              compress_terminal_line_length (tmp_line_buf, 38, 32);
+
+              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+
+              hcfree (tmp_line_buf);
 
               continue;
             }
@@ -1082,7 +1107,15 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           if (parser_status < PARSER_GLOBAL_ZERO)
           {
-            event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, line_buf, strparser (parser_status));
+            char *tmp_line_buf = (char *) malloc (HCBUFSIZ_LARGE);
+
+            snprintf (tmp_line_buf, HCBUFSIZ_LARGE, "%s", line_buf);
+
+            compress_terminal_line_length (tmp_line_buf, 38, 32);
+
+            event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+
+            hcfree (tmp_line_buf);
 
             continue;
           }


### PR DESCRIPTION
This problem was first reported here: https://hashcat.net/forum/thread-7013-post-37438.html#pid37438

Whenever the hash is very long and there was a parsing error for this specific hash, we should make sure that we do not truncate the line before the actual error message within event_log_warning ().

We should always make sure that the error messages is guaranteed to show up within the error line. We could safely truncate the hash instead. This is what this patch is implementing. It shortens the hash if needed.

Thanks