### PR TITLE
increase HCBUFSIZ_LARGE and truncate large strings when copied to old_buf

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -13,6 +13,12 @@
 - Fixed a hash parsing problem when using --show/--left together with hashes with long salts that require pure kernels
 - Fixed the output of --show if $HEX[] passwords are present within the potfile
 
+##
+## Technical
+##
+
+- Changed the way large strings are handled/truncated within the event buffer if they are too large to fit
+
 * changes v4.0.0 -> v4.0.1:
 
 ##

--- a/include/common.h
+++ b/include/common.h
@@ -104,7 +104,7 @@ but this is nededed for VS compiler which doesn't have inline keyword but has __
 #define SALT_MAX_OLD        51
 
 #define HCBUFSIZ_TINY       0x1000
-#define HCBUFSIZ_LARGE      0x50000
+#define HCBUFSIZ_LARGE      0xb0000
 
 #define CPT_CACHE           0x20000
 #define PARAMCNT            64

--- a/src/event.c
+++ b/src/event.c
@@ -45,12 +45,20 @@ void event_call (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, cons
       event_ctx->old_len[i] = event_ctx->old_len[i - 1];
     }
 
+    u32 copy_len = 0;
+
     if (buf)
     {
-      memcpy (event_ctx->old_buf[0], buf, len);
+      // truncate the whole buffer if needed (such that it fits into the old_buf):
+
+      const u32 max_buf_len = sizeof (event_ctx->old_buf[0]);
+
+      copy_len = MIN (len, max_buf_len - 1);
+
+      memcpy (event_ctx->old_buf[0], buf, copy_len);
     }
 
-    event_ctx->old_len[0] = len;
+    event_ctx->old_len[0] = copy_len;
   }
 }
 


### PR DESCRIPTION
This fixes the problem we came across here: https://github.com/hashcat/hashcat/issues/1450#issuecomment-345222507 .

Whenever the buf was too large (e.g. in case of very, very large cracked hashes) a memory problem could happen. This fix just truncates the string to the maximum allowed size.

Thanks