### PR TITLE
fixes #1450: allow longer crc32 data length field for -m 11600

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -11,6 +11,7 @@
 ##
 
 - Fixed a hash parsing problem when using --show/--left together with hashes with long salts that require pure kernels
+- Fixed a hash parsing problem for 7-Zip hashes: allow a longer crc32 data length field within the hash format
 - Fixed the output of --show if $HEX[] passwords are present within the potfile
 
 ##

--- a/src/interface.c
+++ b/src/interface.c
@@ -12226,7 +12226,7 @@ int seven_zip_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_
 
   if (is_compressed == true)
   {
-    if (crc_len_len > 5) return (PARSER_SALT_VALUE);
+    if (crc_len_len > 6) return (PARSER_SALT_VALUE);
 
     if (coder_attributes_len > 10) return (PARSER_SALT_VALUE);
 


### PR DESCRIPTION
As discussed within this newly created issue #1450, we need to allow a larger length of bytes that are used to generate the crc32 checksum. If we allow larger hashes (and therefore for -m 11600 also more compressed/encrypted data), we also need to allow more bytes for the checksum.
This patch should fix the hash rejection problem and allow all possible data lengths supported.

Thanks