### PR TITLE
fixed strtok_r () calls, could prevent memory crashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -19,6 +19,7 @@
 ##
 
 - Changed the way large strings are handled/truncated within the event buffer if they are too large to fit
+- Fixed our use of strtok_r () calls
 
 * changes v4.0.0 -> v4.0.1:
 

--- a/src/affinity.c
+++ b/src/affinity.c
@@ -65,7 +65,7 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 
   if (devices == NULL) return -1;
 
-  char *saveptr;
+  char *saveptr = NULL;
 
   char *next = strtok_r (devices, ",", &saveptr);
 
@@ -99,7 +99,7 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
     CPU_SET ((cpu_id - 1), &cpuset);
     #endif
 
-  } while ((next = strtok_r (NULL, ",", &saveptr)) != NULL);
+  } while ((next = strtok_r ((char *) NULL, ",", &saveptr)) != NULL);
 
   hcfree (devices);
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -5902,9 +5902,13 @@ int ikepsk_md5_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE
 
   if (input_buf == NULL) return (PARSER_HASH_VALUE);
 
-  char *saveptr;
+  char tmp_buf[HCBUFSIZ_TINY] = { 0 };
 
-  in_off[0] = (u8 *) strtok_r ((char *) input_buf, ":", &saveptr);
+  memcpy (tmp_buf, input_buf, input_len);
+
+  char *saveptr = NULL;
+
+  in_off[0] = (u8 *) strtok_r (tmp_buf, ":", &saveptr);
 
   if (in_off[0] == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 
@@ -5990,9 +5994,13 @@ int ikepsk_sha1_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYB
 
   if (input_buf == NULL) return (PARSER_HASH_VALUE);
 
-  char *saveptr;
+  char tmp_buf[HCBUFSIZ_TINY] = { 0 };
 
-  in_off[0] = (u8 *) strtok_r ((char *) input_buf, ":", &saveptr);
+  memcpy (tmp_buf, input_buf, input_len);
+
+  char *saveptr = NULL;
+
+  in_off[0] = (u8 *) strtok_r (tmp_buf, ":", &saveptr);
 
   if (in_off[0] == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 
@@ -25269,7 +25277,7 @@ int hashconfig_general_defaults (hashcat_ctx_t *hashcat_ctx)
 
     if (keyfiles == NULL) return -1;
 
-    char *saveptr;
+    char *saveptr = NULL;
 
     char *keyfile = strtok_r (keyfiles, ",", &saveptr);
 
@@ -25291,7 +25299,7 @@ int hashconfig_general_defaults (hashcat_ctx_t *hashcat_ctx)
         return -1;
       }
 
-    } while ((keyfile = strtok_r (NULL, ",", &saveptr)) != NULL);
+    } while ((keyfile = strtok_r ((char *) NULL, ",", &saveptr)) != NULL);
 
     free (keyfiles);
   }

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -117,7 +117,7 @@ static int setup_opencl_platforms_filter (hashcat_ctx_t *hashcat_ctx, const char
 
     if (platforms == NULL) return -1;
 
-    char *saveptr;
+    char *saveptr = NULL;
 
     char *next = strtok_r (platforms, ",", &saveptr);
 
@@ -136,7 +136,7 @@ static int setup_opencl_platforms_filter (hashcat_ctx_t *hashcat_ctx, const char
 
       opencl_platforms_filter |= 1u << (platform - 1);
 
-    } while ((next = strtok_r (NULL, ",", &saveptr)) != NULL);
+    } while ((next = strtok_r ((char *) NULL, ",", &saveptr)) != NULL);
 
     hcfree (platforms);
   }
@@ -160,7 +160,7 @@ static int setup_devices_filter (hashcat_ctx_t *hashcat_ctx, const char *opencl_
 
     if (devices == NULL) return -1;
 
-    char *saveptr;
+    char *saveptr = NULL;
 
     char *next = strtok_r (devices, ",", &saveptr);
 
@@ -179,7 +179,7 @@ static int setup_devices_filter (hashcat_ctx_t *hashcat_ctx, const char *opencl_
 
       devices_filter |= 1u << (device_id - 1);
 
-    } while ((next = strtok_r (NULL, ",", &saveptr)) != NULL);
+    } while ((next = strtok_r ((char *) NULL, ",", &saveptr)) != NULL);
 
     hcfree (devices);
   }
@@ -203,7 +203,7 @@ static int setup_device_types_filter (hashcat_ctx_t *hashcat_ctx, const char *op
 
     if (device_types == NULL) return -1;
 
-    char *saveptr;
+    char *saveptr = NULL;
 
     char *next = strtok_r (device_types, ",", &saveptr);
 

--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -121,7 +121,7 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
     int token_cnt = 0;
 
-    char *saveptr;
+    char *saveptr = NULL;
 
     char *next = strtok_r (line_buf, "\t ", &saveptr);
 
@@ -129,7 +129,7 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
     token_cnt++;
 
-    while ((next = strtok_r (NULL, "\t ", &saveptr)) != NULL)
+    while ((next = strtok_r ((char *) NULL, "\t ", &saveptr)) != NULL)
     {
       token_ptr[token_cnt] = next;
 


### PR DESCRIPTION
Our use of strtok_r () was not always correct, we must be sure that we are working on a copy of the original buffer.

A simple command like this
```
./hashcat -b -m 5300
```
could have resulted in a crash (segfault).

With this fix applied it shouldn't happen anymore.

Thank you very much