### PR TITLE
self-tests: always work with copies of the self-test hash

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1671,7 +1671,14 @@ int hashes_init_selftest (hashcat_ctx_t *hashcat_ctx)
       }
     }
 
-    parser_status = hashconfig->parse_func ((u8 *) hashconfig->st_hash, strlen (hashconfig->st_hash), &hash, hashconfig_st);
+    // Make sure that we do not modify constant data. Make a copy of the constant self-test hash
+    // Note: sometimes parse_func () modifies the data internally. We always need to use a copy of the original data
+
+    char *tmpdata = hcstrdup (hashconfig->st_hash);
+
+    parser_status = hashconfig->parse_func ((u8 *) tmpdata, strlen (hashconfig->st_hash), &hash, hashconfig_st);
+
+    hcfree (tmpdata);
 
     hcfree (hashconfig_st);
   }


### PR DESCRIPTION
This problem showed up after we changed the self-test hashes to constants (which in theory is correct, this data shouldn't be changed).... but we failed to work with a copy of the original data (we used the constant data and converted it to non-const).
This could have resulted in crashes/segfaults.

These changes I suggest here make a copy of the whole hash buffer and use the temporary buffer in place of the original hash.

Thank you very, very much
P

update: it is important to note that parse_func () and therefore all the parsers could sometimes modify the original buffer that was passed to it. This in general is no problem at all (instead it makes it faster, i.e. we do not need to have an additional copy of the hash in general... only for self-tests it is needed)