### PR TITLE
Get rid of hc_ctime too. Also fix some cppcheck confusion with nvapi.

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -56,8 +56,6 @@ void hc_string_trim_leading (char *s);
 size_t hc_fread (void *ptr, size_t size, size_t nmemb, FILE *stream);
 void   hc_fwrite (const void *ptr, size_t size, size_t nmemb, FILE *stream);
 
-char *hc_ctime (const time_t *t, char *buf, MAYBE_UNUSED const size_t buf_size);
-
 bool hc_same_files (char *file1, char *file2);
 
 #endif // _SHARED_H

--- a/src/opencl.c
+++ b/src/opencl.c
@@ -3169,11 +3169,7 @@ int opencl_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
         {
           need_nvml = true;
 
-          #if defined (_WIN)
-          need_nvapi = true;
-          #endif
-
-          #if defined (__CYGWIN__)
+          #if defined (_WIN) || (__CYGWIN__)
           need_nvapi = true;
           #endif
         }

--- a/src/shared.c
+++ b/src/shared.c
@@ -404,15 +404,6 @@ void hc_fwrite (const void *ptr, size_t size, size_t nmemb, FILE *stream)
   if (rc == 0) rc = 0;
 }
 
-char *hc_ctime (const time_t *t, char *buf, MAYBE_UNUSED const size_t buf_size)
-{
-  char *etc = NULL;
-
-  etc = ctime_r (t, buf); // buf should have room for at least 26 bytes
-
-  return etc;
-}
-
 bool hc_same_files (char *file1, char *file2)
 {
   if ((file1 != NULL) && (file2 != NULL))

--- a/src/status.c
+++ b/src/status.c
@@ -970,7 +970,7 @@ char *status_get_time_started_absolute (const hashcat_ctx_t *hashcat_ctx)
 
   char buf[32] = { 0 };
 
-  char *start = hc_ctime (&time_start, buf, 32);
+  char *start = ctime_r (&time_start, buf);
 
   const size_t start_len = strlen (start);
 
@@ -1056,7 +1056,7 @@ char *status_get_time_estimated_absolute (const hashcat_ctx_t *hashcat_ctx)
   {
     time_t end = now + sec_etc;
 
-    etc = hc_ctime (&end, buf, sizeof (buf));
+    etc = ctime_r (&end, buf);
 
     if (etc == NULL) etc = (char *) ETA_ABSOLUTE_MAX_EXCEEDED;
   }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -91,8 +91,8 @@ void goodbye_screen (hashcat_ctx_t *hashcat_ctx, const time_t proc_start, const 
   char start_buf[32]; memset (start_buf, 0, sizeof (start_buf));
   char stop_buf[32];  memset (start_buf, 0, sizeof (stop_buf));
 
-  event_log_info_nn (hashcat_ctx, "Started: %s", hc_ctime (&proc_start, start_buf, 32));
-  event_log_info_nn (hashcat_ctx, "Stopped: %s", hc_ctime (&proc_stop,  stop_buf, 32));
+  event_log_info_nn (hashcat_ctx, "Started: %s", ctime_r (&proc_start, start_buf));
+  event_log_info_nn (hashcat_ctx, "Stopped: %s", ctime_r (&proc_stop,  stop_buf));
 }
 
 int setup_console ()


### PR DESCRIPTION
Missed from last pull request.