### PR TITLE
Osx clock gettime

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -6,13 +6,6 @@
 #ifndef _TIMER_H
 #define _TIMER_H
 
-#if defined(__APPLE__) && defined(MISSING_CLOCK_GETTIME)
-#include <sys/time.h>
-#include <mach/clock.h>
-#include <mach/mach.h>
-#include <mach/mach_time.h>
-#endif
-
 void   hc_timer_set (hc_timer_t *a);
 double hc_timer_get (hc_timer_t a);
 

--- a/include/timer.h
+++ b/include/timer.h
@@ -6,7 +6,7 @@
 #ifndef _TIMER_H
 #define _TIMER_H
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && defined(MISSING_CLOCK_GETTIME)
 #include <sys/time.h>
 #include <mach/clock.h>
 #include <mach/mach.h>

--- a/include/timer.h
+++ b/include/timer.h
@@ -6,6 +6,13 @@
 #ifndef _TIMER_H
 #define _TIMER_H
 
+#if defined(__APPLE__)
+#include <sys/time.h>
+#include <mach/clock.h>
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
 void   hc_timer_set (hc_timer_t *a);
 double hc_timer_get (hc_timer_t a);
 

--- a/include/types.h
+++ b/include/types.h
@@ -47,6 +47,8 @@ typedef uint64_t u64;
 
 #if defined (_WIN)
 typedef LARGE_INTEGER     hc_timer_t;
+#elif defined(__APPLE__) && defined(MISSING_CLOCK_GETTIME)
+typedef struct timeval    hc_timer_t;
 #else
 typedef struct timespec   hc_timer_t;
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,6 +92,7 @@ ifeq ($(UNAME),Darwin)
 CC                      := clang
 # the sed -i option of macOS requires a parameter for the backup file (we just use "")
 SED_IN_PLACE            := -i ""
+PROD_VERS               := $(shell sw_vers -productVersion | cut -d. -f2)
 endif
 
 ifeq ($(UNAME),FreeBSD)
@@ -215,6 +216,11 @@ endif # FreeBSD
 ifeq ($(UNAME),Darwin)
 export MACOSX_DEPLOYMENT_TARGET=10.9
 CFLAGS_NATIVE           := $(CFLAGS)
+
+ifeq ($(shell test $(PROD_VERS) -le 11; echo $$?), 0)
+CFLAGS_NATIVE           += -DMISSING_CLOCK_GETTIME
+endif
+
 LFLAGS_NATIVE           := $(LFLAGS)
 LFLAGS_NATIVE           += -framework OpenCL
 LFLAGS_NATIVE           += -lpthread

--- a/src/timer.c
+++ b/src/timer.c
@@ -33,7 +33,7 @@ inline double hc_timer_get (hc_timer_t a)
 
 inline void hc_timer_set (hc_timer_t* a)
 {
-  #if defined (__APPLE__)
+  #if defined(__APPLE__) && defined(MISSING_CLOCK_GETTIME)
   // taken from proxmark3/client/util_posix
   static uint64_t clock_start_time = 0;
   static mach_timebase_info_data_t timebase_info = {0, 0};

--- a/src/timer.c
+++ b/src/timer.c
@@ -33,7 +33,25 @@ inline double hc_timer_get (hc_timer_t a)
 
 inline void hc_timer_set (hc_timer_t* a)
 {
+  #if defined (__APPLE__)
+  // taken from proxmark3/client/util_posix
+  static uint64_t clock_start_time = 0;
+  static mach_timebase_info_data_t timebase_info = {0, 0};
+  uint64_t now = mach_absolute_time();
+
+  if (clock_start_time == 0)
+  {
+    mach_timebase_info(&timebase_info);
+    clock_start_time = now;
+  }
+
+  now = (uint64_t)((double)(now - clock_start_time) * (double)timebase_info.numer / (double)timebase_info.denom);
+
+  a->tv_sec = now / 1000000000;
+  a->tv_nsec = now % 1000000000;
+  #else
   clock_gettime (CLOCK_MONOTONIC, a);
+  #endif
 }
 
 inline double hc_timer_get (hc_timer_t a)

--- a/src/timer.c
+++ b/src/timer.c
@@ -34,21 +34,7 @@ inline double hc_timer_get (hc_timer_t a)
 inline void hc_timer_set (hc_timer_t* a)
 {
   #if defined(__APPLE__) && defined(MISSING_CLOCK_GETTIME)
-  // taken from proxmark3/client/util_posix
-  static uint64_t clock_start_time = 0;
-  static mach_timebase_info_data_t timebase_info = {0, 0};
-  uint64_t now = mach_absolute_time();
-
-  if (clock_start_time == 0)
-  {
-    mach_timebase_info(&timebase_info);
-    clock_start_time = now;
-  }
-
-  now = (uint64_t)((double)(now - clock_start_time) * (double)timebase_info.numer / (double)timebase_info.denom);
-
-  a->tv_sec = now / 1000000000;
-  a->tv_nsec = now % 1000000000;
+  gettimeofday (a, NULL);
   #else
   clock_gettime (CLOCK_MONOTONIC, a);
   #endif
@@ -60,6 +46,9 @@ inline double hc_timer_get (hc_timer_t a)
 
   hc_timer_set (&hr_tmp);
 
+  #if defined(__APPLE__) && defined(MISSING_CLOCK_GETTIME)
+  return (double) (((hr_tmp.tv_sec - (a).tv_sec) * 1000) + ((double) (hr_tmp.tv_usec - (a).tv_usec) / 1000));
+  #else
   hc_timer_t s;
 
   s.tv_sec  = hr_tmp.tv_sec  - a.tv_sec;
@@ -74,6 +63,7 @@ inline double hc_timer_get (hc_timer_t a)
   double r = ((double) s.tv_sec * 1000) + ((double) s.tv_nsec / 1000000);
 
   return r;
+  #endif
 }
 
 #endif


### PR DESCRIPTION
Hi,
clock_gettime() in not defined in OSX <= 10.11

> $ make
clang -c -pipe -std=gnu99 -Iinclude/ -Iinclude/lzma_sdk/ -IOpenCL/ -W -Wall -Wextra -Wfloat-equal -Wundef -Wshadow -Wmissing-declarations -Wmissing-prototypes -Wpointer-arith -Wstrict-prototypes -Waggregate-return -Wswitch-enum -Winit-self -Werror-implicit-function-declaration -Wformat -ftrapv -Wwrite-strings -Wno-cast-align -Wno-cast-qual -Wno-conversion -Wno-padded -Wno-pedantic -Wno-sizeof-pointer-memaccess -O2 src/timer.c -o obj/timer.NATIVE.STATIC.o
src/timer.c:36:3: error: implicit declaration of function 'clock_gettime' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  clock_gettime (CLOCK_MONOTONIC, a);
  ^
src/timer.c:36:18: error: use of undeclared identifier 'CLOCK_MONOTONIC'
  clock_gettime (CLOCK_MONOTONIC, a);
                 ^
2 errors generated.
make: *** [obj/timer.NATIVE.STATIC.o] Error 1


I fixed that by
- checking the Product Version in Makefile
- add a clock_gettime() alternative by patching the hc_timer_set() function


Merry Christmas,
Matrix
(★ゝз･)ﾉ~*