### PR TITLE
masks: skipping too large/small masks fixed

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -25,6 +25,7 @@
 - Fixed a hash parsing problem for 7-Zip hashes: allow a longer crc32 data length field within the hash format
 - Fixed the output of --show if $HEX[] passwords are present within the potfile
 - Fixed a restore issue leading to "Restore value is greater than keyspace" in case mask-files or wordlist-folders were used
+- Fixed a mask-length check issue: Return -1 in case the mask-length is not within the password-length range
 
 ##
 ## Improvements

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -1284,18 +1284,20 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
         if (mask_ctx->css_cnt < mask_min)
         {
           event_log_warning (hashcat_ctx, "Skipping mask '%s' because it is smaller than the minimum password length.", mask_ctx->mask);
+          event_log_warning (hashcat_ctx, NULL);
         }
 
         if (mask_ctx->css_cnt > mask_max)
         {
           event_log_warning (hashcat_ctx, "Skipping mask '%s' because it is larger than the maximum password length.", mask_ctx->mask);
+          event_log_warning (hashcat_ctx, NULL);
         }
 
         // skip to next mask
 
         logfile_sub_msg ("STOP");
 
-        return 0;
+        return -1;
       }
 
       if (hashconfig->opts_type & OPTS_TYPE_PT_UTF16LE)


### PR DESCRIPTION
This problem was recently reported in this hashcat forum thread: https://hashcat.net/forum/thread-7159.html

Whenever the masks of a .hcmask file were too short/large hashcat correctly identified the "problem" of a too large/small mask, but the mask was sometimes run anyway because of a wrong return value.

This fixed version with return value -1 should solve the problem

Thank you very much. 