### PR TITLE
Appveyor test fix: the test should not run make install (only test a normal make)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,13 +46,11 @@ test_script:
   #  1. hash file should not exist and therefore hashcat should complain (if it does not there might be a problem)
   #  2. hash file should expand to example0.hash and succeed
   - ps: >-
-      cd $env:APPVEYOR_BUILD_FOLDER
-
-      & $env:BASH -c "./hashcat.exe -m 0 --show *file_not_found.hash" 2>&1 | out-null
+      & $env:BASH -lc "cd '$env:APPVEYOR_BUILD_FOLDER' && ./hashcat.exe -m 0 --show *file_not_found.hash" 2>&1 | out-null
 
       if ($LastExitCode -eq 0)
       {
         throw "test failed"
       }
 
-      & $env:BASH -c "./hashcat.exe -m 0 --show *ple0.hash"
+      & $env:BASH -lc "cd '$env:APPVEYOR_BUILD_FOLDER' && ./hashcat.exe -m 0 --show *ple0.hash"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   CYG_MIRROR: http://cygwin.mirror.constant.com
   CYG_PACKAGES: make,gcc-core,libiconv-devel
-  DOCUMENT_FOLDER: /share/doc/hashcat
   matrix:
     - CYG_ROOT: C:\cygwin64
       CYG_CACHE: C:\cygwin64\var\cache\setup
@@ -15,12 +14,10 @@ environment:
       CC: gcc
     - MSYSTEM: MINGW64
       MSYS_CACHE: C:\msys64\var\cache\pacman\pkg
-      KERNEL_CACHE: C:\msys64\usr\local\bin\OpenCL\
       BASH: C:\msys64\usr\bin\bash
       CC: gcc
     - MSYSTEM: MINGW32
       MSYS_CACHE: C:\msys64\var\cache\pacman\pkg
-      KERNEL_CACHE: C:\msys64\usr\local\bin\OpenCL\
       BASH: C:\msys64\usr\bin\bash
       CC: gcc
 
@@ -42,23 +39,20 @@ install:
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
 
 build_script:
-  - if defined BASH (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && git submodule update --init && make install")
+  - if defined BASH (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && git submodule update --init && make")
 
 test_script:
   # some file globbing tests
   #  1. hash file should not exist and therefore hashcat should complain (if it does not there might be a problem)
   #  2. hash file should expand to example0.hash and succeed
   - ps: >-
-      if (Test-Path Env:\MSYSTEM)
-      {
-        mkdir $env:KERNEL_CACHE 2>&1 | out-null
-      }
+      cd $env:APPVEYOR_BUILD_FOLDER
 
-      & $env:BASH -lc "hashcat.exe -m 0 --show $env:DOCUMENT_FOLDER/*file_not_found.hash" 2>&1 | out-null
+      & $env:BASH -c "./hashcat.exe -m 0 --show *file_not_found.hash" 2>&1 | out-null
 
       if ($LastExitCode -eq 0)
       {
         throw "test failed"
       }
 
-      & $env:BASH -lc "hashcat.exe -m 0 --show $env:DOCUMENT_FOLDER/*ple0.hash"
+      & $env:BASH -c "./hashcat.exe -m 0 --show *ple0.hash"

--- a/src/Makefile
+++ b/src/Makefile
@@ -334,6 +334,19 @@ win64: hashcat64.exe
 ## How to make /usr/bin/install doing recursive??
 ##
 
+# allow (whitelist) "make install" only on unix-based systems (also disallow cygwin/msys)
+
+ifneq ($(findstring install,$(MAKECMDGOALS)),)
+  ifeq (,$(filter $(UNAME),Linux FreeBSD Darwin))
+    define ERROR_INSTALL_DISALLOWED
+! The 'install' target is not allowed on this operating system ($(UNAME)). \
+Only Linux, FreeBSD and Darwin can use the 'install' target
+    endef
+
+    $(error $(ERROR_INSTALL_DISALLOWED))
+  endif
+endif
+
 ifeq ($(SHARED),1)
 install: install_docs install_shared install_include install_library install_hashcat
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -350,55 +350,55 @@ install_make_share_root:
 	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(SHARED_ROOT_FOLDER)
 
 install_docs: install_make_share_root
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(DOCUMENT_FOLDER)
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(DOCUMENT_FOLDER)/docs
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(DOCUMENT_FOLDER)/charsets
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(DOCUMENT_FOLDER)/masks
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(DOCUMENT_FOLDER)/rules
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(DOCUMENT_FOLDER)/extra
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion
-	$(INSTALL) -m 644 example.dict						$(DESTDIR)$(DOCUMENT_FOLDER)/
-	$(INSTALL) -m 644 example0.hash						$(DESTDIR)$(DOCUMENT_FOLDER)/
-	$(INSTALL) -m 644 example400.hash					$(DESTDIR)$(DOCUMENT_FOLDER)/
-	$(INSTALL) -m 644 example500.hash					$(DESTDIR)$(DOCUMENT_FOLDER)/
-	$(INSTALL) -m 755 example0.sh						$(DESTDIR)$(DOCUMENT_FOLDER)/
-	$(INSTALL) -m 755 example400.sh						$(DESTDIR)$(DOCUMENT_FOLDER)/
-	$(INSTALL) -m 755 example500.sh						$(DESTDIR)$(DOCUMENT_FOLDER)/
-	$(INSTALL) -m 644 extra/tab_completion/hashcat.sh			$(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion/
-	$(INSTALL) -m 644 extra/tab_completion/howto.txt			$(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion/
-	$(INSTALL) -m 755 extra/tab_completion/install				$(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion/
-	$(FIND) docs/     -type d -exec $(INSTALL) -m 755 -d			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(FIND) docs/     -type f -exec $(INSTALL) -m 644 {}			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(FIND) charsets/ -type d -exec $(INSTALL) -m 755 -d			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(FIND) charsets/ -type f -exec $(INSTALL) -m 644 {}			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(FIND) masks/    -type d -exec $(INSTALL) -m 755 -d			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(FIND) masks/    -type f -exec $(INSTALL) -m 644 {}			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(FIND) rules/    -type d -exec $(INSTALL) -m 755 -d			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(FIND) rules/    -type f -exec $(INSTALL) -m 644 {}			$(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
-	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'				$(DESTDIR)$(DOCUMENT_FOLDER)/example0.sh
-	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'				$(DESTDIR)$(DOCUMENT_FOLDER)/example400.sh
-	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'				$(DESTDIR)$(DOCUMENT_FOLDER)/example500.sh
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(DOCUMENT_FOLDER)
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(DOCUMENT_FOLDER)/docs
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(DOCUMENT_FOLDER)/charsets
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(DOCUMENT_FOLDER)/masks
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(DOCUMENT_FOLDER)/rules
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(DOCUMENT_FOLDER)/extra
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion
+	$(INSTALL) -m 644 example.dict                          $(DESTDIR)$(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 644 example0.hash                         $(DESTDIR)$(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 644 example400.hash                       $(DESTDIR)$(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 644 example500.hash                       $(DESTDIR)$(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 755 example0.sh                           $(DESTDIR)$(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 755 example400.sh                         $(DESTDIR)$(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 755 example500.sh                         $(DESTDIR)$(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 644 extra/tab_completion/hashcat.sh       $(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion/
+	$(INSTALL) -m 644 extra/tab_completion/howto.txt        $(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion/
+	$(INSTALL) -m 755 extra/tab_completion/install          $(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion/
+	$(FIND) docs/     -type d -exec $(INSTALL) -m 755 -d    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) docs/     -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) charsets/ -type d -exec $(INSTALL) -m 755 -d    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) charsets/ -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) masks/    -type d -exec $(INSTALL) -m 755 -d    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) masks/    -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) rules/    -type d -exec $(INSTALL) -m 755 -d    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) rules/    -type f -exec $(INSTALL) -m 644 {}    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'         $(DESTDIR)$(DOCUMENT_FOLDER)/example0.sh
+	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'         $(DESTDIR)$(DOCUMENT_FOLDER)/example400.sh
+	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'         $(DESTDIR)$(DOCUMENT_FOLDER)/example500.sh
 
 install_shared: install_make_share_root
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(SHARED_FOLDER)
-	$(INSTALL) -m 644 hashcat.hctune					$(DESTDIR)$(SHARED_FOLDER)/
-	$(INSTALL) -m 644 hashcat.hcstat2					$(DESTDIR)$(SHARED_FOLDER)/
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(SHARED_FOLDER)/OpenCL
-	$(FIND) OpenCL/   -type d -mindepth 1 -execdir $(INSTALL) -m 755 -d	$(DESTDIR)$(SHARED_FOLDER)/OpenCL/{} \;
-	$(FIND) OpenCL/   -type f -mindepth 1 -execdir $(INSTALL) -m 644 {}	$(DESTDIR)$(SHARED_FOLDER)/OpenCL/{} \;
+	$(INSTALL) -m 755 -d                                                  $(DESTDIR)$(SHARED_FOLDER)
+	$(INSTALL) -m 644 hashcat.hctune                                      $(DESTDIR)$(SHARED_FOLDER)/
+	$(INSTALL) -m 644 hashcat.hcstat2                                     $(DESTDIR)$(SHARED_FOLDER)/
+	$(INSTALL) -m 755 -d                                                  $(DESTDIR)$(SHARED_FOLDER)/OpenCL
+	$(FIND) OpenCL/   -type d -mindepth 1 -execdir $(INSTALL) -m 755 -d   $(DESTDIR)$(SHARED_FOLDER)/OpenCL/{} \;
+	$(FIND) OpenCL/   -type f -mindepth 1 -execdir $(INSTALL) -m 644 {}   $(DESTDIR)$(SHARED_FOLDER)/OpenCL/{} \;
 
 install_include: install_make_include_root
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(INCLUDE_FOLDER)
-	$(FIND) include/  -type d -mindepth 1 -execdir $(INSTALL) -m 755 -d	$(DESTDIR)$(INCLUDE_FOLDER)/{} \;
-	$(FIND) include/  -type f -mindepth 1 -execdir $(INSTALL) -m 644 {}	$(DESTDIR)$(INCLUDE_FOLDER)/{} \;
+	$(INSTALL) -m 755 -d                                                  $(DESTDIR)$(INCLUDE_FOLDER)
+	$(FIND) include/  -type d -mindepth 1 -execdir $(INSTALL) -m 755 -d   $(DESTDIR)$(INCLUDE_FOLDER)/{} \;
+	$(FIND) include/  -type f -mindepth 1 -execdir $(INSTALL) -m 644 {}   $(DESTDIR)$(INCLUDE_FOLDER)/{} \;
 
 install_library: $(HASHCAT_LIBRARY)
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(LIBRARY_FOLDER)
-	$(INSTALL) -m 755 $(HASHCAT_LIBRARY)					$(DESTDIR)$(LIBRARY_FOLDER)/
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(LIBRARY_FOLDER)
+	$(INSTALL) -m 755 $(HASHCAT_LIBRARY)                    $(DESTDIR)$(LIBRARY_FOLDER)/
 
 install_hashcat: $(HASHCAT_FRONTEND)
-	$(INSTALL) -m 755 -d							$(DESTDIR)$(INSTALL_FOLDER)
-	$(INSTALL) -m 755 $(HASHCAT_FRONTEND)					$(DESTDIR)$(INSTALL_FOLDER)/
+	$(INSTALL) -m 755 -d                                    $(DESTDIR)$(INSTALL_FOLDER)
+	$(INSTALL) -m 755 $(HASHCAT_FRONTEND)                   $(DESTDIR)$(INSTALL_FOLDER)/
 
 uninstall:
 	$(RM) -f  $(DESTDIR)$(INSTALL_FOLDER)/$(HASHCAT_FRONTEND)


### PR DESCRIPTION
The .appveyor.yml file currently uses "make install" to perform the tests. The problem is that we recently disallowed (within the host code) to run "make install" on non-windows systems. Therefore appveyor failed to run the tests for the last months :(

Since we decided that "make install" should only run on linux/maxOS/*BSD etc systems, I suggest that we add those system as exceptions (whitelist) and block the "install" target on all other supported OS.

Thanks