### PR TITLE
max/min password/salt length vs max/min supported lengths by kernel

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -481,15 +481,15 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
    * Optimizer constraints
    */
 
-  event_log_info (hashcat_ctx, "Password length minimum: %u", hashconfig->pw_min);
-  event_log_info (hashcat_ctx, "Password length maximum: %u", hashconfig->pw_max);
+  event_log_info (hashcat_ctx, "Minimum password length supported by kernel: %u", hashconfig->pw_min);
+  event_log_info (hashcat_ctx, "Maximum password length supported by kernel: %u", hashconfig->pw_max);
 
   if (hashconfig->is_salted == true)
   {
     if (hashconfig->opti_type & OPTI_TYPE_RAW_HASH)
     {
-      event_log_info (hashcat_ctx, "Salt length minimum: %u", hashconfig->salt_min);
-      event_log_info (hashcat_ctx, "Salt length maximum: %u", hashconfig->salt_max);
+      event_log_info (hashcat_ctx, "Minimim salt length supported by kernel: %u", hashconfig->salt_min);
+      event_log_info (hashcat_ctx, "Maximum salt length supported by kernel: %u", hashconfig->salt_max);
     }
   }
 


### PR DESCRIPTION
Make it clear that the "pass lengths" and "salt lenghts" hints are only indicative and describe the max/min pass/salt length of the kernels and are not specific to the current attack (e.g. mask attack of length 8)