### PR TITLE
Fix selftest.c warning

### DIFF
--- a/src/selftest.c
+++ b/src/selftest.c
@@ -57,7 +57,7 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
       if (hashconfig->opts_type & OPTS_TYPE_PT_UPPER)
       {
-        uppercase (pw_ptr, pw.pw_len);
+        uppercase ((u8 *) pw_ptr, pw.pw_len);
       }
 
       CL_err = hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->command_queue, device_param->d_pws_buf, CL_TRUE, 0, 1 * sizeof (pw_t), &pw, 0, NULL, NULL);


### PR DESCRIPTION
> src/selftest.c:60:20: warning: passing 'char *' to parameter of type 'u8 *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         uppercase (pw_ptr, pw.pw_len);
>                    ^~~~~~
> include/convert.h:51:21: note: passing argument to parameter 'buf' here
> void uppercase (u8 *buf, const size_t len);
>                     ^
> 1 warning generated.