### PR TITLE
7-Zip: increase the crc length to parse hashes with highly compressed data part

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -12281,7 +12281,7 @@ int seven_zip_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_
 
   if (is_compressed == true)
   {
-    if (crc_len_len > 6) return (PARSER_SALT_VALUE);
+    if (crc_len_len > 7) return (PARSER_SALT_VALUE);
 
     if (coder_attributes_len > 10) return (PARSER_SALT_VALUE);
 


### PR DESCRIPTION
Similar to the increase done with this commit: https://github.com/hashcat/hashcat/commit/d38240080538882ebfa17c4977621daaa41d9083
we need to increase the crc length again such that hashcat can load hashes corresponding to some very highly compressed files within the 7-Zip archive. 

For reference, this problem was first reported here: https://hashcat.net/forum/thread-7378.html :

as you can see
```
...$1059026$5d00001000): Salt-value exception
```

The value 1059026 is about 1MB of decrypted and decompressed data that needs to be checksummed.