### PR TITLE
Mute a macOS -Wpointer-sign warning.

### DIFF
--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -500,7 +500,7 @@ int _old_apply_rule (const char *rule, int rule_len, char in[RP_PASSWORD_SIZE], 
   {
     if (is_hex_notation (rule_new, rule_len, rule_pos))
     {
-      const u8 c = hex_to_u8 (rule_new + rule_pos + 2);
+      const u8 c = hex_to_u8 ((u8 *)rule_new + rule_pos + 2);
 
       rule_new[rule_pos + 0] = c;
       rule_new[rule_pos + 1] = ' ';


### PR DESCRIPTION
Mutes this:
```
src/rp_cpu.c:503:31: warning: passing 'char *' to parameter of type 'const u8 *'
      (aka 'const unsigned char *') converts between pointers to integer types with different sign
      [-Wpointer-sign]
      const u8 c = hex_to_u8 (rule_new + rule_pos + 2);
                              ^~~~~~~~~~~~~~~~~~~~~~~
include/convert.h:26:26: note: passing argument to parameter 'hex' here
u8  hex_to_u8  (const u8 hex[2]);
                         ^
1 warning generated.
```