### PR TITLE
Fixed a missing check for hashmodes using OPTS_TYPE_PT_UPPER

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -29,6 +29,7 @@
 - Fixed a missing kernel in -m 5600 in combination with -a 3 and -O if mask is >= 16 characters
 - Fixed detection of AMD_GCN version in case the rocm driver is used
 - Fixed missing code section in -m 2500 and -m 2501 to crack corrupted handshakes with a LE endian bitness base
+- Fixed a missing check for hashmodes using OPTS_TYPE_PT_UPPER causing the self-test to fail when using combinator- and hybrid-mode
 
 * changes v4.0.1 -> v4.1.0
 

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -79,6 +79,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
       pw.pw_len = (u32) pw_len - 1;
 
+      if (hashconfig->opts_type & OPTS_TYPE_PT_UPPER)
+      {
+        uppercase ((u8 *) pw_ptr, pw.pw_len);
+      }
+
       pw_t comb; memset (&comb, 0, sizeof (comb));
 
       char *comb_ptr = (char *) &comb.i;
@@ -86,6 +91,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       memcpy (comb_ptr, hashconfig->st_pass + pw_len - 1, 1);
 
       comb.pw_len = 1;
+
+      if (hashconfig->opts_type & OPTS_TYPE_PT_UPPER)
+      {
+        uppercase ((u8 *) comb_ptr, comb.pw_len);
+      }
 
       if (hashconfig->opts_type & OPTS_TYPE_PT_ADD01)
       {


### PR DESCRIPTION
Details in #1630 