### PR TITLE
test: fixed verify code for -m 16600 = Electrum Wallet

### DIFF
--- a/tools/test.pl
+++ b/tools/test.pl
@@ -9720,13 +9720,11 @@ END_CODE
     {
       my $encrypted_bin = pack ("H*", $additional_param3);
 
-      my $test_bin = $cipher->decrypt ($encrypted_bin);
-
-      my $test = unpack ("H*", $test_bin);
+      my $test = $cipher->decrypt ($encrypted_bin);
 
       if ($test =~ /^[0-9a-f]+$/)
       {
-        $plain_bin = $test_bin;
+        $plain_bin = $test;
       }
       else
       {


### PR DESCRIPTION
This is a minor fix for the test.pl file whenever we run something like
```
tools/test.pl verify 16600 hash in out
```

It turns out that the verification didn't work at all and that the output always contained a result (the test succeeded all the time) even if the password was wrong.

The problem was that the test/verification only made sure that the **hex converted** decrypted data was only containing 0-9a-f characters. This is of course always the case since hex strings always use this charset.

The fix is to compare the raw data/bytes instead of a converted hex string.

Thanks