### PR TITLE
fixes #1654: missing mask in output of --stdout -a 7

### DIFF
--- a/src/stdout.c
+++ b/src/stdout.c
@@ -266,12 +266,14 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
 
       for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
       {
-        for (int i = 0; i < 64; i++)
-        {
-          plain_buf[i] = pw.i[i];
-        }
+        u64 off = device_param->kernel_params_mp_buf64[3] + gidvid;
 
-        plain_len = pw.pw_len;
+        u32 start = 0;
+        u32 stop  = device_param->kernel_params_mp_buf32[4];
+
+        sp_exec (off, (char *) plain_ptr, mask_ctx->root_css_buf, mask_ctx->markov_css_buf, start, start + stop);
+
+        plain_len = stop;
 
         char *comb_buf = (char *) device_param->combs_buf[il_pos].i;
         u32   comb_len =          device_param->combs_buf[il_pos].pw_len;


### PR DESCRIPTION
There was a problem with --stdout together with -a 7 which implied that the bytes generated by the mask were completely missing within the output of hashcat.
This bug fixes the "missing" first part of the password.
Thank you sooo much.