### PR TITLE
Fixed the ciphertext max length in Ansible Vault parser

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -15,6 +15,7 @@
 - Fixed a invalid scalar datatype return value in hc_bytealign() where it should be a vector datatype return value
 - Fixed a problem with attack mode -a 7 together with stdout mode where the mask bytes were missing in the output
 - Fixed a problem with tab completion where --self-test-disable did incorrecly expect a further parameter/value
+- Fixed the ciphertext max length in Ansible Vault parser
 
 * changes v4.2.0 -> v4.2.1
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -17824,7 +17824,7 @@ int ansible_vault_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MA
 
   token.sep[4]     = '*';
   token.len_min[4] = 32;
-  token.len_max[4] = 8192;
+  token.len_max[4] = 32768;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 


### PR DESCRIPTION
I calculated the max length wrong (math is hard)