### PR TITLE
hcstat2: allow to use option --markov-hcstat2 instead of just --markov-hcstat

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -8,6 +8,7 @@
 - Allow bitcoin master key length not be exactly 96 byte a multiple of 16
 - Getting rid of OPTS_TYPE_HASH_COPY for Ansible Vault
 - Add a tracker for salts, amplifier and iterations to status screen
+- Add option --markov-hcstat2 to make it clear that the new hcstat2 format (compressed hcstat2gen output) must be used
 
 ##
 ## Bugs

--- a/extra/tab_completion/hashcat.sh
+++ b/extra/tab_completion/hashcat.sh
@@ -178,19 +178,19 @@ _hashcat ()
 
   local HASH_MODES="0 10 11 12 20 21 22 23 30 40 50 60 100 101 110 111 112 120 121 122 124 130 131 132 133 140 141 150 160 200 300 400 500 501 600 900 1000 1100 1400 1410 1411 1420 1421 1430 1440 1441 1450 1460 1500 1600 1700 1710 1711 1720 1722 1730 1731 1740 1750 1760 1800 2100 2400 2410 2500 2501 2600 2611 2612 2711 2811 3000 3100 3200 3710 3711 3800 3910 4010 4110 4300 4400 4500 4520 4521 4522 4700 4800 4900 5000 5100 5200 5300 5400 5500 5600 5700 5800 6000 6100 6211 6212 6213 6221 6222 6223 6231 6232 6233 6241 6242 6243 6300 6400 6500 6600 6700 6800 6900 7000 7100 7200 7300 7400 7500 7700 7800 7900 8000 8100 8200 8300 8400 8500 8600 8700 8800 8900 9000 9100 9200 9300 9400 9500 9600 9700 9710 9720 9800 9810 9820 9900 10000 10100 10200 10300 10400 10410 10420 10500 10600 10700 10800 10900 11000 11100 11200 11300 11400 11500 11600 11700 11800 11900 12000 12001 12100 12200 12300 12400 12500 12600 12700 12800 12900 13000 13100 13200 13300 13400 13500 13600 13800 13900 14000 14100 14700 14800 14900 15000 15100 15200 15300 15400 15500 15600 15700 15900 16000 16100 16200 16300 16400 16500 16600 16700 16800 16801 16900"
   local ATTACK_MODES="0 1 3 6 7"
-  local HCCAPX_MESSAGE_PAIR="0 1 2 3 4 5"
+  local HCCAPX_MESSAGE_PAIRS="0 1 2 3 4 5"
   local OUTFILE_FORMATS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
   local OPENCL_DEVICE_TYPES="1 2 3"
   local OPENCL_VECTOR_WIDTH="1 2 4 8 16"
   local DEBUG_MODE="1 2 3 4"
-  local WORKLOAD_PROFILE="1 2 3"
-  local HIDDEN_FILES="exe|bin|pot|hcstat|dictstat|accepted|sh|cmd|bat|restore"
-  local HIDDEN_FILES_AGGRESIVE="exe|bin|pot|hcstat|dictstat|hcmask|hcchr|accepted|sh|cmd|restore"
+  local WORKLOAD_PROFILE="1 2 3 4"
+  local HIDDEN_FILES="exe|bin|potfile|hcstat2|dictstat2|sh|cmd|bat|restore"
+  local HIDDEN_FILES_AGGRESIVE="${HIDDEN_FILES}|hcmask|hcchr"
   local BUILD_IN_CHARSETS='?l ?u ?d ?a ?b ?s ?h ?H'
 
   local SHORT_OPTS="-m -a -V -v -h -b -t -o -p -c -d -w -n -u -j -k -r -g -1 -2 -3 -4 -i -I -s -l -O"
-  local LONG_OPTS="--hash-type --attack-mode --version --help --quiet --benchmark --benchmark-all --hex-salt --hex-wordlist --hex-charset --force --status --status-timer --machine-readable --loopback --markov-hcstat --markov-disable --markov-classic --markov-threshold --runtime --session --speed-only --progress-only --restore --restore-file-path --restore-disable --outfile --outfile-format --outfile-autohex-disable --outfile-check-timer --outfile-check-dir --wordlist-autohex-disable --separator --show --left --username --remove --remove-timer --potfile-disable --potfile-path --debug-mode --debug-file --induction-dir --segment-size --bitmap-min --bitmap-max --cpu-affinity --example-hashes --opencl-info --opencl-devices --opencl-platforms --opencl-device-types --opencl-vector-width --workload-profile --kernel-accel --kernel-loops --nvidia-spin-damp --gpu-temp-disable --gpu-temp-abort --skip --limit --keyspace --rule-left --rule-right --rules-file --generate-rules --generate-rules-func-min --generate-rules-func-max --generate-rules-seed --custom-charset1 --custom-charset2 --custom-charset3 --custom-charset4 --increment --increment-min --increment-max --logfile-disable --scrypt-tmto --truecrypt-keyfiles --veracrypt-keyfiles --veracrypt-pim --stdout --keep-guessing --hccapx-message-pair --nonce-error-corrections --encoding-from --encoding-to --optimized-kernel-enable --self-test-disable"
-  local OPTIONS="-m -a -t -o -p -c -d -w -n -u -j -k -r -g -1 -2 -3 -4 -s -l --hash-type --attack-mode --status-timer --markov-hcstat --markov-threshold --runtime --session --timer --outfile --outfile-format --outfile-check-timer --outfile-check-dir --separator --remove-timer --potfile-path --restore-file-path --debug-mode --debug-file --induction-dir --segment-size --bitmap-min --bitmap-max --cpu-affinity --opencl-devices --opencl-platforms --opencl-device-types --opencl-vector-width --workload-profile --kernel-accel --kernel-loops --nvidia-spin-damp --gpu-temp-abort --skip --limit --rule-left --rule-right --rules-file --generate-rules --generate-rules-func-min --generate-rules-func-max --generate-rules-seed --custom-charset1 --custom-charset2 --custom-charset3 --custom-charset4 --increment-min --increment-max --scrypt-tmto --truecrypt-keyfiles --veracrypt-keyfiles --veracrypt-pim --hccapx-message-pair --nonce-error-corrections --encoding-from --encoding-to"
+  local LONG_OPTS="--hash-type --attack-mode --version --help --quiet --benchmark --benchmark-all --hex-salt --hex-wordlist --hex-charset --force --status --status-timer --machine-readable --loopback --markov-hcstat2 --markov-disable --markov-classic --markov-threshold --runtime --session --speed-only --progress-only --restore --restore-file-path --restore-disable --outfile --outfile-format --outfile-autohex-disable --outfile-check-timer --outfile-check-dir --wordlist-autohex-disable --separator --show --left --username --remove --remove-timer --potfile-disable --potfile-path --debug-mode --debug-file --induction-dir --segment-size --bitmap-min --bitmap-max --cpu-affinity --example-hashes --opencl-info --opencl-devices --opencl-platforms --opencl-device-types --opencl-vector-width --workload-profile --kernel-accel --kernel-loops --nvidia-spin-damp --gpu-temp-disable --gpu-temp-abort --skip --limit --keyspace --rule-left --rule-right --rules-file --generate-rules --generate-rules-func-min --generate-rules-func-max --generate-rules-seed --custom-charset1 --custom-charset2 --custom-charset3 --custom-charset4 --increment --increment-min --increment-max --logfile-disable --scrypt-tmto --truecrypt-keyfiles --veracrypt-keyfiles --veracrypt-pim --stdout --keep-guessing --hccapx-message-pair --nonce-error-corrections --encoding-from --encoding-to --optimized-kernel-enable --self-test-disable"
+  local OPTIONS="-m -a -t -o -p -c -d -w -n -u -j -k -r -g -1 -2 -3 -4 -s -l --hash-type --attack-mode --status-timer --markov-hcstat2 --markov-threshold --runtime --session --timer --outfile --outfile-format --outfile-check-timer --outfile-check-dir --separator --remove-timer --potfile-path --restore-file-path --debug-mode --debug-file --induction-dir --segment-size --bitmap-min --bitmap-max --cpu-affinity --opencl-devices --opencl-platforms --opencl-device-types --opencl-vector-width --workload-profile --kernel-accel --kernel-loops --nvidia-spin-damp --gpu-temp-abort --skip --limit --rule-left --rule-right --rules-file --generate-rules --generate-rules-func-min --generate-rules-func-max --generate-rules-seed --custom-charset1 --custom-charset2 --custom-charset3 --custom-charset4 --increment-min --increment-max --scrypt-tmto --truecrypt-keyfiles --veracrypt-keyfiles --veracrypt-pim --hccapx-message-pair --nonce-error-corrections --encoding-from --encoding-to"
 
   COMPREPLY=()
   local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -244,8 +244,8 @@ _hashcat ()
       return 0
       ;;
 
-    --markov-hcstat)
-      local files=$(ls -d ${cur}* 2> /dev/null | grep -Eiv '*\.('${HIDDEN_FILES}')' 2> /dev/null)
+    --markov-hcstat2)
+      local files=$(ls -d ${cur}* 2> /dev/null | grep '.*\.hcstat2$' 2> /dev/null)
       COMPREPLY=($(compgen -W "${files}" -- ${cur})) # or $(compgen -f -X '*.+('${HIDDEN_FILES_AGGRESIVE}')' -- ${cur})
       return 0
       ;;

--- a/include/types.h
+++ b/include/types.h
@@ -639,7 +639,7 @@ typedef enum user_options_map
   IDX_MACHINE_READABLE          = 0xff19,
   IDX_MARKOV_CLASSIC            = 0xff1a,
   IDX_MARKOV_DISABLE            = 0xff1b,
-  IDX_MARKOV_HCSTAT             = 0xff1c,
+  IDX_MARKOV_HCSTAT2            = 0xff1c,
   IDX_MARKOV_THRESHOLD          = 't',
   IDX_NONCE_ERROR_CORRECTIONS   = 0xff1d,
   IDX_NVIDIA_SPIN_DAMP          = 0xff1e,
@@ -1656,7 +1656,7 @@ typedef struct user_options
   const char  *encoding_from;
   const char  *encoding_to;
   char        *induction_dir;
-  char        *markov_hcstat;
+  char        *markov_hcstat2;
   char        *opencl_devices;
   char        *opencl_device_types;
   char        *opencl_platforms;

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -631,7 +631,7 @@ static int sp_setup_tbl (hashcat_ctx_t *hashcat_ctx)
 
   char *shared_dir = folder_config->shared_dir;
 
-  char *hcstat  = user_options->markov_hcstat;
+  char *hcstat  = user_options->markov_hcstat2;
   u32   disable = user_options->markov_disable;
   u32   classic = user_options->markov_classic;
 

--- a/src/usage.c
+++ b/src/usage.c
@@ -41,7 +41,7 @@ static const char *const USAGE_BIG[] =
   "     --keep-guessing            |      | Keep guessing the hash after it has been cracked     |",
   "     --self-test-disable        |      | Disable self-test functionality on startup           |",
   "     --loopback                 |      | Add new plains to induct directory                   |",
-  "     --markov-hcstat            | File | Specify hcstat file to use                           | --markov-hc=my.hcstat",
+  "     --markov-hcstat2           | File | Specify hcstat2 file to use                          | --markov-hcstat2=my.hcstat2",
   "     --markov-disable           |      | Disables markov-chains, emulates classic brute-force |",
   "     --markov-classic           |      | Enables classic markov-chains, no per-position       |",
   " -t, --markov-threshold         | Num  | Threshold X when to stop accepting new markov-chains | -t 50",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -62,7 +62,7 @@ static const struct option long_options[] =
   {"machine-readable",          no_argument,       NULL, IDX_MACHINE_READABLE},
   {"markov-classic",            no_argument,       NULL, IDX_MARKOV_CLASSIC},
   {"markov-disable",            no_argument,       NULL, IDX_MARKOV_DISABLE},
-  {"markov-hcstat",             required_argument, NULL, IDX_MARKOV_HCSTAT},
+  {"markov-hcstat2",            required_argument, NULL, IDX_MARKOV_HCSTAT2},
   {"markov-threshold",          required_argument, NULL, IDX_MARKOV_THRESHOLD},
   {"nonce-error-corrections",   required_argument, NULL, IDX_NONCE_ERROR_CORRECTIONS},
   {"nvidia-spin-damp",          required_argument, NULL, IDX_NVIDIA_SPIN_DAMP},
@@ -165,7 +165,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->machine_readable          = MACHINE_READABLE;
   user_options->markov_classic            = MARKOV_CLASSIC;
   user_options->markov_disable            = MARKOV_DISABLE;
-  user_options->markov_hcstat             = NULL;
+  user_options->markov_hcstat2            = NULL;
   user_options->markov_threshold          = MARKOV_THRESHOLD;
   user_options->nonce_error_corrections   = NONCE_ERROR_CORRECTIONS;
   user_options->nvidia_spin_damp          = NVIDIA_SPIN_DAMP;
@@ -365,7 +365,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_MARKOV_DISABLE:           user_options->markov_disable            = true;                            break;
       case IDX_MARKOV_CLASSIC:           user_options->markov_classic            = true;                            break;
       case IDX_MARKOV_THRESHOLD:         user_options->markov_threshold          = hc_strtoul (optarg, NULL, 10);   break;
-      case IDX_MARKOV_HCSTAT:            user_options->markov_hcstat             = optarg;                          break;
+      case IDX_MARKOV_HCSTAT2:           user_options->markov_hcstat2            = optarg;                          break;
       case IDX_OUTFILE:                  user_options->outfile                   = optarg;                          break;
       case IDX_OUTFILE_FORMAT:           user_options->outfile_format            = hc_strtoul (optarg, NULL, 10);
                                          user_options->outfile_format_chgd       = true;                            break;
@@ -854,11 +854,11 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
-  if (user_options->markov_hcstat != NULL)
+  if (user_options->markov_hcstat2 != NULL)
   {
-    if (strlen (user_options->markov_hcstat) == 0)
+    if (strlen (user_options->markov_hcstat2) == 0)
     {
-      event_log_error (hashcat_ctx, "Invalid --markov-hcstat value - must not be empty.");
+      event_log_error (hashcat_ctx, "Invalid --markov-hcstat2 value - must not be empty.");
 
       return -1;
     }
@@ -2268,7 +2268,7 @@ void user_options_logger (hashcat_ctx_t *hashcat_ctx)
   logfile_top_string (user_options->encoding_from);
   logfile_top_string (user_options->encoding_to);
   logfile_top_string (user_options->induction_dir);
-  logfile_top_string (user_options->markov_hcstat);
+  logfile_top_string (user_options->markov_hcstat2);
   logfile_top_string (user_options->opencl_devices);
   logfile_top_string (user_options->opencl_device_types);
   logfile_top_string (user_options->opencl_platforms);


### PR DESCRIPTION
I think it makes sense to show in the --help output very clearly that the new hcstat2 (lzma compressed) markov file format should be used with new versions of hashcat.
I think it therefore also makes sense to allow to specify --markov-hcstat2 (but because of the getopts shortcut continue to allow --markov-hcstat too... BUT the file itself always needs to be in the new format of course since version 4.0 of hashcat!).

Thanks