### PR TITLE
outfile check: improve response time when quitting hashcat

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -19,6 +19,7 @@
 - Fixed a problem with attack mode -a 7 together with stdout mode where the mask bytes were missing in the output
 - Fixed a problem with tab completion where --self-test-disable did incorrecly expect a further parameter/value
 - Fixed the ciphertext max length in Ansible Vault parser
+- Fixed speed/delay problem when quitting while the outfile folder is being scanned
 - Removed duplicate words in the dictionary file example.dict
 
 * changes v4.2.0 -> v4.2.1

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -248,18 +248,20 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
                             if (hashes->salts_done == hashes->salts_cnt) mycracked (hashcat_ctx);
                           }
                         }
+
+                        if (status_ctx->shutdown_inner == true) break;
                       }
 
-                      if (status_ctx->devices_status == STATUS_CRACKED) break;
+                      if (status_ctx->shutdown_inner == true) break;
                     }
                   }
 
                   if (found) break;
 
-                  if (status_ctx->devices_status == STATUS_CRACKED) break;
+                  if (status_ctx->shutdown_inner == true) break;
                 }
 
-                if (status_ctx->devices_status == STATUS_CRACKED) break;
+                if (status_ctx->shutdown_inner == true) break;
               }
 
               hcfree (line_buf);
@@ -270,6 +272,8 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
               fclose (fp);
             }
+
+            if (status_ctx->shutdown_inner == true) break;
           }
         }
       }


### PR DESCRIPTION
The outfile folder scan should not block hashcat from quitting... this improved code should exit as soon as possible (approximately with a max 1-2 second delay, which is kind of reasonable).
The current code in the master, instead, continues to check all lines within all files within the outfile folder and this type of checking could take a while.
Therefore, I suggest checking if the variable status_ctx->shutdown_inner is set to true and if this is the case we should exit the (outfile folder check) thread immediately.

Thank you very much