### PR TITLE
Allow hwmon when temp abort is disabled by refactoring guards when hwmon is not present

### DIFF
--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -2012,7 +2012,9 @@ int hwmon_ctx_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->keyspace          == true) return 0;
   if (user_options->left              == true) return 0;
   if (user_options->opencl_info       == true) return 0;
+  if (user_options->progress_only     == true) return 0;
   if (user_options->show              == true) return 0;
+  if (user_options->speed_only        == true) return 0;
   if (user_options->stdout_flag       == true) return 0;
   if (user_options->usage             == true) return 0;
   if (user_options->version           == true) return 0;

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -2004,6 +2004,10 @@ int hwmon_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
   hwmon_ctx->enabled = false;
 
+  #if !defined (WITH_HWMON)
+  return 0;
+  #endif // WITH_HWMON
+
   if (user_options->example_hashes    == true) return 0;
   if (user_options->keyspace          == true) return 0;
   if (user_options->left              == true) return 0;
@@ -2012,7 +2016,6 @@ int hwmon_ctx_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->stdout_flag       == true) return 0;
   if (user_options->usage             == true) return 0;
   if (user_options->version           == true) return 0;
-  if (user_options->gpu_temp_disable  == true) return 0;
 
   hwmon_ctx->hm_device = (hm_attrs_t *) hccalloc (DEVICES_MAX, sizeof (hm_attrs_t));
 

--- a/src/main.c
+++ b/src/main.c
@@ -510,7 +510,7 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
    * Watchdog and Temperature balance
    */
 
-  if (hwmon_ctx->enabled == false && user_options->gpu_temp_disable == false)
+  if (hwmon_ctx->enabled == false)
   {
     event_log_info (hashcat_ctx, "Watchdog: Hardware monitoring interface not found on your system.");
   }

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -143,7 +143,7 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
       hc_thread_mutex_unlock (status_ctx->mux_hwmon);
     }
 
-    if (hwmon_check == true)
+    if (hwmon_check == true && user_options->gpu_temp_disable == false)
     {
       hc_thread_mutex_lock (status_ctx->mux_hwmon);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -780,7 +780,7 @@ void opencl_info_compact (hashcat_ctx_t *hashcat_ctx)
 
 void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
 {
-  const user_options_t *user_options = hashcat_ctx->user_options;
+  const hwmon_ctx_t *hwmon_ctx = hashcat_ctx->hwmon_ctx;
 
   hashcat_status_t *hashcat_status = (hashcat_status_t *) hcmalloc (sizeof (hashcat_status_t));
 
@@ -828,7 +828,7 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
 
   printf ("RECSALT\t%d\t%d\t", hashcat_status->salts_done, hashcat_status->salts_cnt);
 
-  if (user_options->gpu_temp_disable == false)
+  if (hwmon_ctx->enabled == true)
   {
     printf ("TEMP\t");
 
@@ -837,8 +837,6 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
       const device_info_t *device_info = hashcat_status->device_info_buf + device_id;
 
       if (device_info->skipped_dev == true) continue;
-
-      // ok, little cheat here...
 
       const int temp = hm_get_temperature_with_device_id (hashcat_ctx, device_id);
 
@@ -875,6 +873,7 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
 void status_display (hashcat_ctx_t *hashcat_ctx)
 {
   const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
+  const hwmon_ctx_t    *hwmon_ctx    = hashcat_ctx->hwmon_ctx;
   const user_options_t *user_options = hashcat_ctx->user_options;
 
   if (user_options->machine_readable == true)
@@ -1318,7 +1317,7 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
       device_info->guess_candidates_dev);
   }
 
-  if (user_options->gpu_temp_disable == false)
+  if (hwmon_ctx->enabled == true)
   {
     for (int device_id = 0; device_id < hashcat_status->device_info_cnt; device_id++)
     {

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1211,11 +1211,6 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
 {
   user_options_t *user_options = hashcat_ctx->user_options;
 
-  #if !defined (WITH_HWMON)
-  user_options->gpu_temp_disable = true;
-  user_options->gpu_temp_abort   = 0;
-  #endif // WITH_HWMON
-
   // some options can influence or overwrite other options
 
   if (user_options->example_hashes  == true
@@ -1373,6 +1368,10 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
   {
     user_options->segment_size *= (1024 * 1024);
   }
+
+  #if !defined (WITH_HWMON)
+  user_options->gpu_temp_disable = true;
+  #endif // WITH_HWMON
 
   if (user_options->gpu_temp_disable == true)
   {


### PR DESCRIPTION
user_options->gpu_temp_disable is used to return guard hwmon_ctx_init, including in systems without hwmon. However it is also used to prevent display of the "hwmon not found" message so it doesn't display on systems where hwmon cannot be present.

The commit changes the hwmon return guard to use !WITH_HWMON from the Makefile instead of gpu_temp_disable. This allows hwmon when temp abort is disabled, so code depending on gpu_temp is also changed.