### PR TITLE
Refactor hash algorithm update loops

### DIFF
--- a/OpenCL/inc_hash_md4.cl
+++ b/OpenCL/inc_hash_md4.cl
@@ -192,7 +192,7 @@ DECLSPEC void md4_update (md4_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -211,25 +211,10 @@ DECLSPEC void md4_update (md4_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   md4_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -244,7 +229,7 @@ DECLSPEC void md4_update_swap (md4_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -280,42 +265,10 @@ DECLSPEC void md4_update_swap (md4_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md4_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -330,7 +283,7 @@ DECLSPEC void md4_update_utf16le (md4_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -344,20 +297,10 @@ DECLSPEC void md4_update_utf16le (md4_ctx_t *ctx, const u32 *w, const int len)
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   md4_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -372,7 +315,7 @@ DECLSPEC void md4_update_utf16le_swap (md4_ctx_t *ctx, const u32 *w, const int l
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -403,37 +346,10 @@ DECLSPEC void md4_update_utf16le_swap (md4_ctx_t *ctx, const u32 *w, const int l
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md4_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -448,7 +364,7 @@ DECLSPEC void md4_update_global (md4_ctx_t *ctx, const __global u32 *w, const in
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -467,25 +383,10 @@ DECLSPEC void md4_update_global (md4_ctx_t *ctx, const __global u32 *w, const in
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   md4_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -500,7 +401,7 @@ DECLSPEC void md4_update_global_swap (md4_ctx_t *ctx, const __global u32 *w, con
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -536,42 +437,10 @@ DECLSPEC void md4_update_global_swap (md4_ctx_t *ctx, const __global u32 *w, con
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md4_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -586,7 +455,7 @@ DECLSPEC void md4_update_global_utf16le (md4_ctx_t *ctx, const __global u32 *w, 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -600,20 +469,10 @@ DECLSPEC void md4_update_global_utf16le (md4_ctx_t *ctx, const __global u32 *w, 
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   md4_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -628,7 +487,7 @@ DECLSPEC void md4_update_global_utf16le_swap (md4_ctx_t *ctx, const __global u32
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -659,37 +518,10 @@ DECLSPEC void md4_update_global_utf16le_swap (md4_ctx_t *ctx, const __global u32
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     md4_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md4_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1312,7 +1144,7 @@ DECLSPEC void md4_update_vector (md4_ctx_vector_t *ctx, const u32x *w, const int
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1331,25 +1163,10 @@ DECLSPEC void md4_update_vector (md4_ctx_vector_t *ctx, const u32x *w, const int
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     md4_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   md4_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1364,7 +1181,7 @@ DECLSPEC void md4_update_vector_swap (md4_ctx_vector_t *ctx, const u32x *w, cons
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1400,42 +1217,10 @@ DECLSPEC void md4_update_vector_swap (md4_ctx_vector_t *ctx, const u32x *w, cons
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     md4_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   md4_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1450,7 +1235,7 @@ DECLSPEC void md4_update_vector_utf16le (md4_ctx_vector_t *ctx, const u32x *w, c
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1464,20 +1249,10 @@ DECLSPEC void md4_update_vector_utf16le (md4_ctx_vector_t *ctx, const u32x *w, c
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     md4_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   md4_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1492,7 +1267,7 @@ DECLSPEC void md4_update_vector_utf16le_swap (md4_ctx_vector_t *ctx, const u32x 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1523,37 +1298,10 @@ DECLSPEC void md4_update_vector_utf16le_swap (md4_ctx_vector_t *ctx, const u32x 
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     md4_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   md4_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_md5.cl
+++ b/OpenCL/inc_hash_md5.cl
@@ -228,7 +228,7 @@ DECLSPEC void md5_update (md5_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -247,25 +247,10 @@ DECLSPEC void md5_update (md5_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   md5_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -280,7 +265,7 @@ DECLSPEC void md5_update_swap (md5_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -316,42 +301,10 @@ DECLSPEC void md5_update_swap (md5_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md5_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -366,7 +319,7 @@ DECLSPEC void md5_update_utf16le (md5_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -380,20 +333,10 @@ DECLSPEC void md5_update_utf16le (md5_ctx_t *ctx, const u32 *w, const int len)
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   md5_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -408,7 +351,7 @@ DECLSPEC void md5_update_utf16le_swap (md5_ctx_t *ctx, const u32 *w, const int l
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -439,37 +382,10 @@ DECLSPEC void md5_update_utf16le_swap (md5_ctx_t *ctx, const u32 *w, const int l
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md5_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -484,7 +400,7 @@ DECLSPEC void md5_update_global (md5_ctx_t *ctx, const __global u32 *w, const in
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -503,25 +419,10 @@ DECLSPEC void md5_update_global (md5_ctx_t *ctx, const __global u32 *w, const in
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   md5_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -536,7 +437,7 @@ DECLSPEC void md5_update_global_swap (md5_ctx_t *ctx, const __global u32 *w, con
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -572,42 +473,10 @@ DECLSPEC void md5_update_global_swap (md5_ctx_t *ctx, const __global u32 *w, con
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md5_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -622,7 +491,7 @@ DECLSPEC void md5_update_global_utf16le (md5_ctx_t *ctx, const __global u32 *w, 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -636,20 +505,10 @@ DECLSPEC void md5_update_global_utf16le (md5_ctx_t *ctx, const __global u32 *w, 
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   md5_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -664,7 +523,7 @@ DECLSPEC void md5_update_global_utf16le_swap (md5_ctx_t *ctx, const __global u32
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -695,37 +554,10 @@ DECLSPEC void md5_update_global_utf16le_swap (md5_ctx_t *ctx, const __global u32
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     md5_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   md5_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1384,7 +1216,7 @@ DECLSPEC void md5_update_vector (md5_ctx_vector_t *ctx, const u32x *w, const int
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1403,25 +1235,10 @@ DECLSPEC void md5_update_vector (md5_ctx_vector_t *ctx, const u32x *w, const int
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     md5_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   md5_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1436,7 +1253,7 @@ DECLSPEC void md5_update_vector_swap (md5_ctx_vector_t *ctx, const u32x *w, cons
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1472,42 +1289,10 @@ DECLSPEC void md5_update_vector_swap (md5_ctx_vector_t *ctx, const u32x *w, cons
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     md5_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   md5_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1522,7 +1307,7 @@ DECLSPEC void md5_update_vector_utf16le (md5_ctx_vector_t *ctx, const u32x *w, c
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1536,20 +1321,10 @@ DECLSPEC void md5_update_vector_utf16le (md5_ctx_vector_t *ctx, const u32x *w, c
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     md5_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   md5_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1564,7 +1339,7 @@ DECLSPEC void md5_update_vector_utf16le_swap (md5_ctx_vector_t *ctx, const u32x 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1595,37 +1370,10 @@ DECLSPEC void md5_update_vector_utf16le_swap (md5_ctx_vector_t *ctx, const u32x 
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     md5_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   md5_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_ripemd160.cl
+++ b/OpenCL/inc_hash_ripemd160.cl
@@ -326,7 +326,7 @@ DECLSPEC void ripemd160_update (ripemd160_ctx_t *ctx, const u32 *w, const int le
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -345,25 +345,10 @@ DECLSPEC void ripemd160_update (ripemd160_ctx_t *ctx, const u32 *w, const int le
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -378,7 +363,7 @@ DECLSPEC void ripemd160_update_swap (ripemd160_ctx_t *ctx, const u32 *w, const i
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -414,42 +399,10 @@ DECLSPEC void ripemd160_update_swap (ripemd160_ctx_t *ctx, const u32 *w, const i
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -464,7 +417,7 @@ DECLSPEC void ripemd160_update_utf16le (ripemd160_ctx_t *ctx, const u32 *w, cons
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -478,20 +431,10 @@ DECLSPEC void ripemd160_update_utf16le (ripemd160_ctx_t *ctx, const u32 *w, cons
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -506,7 +449,7 @@ DECLSPEC void ripemd160_update_utf16le_swap (ripemd160_ctx_t *ctx, const u32 *w,
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -537,37 +480,10 @@ DECLSPEC void ripemd160_update_utf16le_swap (ripemd160_ctx_t *ctx, const u32 *w,
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -582,7 +498,7 @@ DECLSPEC void ripemd160_update_global (ripemd160_ctx_t *ctx, const __global u32 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -601,25 +517,10 @@ DECLSPEC void ripemd160_update_global (ripemd160_ctx_t *ctx, const __global u32 
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -634,7 +535,7 @@ DECLSPEC void ripemd160_update_global_swap (ripemd160_ctx_t *ctx, const __global
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -670,42 +571,10 @@ DECLSPEC void ripemd160_update_global_swap (ripemd160_ctx_t *ctx, const __global
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -720,7 +589,7 @@ DECLSPEC void ripemd160_update_global_utf16le (ripemd160_ctx_t *ctx, const __glo
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -734,20 +603,10 @@ DECLSPEC void ripemd160_update_global_utf16le (ripemd160_ctx_t *ctx, const __glo
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -762,7 +621,7 @@ DECLSPEC void ripemd160_update_global_utf16le_swap (ripemd160_ctx_t *ctx, const 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -793,37 +652,10 @@ DECLSPEC void ripemd160_update_global_utf16le_swap (ripemd160_ctx_t *ctx, const 
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     ripemd160_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   ripemd160_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1581,7 +1413,7 @@ DECLSPEC void ripemd160_update_vector (ripemd160_ctx_vector_t *ctx, const u32x *
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1600,25 +1432,10 @@ DECLSPEC void ripemd160_update_vector (ripemd160_ctx_vector_t *ctx, const u32x *
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1633,7 +1450,7 @@ DECLSPEC void ripemd160_update_vector_swap (ripemd160_ctx_vector_t *ctx, const u
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1669,42 +1486,10 @@ DECLSPEC void ripemd160_update_vector_swap (ripemd160_ctx_vector_t *ctx, const u
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1719,7 +1504,7 @@ DECLSPEC void ripemd160_update_vector_utf16le (ripemd160_ctx_vector_t *ctx, cons
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1733,20 +1518,10 @@ DECLSPEC void ripemd160_update_vector_utf16le (ripemd160_ctx_vector_t *ctx, cons
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1761,7 +1536,7 @@ DECLSPEC void ripemd160_update_vector_utf16le_swap (ripemd160_ctx_vector_t *ctx,
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1792,37 +1567,10 @@ DECLSPEC void ripemd160_update_vector_utf16le_swap (ripemd160_ctx_vector_t *ctx,
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   ripemd160_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_sha1.cl
+++ b/OpenCL/inc_hash_sha1.cl
@@ -258,7 +258,7 @@ DECLSPEC void sha1_update (sha1_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -277,25 +277,10 @@ DECLSPEC void sha1_update (sha1_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha1_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -310,7 +295,7 @@ DECLSPEC void sha1_update_swap (sha1_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -346,42 +331,10 @@ DECLSPEC void sha1_update_swap (sha1_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -396,7 +349,7 @@ DECLSPEC void sha1_update_utf16le (sha1_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -410,20 +363,10 @@ DECLSPEC void sha1_update_utf16le (sha1_ctx_t *ctx, const u32 *w, const int len)
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -438,7 +381,7 @@ DECLSPEC void sha1_update_utf16le_swap (sha1_ctx_t *ctx, const u32 *w, const int
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -469,37 +412,10 @@ DECLSPEC void sha1_update_utf16le_swap (sha1_ctx_t *ctx, const u32 *w, const int
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -514,7 +430,7 @@ DECLSPEC void sha1_update_utf16be (sha1_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -528,20 +444,10 @@ DECLSPEC void sha1_update_utf16be (sha1_ctx_t *ctx, const u32 *w, const int len)
     make_utf16be_S (w1, w2, w3);
     make_utf16be_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16be_S (w1, w2, w3);
-  make_utf16be_S (w0, w0, w1);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -556,7 +462,7 @@ DECLSPEC void sha1_update_utf16be_swap (sha1_ctx_t *ctx, const u32 *w, const int
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -587,37 +493,10 @@ DECLSPEC void sha1_update_utf16be_swap (sha1_ctx_t *ctx, const u32 *w, const int
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16be_S (w1, w2, w3);
-  make_utf16be_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -632,7 +511,7 @@ DECLSPEC void sha1_update_global (sha1_ctx_t *ctx, const __global u32 *w, const 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -651,25 +530,10 @@ DECLSPEC void sha1_update_global (sha1_ctx_t *ctx, const __global u32 *w, const 
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha1_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -684,7 +548,7 @@ DECLSPEC void sha1_update_global_swap (sha1_ctx_t *ctx, const __global u32 *w, c
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -720,42 +584,10 @@ DECLSPEC void sha1_update_global_swap (sha1_ctx_t *ctx, const __global u32 *w, c
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -770,7 +602,7 @@ DECLSPEC void sha1_update_global_utf16le (sha1_ctx_t *ctx, const __global u32 *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -784,20 +616,10 @@ DECLSPEC void sha1_update_global_utf16le (sha1_ctx_t *ctx, const __global u32 *w
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -812,7 +634,7 @@ DECLSPEC void sha1_update_global_utf16le_swap (sha1_ctx_t *ctx, const __global u
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -843,37 +665,10 @@ DECLSPEC void sha1_update_global_utf16le_swap (sha1_ctx_t *ctx, const __global u
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -888,7 +683,7 @@ DECLSPEC void sha1_update_global_utf16be (sha1_ctx_t *ctx, const __global u32 *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -902,20 +697,10 @@ DECLSPEC void sha1_update_global_utf16be (sha1_ctx_t *ctx, const __global u32 *w
     make_utf16be_S (w1, w2, w3);
     make_utf16be_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16be_S (w1, w2, w3);
-  make_utf16be_S (w0, w0, w1);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -930,7 +715,7 @@ DECLSPEC void sha1_update_global_utf16be_swap (sha1_ctx_t *ctx, const __global u
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -961,37 +746,10 @@ DECLSPEC void sha1_update_global_utf16be_swap (sha1_ctx_t *ctx, const __global u
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16be_S (w1, w2, w3);
-  make_utf16be_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1681,7 +1439,7 @@ DECLSPEC void sha1_update_vector (sha1_ctx_vector_t *ctx, const u32x *w, const i
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1700,25 +1458,10 @@ DECLSPEC void sha1_update_vector (sha1_ctx_vector_t *ctx, const u32x *w, const i
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha1_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha1_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1733,7 +1476,7 @@ DECLSPEC void sha1_update_vector_swap (sha1_ctx_vector_t *ctx, const u32x *w, co
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1769,42 +1512,10 @@ DECLSPEC void sha1_update_vector_swap (sha1_ctx_vector_t *ctx, const u32x *w, co
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha1_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   sha1_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1819,7 +1530,7 @@ DECLSPEC void sha1_update_vector_utf16le (sha1_ctx_vector_t *ctx, const u32x *w,
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1833,20 +1544,10 @@ DECLSPEC void sha1_update_vector_utf16le (sha1_ctx_vector_t *ctx, const u32x *w,
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   sha1_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1861,7 +1562,7 @@ DECLSPEC void sha1_update_vector_utf16le_swap (sha1_ctx_vector_t *ctx, const u32
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1892,37 +1593,10 @@ DECLSPEC void sha1_update_vector_utf16le_swap (sha1_ctx_vector_t *ctx, const u32
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   sha1_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1937,7 +1611,7 @@ DECLSPEC void sha1_update_vector_utf16leN (sha1_ctx_vector_t *ctx, const u32x *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1951,20 +1625,10 @@ DECLSPEC void sha1_update_vector_utf16leN (sha1_ctx_vector_t *ctx, const u32x *w
     make_utf16leN (w1, w2, w3);
     make_utf16leN (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16leN (w1, w2, w3);
-  make_utf16leN (w0, w0, w1);
 
   sha1_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1979,7 +1643,7 @@ DECLSPEC void sha1_update_vector_utf16beN (sha1_ctx_vector_t *ctx, const u32x *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1993,20 +1657,10 @@ DECLSPEC void sha1_update_vector_utf16beN (sha1_ctx_vector_t *ctx, const u32x *w
     make_utf16beN (w1, w2, w3);
     make_utf16beN (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha1_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16beN (w1, w2, w3);
-  make_utf16beN (w0, w0, w1);
 
   sha1_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_sha224.cl
+++ b/OpenCL/inc_hash_sha224.cl
@@ -243,7 +243,7 @@ DECLSPEC void sha224_update (sha224_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -262,25 +262,10 @@ DECLSPEC void sha224_update (sha224_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha224_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -295,7 +280,7 @@ DECLSPEC void sha224_update_swap (sha224_ctx_t *ctx, const u32 *w, const int len
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -331,42 +316,10 @@ DECLSPEC void sha224_update_swap (sha224_ctx_t *ctx, const u32 *w, const int len
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha224_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -381,7 +334,7 @@ DECLSPEC void sha224_update_utf16le (sha224_ctx_t *ctx, const u32 *w, const int 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -395,20 +348,10 @@ DECLSPEC void sha224_update_utf16le (sha224_ctx_t *ctx, const u32 *w, const int 
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha224_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -423,7 +366,7 @@ DECLSPEC void sha224_update_utf16le_swap (sha224_ctx_t *ctx, const u32 *w, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -454,37 +397,10 @@ DECLSPEC void sha224_update_utf16le_swap (sha224_ctx_t *ctx, const u32 *w, const
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha224_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -499,7 +415,7 @@ DECLSPEC void sha224_update_global (sha224_ctx_t *ctx, const __global u32 *w, co
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -518,25 +434,10 @@ DECLSPEC void sha224_update_global (sha224_ctx_t *ctx, const __global u32 *w, co
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha224_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -551,7 +452,7 @@ DECLSPEC void sha224_update_global_swap (sha224_ctx_t *ctx, const __global u32 *
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -587,42 +488,10 @@ DECLSPEC void sha224_update_global_swap (sha224_ctx_t *ctx, const __global u32 *
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha224_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -637,7 +506,7 @@ DECLSPEC void sha224_update_global_utf16le (sha224_ctx_t *ctx, const __global u3
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -651,20 +520,10 @@ DECLSPEC void sha224_update_global_utf16le (sha224_ctx_t *ctx, const __global u3
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha224_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -679,7 +538,7 @@ DECLSPEC void sha224_update_global_utf16le_swap (sha224_ctx_t *ctx, const __glob
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -710,37 +569,10 @@ DECLSPEC void sha224_update_global_utf16le_swap (sha224_ctx_t *ctx, const __glob
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha224_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha224_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1398,7 +1230,7 @@ DECLSPEC void sha224_update_vector (sha224_ctx_vector_t *ctx, const u32x *w, con
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1417,25 +1249,10 @@ DECLSPEC void sha224_update_vector (sha224_ctx_vector_t *ctx, const u32x *w, con
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha224_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha224_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1450,7 +1267,7 @@ DECLSPEC void sha224_update_vector_swap (sha224_ctx_vector_t *ctx, const u32x *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1486,42 +1303,10 @@ DECLSPEC void sha224_update_vector_swap (sha224_ctx_vector_t *ctx, const u32x *w
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha224_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   sha224_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1536,7 +1321,7 @@ DECLSPEC void sha224_update_vector_utf16le (sha224_ctx_vector_t *ctx, const u32x
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1550,20 +1335,10 @@ DECLSPEC void sha224_update_vector_utf16le (sha224_ctx_vector_t *ctx, const u32x
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha224_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   sha224_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1578,7 +1353,7 @@ DECLSPEC void sha224_update_vector_utf16le_swap (sha224_ctx_vector_t *ctx, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1609,37 +1384,10 @@ DECLSPEC void sha224_update_vector_utf16le_swap (sha224_ctx_vector_t *ctx, const
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha224_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   sha224_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1654,7 +1402,7 @@ DECLSPEC void sha224_update_vector_utf16beN (sha224_ctx_vector_t *ctx, const u32
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1668,20 +1416,10 @@ DECLSPEC void sha224_update_vector_utf16beN (sha224_ctx_vector_t *ctx, const u32
     make_utf16beN (w1, w2, w3);
     make_utf16beN (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha224_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16beN (w1, w2, w3);
-  make_utf16beN (w0, w0, w1);
 
   sha224_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_sha256.cl
+++ b/OpenCL/inc_hash_sha256.cl
@@ -243,7 +243,7 @@ DECLSPEC void sha256_update (sha256_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -262,25 +262,10 @@ DECLSPEC void sha256_update (sha256_ctx_t *ctx, const u32 *w, const int len)
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha256_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -295,7 +280,7 @@ DECLSPEC void sha256_update_swap (sha256_ctx_t *ctx, const u32 *w, const int len
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -331,42 +316,10 @@ DECLSPEC void sha256_update_swap (sha256_ctx_t *ctx, const u32 *w, const int len
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha256_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -381,7 +334,7 @@ DECLSPEC void sha256_update_utf16le (sha256_ctx_t *ctx, const u32 *w, const int 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -395,20 +348,10 @@ DECLSPEC void sha256_update_utf16le (sha256_ctx_t *ctx, const u32 *w, const int 
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha256_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -423,7 +366,7 @@ DECLSPEC void sha256_update_utf16le_swap (sha256_ctx_t *ctx, const u32 *w, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -454,37 +397,10 @@ DECLSPEC void sha256_update_utf16le_swap (sha256_ctx_t *ctx, const u32 *w, const
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha256_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -499,7 +415,7 @@ DECLSPEC void sha256_update_global (sha256_ctx_t *ctx, const __global u32 *w, co
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -518,25 +434,10 @@ DECLSPEC void sha256_update_global (sha256_ctx_t *ctx, const __global u32 *w, co
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha256_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -551,7 +452,7 @@ DECLSPEC void sha256_update_global_swap (sha256_ctx_t *ctx, const __global u32 *
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -587,42 +488,10 @@ DECLSPEC void sha256_update_global_swap (sha256_ctx_t *ctx, const __global u32 *
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha256_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -637,7 +506,7 @@ DECLSPEC void sha256_update_global_utf16le (sha256_ctx_t *ctx, const __global u3
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -651,20 +520,10 @@ DECLSPEC void sha256_update_global_utf16le (sha256_ctx_t *ctx, const __global u3
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha256_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -679,7 +538,7 @@ DECLSPEC void sha256_update_global_utf16le_swap (sha256_ctx_t *ctx, const __glob
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -710,37 +569,10 @@ DECLSPEC void sha256_update_global_utf16le_swap (sha256_ctx_t *ctx, const __glob
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha256_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   sha256_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1398,7 +1230,7 @@ DECLSPEC void sha256_update_vector (sha256_ctx_vector_t *ctx, const u32x *w, con
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1417,25 +1249,10 @@ DECLSPEC void sha256_update_vector (sha256_ctx_vector_t *ctx, const u32x *w, con
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     sha256_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   sha256_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1450,7 +1267,7 @@ DECLSPEC void sha256_update_vector_swap (sha256_ctx_vector_t *ctx, const u32x *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1486,42 +1303,10 @@ DECLSPEC void sha256_update_vector_swap (sha256_ctx_vector_t *ctx, const u32x *w
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha256_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   sha256_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1536,7 +1321,7 @@ DECLSPEC void sha256_update_vector_utf16le (sha256_ctx_vector_t *ctx, const u32x
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1550,20 +1335,10 @@ DECLSPEC void sha256_update_vector_utf16le (sha256_ctx_vector_t *ctx, const u32x
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha256_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   sha256_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1578,7 +1353,7 @@ DECLSPEC void sha256_update_vector_utf16le_swap (sha256_ctx_vector_t *ctx, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1609,37 +1384,10 @@ DECLSPEC void sha256_update_vector_utf16le_swap (sha256_ctx_vector_t *ctx, const
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     sha256_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   sha256_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1654,7 +1402,7 @@ DECLSPEC void sha256_update_vector_utf16beN (sha256_ctx_vector_t *ctx, const u32
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1668,20 +1416,10 @@ DECLSPEC void sha256_update_vector_utf16beN (sha256_ctx_vector_t *ctx, const u32
     make_utf16beN (w1, w2, w3);
     make_utf16beN (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     sha256_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16beN (w1, w2, w3);
-  make_utf16beN (w0, w0, w1);
 
   sha256_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_sha384.cl
+++ b/OpenCL/inc_hash_sha384.cl
@@ -323,7 +323,7 @@ DECLSPEC void sha384_update (sha384_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -358,41 +358,10 @@ DECLSPEC void sha384_update (sha384_ctx_t *ctx, const u32 *w, const int len)
     w7[2] = w[pos4 + 30];
     w7[3] = w[pos4 + 31];
 
+    if (pos1 >= len - 128) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -411,7 +380,7 @@ DECLSPEC void sha384_update_swap (sha384_ctx_t *ctx, const u32 *w, const int len
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -479,74 +448,10 @@ DECLSPEC void sha384_update_swap (sha384_ctx_t *ctx, const u32 *w, const int len
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 128) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -565,7 +470,7 @@ DECLSPEC void sha384_update_utf16le (sha384_ctx_t *ctx, const u32 *w, const int 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -589,30 +494,10 @@ DECLSPEC void sha384_update_utf16le (sha384_ctx_t *ctx, const u32 *w, const int 
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -631,7 +516,7 @@ DECLSPEC void sha384_update_utf16le_swap (sha384_ctx_t *ctx, const u32 *w, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -688,63 +573,10 @@ DECLSPEC void sha384_update_utf16le_swap (sha384_ctx_t *ctx, const u32 *w, const
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -763,7 +595,7 @@ DECLSPEC void sha384_update_global (sha384_ctx_t *ctx, const __global u32 *w, co
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -798,41 +630,10 @@ DECLSPEC void sha384_update_global (sha384_ctx_t *ctx, const __global u32 *w, co
     w7[2] = w[pos4 + 30];
     w7[3] = w[pos4 + 31];
 
+    if (pos1 >= len - 128) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -851,7 +652,7 @@ DECLSPEC void sha384_update_global_swap (sha384_ctx_t *ctx, const __global u32 *
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -919,74 +720,10 @@ DECLSPEC void sha384_update_global_swap (sha384_ctx_t *ctx, const __global u32 *
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 128) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -1005,7 +742,7 @@ DECLSPEC void sha384_update_global_utf16le (sha384_ctx_t *ctx, const __global u3
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1029,30 +766,10 @@ DECLSPEC void sha384_update_global_utf16le (sha384_ctx_t *ctx, const __global u3
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -1071,7 +788,7 @@ DECLSPEC void sha384_update_global_utf16le_swap (sha384_ctx_t *ctx, const __glob
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1128,63 +845,10 @@ DECLSPEC void sha384_update_global_utf16le_swap (sha384_ctx_t *ctx, const __glob
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha384_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -2150,7 +1814,7 @@ DECLSPEC void sha384_update_vector (sha384_ctx_vector_t *ctx, const u32x *w, con
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2185,41 +1849,10 @@ DECLSPEC void sha384_update_vector (sha384_ctx_vector_t *ctx, const u32x *w, con
     w7[2] = w[pos4 + 30];
     w7[3] = w[pos4 + 31];
 
+    if (pos1 >= len - 128) break;
+
     sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
 
   sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -2238,7 +1871,7 @@ DECLSPEC void sha384_update_vector_swap (sha384_ctx_vector_t *ctx, const u32x *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2306,74 +1939,10 @@ DECLSPEC void sha384_update_vector_swap (sha384_ctx_vector_t *ctx, const u32x *w
     w7[2] = swap32 (w7[2]);
     w7[3] = swap32 (w7[3]);
 
+    if (pos1 >= len - 128) break;
+
     sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
-  w4[0] = swap32 (w4[0]);
-  w4[1] = swap32 (w4[1]);
-  w4[2] = swap32 (w4[2]);
-  w4[3] = swap32 (w4[3]);
-  w5[0] = swap32 (w5[0]);
-  w5[1] = swap32 (w5[1]);
-  w5[2] = swap32 (w5[2]);
-  w5[3] = swap32 (w5[3]);
-  w6[0] = swap32 (w6[0]);
-  w6[1] = swap32 (w6[1]);
-  w6[2] = swap32 (w6[2]);
-  w6[3] = swap32 (w6[3]);
-  w7[0] = swap32 (w7[0]);
-  w7[1] = swap32 (w7[1]);
-  w7[2] = swap32 (w7[2]);
-  w7[3] = swap32 (w7[3]);
 
   sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -2392,7 +1961,7 @@ DECLSPEC void sha384_update_vector_utf16le (sha384_ctx_vector_t *ctx, const u32x
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2416,30 +1985,10 @@ DECLSPEC void sha384_update_vector_utf16le (sha384_ctx_vector_t *ctx, const u32x
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le (w3, w6, w7);
-  make_utf16le (w2, w4, w5);
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -2458,7 +2007,7 @@ DECLSPEC void sha384_update_vector_utf16le_swap (sha384_ctx_vector_t *ctx, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2515,63 +2064,10 @@ DECLSPEC void sha384_update_vector_utf16le_swap (sha384_ctx_vector_t *ctx, const
     w7[2] = swap32 (w7[2]);
     w7[3] = swap32 (w7[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le (w3, w6, w7);
-  make_utf16le (w2, w4, w5);
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
-  w4[0] = swap32 (w4[0]);
-  w4[1] = swap32 (w4[1]);
-  w4[2] = swap32 (w4[2]);
-  w4[3] = swap32 (w4[3]);
-  w5[0] = swap32 (w5[0]);
-  w5[1] = swap32 (w5[1]);
-  w5[2] = swap32 (w5[2]);
-  w5[3] = swap32 (w5[3]);
-  w6[0] = swap32 (w6[0]);
-  w6[1] = swap32 (w6[1]);
-  w6[2] = swap32 (w6[2]);
-  w6[3] = swap32 (w6[3]);
-  w7[0] = swap32 (w7[0]);
-  w7[1] = swap32 (w7[1]);
-  w7[2] = swap32 (w7[2]);
-  w7[3] = swap32 (w7[3]);
 
   sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -2590,7 +2086,7 @@ DECLSPEC void sha384_update_vector_utf16beN (sha384_ctx_vector_t *ctx, const u32
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2614,30 +2110,10 @@ DECLSPEC void sha384_update_vector_utf16beN (sha384_ctx_vector_t *ctx, const u32
     make_utf16beN (w1, w2, w3);
     make_utf16beN (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16beN (w3, w6, w7);
-  make_utf16beN (w2, w4, w5);
-  make_utf16beN (w1, w2, w3);
-  make_utf16beN (w0, w0, w1);
 
   sha384_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_sha512.cl
+++ b/OpenCL/inc_hash_sha512.cl
@@ -323,7 +323,7 @@ DECLSPEC void sha512_update (sha512_ctx_t *ctx, const u32 *w, const int len)
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -358,41 +358,10 @@ DECLSPEC void sha512_update (sha512_ctx_t *ctx, const u32 *w, const int len)
     w7[2] = w[pos4 + 30];
     w7[3] = w[pos4 + 31];
 
+    if (pos1 >= len - 128) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -411,7 +380,7 @@ DECLSPEC void sha512_update_swap (sha512_ctx_t *ctx, const u32 *w, const int len
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -479,74 +448,10 @@ DECLSPEC void sha512_update_swap (sha512_ctx_t *ctx, const u32 *w, const int len
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 128) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -565,7 +470,7 @@ DECLSPEC void sha512_update_utf16le (sha512_ctx_t *ctx, const u32 *w, const int 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -589,30 +494,10 @@ DECLSPEC void sha512_update_utf16le (sha512_ctx_t *ctx, const u32 *w, const int 
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -631,7 +516,7 @@ DECLSPEC void sha512_update_utf16le_swap (sha512_ctx_t *ctx, const u32 *w, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -688,63 +573,10 @@ DECLSPEC void sha512_update_utf16le_swap (sha512_ctx_t *ctx, const u32 *w, const
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -763,7 +595,7 @@ DECLSPEC void sha512_update_global (sha512_ctx_t *ctx, const __global u32 *w, co
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -798,41 +630,10 @@ DECLSPEC void sha512_update_global (sha512_ctx_t *ctx, const __global u32 *w, co
     w7[2] = w[pos4 + 30];
     w7[3] = w[pos4 + 31];
 
+    if (pos1 >= len - 128) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -851,7 +652,7 @@ DECLSPEC void sha512_update_global_swap (sha512_ctx_t *ctx, const __global u32 *
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -919,74 +720,10 @@ DECLSPEC void sha512_update_global_swap (sha512_ctx_t *ctx, const __global u32 *
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 128) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -1005,7 +742,7 @@ DECLSPEC void sha512_update_global_utf16le (sha512_ctx_t *ctx, const __global u3
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1029,30 +766,10 @@ DECLSPEC void sha512_update_global_utf16le (sha512_ctx_t *ctx, const __global u3
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -1071,7 +788,7 @@ DECLSPEC void sha512_update_global_utf16le_swap (sha512_ctx_t *ctx, const __glob
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1128,63 +845,10 @@ DECLSPEC void sha512_update_global_utf16le_swap (sha512_ctx_t *ctx, const __glob
     w7[2] = swap32_S (w7[2]);
     w7[3] = swap32_S (w7[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le_S (w3, w6, w7);
-  make_utf16le_S (w2, w4, w5);
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
-  w4[0] = swap32_S (w4[0]);
-  w4[1] = swap32_S (w4[1]);
-  w4[2] = swap32_S (w4[2]);
-  w4[3] = swap32_S (w4[3]);
-  w5[0] = swap32_S (w5[0]);
-  w5[1] = swap32_S (w5[1]);
-  w5[2] = swap32_S (w5[2]);
-  w5[3] = swap32_S (w5[3]);
-  w6[0] = swap32_S (w6[0]);
-  w6[1] = swap32_S (w6[1]);
-  w6[2] = swap32_S (w6[2]);
-  w6[3] = swap32_S (w6[3]);
-  w7[0] = swap32_S (w7[0]);
-  w7[1] = swap32_S (w7[1]);
-  w7[2] = swap32_S (w7[2]);
-  w7[3] = swap32_S (w7[3]);
 
   sha512_update_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -2150,7 +1814,7 @@ DECLSPEC void sha512_update_vector (sha512_ctx_vector_t *ctx, const u32x *w, con
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2185,41 +1849,10 @@ DECLSPEC void sha512_update_vector (sha512_ctx_vector_t *ctx, const u32x *w, con
     w7[2] = w[pos4 + 30];
     w7[3] = w[pos4 + 31];
 
+    if (pos1 >= len - 128) break;
+
     sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
 
   sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -2238,7 +1871,7 @@ DECLSPEC void sha512_update_vector_swap (sha512_ctx_vector_t *ctx, const u32x *w
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 128; pos1 += 128, pos4 += 32)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 128, pos4 += 32)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2306,74 +1939,10 @@ DECLSPEC void sha512_update_vector_swap (sha512_ctx_vector_t *ctx, const u32x *w
     w7[2] = swap32 (w7[2]);
     w7[3] = swap32 (w7[3]);
 
+    if (pos1 >= len - 128) break;
+
     sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-  w4[0] = w[pos4 + 16];
-  w4[1] = w[pos4 + 17];
-  w4[2] = w[pos4 + 18];
-  w4[3] = w[pos4 + 19];
-  w5[0] = w[pos4 + 20];
-  w5[1] = w[pos4 + 21];
-  w5[2] = w[pos4 + 22];
-  w5[3] = w[pos4 + 23];
-  w6[0] = w[pos4 + 24];
-  w6[1] = w[pos4 + 25];
-  w6[2] = w[pos4 + 26];
-  w6[3] = w[pos4 + 27];
-  w7[0] = w[pos4 + 28];
-  w7[1] = w[pos4 + 29];
-  w7[2] = w[pos4 + 30];
-  w7[3] = w[pos4 + 31];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
-  w4[0] = swap32 (w4[0]);
-  w4[1] = swap32 (w4[1]);
-  w4[2] = swap32 (w4[2]);
-  w4[3] = swap32 (w4[3]);
-  w5[0] = swap32 (w5[0]);
-  w5[1] = swap32 (w5[1]);
-  w5[2] = swap32 (w5[2]);
-  w5[3] = swap32 (w5[3]);
-  w6[0] = swap32 (w6[0]);
-  w6[1] = swap32 (w6[1]);
-  w6[2] = swap32 (w6[2]);
-  w6[3] = swap32 (w6[3]);
-  w7[0] = swap32 (w7[0]);
-  w7[1] = swap32 (w7[1]);
-  w7[2] = swap32 (w7[2]);
-  w7[3] = swap32 (w7[3]);
 
   sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, len - pos1);
 }
@@ -2392,7 +1961,7 @@ DECLSPEC void sha512_update_vector_utf16le (sha512_ctx_vector_t *ctx, const u32x
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2416,30 +1985,10 @@ DECLSPEC void sha512_update_vector_utf16le (sha512_ctx_vector_t *ctx, const u32x
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le (w3, w6, w7);
-  make_utf16le (w2, w4, w5);
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -2458,7 +2007,7 @@ DECLSPEC void sha512_update_vector_utf16le_swap (sha512_ctx_vector_t *ctx, const
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2515,63 +2064,10 @@ DECLSPEC void sha512_update_vector_utf16le_swap (sha512_ctx_vector_t *ctx, const
     w7[2] = swap32 (w7[2]);
     w7[3] = swap32 (w7[3]);
 
+    if (pos1 >= len - 64) break;
+
     sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16le (w3, w6, w7);
-  make_utf16le (w2, w4, w5);
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
-  w4[0] = swap32 (w4[0]);
-  w4[1] = swap32 (w4[1]);
-  w4[2] = swap32 (w4[2]);
-  w4[3] = swap32 (w4[3]);
-  w5[0] = swap32 (w5[0]);
-  w5[1] = swap32 (w5[1]);
-  w5[2] = swap32 (w5[2]);
-  w5[3] = swap32 (w5[3]);
-  w6[0] = swap32 (w6[0]);
-  w6[1] = swap32 (w6[1]);
-  w6[2] = swap32 (w6[2]);
-  w6[3] = swap32 (w6[3]);
-  w7[0] = swap32 (w7[0]);
-  w7[1] = swap32 (w7[1]);
-  w7[2] = swap32 (w7[2]);
-  w7[3] = swap32 (w7[3]);
 
   sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }
@@ -2590,7 +2086,7 @@ DECLSPEC void sha512_update_vector_utf16beN (sha512_ctx_vector_t *ctx, const u32
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2614,30 +2110,10 @@ DECLSPEC void sha512_update_vector_utf16beN (sha512_ctx_vector_t *ctx, const u32
     make_utf16beN (w1, w2, w3);
     make_utf16beN (w0, w0, w1);
 
+    if (pos1 >= len - 64) break;
+
     sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, 64 * 2);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  make_utf16beN (w3, w6, w7);
-  make_utf16beN (w2, w4, w5);
-  make_utf16beN (w1, w2, w3);
-  make_utf16beN (w0, w0, w1);
 
   sha512_update_vector_128 (ctx, w0, w1, w2, w3, w4, w5, w6, w7, (len - pos1) * 2);
 }

--- a/OpenCL/inc_hash_whirlpool.cl
+++ b/OpenCL/inc_hash_whirlpool.cl
@@ -1426,7 +1426,7 @@ DECLSPEC void whirlpool_update (whirlpool_ctx_t *ctx, const u32 *w, const int le
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1445,25 +1445,10 @@ DECLSPEC void whirlpool_update (whirlpool_ctx_t *ctx, const u32 *w, const int le
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1478,7 +1463,7 @@ DECLSPEC void whirlpool_update_swap (whirlpool_ctx_t *ctx, const u32 *w, const i
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1514,42 +1499,10 @@ DECLSPEC void whirlpool_update_swap (whirlpool_ctx_t *ctx, const u32 *w, const i
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1564,7 +1517,7 @@ DECLSPEC void whirlpool_update_utf16le (whirlpool_ctx_t *ctx, const u32 *w, cons
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1578,20 +1531,10 @@ DECLSPEC void whirlpool_update_utf16le (whirlpool_ctx_t *ctx, const u32 *w, cons
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1606,7 +1549,7 @@ DECLSPEC void whirlpool_update_utf16le_swap (whirlpool_ctx_t *ctx, const u32 *w,
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1637,37 +1580,10 @@ DECLSPEC void whirlpool_update_utf16le_swap (whirlpool_ctx_t *ctx, const u32 *w,
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1682,7 +1598,7 @@ DECLSPEC void whirlpool_update_global (whirlpool_ctx_t *ctx, const __global u32 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1701,25 +1617,10 @@ DECLSPEC void whirlpool_update_global (whirlpool_ctx_t *ctx, const __global u32 
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1734,7 +1635,7 @@ DECLSPEC void whirlpool_update_global_swap (whirlpool_ctx_t *ctx, const __global
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -1770,42 +1671,10 @@ DECLSPEC void whirlpool_update_global_swap (whirlpool_ctx_t *ctx, const __global
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -1820,7 +1689,7 @@ DECLSPEC void whirlpool_update_global_utf16le (whirlpool_ctx_t *ctx, const __glo
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1834,20 +1703,10 @@ DECLSPEC void whirlpool_update_global_utf16le (whirlpool_ctx_t *ctx, const __glo
     make_utf16le_S (w1, w2, w3);
     make_utf16le_S (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -1862,7 +1721,7 @@ DECLSPEC void whirlpool_update_global_utf16le_swap (whirlpool_ctx_t *ctx, const 
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -1893,37 +1752,10 @@ DECLSPEC void whirlpool_update_global_utf16le_swap (whirlpool_ctx_t *ctx, const 
     w3[2] = swap32_S (w3[2]);
     w3[3] = swap32_S (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     whirlpool_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le_S (w1, w2, w3);
-  make_utf16le_S (w0, w0, w1);
-
-  w0[0] = swap32_S (w0[0]);
-  w0[1] = swap32_S (w0[1]);
-  w0[2] = swap32_S (w0[2]);
-  w0[3] = swap32_S (w0[3]);
-  w1[0] = swap32_S (w1[0]);
-  w1[1] = swap32_S (w1[1]);
-  w1[2] = swap32_S (w1[2]);
-  w1[3] = swap32_S (w1[3]);
-  w2[0] = swap32_S (w2[0]);
-  w2[1] = swap32_S (w2[1]);
-  w2[2] = swap32_S (w2[2]);
-  w2[3] = swap32_S (w2[3]);
-  w3[0] = swap32_S (w3[0]);
-  w3[1] = swap32_S (w3[1]);
-  w3[2] = swap32_S (w3[2]);
-  w3[3] = swap32_S (w3[3]);
 
   whirlpool_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -2685,7 +2517,7 @@ DECLSPEC void whirlpool_update_vector (whirlpool_ctx_vector_t *ctx, const u32x *
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2704,25 +2536,10 @@ DECLSPEC void whirlpool_update_vector (whirlpool_ctx_vector_t *ctx, const u32x *
     w3[2] = w[pos4 + 14];
     w3[3] = w[pos4 + 15];
 
+    if (pos1 >= len - 64) break;
+
     whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
 
   whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -2737,7 +2554,7 @@ DECLSPEC void whirlpool_update_vector_swap (whirlpool_ctx_vector_t *ctx, const u
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 64; pos1 += 64, pos4 += 16)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 64, pos4 += 16)
   {
     w0[0] = w[pos4 +  0];
     w0[1] = w[pos4 +  1];
@@ -2773,42 +2590,10 @@ DECLSPEC void whirlpool_update_vector_swap (whirlpool_ctx_vector_t *ctx, const u
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 64) break;
+
     whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, 64);
   }
-
-  w0[0] = w[pos4 +  0];
-  w0[1] = w[pos4 +  1];
-  w0[2] = w[pos4 +  2];
-  w0[3] = w[pos4 +  3];
-  w1[0] = w[pos4 +  4];
-  w1[1] = w[pos4 +  5];
-  w1[2] = w[pos4 +  6];
-  w1[3] = w[pos4 +  7];
-  w2[0] = w[pos4 +  8];
-  w2[1] = w[pos4 +  9];
-  w2[2] = w[pos4 + 10];
-  w2[3] = w[pos4 + 11];
-  w3[0] = w[pos4 + 12];
-  w3[1] = w[pos4 + 13];
-  w3[2] = w[pos4 + 14];
-  w3[3] = w[pos4 + 15];
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
@@ -2823,7 +2608,7 @@ DECLSPEC void whirlpool_update_vector_utf16le (whirlpool_ctx_vector_t *ctx, cons
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -2837,20 +2622,10 @@ DECLSPEC void whirlpool_update_vector_utf16le (whirlpool_ctx_vector_t *ctx, cons
     make_utf16le (w1, w2, w3);
     make_utf16le (w0, w0, w1);
 
+    if (pos1 >= len - 32) break;
+
     whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
 
   whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
@@ -2865,7 +2640,7 @@ DECLSPEC void whirlpool_update_vector_utf16le_swap (whirlpool_ctx_vector_t *ctx,
   int pos1;
   int pos4;
 
-  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  for (pos1 = 0, pos4 = 0; ; pos1 += 32, pos4 += 8)
   {
     w0[0] = w[pos4 + 0];
     w0[1] = w[pos4 + 1];
@@ -2896,37 +2671,10 @@ DECLSPEC void whirlpool_update_vector_utf16le_swap (whirlpool_ctx_vector_t *ctx,
     w3[2] = swap32 (w3[2]);
     w3[3] = swap32 (w3[3]);
 
+    if (pos1 >= len - 32) break;
+
     whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, 32 * 2);
   }
-
-  w0[0] = w[pos4 + 0];
-  w0[1] = w[pos4 + 1];
-  w0[2] = w[pos4 + 2];
-  w0[3] = w[pos4 + 3];
-  w1[0] = w[pos4 + 4];
-  w1[1] = w[pos4 + 5];
-  w1[2] = w[pos4 + 6];
-  w1[3] = w[pos4 + 7];
-
-  make_utf16le (w1, w2, w3);
-  make_utf16le (w0, w0, w1);
-
-  w0[0] = swap32 (w0[0]);
-  w0[1] = swap32 (w0[1]);
-  w0[2] = swap32 (w0[2]);
-  w0[3] = swap32 (w0[3]);
-  w1[0] = swap32 (w1[0]);
-  w1[1] = swap32 (w1[1]);
-  w1[2] = swap32 (w1[2]);
-  w1[3] = swap32 (w1[3]);
-  w2[0] = swap32 (w2[0]);
-  w2[1] = swap32 (w2[1]);
-  w2[2] = swap32 (w2[2]);
-  w2[3] = swap32 (w2[3]);
-  w3[0] = swap32 (w3[0]);
-  w3[1] = swap32 (w3[1]);
-  w3[2] = swap32 (w3[2]);
-  w3[3] = swap32 (w3[3]);
 
   whirlpool_update_vector_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }


### PR DESCRIPTION
This restructures the update loops so the pos/len condition is checked before the main update call, so the last pass on the message can be moved into the loop body. It should be an almost-identical representation.