### PR TITLE
Increased the maximum size of edata2 in Kerberos 5 TGS-REP etype 23

### DIFF
--- a/OpenCL/inc_types.cl
+++ b/OpenCL/inc_types.cl
@@ -1292,7 +1292,7 @@ typedef struct krb5tgs
 {
   u32 account_info[512];
   u32 checksum[4];
-  u32 edata2[2560];
+  u32 edata2[5120];
   u32 edata2_len;
 
 } krb5tgs_t;

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -19,6 +19,7 @@
 - Removed duplicate words in the dictionary file example.dict
 - Improved the speed of the outfile folder scan when using lots of hashes/salts
 - Added additional hybrid "passthrough" rules, to enable variable-length append/prepend attacks
+- Increased the maximum size of edata2 in Kerberos 5 TGS-REP etype 23
 
 ##
 ## Bugs

--- a/include/interface.h
+++ b/include/interface.h
@@ -280,7 +280,7 @@ typedef struct krb5tgs
 {
   u32 account_info[512];
   u32 checksum[4];
-  u32 edata2[2560];
+  u32 edata2[5120];
   u32 edata2_len;
 
 } krb5tgs_t;

--- a/src/interface.c
+++ b/src/interface.c
@@ -13961,7 +13961,7 @@ int krb5tgs_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UN
 
     token.sep[3]     = '$';
     token.len_min[3] = 64;
-    token.len_max[3] = 20480;
+    token.len_max[3] = 40960;
     token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                      | TOKEN_ATTR_VERIFY_HEX;
   }
@@ -13977,7 +13977,7 @@ int krb5tgs_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf, MAYBE_UN
 
     token.sep[2]     = '$';
     token.len_min[2] = 64;
-    token.len_max[2] = 20480;
+    token.len_max[2] = 40960;
     token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
                      | TOKEN_ATTR_VERIFY_HEX;
   }
@@ -21039,7 +21039,7 @@ int ascii_digest (hashcat_ctx_t *hashcat_ctx, char *out_buf, const size_t out_le
 
     krb5tgs_t *krb5tgs = &krb5tgss[digest_cur];
 
-    char data[2560 * 4 * 2] = { 0 };
+    char data[5120 * 4 * 2] = { 0 };
 
     for (u32 i = 0, j = 0; i < krb5tgs->edata2_len; i += 1, j += 2)
     {


### PR DESCRIPTION
@evilmog found hashes in the wild which had edata2 length of around 25000 hex chars (or ~12.5kb).
Obviously he couldn't share an example but, that wasn't necessary. I created this patch, shared it with him and it worked.
So I suggest we increase the maximum size of edata2 from 10kb to 20kb.