### PR TITLE
Add HC_API_CALL to a few functions

### DIFF
--- a/include/autotune.h
+++ b/include/autotune.h
@@ -6,6 +6,6 @@
 #ifndef _AUTOTUNE_H
 #define _AUTOTUNE_H
 
-void *thread_autotune (void *p);
+HC_API_CALL void *thread_autotune (void *p);
 
 #endif // _AUTOTUNE_H

--- a/include/dispatch.h
+++ b/include/dispatch.h
@@ -6,7 +6,7 @@
 #ifndef _DISPATCH_H
 #define _DISPATCH_H
 
-void *thread_calc_stdin (void *p);
-void *thread_calc (void *p);
+HC_API_CALL void *thread_calc_stdin (void *p);
+HC_API_CALL void *thread_calc (void *p);
 
 #endif // _DISPATCH_H

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -8,6 +8,6 @@
 
 int get_runtime_left (const hashcat_ctx_t *hashcat_ctx);
 
-void *thread_monitor (void *p);
+HC_API_CALL void *thread_monitor (void *p);
 
 #endif // _MONITOR_H

--- a/include/outfile_check.h
+++ b/include/outfile_check.h
@@ -11,7 +11,7 @@
 
 #define OUTFILES_DIR "outfiles"
 
-void *thread_outfile_remove (void *p);
+HC_API_CALL void *thread_outfile_remove (void *p);
 
 int  outcheck_ctx_init    (hashcat_ctx_t *hashcat_ctx);
 void outcheck_ctx_destroy (hashcat_ctx_t *hashcat_ctx);

--- a/include/selftest.h
+++ b/include/selftest.h
@@ -6,6 +6,6 @@
 #ifndef _SELFTEST_H
 #define _SELFTEST_H
 
-void *thread_selftest (void *p);
+HC_API_CALL void *thread_selftest (void *p);
 
 #endif // _SELFTEST_H

--- a/include/terminal.h
+++ b/include/terminal.h
@@ -29,7 +29,7 @@ int setup_console (void);
 void send_prompt  (hashcat_ctx_t *hashcat_ctx);
 void clear_prompt (hashcat_ctx_t *hashcat_ctx);
 
-void *thread_keypress (void *p);
+HC_API_CALL void *thread_keypress (void *p);
 
 #if defined (_WIN)
 void SetConsoleWindowSize (const int x);

--- a/src/autotune.c
+++ b/src/autotune.c
@@ -272,7 +272,7 @@ static int autotune (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
   return 0;
 }
 
-void *thread_autotune (void *p)
+HC_API_CALL void *thread_autotune (void *p)
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -474,7 +474,7 @@ static int calc_stdin (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_par
   return 0;
 }
 
-void *thread_calc_stdin (void *p)
+HC_API_CALL void *thread_calc_stdin (void *p)
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 
@@ -1429,7 +1429,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
   return 0;
 }
 
-void *thread_calc (void *p)
+HC_API_CALL void *thread_calc (void *p)
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -308,7 +308,7 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
   return 0;
 }
 
-void *thread_monitor (void *p)
+HC_API_CALL void *thread_monitor (void *p)
 {
   hashcat_ctx_t *hashcat_ctx = (hashcat_ctx_t *) p;
 

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -325,7 +325,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
   return 0;
 }
 
-void *thread_outfile_remove (void *p)
+HC_API_CALL void *thread_outfile_remove (void *p)
 {
   hashcat_ctx_t *hashcat_ctx = (hashcat_ctx_t *) p;
 

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -552,7 +552,7 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
   return 0;
 }
 
-void *thread_selftest (void *p)
+HC_API_CALL void *thread_selftest (void *p)
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -314,7 +314,7 @@ static void keypress (hashcat_ctx_t *hashcat_ctx)
   tty_fix ();
 }
 
-void *thread_keypress (void *p)
+HC_API_CALL void *thread_keypress (void *p)
 {
   hashcat_ctx_t *hashcat_ctx = (hashcat_ctx_t *) p;
 


### PR DESCRIPTION
On 32-bit MinGW, clang was throwing errors about this.

64-bit MinGW and regular MSYS does not throw warnings after the change.