### PR TITLE
fixes #1708: reject invalid masks with only a single ? at the end

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -25,7 +25,7 @@
 ##
 
 - Workaround some AMD OpenCL runtime segmentation faults
-- Allow bitcoin master key length not be exactly 96 byte a multiple of 16
+- Allow bitcoin master key lengths different from 96 bytes, but they must be always a multiple of 16
 - Getting rid of OPTS_TYPE_HASH_COPY for Ansible Vault
 - Add a tracker for salts, amplifier and iterations to status screen
 - Add option --markov-hcstat2 to make it clear that the new hcstat2 format (compressed hcstat2gen output) must be used
@@ -35,6 +35,7 @@
 - Added additional hybrid "passthrough" rules, to enable variable-length append/prepend attacks
 - Increased the maximum size of edata2 in Kerberos 5 TGS-REP etype 23
 - Allow hashfile for -m 16800 to be used with -m 16801
+- Make the masks parser more restrictive by rejecting a single '?' at the end of the mask (use ?? instead)
 
 ##
 ## Bugs

--- a/src/main.c
+++ b/src/main.c
@@ -205,6 +205,14 @@ static void main_outerloop_finished (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MA
   hashcat_user_t *hashcat_user = hashcat_ctx->hashcat_user;
   status_ctx_t   *status_ctx   = hashcat_ctx->status_ctx;
 
+  // we should never stop hashcat with STATUS_INIT:
+  // keypress thread blocks on STATUS_INIT forever!
+
+  if (status_ctx->devices_status == STATUS_INIT)
+  {
+    status_ctx->devices_status = STATUS_ERROR;
+  }
+
   // wait for outer threads
 
   status_ctx->shutdown_outer = true;

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -268,7 +268,12 @@ static int mp_expand (hashcat_ctx_t *hashcat_ctx, const char *in_buf, size_t in_
     {
       in_pos++;
 
-      if (in_pos == in_len) break;
+      if (in_pos == in_len)
+      {
+        event_log_error (hashcat_ctx, "Syntax error in mask: %s", in_buf);
+
+        return -1;
+      }
 
       u32 p1 = in_buf[in_pos] & 0xff;
 
@@ -306,7 +311,7 @@ static int mp_expand (hashcat_ctx_t *hashcat_ctx, const char *in_buf, size_t in_
                   break;
         case '?': rc = mp_add_cs_buf (hashcat_ctx, &p0, 1, mp_usr, mp_usr_offset);
                   break;
-        default:  event_log_error (hashcat_ctx, "Syntax error: %s", in_buf);
+        default:  event_log_error (hashcat_ctx, "Syntax error in mask: %s", in_buf);
                   return -1;
       }
 
@@ -372,7 +377,12 @@ static int mp_gen_css (hashcat_ctx_t *hashcat_ctx, char *mask_buf, size_t mask_l
     {
       mask_pos++;
 
-      if (mask_pos == mask_len) break;
+      if (mask_pos == mask_len)
+      {
+        event_log_error (hashcat_ctx, "Syntax error in mask: %s", mask_buf);
+
+        return -1;
+      }
 
       char p1 = mask_buf[mask_pos];
 
@@ -412,7 +422,7 @@ static int mp_gen_css (hashcat_ctx_t *hashcat_ctx, char *mask_buf, size_t mask_l
                   break;
         case '?': rc = mp_add_cs_buf (hashcat_ctx, &chr, 1, css_buf, css_pos);
                   break;
-        default:  event_log_error (hashcat_ctx, "Syntax error: %s", mask_buf);
+        default:  event_log_error (hashcat_ctx, "Syntax error in mask: %s", mask_buf);
                   return -1;
       }
 


### PR DESCRIPTION
This fixes issue #1708 where a masks like ?a?a?a?a? was accepted as it was ?a?a?a?a?? .
Since the explanation on the wiki and faq make it very clear that we need to use ?? to represent a single quotation mark character within a mask, I would recommend that we make this more restrictive and reject every mask that doesn't comply with it.

BTW I looped/searched over all masks within the hashcat's "masks\" directory and there was none that had a syntax error like this. we should be fine there and as @s3inlc mentioned we shouldn't allow masks that do not respect the "rules".
Thx