### PR TITLE
stdin: add read timeout checks (abort if no input for a long time)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -36,6 +36,7 @@
 - Increased the maximum size of edata2 in Kerberos 5 TGS-REP etype 23
 - Allow hashfile for -m 16800 to be used with -m 16801
 - Make the masks parser more restrictive by rejecting a single '?' at the end of the mask (use ?? instead)
+- Add a periodic check for read timeouts in stdin/pipe mode and abort if no input was provided
 
 ##
 ## Bugs

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -6,6 +6,9 @@
 #ifndef _MONITOR_H
 #define _MONITOR_H
 
+#define STDIN_TIMEOUT_MIN  20 // warn  after no input from stdin for x seconds
+#define STDIN_TIMEOUT_MAX 120 // abort after no input from stdin for x seconds
+
 int get_runtime_left (const hashcat_ctx_t *hashcat_ctx);
 
 HC_API_CALL void *thread_monitor (void *p);

--- a/include/types.h
+++ b/include/types.h
@@ -120,6 +120,8 @@ typedef enum event_identifier
   EVENT_MONITOR_THROTTLE2         = 0x00000084,
   EVENT_MONITOR_THROTTLE3         = 0x00000085,
   EVENT_MONITOR_PERFORMANCE_HINT  = 0x00000086,
+  EVENT_MONITOR_NOINPUT_HINT      = 0x00000087,
+  EVENT_MONITOR_NOINPUT_ABORT     = 0x00000088,
   EVENT_OPENCL_SESSION_POST       = 0x00000090,
   EVENT_OPENCL_SESSION_PRE        = 0x00000091,
   EVENT_OUTERLOOP_FINISHED        = 0x000000a0,
@@ -2021,6 +2023,12 @@ typedef struct status_ctx
   hc_timer_t timer_paused;      // timer on current dict
 
   double  msec_paused;          // timer on current dict
+
+  /**
+   * read timeouts
+   */
+
+  u32  stdin_read_timeout_cnt;
 
 } status_ctx_t;
 

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -179,8 +179,12 @@ static int calc_stdin (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_par
         {
           if (status_ctx->run_thread_level1 == false) break;
 
+          status_ctx->stdin_read_timeout_cnt++;
+
           continue;
         }
+
+        status_ctx->stdin_read_timeout_cnt = 0;
 
         char *line_buf = fgets (buf, HCBUFSIZ_LARGE - 1, stdin);
 
@@ -343,8 +347,12 @@ static int calc_stdin (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_par
         {
           if (status_ctx->run_thread_level1 == false) break;
 
+          status_ctx->stdin_read_timeout_cnt++;
+
           continue;
         }
+
+        status_ctx->stdin_read_timeout_cnt = 0;
 
         char *line_buf = fgets (buf, HCBUFSIZ_LARGE - 1, stdin);
 

--- a/src/main.c
+++ b/src/main.c
@@ -700,6 +700,24 @@ static void main_monitor_performance_hint (MAYBE_UNUSED hashcat_ctx_t *hashcat_c
   }
 }
 
+static void main_monitor_noinput_hint (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const void *buf, MAYBE_UNUSED const size_t len)
+{
+  const user_options_t *user_options = hashcat_ctx->user_options;
+
+  if (user_options->quiet == true) return;
+
+  event_log_advice (hashcat_ctx, "ATTENTION! Read timeout in stdin mode. The password candidates input is too slow:");
+  event_log_advice (hashcat_ctx, "* Are you sure that you are using the correct attack mode (--attack-mode or -a)?");
+  event_log_advice (hashcat_ctx, "* Are you sure that you want to use input from standard input (stdin)?");
+  event_log_advice (hashcat_ctx, "* If so, are you sure that the input from stdin (the pipe) is working correctly and is fast enough?");
+  event_log_advice (hashcat_ctx, NULL);
+}
+
+static void main_monitor_noinput_abort (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const void *buf, MAYBE_UNUSED const size_t len)
+{
+  event_log_error (hashcat_ctx, "No password candidates received in stdin mode, aborting...");
+}
+
 static void main_monitor_temp_abort (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const void *buf, MAYBE_UNUSED const size_t len)
 {
   const user_options_t       *user_options       = hashcat_ctx->user_options;
@@ -952,6 +970,8 @@ static void event (const u32 id, hashcat_ctx_t *hashcat_ctx, const void *buf, co
     case EVENT_MONITOR_THROTTLE2:         main_monitor_throttle2         (hashcat_ctx, buf, len); break;
     case EVENT_MONITOR_THROTTLE3:         main_monitor_throttle3         (hashcat_ctx, buf, len); break;
     case EVENT_MONITOR_PERFORMANCE_HINT:  main_monitor_performance_hint  (hashcat_ctx, buf, len); break;
+    case EVENT_MONITOR_NOINPUT_HINT:      main_monitor_noinput_hint      (hashcat_ctx, buf, len); break;
+    case EVENT_MONITOR_NOINPUT_ABORT:     main_monitor_noinput_abort     (hashcat_ctx, buf, len); break;
     case EVENT_OPENCL_SESSION_POST:       main_opencl_session_post       (hashcat_ctx, buf, len); break;
     case EVENT_OPENCL_SESSION_PRE:        main_opencl_session_pre        (hashcat_ctx, buf, len); break;
     case EVENT_OUTERLOOP_FINISHED:        main_outerloop_finished        (hashcat_ctx, buf, len); break;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -282,6 +282,27 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
         if (performance_warnings == 10) EVENT_DATA (EVENT_MONITOR_PERFORMANCE_HINT, NULL, 0);
       }
     }
+
+    // stdin read timeout check
+
+    if (status_ctx->stdin_read_timeout_cnt >= STDIN_TIMEOUT_MIN)
+    {
+      if (status_ctx->stdin_read_timeout_cnt >= STDIN_TIMEOUT_MAX)
+      {
+        EVENT_DATA (EVENT_MONITOR_NOINPUT_ABORT, NULL, 0);
+
+        myabort (hashcat_ctx);
+
+        status_ctx->shutdown_inner = true;
+
+        break;
+      }
+
+      if ((status_ctx->stdin_read_timeout_cnt % STDIN_TIMEOUT_MIN) == 0)
+      {
+        EVENT_DATA (EVENT_MONITOR_NOINPUT_HINT, NULL, 0);
+      }
+    }
   }
 
   // final round of save_hash


### PR DESCRIPTION
The problem we try to fix here is whenever the user forgets to specify any attack mode or dictionary file, the stdin mode is automatically used and it could happen that the user doesn't understand that hashcat expects the input from stdin (a pipe).
With these few code changes we detect if nothing can be read from stdin and if we exceed a certain wait limit (currently it is set to 120 seconds, which is 2 minutes), we abort the cracking job.
Before we abort the cracking job the user is warned (several times on a regular time frame) that hashcat was unable to read from the pipe/stdin.

Examples of when this could happen (wrong commands):
```
hashcat -m 0 hash.txt
```
(here hashcat waits for input on stdin because no dictionary file was provided)

second example:
```
while :; do sleep 180; echo; done | hashcat -m 0 hash.txt
```
(here the pipe is way too slow and hashcat can't use the full GPU power. We can say that the "password candidat generator is way too slow")