### PR TITLE
Fix duplicate brain session id bug

### DIFF
--- a/src/brain.c
+++ b/src/brain.c
@@ -124,7 +124,7 @@ u32 brain_compute_session (hashcat_ctx_t *hashcat_ctx)
 
     qsort (out_bufs, out_idx, sizeof (char *), sort_by_string);
 
-    for (int i = 0; i < out_idx; i++)
+    for (int i = 0; i <= out_idx; i++)
     {
       const size_t out_len = strlen (out_bufs[out_idx]);
 


### PR DESCRIPTION
For hash lists containing only a single hash, no xxhash iterations were performed when creating the session ID for the brain client. This caused duplicate session IDs, since only the seed (hash mode) was used to compute them.

Fixes #1739