### PR TITLE
Electrum Salt-Type 2

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -236,6 +236,26 @@ DECLSPEC int is_valid_hex_32 (const u32 v)
   return 1;
 }
 
+DECLSPEC int is_valid_base58_8 (const u8 v)
+{
+  if (v > 'z') return 0;
+  if (v < '1') return 0;
+  if ((v > '9') && (v < 'A')) return 0;
+  if ((v > 'Z') && (v < 'a')) return 0;
+
+  return 1;
+}
+
+DECLSPEC int is_valid_base58_32 (const u32 v)
+{
+  if (is_valid_base58_8 ((u8) (v >>  0)) == 0) return 0;
+  if (is_valid_base58_8 ((u8) (v >>  8)) == 0) return 0;
+  if (is_valid_base58_8 ((u8) (v >> 16)) == 0) return 0;
+  if (is_valid_base58_8 ((u8) (v >> 24)) == 0) return 0;
+
+  return 1;
+}
+
 DECLSPEC int find_keyboard_layout_map (const u32 search, const int search_len, __local keyboard_layout_mapping_t *s_keyboard_layout_mapping_buf, const int keyboard_layout_mapping_cnt)
 {
   for (int idx = 0; idx < keyboard_layout_mapping_cnt; idx++)

--- a/OpenCL/m16600_a0-optimized.cl
+++ b/OpenCL/m16600_a0-optimized.cl
@@ -373,6 +373,22 @@ __kernel void m16600_m04 (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
   }
 }
 
@@ -736,6 +752,22 @@ __kernel void m16600_s04 (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
       if (is_valid_hex_32 (out[1]) == 0) continue;
       if (is_valid_hex_32 (out[2]) == 0) continue;
       if (is_valid_hex_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
 
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {

--- a/OpenCL/m16600_a0-pure.cl
+++ b/OpenCL/m16600_a0-pure.cl
@@ -188,6 +188,22 @@ __kernel void m16600_mxx (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
   }
 }
 
@@ -357,6 +373,22 @@ __kernel void m16600_sxx (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
       if (is_valid_hex_32 (out[1]) == 0) continue;
       if (is_valid_hex_32 (out[2]) == 0) continue;
       if (is_valid_hex_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
 
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {

--- a/OpenCL/m16600_a1-optimized.cl
+++ b/OpenCL/m16600_a1-optimized.cl
@@ -429,6 +429,22 @@ __kernel void m16600_m04 (KERN_ATTR_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
   }
 }
 
@@ -850,6 +866,22 @@ __kernel void m16600_s04 (KERN_ATTR_ESALT (electrum_wallet_t))
       if (is_valid_hex_32 (out[1]) == 0) continue;
       if (is_valid_hex_32 (out[2]) == 0) continue;
       if (is_valid_hex_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
 
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {

--- a/OpenCL/m16600_a1-pure.cl
+++ b/OpenCL/m16600_a1-pure.cl
@@ -184,6 +184,22 @@ __kernel void m16600_mxx (KERN_ATTR_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
   }
 }
 
@@ -351,6 +367,22 @@ __kernel void m16600_sxx (KERN_ATTR_ESALT (electrum_wallet_t))
       if (is_valid_hex_32 (out[1]) == 0) continue;
       if (is_valid_hex_32 (out[2]) == 0) continue;
       if (is_valid_hex_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
 
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {

--- a/OpenCL/m16600_a3-optimized.cl
+++ b/OpenCL/m16600_a3-optimized.cl
@@ -291,6 +291,22 @@ DECLSPEC void m16600 (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a 
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
   }
 }
 

--- a/OpenCL/m16600_a3-pure.cl
+++ b/OpenCL/m16600_a3-pure.cl
@@ -197,6 +197,22 @@ __kernel void m16600_mxx (KERN_ATTR_VECTOR_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
   }
 }
 
@@ -377,6 +393,22 @@ __kernel void m16600_sxx (KERN_ATTR_VECTOR_ESALT (electrum_wallet_t))
       if (is_valid_hex_32 (out[1]) == 0) continue;
       if (is_valid_hex_32 (out[2]) == 0) continue;
       if (is_valid_hex_32 (out[3]) == 0) continue;
+
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 2)
+    {
+      if ((u8) (out[0] >> 0) != 'x') continue;
+      if ((u8) (out[0] >> 8) != 'p') continue;
+      if ((u8) (out[0] >> 16) != 'r') continue;
+      if ((u8) (out[0] >> 24) != 'v') continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
 
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -242,7 +242,7 @@
 - Added hash-mode 16300 = Ethereum Pre-Sale Wallet, PBKDF2-SHA256
 - Added hash-mode 16400 = CRAM-MD5 Dovecot
 - Added hash-mode 16500 = JWT (JSON Web Token)
-- Added hash-mode 16600 = Electrum Wallet (Salt-Type 1-3)
+- Added hash-mode 16600 = Electrum Wallet (Salt-Type 1)
 
 ##
 ## Bugs

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -252,7 +252,7 @@ NVIDIA GPUs require "NVIDIA Driver" (367.x or later)
 - Bitcoin/Litecoin wallet.dat
 - Blockchain, My Wallet
 - Blockchain, My Wallet, V2
-- Electrum Wallet (Salt-Type 1-3)
+- Electrum Wallet (Salt-Type 1-2)
 - KeePass 1 (AES/Twofish) and KeePass 2 (AES)
 - JKS Java Key Store Private Keys (SHA1)
 - Ethereum Wallet, PBKDF2-HMAC-SHA256

--- a/src/interface.c
+++ b/src/interface.c
@@ -17860,7 +17860,7 @@ int electrum_wallet13_parse_hash (u8 *input_buf, u32 input_len, hash_t *hash_buf
 
   const u32 salt_type = hc_strtoul ((const char *) salt_type_pos, NULL, 10);
 
-  if ((salt_type == 1) || (salt_type == 2) || (salt_type == 3))
+  if ((salt_type == 1) || (salt_type == 2))
   {
     // all ok
   }

--- a/src/usage.c
+++ b/src/usage.c
@@ -401,7 +401,7 @@ static const char *const USAGE_BIG[] =
   "  11300 | Bitcoin/Litecoin wallet.dat                      | Password Managers",
   "  12700 | Blockchain, My Wallet                            | Password Managers",
   "  15200 | Blockchain, My Wallet, V2                        | Password Managers",
-  "  16600 | Electrum Wallet (Salt-Type 1-3)                  | Password Managers",
+  "  16600 | Electrum Wallet (Salt-Type 1-2)                  | Password Managers",
   "  13400 | KeePass 1 (AES/Twofish) and KeePass 2 (AES)      | Password Managers",
   "  15500 | JKS Java Key Store Private Keys (SHA1)           | Password Managers",
   "  15600 | Ethereum Wallet, PBKDF2-HMAC-SHA256              | Password Managers",


### PR DESCRIPTION
This adds support for Electrum Salt-Type 2 hashes. It follows the [method implemented in JohnTheRipper](https://github.com/magnumripper/JohnTheRipper/issues/2504#issuecomment-309152292). If the hash has successfully been cracked, the first four characters of the plaintext are `xprv` and the following 12 characters are valid [Base58](https://en.wikipedia.org/wiki/Base58) characters.

Closes #1510 