### PR TITLE
Changed cat -A to cat -vet in test.sh

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -2833,7 +2833,7 @@ fi
 # fix logfile
 if [ "${PACKAGE}" -eq 0 ]; then
 
-  cat -A ${OUTD}/logfull.txt | sed -e 's/\^M                                             \^M//g' | sed -e 's/\$$//g' > ${OUTD}/test_report.log
+  cat -vet ${OUTD}/logfull.txt | sed -e 's/\^M                                             \^M//g' | sed -e 's/\$$//g' > ${OUTD}/test_report.log
 
 fi
 


### PR DESCRIPTION
The `cat -A` flag is not available on Mac OS. Therefore I propose to replace it with `-vet` which has the same effect, but is supported as well on Mac OS to have a broader compatibility for testing.