### PR TITLE
Add Makefile target 'modules'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ hashcat.dll
 *.dSYM
 kernels/**
 lib/*.a
+modules/*.so
 obj/*.o
 include/CL

--- a/src/Makefile
+++ b/src/Makefile
@@ -540,10 +540,13 @@ endif
 ##
 
 MODULE_DEPEND := src/bitops.c src/convert.c src/interface.c src/shared.c
+MODULES_SRC   := $(wildcard modules/*.c)
+MODULES       := $(patsubst %.c, %.so, $(MODULES_SRC))
 
 modules/module_%.so: modules/module_%.c
 	$(CC)    $(CFLAGS_NATIVE) $< -o $@ -shared -fPIC $(MODULE_DEPEND)
 
+modules: $(MODULES)
 
 ##
 ## cross compiled hashcat


### PR DESCRIPTION
Allows to build all shared objects in modules directory using the
command `make modules`. Also add objects to `.gitignore`.