### PR TITLE
fixes 7-Zip parser limits for encrypted/decrypted data lengths

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -15,6 +15,7 @@
 - Fixed output of IKE PSK (mode 5300 and 5400) hashes to have separators at right position
 - Fixed the validation of the --brain-client-features command line argument (only values 1, 2 or 3 are allowed)
 - Fixed cracking of Cisco-PIX and Cisco-ASA MD5 passwords in mask-attack mode if mask > length 16
+- Fixed the 7-Zip parser to allow the entire supported range of encrypted and decrypted data lengths
 
 ##
 ## Technical

--- a/src/modules/module_11600.c
+++ b/src/modules/module_11600.c
@@ -341,13 +341,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[8]      = '$';
   token.len_min[8]  = 1;
-  token.len_max[8]  = 4;
+  token.len_max[8]  = 6;
   token.attr[8]     = TOKEN_ATTR_VERIFY_LENGTH
                     | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.sep[9]      = '$';
   token.len_min[9]  = 1;
-  token.len_max[9]  = 4;
+  token.len_max[9]  = 6;
   token.attr[9]     = TOKEN_ATTR_VERIFY_LENGTH
                     | TOKEN_ATTR_VERIFY_DIGIT;
 


### PR DESCRIPTION
This problem was first reported on the hashcat forum (see https://hashcat.net/forum/thread-8153.html).

The problem was that the field(s) didn't allow the integer of > 9999 because the parser only allowed 4 digit numbers. The current max lengths supported, on the other hand, is about 320KB and therefore we need to allow a number with 6 digits $xxxxxx$.

Thanks