### PR TITLE
tests: fixed a new macOS compatiblity issue (sort/sed)

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -11,28 +11,7 @@ TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # missing hash types: 5200,6251,6261,6271,6281
 
-# Array of all hash-modes supported by the test suite
-HASH_TYPES="0    10    11    12    20    21    22    23    30    40    50    60\
-    100   101   110   111   112   120   121   122   125   130   131   132   133\
-    140   141   150   160   200   300   400   500   600   900  1000  1100  1300\
-   1400  1410  1411  1420  1430  1440  1441  1450  1460  1500  1600  1700  1710\
-   1711  1720  1722  1730  1731  1740  1750  1760  1800  2100  2400  2410  2500\
-   2600  2611  2612  2711  2811  3000  3100  3200  3710  3711  3800  3910  4010\
-   4110  4300  4400  4500  4520  4521  4522  4700  4800  4900  5100  5300  5400\
-   5500  5600  5700  5800  6000  6100  6211  6212  6213  6221  6222  6223  6231\
-   6232  6233  6241  6242  6243  6300  6400  6500  6600  6700  6800  6900  7000\
-   7100  7200  7300  7400  7500  7700  7701  7800  7801  7900  8000  8100  8200\
-   8300  8400  8500  8600  8700  8900  9100  9200  9300  9400  9500  9600  9700\
-   9800  9900 10000 10100 10200 10300 10400 10500 10600 10700 10800 10900 11000\
-  11100 11200 11300 11400 11500 11600 11700 11750 11760 11800 11850 11860 11900\
-  12000 12001 12100 12200 12300 12400 12600 12700 12800 12900 13000 13100 13200\
-  13300 13400 13500 13600 13711 13712 13713 13721 13722 13723 13731 13732 13733\
-  13751 13752 13753 13771 13772 13773 13800 13900 14000 14100 14400 14600 14700\
-  14800 14900 15000 15100 15200 15300 15400 15500 15600 15700 15900 16000 16100\
-  16200 16300 16400 16500 16600 16700 16800 16900 17300 17400 17500 17600 17700\
-  17800 17900 18000 18100 18200 18300 18400 18500 18600 99999"
-
-HASH_TYPES=$(ls ${TDIR}/test_modules/*.pm | sed -r 's/.*m0*([0-9]+).pm/\1/')
+HASH_TYPES=$(ls ${TDIR}/test_modules/*.pm | sed 's/.*m0*\([0-9]\+\)\.pm/\1/')
 
 VECTOR_WIDTHS="1 2 4 8 16"
 
@@ -1470,8 +1449,37 @@ function attack_6()
         fi
 
         echo ${pass} | cut -b -$((${#pass} - ${i})) >> ${dict1_a6}
-        sort -R ${dict1_a6} > ${dict1_a6}.txt
+
+        # the block below is just a fancy way to do a "shuf" (or sort -R) because macOS doesn't really support it natively
+        # we do not really need a shuf, but it's actually better for testing purposes
+
+        rm -f ${dict1_a6}.txt # temporary file
+
+        line_num=$(wc -l ${dict1_a6} | sed 's/ .*$//')
+
+        sorted_lines=$(seq 1 ${line_num})
+
+        for lines in $(seq 1 ${line_num}); do
+
+          random_num=$((${RANDOM} % ${line_num}))
+          random_num=$((${random_num} + 1)) # sed -n [n]p starts counting with 1 (not 0)
+
+          random_line=$(echo -n "${sorted_lines}" | sed -n ${random_num}p)
+
+          sed -n ${random_line}p ${dict1_a6} >> ${dict1_a6}.txt
+
+          # update the temp list of lines
+
+          sorted_lines=$(echo -n "${sorted_lines}" | grep -v "^${random_line}$")
+
+          line_num=$((${line_num} - 1))
+
+        done
+
         mv ${dict1_a6}.txt ${dict1_a6}
+
+        # end of shuf/sort -R
+
 
         mask=""
 


### PR DESCRIPTION
unfortunately macOS doesn't support sed -r natively and also sort -R is not available (neither shuf, only gshuf with brew).

I suggest that we use sed without -r (modified sed string without extended regex) and a custom random sorting algorithm using bash's ${RANDOM} variable.

Thanks