### PR TITLE
tests: fixed problem with -m 0 or -m 0-10 with new hash type range code

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -2682,10 +2682,10 @@ if [ "${PACKAGE}" -eq 0 -o -z "${PACKAGE_FOLDER}" ]; then
   HT_MIN=0
   HT_MAX=0
 
-  if echo -n ${HT} | grep -q '^[1-9][0-9]*$'; then
+  if echo -n ${HT} | grep -q '^[0-9]\+$'; then
     HT_MIN=${HT}
     HT_MAX=${HT}
-  elif echo -n ${HT} | grep -q '^[1-9][0-9]*-[1-9][0-9]*$'; then
+  elif echo -n ${HT} | grep -q '^[0-9]\+-[1-9][0-9]*$'; then
 
     HT_MIN=$(echo -n ${HT} | sed "s/-.*//")
     HT_MAX=$(echo -n ${HT} | sed "s/.*-//")


### PR DESCRIPTION
There was a new problem with ./tools/test.sh -m 0 or -m 0-x runs (because test.sh didn't accept 0 as a number ;) )

This is fixed with this new patch.

Sorry for the inconvenience

Thanks