### PR TITLE
Fix potfile line splitting for LM

### DIFF
--- a/src/potfile.c
+++ b/src/potfile.c
@@ -535,17 +535,17 @@ int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
 
     if (line_len == 0) continue;
 
-    char *last_separator = strrchr (line_buf, hashconfig->separator);
+    char *first_separator = strchr (line_buf, hashconfig->separator);
 
-    if (last_separator == NULL) continue; // ??
+    if (first_separator == NULL) continue; // ??
 
-    char *line_pw_buf = last_separator + 1;
+    char *line_pw_buf = first_separator + 1;
 
     size_t line_pw_len = line_buf + line_len - line_pw_buf;
 
     char *line_hash_buf = line_buf;
 
-    size_t line_hash_len = last_separator - line_buf;
+    size_t line_hash_len = first_separator - line_buf;
 
     line_hash_buf[line_hash_len] = 0;
 


### PR DESCRIPTION
Lines in a potfile with LM hashes have the format <hash>:<pw>. Splitting for --show is done by finding the last occurrence of the separator : in a line.
This breaks found password with a : in it as they will be marked as [notfound].

Fix this by looking for the FIRST occurrence instead of the LAST one (strchr vs strrchr).