### PR TITLE
tests: fix -p and slow_algos/never_crack/hashfile_only

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -2980,10 +2980,16 @@ if [ "${PACKAGE}" -eq 1 ]; then
     HT_PACKAGED=${HT_MIN}-${HT_MAX}
   fi
 
-  HASH_TYPES_PACKAGED=$(echo ${HASH_TYPES} | tr '\n' ' ' | sed 's/ $//')
+  HASH_TYPES_PACKAGED=$(   echo ${HASH_TYPES}    | tr '\n' ' ' | sed 's/ $//')
+  HASHFILE_ONLY_PACKAGED=$(echo ${HASHFILE_ONLY} | tr '\n' ' ' | sed 's/ $//')
+  NEVER_CRACK_PACKAGED=$(  echo ${NEVER_CRACK}   | tr '\n' ' ' | sed 's/ $//')
+  SLOW_ALGOS_PACKAGED=$(   echo ${SLOW_ALGOS}    | tr '\n' ' ' | sed 's/ $//')
 
   sed "${SED_IN_PLACE}" -e 's/^\(PACKAGE_FOLDER\)=""/\1="$( echo "${BASH_SOURCE[0]}" | sed \"s!test.sh\\$!!\" )"/' \
     -e "s/^\(HASH_TYPES\)=\$(.*/\1=\"${HASH_TYPES_PACKAGED}\"/" \
+    -e "s/^\(HASHFILE_ONLY\)=\$(.*/\1=\"${HASHFILE_ONLY_PACKAGED}\"/" \
+    -e "s/^\(NEVER_CRACK\)=\$(.*/\1=\"${NEVER_CRACK_PACKAGED}\"/" \
+    -e "s/^\(SLOW_ALGOS\)=\$(.*/\1=\"${SLOW_ALGOS_PACKAGED}\"/" \
     -e "s/^\(HT\)=0/\1=${HT_PACKAGED}/" \
     -e "s/^\(MODE\)=0/\1=${MODE}/" \
     -e "s/^\(ATTACK\)=0/\1=${ATTACK}/" \


### PR DESCRIPTION
The new automatic array filling with grep+sed within src/modules/ from this commit https://github.com/hashcat/hashcat/commit/2f75a2bcfff8cecef712bfea64f10f3a6f0ee1d4 broke the -p packaging of the tests a little bit.

This patch fixes this. Of course the arrays - by using this fix - are constant for the packaged tests, but I think it's the right way to do it, because we always have a test package for a specific release/beta version with a kind of static amount/array of hash types. ... only for the development and random tests we need the array to be more dynamically/flexible to test.

Thank you very much