### PR TITLE
added note about $electrum2$ to changelog

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -28,6 +28,7 @@
 - Fixed maximum password length limit which was announced as 256 but actually was 255
 - Fixed cracking raw Streebog-HMAC 256 and 512 hashes with password of length >= 64
 - Fixed cracking raw Whirlpool hashes cracking with password of length >= 32
+- Fixed cracking of Electrum Wallet Salt-Type 2 hashes
 
 ##
 ## Improvements
@@ -289,7 +290,7 @@
 - Added hash-mode 16300 = Ethereum Pre-Sale Wallet, PBKDF2-SHA256
 - Added hash-mode 16400 = CRAM-MD5 Dovecot
 - Added hash-mode 16500 = JWT (JSON Web Token)
-- Added hash-mode 16600 = Electrum Wallet (Salt-Type 1)
+- Added hash-mode 16600 = Electrum Wallet (Salt-Type 1-2)
 
 ##
 ## Bugs


### PR DESCRIPTION
If we have a look at this issue https://github.com/hashcat/hashcat/issues/1942 and this commit https://github.com/hashcat/hashcat/pull/1805 it's not very clear when $electrum2$ was fixed/supported from reading the changelog.

I think this is the best way to make it clear that we added support for -m 16600 (Electrum Wallet), but fixed it with the newest version (> 5.1.0).

Thanks