### PR TITLE
-m 16600: currently only electrum1 and electrum2 are supported

### DIFF
--- a/src/modules/module_16600.c
+++ b/src/modules/module_16600.c
@@ -17,7 +17,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_8;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_PASSWORD_MANAGER;
-static const char *HASH_NAME      = "Electrum Wallet (Salt-Type 1-3)";
+static const char *HASH_NAME      = "Electrum Wallet (Salt-Type 1-2)";
 static const u64   KERN_TYPE      = 16600;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_PRECOMPUTE_INIT;


### PR DESCRIPTION
As we can see here: https://github.com/hashcat/hashcat/blob/9bcfa2e201c756018073d43d62f8120ba5e26183/src/modules/module_16600.c#L108 we currently only support $electrum1$ and $electrum2$ hashes.
Salt-Type 3 are not supported yet. We should make this very clear in the --help text etc.

also see https://github.com/hashcat/hashcat/issues/1806 and https://github.com/hashcat/hashcat/pull/1805

Thanks