### PR TITLE
tests: fixed -P command line argument

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -5,7 +5,7 @@
 ## License.....: MIT
 ##
 
-OPTS="--quiet --potfile-disable --runtime 400 --hwmon-disable -O"
+OPTS="--quiet --potfile-disable --runtime 400 --hwmon-disable"
 
 TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -2668,7 +2668,6 @@ while getopts "V:t:m:a:b:hcpd:x:o:d:D:F:POI:s:" opt; do
       ;;
 
     "P")
-        OPTS="$(echo "${OPTS}" | sed 's/ -O$//' | sed 's/^-O //' | sed 's/ -O //')"
         OPTIMIZED=0
       ;;
 
@@ -2685,9 +2684,13 @@ done
 
 export IS_OPTIMIZED=${OPTIMIZED}
 
+if [ "${OPTIMIZED}" -eq 1 ]; then
+  OPTS="${OPTS} -O"
+fi
+
 if [ "${TYPE}" == "null" ]; then
-   OPTS="${OPTS} -D 2"
-   TYPE="Gpu"
+  OPTS="${OPTS} -D 2"
+  TYPE="Gpu"
 fi
 
 if [ -n "${ARCHITECTURE}" ]; then


### PR DESCRIPTION
The -P parameter was not correctly changing the OPTS command line argument to hashcat.
This fix changes the way -O/-P are handled within test.sh, i.e. -O is set if -P was not specified and the OPTS argument list will be drafted accordingly.

Thanks