### PR TITLE
Add hash modes 19600 (krb5tgs enctype 17) and 19700 (krb5tgs enctype 18)

### DIFF
--- a/OpenCL/m19600-pure.cl
+++ b/OpenCL/m19600-pure.cl
@@ -1,0 +1,1007 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+
+typedef struct krb5tgs_17
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+
+} krb5tgs_17_t;
+
+typedef struct krb5tgs_17_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[10];
+  u32 out[10];
+
+} krb5tgs_17_tmp_t;
+
+DECLSPEC void aes128_encrypt_cbc (const u32 *aes_ks, u32 *aes_iv, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 data[4];
+
+  data[0] = swap32_S (in[0]);
+  data[1] = swap32_S (in[1]);
+  data[2] = swap32_S (in[2]);
+  data[3] = swap32_S (in[3]);
+
+  data[0] ^= aes_iv[0];
+  data[1] ^= aes_iv[1];
+  data[2] ^= aes_iv[2];
+  data[3] ^= aes_iv[3];
+
+  aes128_encrypt (aes_ks, data, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  aes_iv[0] = out[0];
+  aes_iv[1] = out[1];
+  aes_iv[2] = out[2];
+  aes_iv[3] = out[3];
+
+  out[0] = swap32_S (out[0]);
+  out[1] = swap32_S (out[1]);
+  out[2] = swap32_S (out[2]);
+  out[3] = swap32_S (out[3]);
+}
+
+DECLSPEC void aes128_decrypt_cbc (const u32 *ks1, const u32 *in, u32 *out, u32 *essiv, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4)
+{
+  aes128_decrypt (ks1, in, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  out[0] ^= essiv[0];
+  out[1] ^= essiv[1];
+  out[2] ^= essiv[2];
+  out[3] ^= essiv[3];
+
+  essiv[0] = in[0];
+  essiv[1] = in[1];
+  essiv[2] = in[2];
+  essiv[3] = in[3];
+}
+
+DECLSPEC void hmac_sha1_run_V (u32x *w0, u32x *w1, u32x *w2, u32x *w3, u32x *ipad, u32x *opad, u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = 0x80000000;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 20) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+}
+
+__kernel void m19600_init (KERN_ATTR_TMPS_ESALT (krb5tgs_17_tmp_t, krb5tgs_17_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * main
+   */
+
+  /* initialize hmac-sha1 for pbkdf2(password, account, 4096, account_len) */
+
+  sha1_hmac_ctx_t sha1_hmac_ctx;
+
+  sha1_hmac_init_global_swap (&sha1_hmac_ctx, pws[gid].i, pws[gid].pw_len);
+
+  tmps[gid].ipad[0] = sha1_hmac_ctx.ipad.h[0];
+  tmps[gid].ipad[1] = sha1_hmac_ctx.ipad.h[1];
+  tmps[gid].ipad[2] = sha1_hmac_ctx.ipad.h[2];
+  tmps[gid].ipad[3] = sha1_hmac_ctx.ipad.h[3];
+  tmps[gid].ipad[4] = sha1_hmac_ctx.ipad.h[4];
+
+  tmps[gid].opad[0] = sha1_hmac_ctx.opad.h[0];
+  tmps[gid].opad[1] = sha1_hmac_ctx.opad.h[1];
+  tmps[gid].opad[2] = sha1_hmac_ctx.opad.h[2];
+  tmps[gid].opad[3] = sha1_hmac_ctx.opad.h[3];
+  tmps[gid].opad[4] = sha1_hmac_ctx.opad.h[4];
+
+  sha1_hmac_update_global_swap (&sha1_hmac_ctx, esalt_bufs[digests_offset].account_info, esalt_bufs[digests_offset].account_info_len);
+
+ for (u32 i = 0, j = 1; i < 4; i += 5, j += 1)
+  {
+    sha1_hmac_ctx_t sha1_hmac_ctx2 = sha1_hmac_ctx;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = j;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx2, w0, w1, w2, w3, 4);
+
+    sha1_hmac_final (&sha1_hmac_ctx2);
+
+    tmps[gid].dgst[i + 0] = sha1_hmac_ctx2.opad.h[0];
+    tmps[gid].dgst[i + 1] = sha1_hmac_ctx2.opad.h[1];
+    tmps[gid].dgst[i + 2] = sha1_hmac_ctx2.opad.h[2];
+    tmps[gid].dgst[i + 3] = sha1_hmac_ctx2.opad.h[3];
+    tmps[gid].dgst[i + 4] = sha1_hmac_ctx2.opad.h[4];
+
+    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  }
+}
+
+__kernel void m19600_loop (KERN_ATTR_TMPS_ESALT (krb5tgs_17_tmp_t, krb5tgs_17_t))
+{
+   /**
+   * base
+   */
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= gid_max) return;
+
+  u32x ipad[5];
+  u32x opad[5];
+
+  ipad[0] = packv (tmps, ipad, gid, 0);
+  ipad[1] = packv (tmps, ipad, gid, 1);
+  ipad[2] = packv (tmps, ipad, gid, 2);
+  ipad[3] = packv (tmps, ipad, gid, 3);
+  ipad[4] = packv (tmps, ipad, gid, 4);
+
+  opad[0] = packv (tmps, opad, gid, 0);
+  opad[1] = packv (tmps, opad, gid, 1);
+  opad[2] = packv (tmps, opad, gid, 2);
+  opad[3] = packv (tmps, opad, gid, 3);
+  opad[4] = packv (tmps, opad, gid, 4);
+
+  for (u32 i = 0; i < 4; i += 5)
+  {
+    u32x dgst[5];
+    u32x out[5];
+
+    dgst[0] = packv (tmps, dgst, gid, i + 0);
+    dgst[1] = packv (tmps, dgst, gid, i + 1);
+    dgst[2] = packv (tmps, dgst, gid, i + 2);
+    dgst[3] = packv (tmps, dgst, gid, i + 3);
+    dgst[4] = packv (tmps, dgst, gid, i + 4);
+
+    out[0] = packv (tmps, out, gid, i + 0);
+    out[1] = packv (tmps, out, gid, i + 1);
+    out[2] = packv (tmps, out, gid, i + 2);
+    out[3] = packv (tmps, out, gid, i + 3);
+    out[4] = packv (tmps, out, gid, i + 4);
+
+    for (u32 j = 0; j < loop_cnt; j++)
+    {
+      u32x w0[4];
+      u32x w1[4];
+      u32x w2[4];
+      u32x w3[4];
+
+      w0[0] = dgst[0];
+      w0[1] = dgst[1];
+      w0[2] = dgst[2];
+      w0[3] = dgst[3];
+      w1[0] = dgst[4];
+      w1[1] = 0x80000000;
+      w1[2] = 0;
+      w1[3] = 0;
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = (64 + 20) * 8;
+
+      hmac_sha1_run_V (w0, w1, w2, w3, ipad, opad, dgst);
+
+      out[0] ^= dgst[0];
+      out[1] ^= dgst[1];
+      out[2] ^= dgst[2];
+      out[3] ^= dgst[3];
+      out[4] ^= dgst[4];
+    }
+
+    unpackv (tmps, dgst, gid, i + 0, dgst[0]);
+    unpackv (tmps, dgst, gid, i + 1, dgst[1]);
+    unpackv (tmps, dgst, gid, i + 2, dgst[2]);
+    unpackv (tmps, dgst, gid, i + 3, dgst[3]);
+    unpackv (tmps, dgst, gid, i + 4, dgst[4]);
+
+    unpackv (tmps, out, gid, i + 0, out[0]);
+    unpackv (tmps, out, gid, i + 1, out[1]);
+    unpackv (tmps, out, gid, i + 2, out[2]);
+    unpackv (tmps, out, gid, i + 3, out[3]);
+    unpackv (tmps, out, gid, i + 4, out[4]);
+  }
+}
+
+__kernel void m19600_comp (KERN_ATTR_TMPS_ESALT (krb5tgs_17_tmp_t, krb5tgs_17_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  __local u32 s_te0[256];
+  __local u32 s_te1[256];
+  __local u32 s_te2[256];
+  __local u32 s_te3[256];
+  __local u32 s_te4[256];
+
+  __local u32 s_td0[256];
+  __local u32 s_td1[256];
+  __local u32 s_td2[256];
+  __local u32 s_td3[256];
+  __local u32 s_td4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  #else
+
+  __constant u32a *s_te0 = te0;
+  __constant u32a *s_te1 = te1;
+  __constant u32a *s_te2 = te2;
+  __constant u32a *s_te3 = te3;
+  __constant u32a *s_te4 = te4;
+
+  __constant u32a *s_td0 = td0;
+  __constant u32a *s_td1 = td1;
+  __constant u32a *s_td2 = td2;
+  __constant u32a *s_td3 = td3;
+  __constant u32a *s_td4 = td4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /*
+    at this point, the output ('seed') will be used to generate AES keys:
+
+    key_bytes = derive(seed, 'kerberos'.encode(), seedsize)
+
+    'key_bytes' will be the AES key used to generate 'ke' and 'ki'
+    'ke' will be the AES key to decrypt the ticket
+    'ki' will be the key to compute the final HMAC
+  */
+
+  u32 nfolded[4];
+
+  // we can precompute _nfold('kerberos', 16)
+  nfolded[0] = 0x6b657262;
+  nfolded[1] = 0x65726f73;
+  nfolded[2] = 0x7b9b5b2b;
+  nfolded[3] = 0x93132b93;
+
+  // then aes_cbc encrypt this nfolded value with 'seed' as key along with a null IV
+  u32 aes_key[4];
+
+  aes_key[0] = swap32_S (tmps[gid].out[0]);
+  aes_key[1] = swap32_S (tmps[gid].out[1]);
+  aes_key[2] = swap32_S (tmps[gid].out[2]);
+  aes_key[3] = swap32_S (tmps[gid].out[3]);
+
+  u32 aes_iv[4];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  u32 aes_ks[44];
+
+  aes128_set_encrypt_key (aes_ks, aes_key, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  u32 key_bytes[4];
+
+  aes128_encrypt_cbc (aes_ks, aes_iv, nfolded, key_bytes, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  /* we will now compute 'ki', having 'key_bytes' */
+
+  u32 ki[4];
+
+  key_bytes[0] = swap32_S (key_bytes[0]);
+  key_bytes[1] = swap32_S (key_bytes[1]);
+  key_bytes[2] = swap32_S (key_bytes[2]);
+  key_bytes[3] = swap32_S (key_bytes[3]);
+
+  // we can precompute _nfold(pack('>IB', 2, 0x55), 16)
+  nfolded[0] = 0x62dc6e37;
+  nfolded[1] = 0x1a63a809;
+  nfolded[2] = 0x58ac562b;
+  nfolded[3] = 0x15404ac5;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes128_set_encrypt_key (aes_ks, key_bytes, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  aes128_encrypt_cbc (aes_ks, aes_iv, nfolded, ki, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  /* we will now compute 'ke' */
+
+  u32 ke[4];
+
+  // we can precompute _nfold(pack('>IB', 2, 0xAA), 16)
+  nfolded[0] = 0xb5b0582c;
+  nfolded[1] = 0x14b6500a;
+  nfolded[2] = 0xad56ab55;
+  nfolded[3] = 0xaa80556a;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes128_encrypt_cbc (aes_ks, aes_iv, nfolded, ke, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  /*
+      we now have 'ke' and 'ki'
+
+      we will decrypt (with 'ke') the 32 first bytes to search for ASN.1 structs
+      and if we find ASN.1 structs, we will compute the hmac (with 'ki')
+
+      if length >= 128 bytes:
+          length is on 2 bytes and type is \x63\x82 (encode_krb5_enc_tkt_part) and data is an ASN1 sequence \x30\x82
+      else:
+          length is on 1 byte and type is \x63\x81 and data is an ASN1 sequence \x30\x81
+
+      next headers follow the same ASN1 "type-length-data" scheme
+  */
+
+  u32 first_blocks[16];
+
+  u32 decrypted_block[4];
+
+  first_blocks[0] = esalt_bufs[digests_offset].edata2[0];
+  first_blocks[1] = esalt_bufs[digests_offset].edata2[1];
+  first_blocks[2] = esalt_bufs[digests_offset].edata2[2];
+  first_blocks[3] = esalt_bufs[digests_offset].edata2[3];
+
+  first_blocks[4] = esalt_bufs[digests_offset].edata2[4]; // possible ASN1 structs
+  first_blocks[5] = esalt_bufs[digests_offset].edata2[5];
+  first_blocks[6] = esalt_bufs[digests_offset].edata2[6]; // possible ASN1 structs
+  first_blocks[7] = esalt_bufs[digests_offset].edata2[7];
+
+  /*
+     we will decrypt them here in order to be able to compute hmac directly
+     if ASN1 structs were to be found
+  */
+  first_blocks[8]  = esalt_bufs[digests_offset].edata2[8];
+  first_blocks[9]  = esalt_bufs[digests_offset].edata2[9];
+  first_blocks[10] = esalt_bufs[digests_offset].edata2[10];
+  first_blocks[11] = esalt_bufs[digests_offset].edata2[11];
+
+  first_blocks[12] = esalt_bufs[digests_offset].edata2[12];
+  first_blocks[13] = esalt_bufs[digests_offset].edata2[13];
+  first_blocks[14] = esalt_bufs[digests_offset].edata2[14];
+  first_blocks[15] = esalt_bufs[digests_offset].edata2[15];
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  u32 aes_cts_decrypt_ks[44];
+
+  AES128_set_decrypt_key (aes_cts_decrypt_ks, ke, s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w0[0] = swap32_S (decrypted_block[0]);
+  w0[1] = swap32_S (decrypted_block[1]);
+  w0[2] = swap32_S (decrypted_block[2]);
+  w0[3] = swap32_S (decrypted_block[3]);
+
+  aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w1[0] = swap32_S (decrypted_block[0]);
+  w1[1] = swap32_S (decrypted_block[1]);
+  w1[2] = swap32_S (decrypted_block[2]);
+  w1[3] = swap32_S (decrypted_block[3]);
+
+  if (((decrypted_block[0] & 0xff00ffff) == 0x30008163) || ((decrypted_block[0] & 0x0000ffff) == 0x00008263))
+  {
+    if (((decrypted_block[2] & 0x00ffffff) == 0x00000503) || (decrypted_block[2] == 0x050307A0))
+    {
+      // now we decrypt all the ticket to verify checksum
+      int block_position;
+
+      int edata2_len = esalt_bufs[digests_offset].edata2_len;
+
+      int edata2_left;
+
+      u32 block[16];
+
+      int last_block_size = edata2_len % 16;
+
+      if(last_block_size == 0)
+      {
+        last_block_size = 16;
+      }
+
+      int last_part = last_block_size + 16;
+
+      int need = edata2_len - last_part;
+
+      int last_block_cbc_position = (need - 16) / 4;
+
+      // we need to decrypt also the 2 following blocks in order to be able to compute the hmac directly
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w2[0] = swap32_S (decrypted_block[0]);
+      w2[1] = swap32_S (decrypted_block[1]);
+      w2[2] = swap32_S (decrypted_block[2]);
+      w2[3] = swap32_S (decrypted_block[3]);
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w3[0] = swap32_S (decrypted_block[0]);
+      w3[1] = swap32_S (decrypted_block[1]);
+      w3[2] = swap32_S (decrypted_block[2]);
+      w3[3] = swap32_S (decrypted_block[3]);
+
+      sha1_hmac_ctx_t sha1_hmac_ctx;
+
+      /*
+        hmac message = plaintext
+        hmac key = ki
+      */
+
+      u32 k0[4];
+      u32 k1[4];
+      u32 k2[4];
+      u32 k3[4];
+
+      k0[0] = ki[0];
+      k0[1] = ki[1];
+      k0[2] = ki[2];
+      k0[3] = ki[3];
+
+      k1[0] = 0;
+      k1[1] = 0;
+      k1[2] = 0;
+      k1[3] = 0;
+
+      k2[0] = 0;
+      k2[1] = 0;
+      k2[2] = 0;
+      k2[3] = 0;
+
+      k3[0] = 0;
+      k3[1] = 0;
+      k3[2] = 0;
+      k3[3] = 0;
+
+      sha1_hmac_init_64 (&sha1_hmac_ctx, k0, k1, k2, k3);
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+      block_position = 16;
+
+      // first 4 blocks are already decrypted
+      for (edata2_left = need - 64; edata2_left >= 64; edata2_left -= 64)
+      {
+        block[0]  = esalt_bufs[digests_offset].edata2[block_position +  0];
+        block[1]  = esalt_bufs[digests_offset].edata2[block_position +  1];
+        block[2]  = esalt_bufs[digests_offset].edata2[block_position +  2];
+        block[3]  = esalt_bufs[digests_offset].edata2[block_position +  3];
+        block[4]  = esalt_bufs[digests_offset].edata2[block_position +  4];
+        block[5]  = esalt_bufs[digests_offset].edata2[block_position +  5];
+        block[6]  = esalt_bufs[digests_offset].edata2[block_position +  6];
+        block[7]  = esalt_bufs[digests_offset].edata2[block_position +  7];
+        block[8]  = esalt_bufs[digests_offset].edata2[block_position +  8];
+        block[9]  = esalt_bufs[digests_offset].edata2[block_position +  9];
+        block[10] = esalt_bufs[digests_offset].edata2[block_position + 10];
+        block[11] = esalt_bufs[digests_offset].edata2[block_position + 11];
+        block[12] = esalt_bufs[digests_offset].edata2[block_position + 12];
+        block[13] = esalt_bufs[digests_offset].edata2[block_position + 13];
+        block[14] = esalt_bufs[digests_offset].edata2[block_position + 14];
+        block[15] = esalt_bufs[digests_offset].edata2[block_position + 15];
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w1[0] = swap32_S (decrypted_block[0]);
+        w1[1] = swap32_S (decrypted_block[1]);
+        w1[2] = swap32_S (decrypted_block[2]);
+        w1[3] = swap32_S (decrypted_block[3]);
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w2[0] = swap32_S (decrypted_block[0]);
+        w2[1] = swap32_S (decrypted_block[1]);
+        w2[2] = swap32_S (decrypted_block[2]);
+        w2[3] = swap32_S (decrypted_block[3]);
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w3[0] = swap32_S (decrypted_block[0]);
+        w3[1] = swap32_S (decrypted_block[1]);
+        w3[2] = swap32_S (decrypted_block[2]);
+        w3[3] = swap32_S (decrypted_block[3]);
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+        block_position += 16;
+      }
+
+      if (edata2_left == 16)
+      {
+        block[0] = esalt_bufs[digests_offset].edata2[block_position + 0];
+        block[1] = esalt_bufs[digests_offset].edata2[block_position + 1];
+        block[2] = esalt_bufs[digests_offset].edata2[block_position + 2];
+        block[3] = esalt_bufs[digests_offset].edata2[block_position + 3];
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        w1[0] = 0;
+        w1[1] = 0;
+        w1[2] = 0;
+        w1[3] = 0;
+
+        w2[0] = 0;
+        w2[1] = 0;
+        w2[2] = 0;
+        w2[3] = 0;
+
+        w3[0] = 0;
+        w3[1] = 0;
+        w3[2] = 0;
+        w3[3] = 0;
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16);
+
+        block_position += 4;
+      }
+      else if (edata2_left == 32)
+      {
+        block[0] = esalt_bufs[digests_offset].edata2[block_position + 0];
+        block[1] = esalt_bufs[digests_offset].edata2[block_position + 1];
+        block[2] = esalt_bufs[digests_offset].edata2[block_position + 2];
+        block[3] = esalt_bufs[digests_offset].edata2[block_position + 3];
+        block[4] = esalt_bufs[digests_offset].edata2[block_position + 4];
+        block[5] = esalt_bufs[digests_offset].edata2[block_position + 5];
+        block[6] = esalt_bufs[digests_offset].edata2[block_position + 6];
+        block[7] = esalt_bufs[digests_offset].edata2[block_position + 7];
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w1[0] = swap32_S (decrypted_block[0]);
+        w1[1] = swap32_S (decrypted_block[1]);
+        w1[2] = swap32_S (decrypted_block[2]);
+        w1[3] = swap32_S (decrypted_block[3]);
+
+        w2[0] = 0;
+        w2[1] = 0;
+        w2[2] = 0;
+        w2[3] = 0;
+
+        w3[0] = 0;
+        w3[1] = 0;
+        w3[2] = 0;
+        w3[3] = 0;
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 32);
+
+        block_position += 8;
+      }
+      else if (edata2_left == 48)
+      {
+        block[0]  = esalt_bufs[digests_offset].edata2[block_position +  0];
+        block[1]  = esalt_bufs[digests_offset].edata2[block_position +  1];
+        block[2]  = esalt_bufs[digests_offset].edata2[block_position +  2];
+        block[3]  = esalt_bufs[digests_offset].edata2[block_position +  3];
+        block[4]  = esalt_bufs[digests_offset].edata2[block_position +  4];
+        block[5]  = esalt_bufs[digests_offset].edata2[block_position +  5];
+        block[6]  = esalt_bufs[digests_offset].edata2[block_position +  6];
+        block[7]  = esalt_bufs[digests_offset].edata2[block_position +  7];
+        block[8]  = esalt_bufs[digests_offset].edata2[block_position +  8];
+        block[9]  = esalt_bufs[digests_offset].edata2[block_position +  9];
+        block[10] = esalt_bufs[digests_offset].edata2[block_position + 10];
+        block[11] = esalt_bufs[digests_offset].edata2[block_position + 11];
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w1[0] = swap32_S (decrypted_block[0]);
+        w1[1] = swap32_S (decrypted_block[1]);
+        w1[2] = swap32_S (decrypted_block[2]);
+        w1[3] = swap32_S (decrypted_block[3]);
+
+        aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w2[0] = swap32_S (decrypted_block[0]);
+        w2[1] = swap32_S (decrypted_block[1]);
+        w2[2] = swap32_S (decrypted_block[2]);
+        w2[3] = swap32_S (decrypted_block[3]);
+
+        w3[0] = 0;
+        w3[1] = 0;
+        w3[2] = 0;
+        w3[3] = 0;
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 48);
+
+        block_position += 12;
+      }
+
+      /*
+        now all the ticket should be decrypted until block n-1 (not included)
+        and n
+      */
+
+      // this is block n-2, it will be xored with the n-1 block later crafted
+      u32 last_block_cbc[4];
+
+      last_block_cbc[0] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 0];
+      last_block_cbc[1] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 1];
+      last_block_cbc[2] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 2];
+      last_block_cbc[3] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 3];
+
+      // n-1 block is decrypted separately from the previous blocks which were cbc decrypted
+      block[0] = esalt_bufs[digests_offset].edata2[block_position + 0];
+      block[1] = esalt_bufs[digests_offset].edata2[block_position + 1];
+      block[2] = esalt_bufs[digests_offset].edata2[block_position + 2];
+      block[3] = esalt_bufs[digests_offset].edata2[block_position + 3];
+
+      aes128_decrypt (aes_cts_decrypt_ks, block, decrypted_block, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      u32 last_block[4];
+
+      int last_block_position = (edata2_len - last_block_size) / 4;
+
+      u32 n_1_crafted[4];
+
+      u32 last_plaintext[4];
+
+      last_plaintext[0] = 0;
+      last_plaintext[1] = 0;
+      last_plaintext[2] = 0;
+      last_plaintext[3] = 0;
+
+      /*
+        n-1 block is first computed as follows:
+          - fill n-1 block with the X first bytes of the encrypted last block (n)
+            with X == length of last block
+          - complete the rest of the block with
+
+        Final block (n) is computed as follows:
+          - fill with the X first bytes from n-1 block decrypted and xor them with last block (n)
+            with X == length of last block
+      */
+      int remaining_blocks = last_block_size / 4;
+
+      /*
+        last block is not necessarily aligned on 4 bytes so we will have
+        to shift values for the CTS crap...
+      */
+      u32 shift = last_block_size % 4;
+
+      switch (remaining_blocks)
+      {
+        case 0:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+
+          u32 mask = (0xffffffff >> ((4 - last_block_size) * 8));
+
+          last_plaintext[0] = last_block[0] ^ (decrypted_block[0] & mask);
+          last_plaintext[0] = swap32_S (last_plaintext[0]);
+
+          n_1_crafted[0] = (last_block[0] & mask) | (decrypted_block[0] & (mask ^ 0xffffffff));
+          n_1_crafted[1] = decrypted_block[1];
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+          break;
+
+        case 1:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+
+          if (shift == 0)
+          {
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = decrypted_block[1];
+            n_1_crafted[2] = decrypted_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+          }
+          else
+          {
+            last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+
+            u32 mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ (decrypted_block[1] & mask);
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = (last_block[1] & mask) | (decrypted_block[1] & (mask ^ 0xffffffff));
+            n_1_crafted[2] = decrypted_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+          }
+          break;
+
+        case 2:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+          last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+
+          if (shift == 0)
+          {
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = decrypted_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+          }
+          else
+          {
+            last_block[2] = esalt_bufs[digests_offset].edata2[last_block_position + 2];
+
+            u32 mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+            last_plaintext[2] = last_block[2] ^ (decrypted_block[2] & mask);
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+            last_plaintext[2] = swap32_S (last_plaintext[2]);
+
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = (last_block[2] & mask) | (decrypted_block[2] & (mask ^ 0xffffffff));
+            n_1_crafted[3] = decrypted_block[3];
+          }
+          break;
+
+        case 3:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+          last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+          last_block[2] = esalt_bufs[digests_offset].edata2[last_block_position + 2];
+
+          if (shift == 0)
+          {
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = last_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+            last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+            last_plaintext[2] = swap32_S (last_plaintext[2]);
+          }
+          else
+          {
+            last_block[3] = esalt_bufs[digests_offset].edata2[last_block_position + 3];
+
+            u32 mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+            last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+            last_plaintext[3] = last_block[3] ^ (decrypted_block[3] & mask);
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+            last_plaintext[2] = swap32_S (last_plaintext[2]);
+            last_plaintext[3] = swap32_S (last_plaintext[3]);
+
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = last_block[2];
+            n_1_crafted[3] = (last_block[3] & mask) | (decrypted_block[3] & (mask ^ 0xffffffff));
+          }
+          break;
+
+        case 4:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+          last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+          last_block[2] = esalt_bufs[digests_offset].edata2[last_block_position + 2];
+          last_block[3] = esalt_bufs[digests_offset].edata2[last_block_position + 3];
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = last_block[2];
+          n_1_crafted[3] = last_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+          last_plaintext[3] = last_block[3] ^ decrypted_block[3];
+
+          last_plaintext[0] = swap32_S (last_plaintext[0]);
+          last_plaintext[1] = swap32_S (last_plaintext[1]);
+          last_plaintext[2] = swap32_S (last_plaintext[2]);
+          last_plaintext[3] = swap32_S (last_plaintext[3]);
+          break;
+
+        default:
+          return;
+      }
+
+      // then decrypt this newly created n-1 with 'ke'
+      aes128_decrypt (aes_cts_decrypt_ks, n_1_crafted, n_1_crafted, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      // then xor with the encrypted n-2 block
+      n_1_crafted[0] ^= last_block_cbc[0];
+      n_1_crafted[1] ^= last_block_cbc[1];
+      n_1_crafted[2] ^= last_block_cbc[2];
+      n_1_crafted[3] ^= last_block_cbc[3];
+
+      w0[0] = swap32_S (n_1_crafted[0]);
+      w0[1] = swap32_S (n_1_crafted[1]);
+      w0[2] = swap32_S (n_1_crafted[2]);
+      w0[3] = swap32_S (n_1_crafted[3]);
+
+      w1[0] = last_plaintext[0];
+      w1[1] = last_plaintext[1];
+      w1[2] = last_plaintext[2];
+      w1[3] = last_plaintext[3];
+
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16 + last_block_size);
+
+      sha1_hmac_final(&sha1_hmac_ctx);
+
+      if(sha1_hmac_ctx.opad.h[0]   == esalt_bufs[digests_offset].checksum[0]
+        && sha1_hmac_ctx.opad.h[1] == esalt_bufs[digests_offset].checksum[1]
+        && sha1_hmac_ctx.opad.h[2] == esalt_bufs[digests_offset].checksum[2])
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          #define il_pos 0
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+        }
+      }
+    }
+  }
+}

--- a/OpenCL/m19700-pure.cl
+++ b/OpenCL/m19700-pure.cl
@@ -1,0 +1,1071 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#include "inc_vendor.cl"
+#include "inc_hash_constants.h"
+#include "inc_hash_functions.cl"
+#include "inc_types.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+
+typedef struct krb5tgs_18
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+
+} krb5tgs_18_t;
+
+typedef struct krb5tgs_18_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[16];
+  u32 out[16];
+
+} krb5tgs_18_tmp_t;
+
+DECLSPEC void aes256_encrypt_cbc (const u32 *aes_ks, u32 *aes_iv, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 data[4];
+
+  data[0] = swap32_S (in[0]);
+  data[1] = swap32_S (in[1]);
+  data[2] = swap32_S (in[2]);
+  data[3] = swap32_S (in[3]);
+
+  data[0] ^= aes_iv[0];
+  data[1] ^= aes_iv[1];
+  data[2] ^= aes_iv[2];
+  data[3] ^= aes_iv[3];
+
+  aes256_encrypt (aes_ks, data, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  aes_iv[0] = out[0];
+  aes_iv[1] = out[1];
+  aes_iv[2] = out[2];
+  aes_iv[3] = out[3];
+
+  out[0] = swap32_S (out[0]);
+  out[1] = swap32_S (out[1]);
+  out[2] = swap32_S (out[2]);
+  out[3] = swap32_S (out[3]);
+}
+
+DECLSPEC void aes256_decrypt_cbc (const u32 *ks1, const u32 *in, u32 *out, u32 *essiv, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4)
+{
+  aes256_decrypt (ks1, in, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  out[0] ^= essiv[0];
+  out[1] ^= essiv[1];
+  out[2] ^= essiv[2];
+  out[3] ^= essiv[3];
+
+  essiv[0] = in[0];
+  essiv[1] = in[1];
+  essiv[2] = in[2];
+  essiv[3] = in[3];
+}
+
+DECLSPEC void hmac_sha1_run_V (u32x *w0, u32x *w1, u32x *w2, u32x *w3, u32x *ipad, u32x *opad, u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = 0x80000000;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 20) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+}
+
+__kernel void m19700_init (KERN_ATTR_TMPS_ESALT (krb5tgs_18_tmp_t, krb5tgs_18_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * main
+   */
+
+  /* initialize hmac-sha1 for pbkdf2(password, account, 4096, account_len) */
+
+  sha1_hmac_ctx_t sha1_hmac_ctx;
+
+  sha1_hmac_init_global_swap (&sha1_hmac_ctx, pws[gid].i, pws[gid].pw_len);
+
+  tmps[gid].ipad[0] = sha1_hmac_ctx.ipad.h[0];
+  tmps[gid].ipad[1] = sha1_hmac_ctx.ipad.h[1];
+  tmps[gid].ipad[2] = sha1_hmac_ctx.ipad.h[2];
+  tmps[gid].ipad[3] = sha1_hmac_ctx.ipad.h[3];
+  tmps[gid].ipad[4] = sha1_hmac_ctx.ipad.h[4];
+
+  tmps[gid].opad[0] = sha1_hmac_ctx.opad.h[0];
+  tmps[gid].opad[1] = sha1_hmac_ctx.opad.h[1];
+  tmps[gid].opad[2] = sha1_hmac_ctx.opad.h[2];
+  tmps[gid].opad[3] = sha1_hmac_ctx.opad.h[3];
+  tmps[gid].opad[4] = sha1_hmac_ctx.opad.h[4];
+
+  sha1_hmac_update_global_swap (&sha1_hmac_ctx, esalt_bufs[digests_offset].account_info, esalt_bufs[digests_offset].account_info_len);
+
+ for (u32 i = 0, j = 1; i < 8; i += 5, j += 1)
+  {
+    sha1_hmac_ctx_t sha1_hmac_ctx2 = sha1_hmac_ctx;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = j;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx2, w0, w1, w2, w3, 4);
+
+    sha1_hmac_final (&sha1_hmac_ctx2);
+
+    tmps[gid].dgst[i + 0] = sha1_hmac_ctx2.opad.h[0];
+    tmps[gid].dgst[i + 1] = sha1_hmac_ctx2.opad.h[1];
+    tmps[gid].dgst[i + 2] = sha1_hmac_ctx2.opad.h[2];
+    tmps[gid].dgst[i + 3] = sha1_hmac_ctx2.opad.h[3];
+    tmps[gid].dgst[i + 4] = sha1_hmac_ctx2.opad.h[4];
+
+    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  }
+}
+
+__kernel void m19700_loop (KERN_ATTR_TMPS_ESALT (krb5tgs_18_tmp_t, krb5tgs_18_t))
+{
+   /**
+   * base
+   */
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= gid_max) return;
+
+  u32x ipad[5];
+  u32x opad[5];
+
+  ipad[0] = packv (tmps, ipad, gid, 0);
+  ipad[1] = packv (tmps, ipad, gid, 1);
+  ipad[2] = packv (tmps, ipad, gid, 2);
+  ipad[3] = packv (tmps, ipad, gid, 3);
+  ipad[4] = packv (tmps, ipad, gid, 4);
+
+  opad[0] = packv (tmps, opad, gid, 0);
+  opad[1] = packv (tmps, opad, gid, 1);
+  opad[2] = packv (tmps, opad, gid, 2);
+  opad[3] = packv (tmps, opad, gid, 3);
+  opad[4] = packv (tmps, opad, gid, 4);
+
+  for (u32 i = 0; i < 8; i += 5)
+  {
+    u32x dgst[5];
+    u32x out[5];
+
+    dgst[0] = packv (tmps, dgst, gid, i + 0);
+    dgst[1] = packv (tmps, dgst, gid, i + 1);
+    dgst[2] = packv (tmps, dgst, gid, i + 2);
+    dgst[3] = packv (tmps, dgst, gid, i + 3);
+    dgst[4] = packv (tmps, dgst, gid, i + 4);
+
+    out[0] = packv (tmps, out, gid, i + 0);
+    out[1] = packv (tmps, out, gid, i + 1);
+    out[2] = packv (tmps, out, gid, i + 2);
+    out[3] = packv (tmps, out, gid, i + 3);
+    out[4] = packv (tmps, out, gid, i + 4);
+
+    for (u32 j = 0; j < loop_cnt; j++)
+    {
+      u32x w0[4];
+      u32x w1[4];
+      u32x w2[4];
+      u32x w3[4];
+
+      w0[0] = dgst[0];
+      w0[1] = dgst[1];
+      w0[2] = dgst[2];
+      w0[3] = dgst[3];
+      w1[0] = dgst[4];
+      w1[1] = 0x80000000;
+      w1[2] = 0;
+      w1[3] = 0;
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = (64 + 20) * 8;
+
+      hmac_sha1_run_V (w0, w1, w2, w3, ipad, opad, dgst);
+
+      out[0] ^= dgst[0];
+      out[1] ^= dgst[1];
+      out[2] ^= dgst[2];
+      out[3] ^= dgst[3];
+      out[4] ^= dgst[4];
+    }
+
+    unpackv (tmps, dgst, gid, i + 0, dgst[0]);
+    unpackv (tmps, dgst, gid, i + 1, dgst[1]);
+    unpackv (tmps, dgst, gid, i + 2, dgst[2]);
+    unpackv (tmps, dgst, gid, i + 3, dgst[3]);
+    unpackv (tmps, dgst, gid, i + 4, dgst[4]);
+
+    unpackv (tmps, out, gid, i + 0, out[0]);
+    unpackv (tmps, out, gid, i + 1, out[1]);
+    unpackv (tmps, out, gid, i + 2, out[2]);
+    unpackv (tmps, out, gid, i + 3, out[3]);
+    unpackv (tmps, out, gid, i + 4, out[4]);
+  }
+}
+
+__kernel void m19700_comp (KERN_ATTR_TMPS_ESALT (krb5tgs_18_tmp_t, krb5tgs_18_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  __local u32 s_td0[256];
+  __local u32 s_td1[256];
+  __local u32 s_td2[256];
+  __local u32 s_td3[256];
+  __local u32 s_td4[256];
+
+  __local u32 s_te0[256];
+  __local u32 s_te1[256];
+  __local u32 s_te2[256];
+  __local u32 s_te3[256];
+  __local u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  barrier (CLK_LOCAL_MEM_FENCE);
+
+  #else
+
+  __constant u32a *s_td0 = td0;
+  __constant u32a *s_td1 = td1;
+  __constant u32a *s_td2 = td2;
+  __constant u32a *s_td3 = td3;
+  __constant u32a *s_td4 = td4;
+
+  __constant u32a *s_te0 = te0;
+  __constant u32a *s_te1 = te1;
+  __constant u32a *s_te2 = te2;
+  __constant u32a *s_te3 = te3;
+  __constant u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /*
+    at this point, the output ('seed') will be used to generate AES keys:
+
+    key_bytes = derive(seed, 'kerberos'.encode(), seedsize)
+
+    'key_bytes' will be the AES key used to generate 'ke' and 'ki'
+    'ke' will be the AES key to decrypt the ticket
+    'ki' will be the key to compute the final HMAC
+  */
+
+  u32 nfolded[4];
+
+  // we can precompute _nfold('kerberos', 16)
+  nfolded[0] = 0x6b657262;
+  nfolded[1] = 0x65726f73;
+  nfolded[2] = 0x7b9b5b2b;
+  nfolded[3] = 0x93132b93;
+
+  // then aes_cbc encrypt this nfolded value with 'seed' as key along with a null IV
+  u32 aes_key[8];
+
+  aes_key[0] = swap32_S (tmps[gid].out[0]);
+  aes_key[1] = swap32_S (tmps[gid].out[1]);
+  aes_key[2] = swap32_S (tmps[gid].out[2]);
+  aes_key[3] = swap32_S (tmps[gid].out[3]);
+  aes_key[4] = swap32_S (tmps[gid].out[4]);
+  aes_key[5] = swap32_S (tmps[gid].out[5]);
+  aes_key[6] = swap32_S (tmps[gid].out[6]);
+  aes_key[7] = swap32_S (tmps[gid].out[7]);
+
+  u32 aes_iv[4];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  u32 aes_ks[60];
+
+  aes256_set_encrypt_key (aes_ks, aes_key, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  u32 key_bytes[8];
+
+  u32 out[4];
+  aes256_encrypt_cbc (aes_ks, aes_iv, nfolded, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  key_bytes[0] = out[0];
+  key_bytes[1] = out[1];
+  key_bytes[2] = out[2];
+  key_bytes[3] = out[3];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, out, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  key_bytes[4] = out[0];
+  key_bytes[5] = out[1];
+  key_bytes[6] = out[2];
+  key_bytes[7] = out[3];
+
+  /* we will now compute 'ki', having 'key_bytes' */
+
+  u32 ki[8];
+
+  // we can precompute _nfold(pack('>IB', 2, 0x55), 16)
+  nfolded[0] = 0x62dc6e37;
+  nfolded[1] = 0x1a63a809;
+  nfolded[2] = 0x58ac562b;
+  nfolded[3] = 0x15404ac5;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  key_bytes[0] = swap32_S (key_bytes[0]);
+  key_bytes[1] = swap32_S (key_bytes[1]);
+  key_bytes[2] = swap32_S (key_bytes[2]);
+  key_bytes[3] = swap32_S (key_bytes[3]);
+  key_bytes[4] = swap32_S (key_bytes[4]);
+  key_bytes[5] = swap32_S (key_bytes[5]);
+  key_bytes[6] = swap32_S (key_bytes[6]);
+  key_bytes[7] = swap32_S (key_bytes[7]);
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes256_set_encrypt_key (aes_ks, key_bytes, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, nfolded, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ki[0] = out[0];
+  ki[1] = out[1];
+  ki[2] = out[2];
+  ki[3] = out[3];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, out, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ki[4] = out[0];
+  ki[5] = out[1];
+  ki[6] = out[2];
+  ki[7] = out[3];
+
+  /* we will now compute 'ke' */
+
+  u32 ke[8];
+
+  // we can precompute _nfold(pack('>IB', 2, 0xAA), 16)
+  nfolded[0] = 0xb5b0582c;
+  nfolded[1] = 0x14b6500a;
+  nfolded[2] = 0xad56ab55;
+  nfolded[3] = 0xaa80556a;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes256_encrypt_cbc (aes_ks, aes_iv, nfolded, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ke[0] = out[0];
+  ke[1] = out[1];
+  ke[2] = out[2];
+  ke[3] = out[3];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, out, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ke[4] = out[0];
+  ke[5] = out[1];
+  ke[6] = out[2];
+  ke[7] = out[3];
+
+  /*
+      we now have 'ke' and 'ki'
+
+      we will decrypt (with 'ke') the 32 first bytes to search for ASN.1 structs
+      and if we find ASN.1 structs, we will compute the hmac (with 'ki')
+
+      if length >= 128 bytes:
+          length is on 2 bytes and type is \x63\x82 (encode_krb5_enc_tkt_part) and data is an ASN1 sequence \x30\x82
+      else:
+          length is on 1 byte and type is \x63\x81 and data is an ASN1 sequence \x30\x81
+
+      next headers follow the same ASN1 "type-length-data" scheme
+  */
+
+  u32 first_blocks[16];
+
+  u32 decrypted_block[8];
+
+  first_blocks[0] = esalt_bufs[digests_offset].edata2[0];
+  first_blocks[1] = esalt_bufs[digests_offset].edata2[1];
+  first_blocks[2] = esalt_bufs[digests_offset].edata2[2];
+  first_blocks[3] = esalt_bufs[digests_offset].edata2[3];
+
+  first_blocks[4] = esalt_bufs[digests_offset].edata2[4];  // possible ASN1 structs
+  first_blocks[5] = esalt_bufs[digests_offset].edata2[5];
+  first_blocks[6] = esalt_bufs[digests_offset].edata2[6];  // possible ASN1 structs
+  first_blocks[7] = esalt_bufs[digests_offset].edata2[7];
+
+  /*
+     we will decrypt them here in order to be able to compute hmac directly
+     if ASN1 structs were to be found
+  */
+  first_blocks[8]  = esalt_bufs[digests_offset].edata2[8];
+  first_blocks[9]  = esalt_bufs[digests_offset].edata2[9];
+  first_blocks[10] = esalt_bufs[digests_offset].edata2[10];
+  first_blocks[11] = esalt_bufs[digests_offset].edata2[11];
+
+  first_blocks[12] = esalt_bufs[digests_offset].edata2[12];
+  first_blocks[13] = esalt_bufs[digests_offset].edata2[13];
+  first_blocks[14] = esalt_bufs[digests_offset].edata2[14];
+  first_blocks[15] = esalt_bufs[digests_offset].edata2[15];
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  u32 aes_cts_decrypt_ks[60];
+
+  AES256_set_decrypt_key (aes_cts_decrypt_ks, ke, s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w0[0] = swap32_S (decrypted_block[0]);
+  w0[1] = swap32_S (decrypted_block[1]);
+  w0[2] = swap32_S (decrypted_block[2]);
+  w0[3] = swap32_S (decrypted_block[3]);
+
+  aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w1[0] = swap32_S (decrypted_block[0]);
+  w1[1] = swap32_S (decrypted_block[1]);
+  w1[2] = swap32_S (decrypted_block[2]);
+  w1[3] = swap32_S (decrypted_block[3]);
+
+  if (((decrypted_block[0] & 0xff00ffff) == 0x30008163) || ((decrypted_block[0] & 0x0000ffff) == 0x00008263))
+  {
+    if (((decrypted_block[2] & 0x00ffffff) == 0x00000503) || (decrypted_block[2] == 0x050307A0))
+    {
+
+      // now we decrypt all the ticket to verify checksum
+
+      // we need to decrypt also the 2 following blocks in order to be able to compute the hmac directly
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w2[0] = swap32_S (decrypted_block[0]);
+      w2[1] = swap32_S (decrypted_block[1]);
+      w2[2] = swap32_S (decrypted_block[2]);
+      w2[3] = swap32_S (decrypted_block[3]);
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w3[0] = swap32_S (decrypted_block[0]);
+      w3[1] = swap32_S (decrypted_block[1]);
+      w3[2] = swap32_S (decrypted_block[2]);
+      w3[3] = swap32_S (decrypted_block[3]);
+
+      int block_position;
+
+      int edata2_len = esalt_bufs[digests_offset].edata2_len;
+
+      int edata2_left;
+
+      u32 block[16];
+
+      int last_block_size = edata2_len % 16;
+
+      if(last_block_size == 0)
+      {
+        last_block_size = 16;
+      }
+
+      int last_part = last_block_size + 16;
+
+      int need = edata2_len - last_part;
+
+      int last_block_cbc_position = (need - 16) / 4;
+
+      sha1_hmac_ctx_t sha1_hmac_ctx;
+
+      /*
+        hmac message = plaintext
+        hmac key = ki
+      */
+
+      u32 k0[4];
+      u32 k1[4];
+      u32 k2[4];
+      u32 k3[4];
+
+      k0[0] = ki[0];
+      k0[1] = ki[1];
+      k0[2] = ki[2];
+      k0[3] = ki[3];
+
+      k1[0] = ki[4];
+      k1[1] = ki[5];
+      k1[2] = ki[6];
+      k1[3] = ki[7];
+
+      k2[0] = 0;
+      k2[1] = 0;
+      k2[2] = 0;
+      k2[3] = 0;
+
+      k3[0] = 0;
+      k3[1] = 0;
+      k3[2] = 0;
+      k3[3] = 0;
+
+      sha1_hmac_init_64 (&sha1_hmac_ctx, k0, k1, k2, k3);
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+      block_position = 16;
+
+      // first 4 blocks are already decrypted
+      for (edata2_left = need - 64; edata2_left >= 64; edata2_left -= 64)
+      {
+        block[0]  = esalt_bufs[digests_offset].edata2[block_position +  0];
+        block[1]  = esalt_bufs[digests_offset].edata2[block_position +  1];
+        block[2]  = esalt_bufs[digests_offset].edata2[block_position +  2];
+        block[3]  = esalt_bufs[digests_offset].edata2[block_position +  3];
+        block[4]  = esalt_bufs[digests_offset].edata2[block_position +  4];
+        block[5]  = esalt_bufs[digests_offset].edata2[block_position +  5];
+        block[6]  = esalt_bufs[digests_offset].edata2[block_position +  6];
+        block[7]  = esalt_bufs[digests_offset].edata2[block_position +  7];
+        block[8]  = esalt_bufs[digests_offset].edata2[block_position +  8];
+        block[9]  = esalt_bufs[digests_offset].edata2[block_position +  9];
+        block[10] = esalt_bufs[digests_offset].edata2[block_position + 10];
+        block[11] = esalt_bufs[digests_offset].edata2[block_position + 11];
+        block[12] = esalt_bufs[digests_offset].edata2[block_position + 12];
+        block[13] = esalt_bufs[digests_offset].edata2[block_position + 13];
+        block[14] = esalt_bufs[digests_offset].edata2[block_position + 14];
+        block[15] = esalt_bufs[digests_offset].edata2[block_position + 15];
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w1[0] = swap32_S (decrypted_block[0]);
+        w1[1] = swap32_S (decrypted_block[1]);
+        w1[2] = swap32_S (decrypted_block[2]);
+        w1[3] = swap32_S (decrypted_block[3]);
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w2[0] = swap32_S (decrypted_block[0]);
+        w2[1] = swap32_S (decrypted_block[1]);
+        w2[2] = swap32_S (decrypted_block[2]);
+        w2[3] = swap32_S (decrypted_block[3]);
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w3[0] = swap32_S (decrypted_block[0]);
+        w3[1] = swap32_S (decrypted_block[1]);
+        w3[2] = swap32_S (decrypted_block[2]);
+        w3[3] = swap32_S (decrypted_block[3]);
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+        block_position += 16;
+      }
+
+      if (edata2_left == 16)
+      {
+
+        block[0] = esalt_bufs[digests_offset].edata2[block_position + 0];
+        block[1] = esalt_bufs[digests_offset].edata2[block_position + 1];
+        block[2] = esalt_bufs[digests_offset].edata2[block_position + 2];
+        block[3] = esalt_bufs[digests_offset].edata2[block_position + 3];
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        w1[0] = 0;
+        w1[1] = 0;
+        w1[2] = 0;
+        w1[3] = 0;
+
+        w2[0] = 0;
+        w2[1] = 0;
+        w2[2] = 0;
+        w2[3] = 0;
+
+        w3[0] = 0;
+        w3[1] = 0;
+        w3[2] = 0;
+        w3[3] = 0;
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16);
+
+        block_position += 4;
+      }
+      else if (edata2_left == 32)
+      {
+        block[0] = esalt_bufs[digests_offset].edata2[block_position + 0];
+        block[1] = esalt_bufs[digests_offset].edata2[block_position + 1];
+        block[2] = esalt_bufs[digests_offset].edata2[block_position + 2];
+        block[3] = esalt_bufs[digests_offset].edata2[block_position + 3];
+        block[4] = esalt_bufs[digests_offset].edata2[block_position + 4];
+        block[5] = esalt_bufs[digests_offset].edata2[block_position + 5];
+        block[6] = esalt_bufs[digests_offset].edata2[block_position + 6];
+        block[7] = esalt_bufs[digests_offset].edata2[block_position + 7];
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w1[0] = swap32_S (decrypted_block[0]);
+        w1[1] = swap32_S (decrypted_block[1]);
+        w1[2] = swap32_S (decrypted_block[2]);
+        w1[3] = swap32_S (decrypted_block[3]);
+
+        w2[0] = 0;
+        w2[1] = 0;
+        w2[2] = 0;
+        w2[3] = 0;
+
+        w3[0] = 0;
+        w3[1] = 0;
+        w3[2] = 0;
+        w3[3] = 0;
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 32);
+
+        block_position += 8;
+      }
+      else if (edata2_left == 48)
+      {
+        block[0]  = esalt_bufs[digests_offset].edata2[block_position +  0];
+        block[1]  = esalt_bufs[digests_offset].edata2[block_position +  1];
+        block[2]  = esalt_bufs[digests_offset].edata2[block_position +  2];
+        block[3]  = esalt_bufs[digests_offset].edata2[block_position +  3];
+        block[4]  = esalt_bufs[digests_offset].edata2[block_position +  4];
+        block[5]  = esalt_bufs[digests_offset].edata2[block_position +  5];
+        block[6]  = esalt_bufs[digests_offset].edata2[block_position +  6];
+        block[7]  = esalt_bufs[digests_offset].edata2[block_position +  7];
+        block[8]  = esalt_bufs[digests_offset].edata2[block_position +  8];
+        block[9]  = esalt_bufs[digests_offset].edata2[block_position +  9];
+        block[10] = esalt_bufs[digests_offset].edata2[block_position + 10];
+        block[11] = esalt_bufs[digests_offset].edata2[block_position + 11];
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w0[0] = swap32_S (decrypted_block[0]);
+        w0[1] = swap32_S (decrypted_block[1]);
+        w0[2] = swap32_S (decrypted_block[2]);
+        w0[3] = swap32_S (decrypted_block[3]);
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w1[0] = swap32_S (decrypted_block[0]);
+        w1[1] = swap32_S (decrypted_block[1]);
+        w1[2] = swap32_S (decrypted_block[2]);
+        w1[3] = swap32_S (decrypted_block[3]);
+
+        aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+        w2[0] = swap32_S (decrypted_block[0]);
+        w2[1] = swap32_S (decrypted_block[1]);
+        w2[2] = swap32_S (decrypted_block[2]);
+        w2[3] = swap32_S (decrypted_block[3]);
+
+        w3[0] = 0;
+        w3[1] = 0;
+        w3[2] = 0;
+        w3[3] = 0;
+
+        sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 48);
+
+        block_position += 12;
+      }
+
+       /*
+        now all the ticket should be decrypted until block n-1 (not included)
+        and n
+      */
+
+      // this is block n-2, it will be xored with the n-1 block later crafted
+      u32 last_block_cbc[4];
+
+      last_block_cbc[0] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 0];
+      last_block_cbc[1] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 1];
+      last_block_cbc[2] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 2];
+      last_block_cbc[3] = esalt_bufs[digests_offset].edata2[last_block_cbc_position + 3];
+
+      // n-1 block is decrypted separately from the previous blocks which were cbc decrypted
+      block[0] = esalt_bufs[digests_offset].edata2[block_position + 0];
+      block[1] = esalt_bufs[digests_offset].edata2[block_position + 1];
+      block[2] = esalt_bufs[digests_offset].edata2[block_position + 2];
+      block[3] = esalt_bufs[digests_offset].edata2[block_position + 3];
+
+      aes256_decrypt (aes_cts_decrypt_ks, block, decrypted_block, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      u32 last_block[4];
+
+      int last_block_position = (edata2_len - last_block_size) / 4;
+
+      u32 n_1_crafted[4];
+
+      u32 last_plaintext[4];
+
+      last_plaintext[0] = 0;
+      last_plaintext[1] = 0;
+      last_plaintext[2] = 0;
+      last_plaintext[3] = 0;
+
+      /*
+        n-1 block is first computed as follows:
+          - fill n-1 block with the X first bytes of the encrypted last block (n)
+            with X == length of last block
+          - complete the rest of the block with
+
+        Final block (n) is computed as follows:
+          - fill with the X first bytes from n-1 block decrypted and xor them with last block (n)
+            with X == length of last block
+      */
+      int remaining_blocks = last_block_size / 4;
+
+     /*
+        last block is not necessarily aligned on 4 bytes so we will have
+        to shift values for the CTS crap...
+      */
+      u32 shift = last_block_size % 4;
+
+      switch (remaining_blocks)
+      {
+        case 0:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+
+          u32 mask = (0xffffffff >> ((4 - last_block_size) * 8));
+
+          last_plaintext[0] = last_block[0] ^ (decrypted_block[0] & mask);
+          last_plaintext[0] = swap32_S (last_plaintext[0]);
+
+          n_1_crafted[0] = (last_block[0] & mask) | (decrypted_block[0] & (mask ^ 0xffffffff));
+          n_1_crafted[1] = decrypted_block[1];
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+          break;
+
+        case 1:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+
+          if (shift == 0)
+          {
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = decrypted_block[1];
+            n_1_crafted[2] = decrypted_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+          }
+          else
+          {
+            last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+
+            u32 mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ (decrypted_block[1] & mask);
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = (last_block[1] & mask) | (decrypted_block[1] & (mask ^ 0xffffffff));
+            n_1_crafted[2] = decrypted_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+          }
+          break;
+
+        case 2:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+          last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+
+          if (shift == 0)
+          {
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = decrypted_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+          }
+          else
+          {
+            last_block[2] = esalt_bufs[digests_offset].edata2[last_block_position + 2];
+
+            u32 mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+            last_plaintext[2] = last_block[2] ^ (decrypted_block[2] & mask);
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+            last_plaintext[2] = swap32_S (last_plaintext[2]);
+
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = (last_block[2] & mask) | (decrypted_block[2] & (mask ^ 0xffffffff));
+            n_1_crafted[3] = decrypted_block[3];
+          }
+          break;
+
+        case 3:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+          last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+          last_block[2] = esalt_bufs[digests_offset].edata2[last_block_position + 2];
+
+          if (shift == 0)
+          {
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = last_block[2];
+            n_1_crafted[3] = decrypted_block[3];
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+            last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+            last_plaintext[2] = swap32_S (last_plaintext[2]);
+          }
+          else
+          {
+            last_block[3] = esalt_bufs[digests_offset].edata2[last_block_position + 3];
+
+            u32 mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+            last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+            last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+            last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+            last_plaintext[3] = last_block[3] ^ (decrypted_block[3] & mask);
+
+            last_plaintext[0] = swap32_S (last_plaintext[0]);
+            last_plaintext[1] = swap32_S (last_plaintext[1]);
+            last_plaintext[2] = swap32_S (last_plaintext[2]);
+            last_plaintext[3] = swap32_S (last_plaintext[3]);
+
+            n_1_crafted[0] = last_block[0];
+            n_1_crafted[1] = last_block[1];
+            n_1_crafted[2] = last_block[2];
+            n_1_crafted[3] = (last_block[3] & mask) | (decrypted_block[3] & (mask ^ 0xffffffff));
+          }
+          break;
+
+        case 4:
+
+          last_block[0] = esalt_bufs[digests_offset].edata2[last_block_position + 0];
+          last_block[1] = esalt_bufs[digests_offset].edata2[last_block_position + 1];
+          last_block[2] = esalt_bufs[digests_offset].edata2[last_block_position + 2];
+          last_block[3] = esalt_bufs[digests_offset].edata2[last_block_position + 3];
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = last_block[2];
+          n_1_crafted[3] = last_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+          last_plaintext[3] = last_block[3] ^ decrypted_block[3];
+
+          last_plaintext[0] = swap32_S (last_plaintext[0]);
+          last_plaintext[1] = swap32_S (last_plaintext[1]);
+          last_plaintext[2] = swap32_S (last_plaintext[2]);
+          last_plaintext[3] = swap32_S (last_plaintext[3]);
+          break;
+
+        default:
+          return;
+      }
+
+
+      // then decrypt this newly created n-1 with 'ke'
+      aes256_decrypt (aes_cts_decrypt_ks, n_1_crafted, n_1_crafted, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      // then xor with the encrypted n-2 block
+      n_1_crafted[0] ^= last_block_cbc[0];
+      n_1_crafted[1] ^= last_block_cbc[1];
+      n_1_crafted[2] ^= last_block_cbc[2];
+      n_1_crafted[3] ^= last_block_cbc[3];
+
+      w0[0] = swap32_S (n_1_crafted[0]);
+      w0[1] = swap32_S (n_1_crafted[1]);
+      w0[2] = swap32_S (n_1_crafted[2]);
+      w0[3] = swap32_S (n_1_crafted[3]);
+
+      w1[0] = last_plaintext[0];
+      w1[1] = last_plaintext[1];
+      w1[2] = last_plaintext[2];
+      w1[3] = last_plaintext[3];
+
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16 + last_block_size);
+
+      sha1_hmac_final(&sha1_hmac_ctx);
+
+      if(sha1_hmac_ctx.opad.h[0]   == esalt_bufs[digests_offset].checksum[0]
+        && sha1_hmac_ctx.opad.h[1] == esalt_bufs[digests_offset].checksum[1]
+        && sha1_hmac_ctx.opad.h[2] == esalt_bufs[digests_offset].checksum[2])
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          #define il_pos 0
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos);
+        }
+      }
+    }
+  }
+}

--- a/src/modules/module_19600.c
+++ b/src/modules/module_19600.c
@@ -1,0 +1,349 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "Kerberos 5 TGS-REP etype 17 (AES128-CTS-HMAC-SHA1-96)";
+static const u64   KERN_TYPE      = 19600;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$krb5tgs$17$srv_http$synacktiv.local$849e31b3db1c1f203fa20b85$948690f5875125348286ad3346d27b43eaabc71896b620c16de7ddcdbd561628c650c508856a3f574261948b6db4b48332d30536e978046a423ad4368f9a69b4dc4642dab4e0d475d8299be718fd6f98ac85a771b457b2453e78c9411dfce572b19660fe7a5a8246d9b2a91ea2f14d1986ea0a77ecf9b8330bc8fd9ab540bcf46b74c5aa7005cfccd89ec05f66aeab30c6b2bf8595cf6c9a1b68ad885258850c4b1dd9265f270fb2af52fd76c16246df51ea67efc58a65c345686c84e43642febe908a";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct krb5tgs_17
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+
+} krb5tgs_17_t;
+
+typedef struct krb5tgs_17_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[10];
+  u32 out[10];
+
+} krb5tgs_17_tmp_t;
+
+static const char *SIGNATURE_KRB5TGS = "$krb5tgs$17$";
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (krb5tgs_17_tmp_t);
+
+  return tmp_size;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (krb5tgs_17_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  krb5tgs_17_t *krb5tgs = (krb5tgs_17_t *) esalt_buf;
+
+  token_t token;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_KRB5TGS;
+
+  token.len[0]  = 12;
+  token.attr[0] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  /**
+   * $krb5tgs$17$*user*realm*$checksum$edata2
+   * $krb5tgs$17$*user*realm*spn*$checksum$edata2
+   */
+
+  // assume no signature found
+  if (line_len < 12) return (PARSER_SALT_LENGTH);
+
+  char *spn_info_start  = strchr ((const char *) line_buf + 12 + 1, '*');
+
+  int is_spn_provided = 0;
+
+  // assume $krb5tgs$17$user$realm$checksum$edata2
+  if (spn_info_start == NULL)
+  {
+    token.token_cnt  = 5;
+
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.sep[2]     = '$';
+    token.len_min[2] = 1;
+    token.len_max[2] = 512;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.sep[3]     = '$';
+    // hmac-sha1 stripped to 12bytes
+    token.len_min[3] = 24;
+    token.len_max[3] = 24;
+    token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+
+    token.sep[4]     = '$';
+    token.len_min[4] = 64;
+    token.len_max[4] = 40960;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+  }
+  // assume $krb5tgs$17$user$realm$*spn*$checksum$edata2
+  else
+  {
+    char *spn_info_stop = strchr ((const char *) spn_info_start + 1, '*');
+
+    if (spn_info_stop == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+
+    spn_info_stop++; // we want the * $char included
+    spn_info_stop++; // we want the $ char included
+
+    const int spn_info_len = spn_info_stop - spn_info_start;
+
+    token.token_cnt  = 6;
+
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.sep[2]     = '$';
+    token.len_min[2] = 1;
+    token.len_max[2] = 512;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.len[3]     = spn_info_len;
+    token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH;
+
+    token.sep[4]     = '$';
+    token.len_min[4] = 24;
+    token.len_max[4] = 24;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+
+    token.sep[5]     = '$';
+    token.len_min[5] = 64;
+    token.len_max[5] = 40960;
+    token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+
+    is_spn_provided = 1;
+  }
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *user_pos;
+  const u8 *domain_pos;
+  const u8 *checksum_pos;
+  const u8 *data_pos;
+
+  int user_len;
+  int domain_len;
+  int data_len;
+  int account_info_len;
+
+  user_pos = token.buf[1];
+  user_len = token.len[1];
+
+  memcpy(krb5tgs->user, user_pos, user_len);
+
+  domain_pos = token.buf[2];
+  domain_len = token.len[2];
+
+  memcpy(krb5tgs->domain, domain_pos, domain_len);
+
+  checksum_pos = token.buf[3 + is_spn_provided];
+
+  data_pos = token.buf[4 + is_spn_provided];
+  data_len = token.len[4 + is_spn_provided];
+
+  account_info_len = token.len[2] + token.len[1];
+
+  u8 *account_info_ptr = (u8 *) krb5tgs->account_info;
+
+  // domain must be uppercase
+  u8 domain[128];
+  memcpy(domain, domain_pos, domain_len);
+  uppercase(domain, domain_len);
+
+  memcpy(account_info_ptr, domain, domain_len);
+  memcpy(account_info_ptr + domain_len, user_pos, user_len);
+
+  krb5tgs->account_info_len = account_info_len;
+
+  // hmac-sha1 is reduced to 12 bytes
+  krb5tgs->checksum[0] = byte_swap_32 (hex_to_u32 (checksum_pos +  0));
+  krb5tgs->checksum[1] = byte_swap_32 (hex_to_u32 (checksum_pos +  8));
+  krb5tgs->checksum[2] = byte_swap_32 (hex_to_u32 (checksum_pos + 16));
+
+  u8 *edata_ptr = (u8 *) krb5tgs->edata2;
+
+  for (int i = 0; i < data_len; i += 2)
+  {
+    const u8 p0 = data_pos[i + 0];
+    const u8 p1 = data_pos[i + 1];
+
+    *edata_ptr++ = hex_convert (p1) << 0
+                 | hex_convert (p0) << 4;
+  }
+
+  krb5tgs->edata2_len = data_len / 2;
+
+  salt->salt_buf[0] = krb5tgs->checksum[0];
+  salt->salt_buf[1] = krb5tgs->checksum[1];
+  salt->salt_buf[2] = krb5tgs->checksum[2];
+
+  salt->salt_iter = 4096 - 1;
+
+  digest[0] = krb5tgs->checksum[0];
+  digest[1] = krb5tgs->checksum[1];
+  digest[2] = krb5tgs->checksum[2];
+  digest[3] = 0;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  const krb5tgs_17_t *krb5tgs = (const krb5tgs_17_t *) esalt_buf;
+
+  char data[5120 * 4 * 2] = { 0 };
+
+  for (u32 i = 0, j = 0; i < krb5tgs->edata2_len; i += 1, j += 2)
+  {
+    u8 *ptr_edata2 = (u8 *) krb5tgs->edata2;
+
+    sprintf (data + j, "%02x", ptr_edata2[i]);
+  }
+
+  const int line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x$%s",
+    SIGNATURE_KRB5TGS,
+    (char *) krb5tgs->user,
+    (char *) krb5tgs->domain,
+    krb5tgs->checksum[0],
+    krb5tgs->checksum[1],
+    krb5tgs->checksum[2],
+    data);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_outfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_19700.c
+++ b/src/modules/module_19700.c
@@ -1,0 +1,349 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "Kerberos 5 TGS-REP etype 18 (AES256-CTS-HMAC-SHA1-96)";
+static const u64   KERN_TYPE      = 19700;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$krb5tgs$18$srv_http$synacktiv.local$16ce51f6eba20c8ee534ff8a$57d07b23643a516834795f0c010da8f549b7e65063e5a367ca9240f9b800adad1734df7e7d5dd8307e785de4f40aacf901df41aa6ce695f8619ec579c1fa57ee93661cf402aeef4e3a42e7e3477645d52c09dc72feade03512dffe0df517344f673c63532b790c242cc1d50f4b4b34976cb6e08ab325b3aefb2684262a5ee9faacb14d059754f50553be5bfa5c4c51e833ff2b6ac02c6e5d4c4eb193e27d7dde301bd1ddf480e5e282b8c27ef37b136c8f140b56de105b73adeb1de16232fa1ab5c9f6";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct krb5tgs_18
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+
+} krb5tgs_18_t;
+
+typedef struct krb5tgs_18_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[16];
+  u32 out[16];
+
+} krb5tgs_18_tmp_t;
+
+static const char *SIGNATURE_KRB5TGS = "$krb5tgs$18$";
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (krb5tgs_18_tmp_t);
+
+  return tmp_size;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (krb5tgs_18_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  krb5tgs_18_t *krb5tgs = (krb5tgs_18_t *) esalt_buf;
+
+  token_t token;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_KRB5TGS;
+
+  token.len[0]  = 12;
+  token.attr[0] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  /**
+   * $krb5tgs$18$*user*realm*$checksum$edata2
+   * $krb5tgs$18$*user*realm*spn*$checksum$edata2
+   */
+
+  // assume no signature found
+  if (line_len < 12) return (PARSER_SALT_LENGTH);
+
+  char *spn_info_start  = strchr ((const char *) line_buf + 12 + 1, '*');
+
+  int is_spn_provided = 0;
+
+  // assume $krb5tgs$17$user$realm$checksum$edata2
+  if (spn_info_start == NULL)
+  {
+    token.token_cnt  = 5;
+
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.sep[2]     = '$';
+    token.len_min[2] = 1;
+    token.len_max[2] = 512;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.sep[3]     = '$';
+    // hmac-sha1 stripped to 12bytes
+    token.len_min[3] = 24;
+    token.len_max[3] = 24;
+    token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+
+    token.sep[4]     = '$';
+    token.len_min[4] = 64;
+    token.len_max[4] = 40960;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+  }
+  // assume $krb5tgs$18$user$realm$*spn*$checksum$edata2
+  else
+  {
+    char *spn_info_stop = strchr ((const char *) spn_info_start + 1, '*');
+
+    if (spn_info_stop == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+
+    spn_info_stop++; // we want the * $char included
+    spn_info_stop++; // we want the $ char included
+
+    const int spn_info_len = spn_info_stop - spn_info_start;
+
+    token.token_cnt  = 6;
+
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.sep[2]     = '$';
+    token.len_min[2] = 1;
+    token.len_max[2] = 512;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    token.len[3]     = spn_info_len;
+    token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH;
+
+    token.sep[4]     = '$';
+    token.len_min[4] = 24;
+    token.len_max[4] = 24;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+
+    token.sep[5]     = '$';
+    token.len_min[5] = 64;
+    token.len_max[5] = 40960;
+    token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                       | TOKEN_ATTR_VERIFY_HEX;
+
+    is_spn_provided = 1;
+  }
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *user_pos;
+  const u8 *domain_pos;
+  const u8 *checksum_pos;
+  const u8 *data_pos;
+
+  int user_len;
+  int domain_len;
+  int data_len;
+  int account_info_len;
+
+  user_pos = token.buf[1];
+  user_len = token.len[1];
+
+  memcpy(krb5tgs->user, user_pos, user_len);
+
+  domain_pos = token.buf[2];
+  domain_len = token.len[2];
+
+  memcpy(krb5tgs->domain, domain_pos, domain_len);
+
+  checksum_pos = token.buf[3 + is_spn_provided];
+
+  data_pos = token.buf[4 + is_spn_provided];
+  data_len = token.len[4 + is_spn_provided];
+
+  account_info_len = token.len[2] + token.len[1];
+
+  u8 *account_info_ptr = (u8 *) krb5tgs->account_info;
+
+  // domain must be uppercase
+  u8 domain[128];
+  memcpy(domain, domain_pos, domain_len);
+  uppercase(domain, domain_len);
+
+  memcpy(account_info_ptr, domain, domain_len);
+  memcpy(account_info_ptr + domain_len, user_pos, user_len);
+
+  krb5tgs->account_info_len = account_info_len;
+
+  // hmac-sha1 is reduced to 12 bytes
+  krb5tgs->checksum[0] = byte_swap_32 (hex_to_u32 (checksum_pos +  0));
+  krb5tgs->checksum[1] = byte_swap_32 (hex_to_u32 (checksum_pos +  8));
+  krb5tgs->checksum[2] = byte_swap_32 (hex_to_u32 (checksum_pos + 16));
+
+  u8 *edata_ptr = (u8 *) krb5tgs->edata2;
+
+  for (int i = 0; i < data_len; i += 2)
+  {
+    const u8 p0 = data_pos[i + 0];
+    const u8 p1 = data_pos[i + 1];
+
+    *edata_ptr++ = hex_convert (p1) << 0
+                 | hex_convert (p0) << 4;
+  }
+
+  krb5tgs->edata2_len = data_len / 2;
+
+  salt->salt_buf[0] = krb5tgs->checksum[0];
+  salt->salt_buf[1] = krb5tgs->checksum[1];
+  salt->salt_buf[2] = krb5tgs->checksum[2];
+
+  salt->salt_iter = 4096 - 1;
+
+  digest[0] = krb5tgs->checksum[0];
+  digest[1] = krb5tgs->checksum[1];
+  digest[2] = krb5tgs->checksum[2];
+  digest[3] = 0;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  const krb5tgs_18_t *krb5tgs = (const krb5tgs_18_t *) esalt_buf;
+
+  char data[5120 * 4 * 2] = { 0 };
+
+  for (u32 i = 0, j = 0; i < krb5tgs->edata2_len; i += 1, j += 2)
+  {
+    u8 *ptr_edata2 = (u8 *) krb5tgs->edata2;
+
+    sprintf (data + j, "%02x", ptr_edata2[i]);
+  }
+
+  const int line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x$%s",
+    SIGNATURE_KRB5TGS,
+    (char *) krb5tgs->user,
+    (char *) krb5tgs->domain,
+    krb5tgs->checksum[0],
+    krb5tgs->checksum[1],
+    krb5tgs->checksum[2],
+    data);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_outfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m19600.pm
+++ b/tools/test_modules/m19600.pm
@@ -1,0 +1,219 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (hmac_sha1);
+use Crypt::Mode::CBC;
+use Crypt::PBKDF2;
+use Encode;
+use POSIX            qw (strftime);
+
+sub byte2hex
+{
+  my $input = shift;
+  return unpack ("H*", $input);
+}
+
+sub hex2byte
+{
+  my $input = shift;
+  return pack ("H*", $input);
+}
+
+sub pad
+{
+  my $n = shift;
+  my $size = shift;
+
+  return (~$n + 1) & ($size - 1);
+}
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word      = shift;
+  my $salt      = shift;
+  my $user      = shift // "user";
+  my $realm     = shift // "realm";
+  my $checksum  = shift;
+  my $edata2    = shift;
+
+  my $mysalt = uc $realm;
+  $mysalt = $mysalt . $user;
+
+  # first we generate the 'seed'
+  my $iter = 4096;
+  my $pbkdf2 = Crypt::PBKDF2->new
+  (
+    hash_class => 'HMACSHA1',
+    iterations => $iter,
+    output_len => 16
+  );
+
+  my $b_seed = $pbkdf2->PBKDF2 ($mysalt, $word);
+
+  # we can precompute this
+  my $b_kerberos_nfolded = hex2byte('6b65726265726f737b9b5b2b93132b93');
+
+  my $b_iv = hex2byte('0' x 32);
+
+  # 'key_bytes' will be the AES key used to generate 'ki' (for final hmac-sha1)
+  # and 'ke' (AES key to decrypt/encrypt the ticket)
+  my $cbc       = Crypt::Mode::CBC->new ('AES', 0);
+  my $b_key_bytes = $cbc->encrypt ($b_kerberos_nfolded, $b_seed, $b_iv);
+
+  # precomputed stuff
+  my $b_nfolded1 = hex2byte('62dc6e371a63a80958ac562b15404ac5');
+  my $b_nfolded2 = hex2byte('b5b0582c14b6500aad56ab55aa80556a');
+
+  my $b_ki = $cbc->encrypt ($b_nfolded1, $b_key_bytes, $b_iv);
+  my $b_ke = $cbc->encrypt ($b_nfolded2, $b_key_bytes, $b_iv);
+
+  my $cleartext_ticket = '6381b03081ada00703050050a00000a11b3019a003020117a1'.
+    '12041058e0d77776e8b8e03991f2966939222aa2171b154d594b5242544553542e434f4e5'.
+    '44f534f2e434f4da3133011a003020102a10a30081b067472616e6365a40b3009a0030201'.
+    '01a1020400a511180f32303136303231353134343735305aa611180f32303136303231353'.
+    '134343735305aa711180f32303136303231363030343735305aa811180f32303136303232'.
+    '323134343735305a';
+
+  if (defined $edata2)
+  {
+    my $len_last_block  = length($edata2) % 32;
+
+    my $tmp = $len_last_block + 32;
+
+    my $b_truncated_enc_ticket = hex2byte (substr $edata2, 0, -$tmp);
+
+    my $b_last_block = hex2byte (substr $edata2, -$len_last_block);
+
+    my $b_n_1_block = hex2byte (substr(substr($edata2, -$tmp), 0, 32));
+
+    my $b_truncated_ticket_decrypted = $cbc->decrypt ($b_truncated_enc_ticket, $b_ke, $b_iv);
+
+    my $truncated_ticket_decrypted = byte2hex($b_truncated_ticket_decrypted);
+
+    my $check_correct  = ((substr ($truncated_ticket_decrypted, 32, 4) eq "6381" && substr ($truncated_ticket_decrypted, 38, 2) eq "30") ||
+                          (substr ($truncated_ticket_decrypted, 32, 4) eq "6382")) &&
+                         ((substr ($truncated_ticket_decrypted, 48, 6) eq "030500") ||
+                          (substr ($truncated_ticket_decrypted, 48, 8) eq "050307A0"));
+
+    if ($check_correct == 1)
+    {
+      my $b_n_2 = substr $b_truncated_enc_ticket, -16;
+
+      my $b_n_1_decrypted = $cbc->decrypt ($b_n_1_block, $b_ke, $b_iv);
+
+      my $b_last_plain = substr $b_n_1_decrypted, 0, $len_last_block/2;
+
+      $b_last_plain =  $b_last_plain ^ $b_last_block;
+
+      my $omitted = substr $b_n_1_decrypted,  -(16 - $len_last_block/2);
+
+      my $b_n_1 = $b_last_block . $omitted;
+
+      $b_n_1 = $cbc->decrypt ($b_n_1, $b_ke, $b_iv);
+
+      $b_n_1 = $b_n_1 ^ $b_n_2;
+
+      my $b_cleartext_ticket = $b_truncated_ticket_decrypted . $b_n_1 . $b_last_plain;
+
+      $cleartext_ticket = byte2hex($b_cleartext_ticket);
+    }
+    else # validation failed
+    {
+      # fake/wrong ticket (otherwise if we just decrypt/encrypt we end
+      #up with false positives all the time)
+      $cleartext_ticket = "0" x (length ($cleartext_ticket) + 32);
+    }
+  }
+
+  if (defined $checksum)
+  {
+    $checksum = pack ("H*", $checksum);
+  }
+  else
+  {
+    if (!defined $edata2)
+    {
+      my $nonce = unpack ("H*", random_bytes (16));
+
+      $cleartext_ticket = $nonce . $cleartext_ticket;
+    }
+      # we have what is required to compute checksum
+    $checksum = hmac_sha1 (hex2byte($cleartext_ticket), $b_ki);
+
+    $checksum = substr $checksum, 0, 12;
+  }
+
+  my $len_cleartext_last_block = length($cleartext_ticket) % 32;
+  my $cleartext_last_block = substr $cleartext_ticket, -$len_cleartext_last_block;
+
+  my $padding = pad(length($cleartext_ticket), 32);
+
+  my $b_cleartext_last_block_padded = hex2byte($cleartext_last_block . '0' x $padding);
+
+  # we will encrypt until n-1 block (included)
+  my $truncated_cleartext_ticket = substr $cleartext_ticket, 0, -$len_cleartext_last_block;
+
+  my $b_truncated_enc_ticket = $cbc->encrypt (hex2byte($truncated_cleartext_ticket), $b_ke, $b_iv);
+
+  my $b_enc_ticket_n_1_block= substr $b_truncated_enc_ticket, -16;
+
+  my $b_enc_last_block = substr $b_enc_ticket_n_1_block, 0, $len_cleartext_last_block/2;
+
+  # we now craft the new n-1 block
+  my $tmp = $b_enc_ticket_n_1_block ^ $b_cleartext_last_block_padded;
+
+  $b_enc_ticket_n_1_block = $cbc->encrypt ($tmp, $b_ke, $b_iv);
+
+  $tmp = substr $b_truncated_enc_ticket, 0, -16;
+
+  $edata2 = $tmp . $b_enc_ticket_n_1_block . $b_enc_last_block;
+
+  my $tmp_hash = sprintf ('$krb5tgs$17$%s$%s$%s$%s', $user, $realm, unpack ("H*", $checksum), unpack ("H*", $edata2));
+
+  return $tmp_hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @data = split ('\$', $hash);
+
+  return unless scalar @data == 7;
+
+  shift @data;
+
+  my $signature = shift @data;
+  my $algorithm = shift @data;
+  my $user      = shift @data;
+  my $realm     = shift @data;
+  my $checksum  = shift @data;
+  my $edata2    = shift @data;
+
+  return unless ($signature eq "krb5tgs");
+  return unless ($algorithm eq "17");
+  return unless (length ($checksum) == 24);
+  return unless (length ($edata2) >= 64);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, undef, $user, $realm, $checksum, $edata2);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m19700.pm
+++ b/tools/test_modules/m19700.pm
@@ -1,0 +1,234 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (hmac_sha1);
+use Crypt::Mode::CBC;
+use Crypt::PBKDF2;
+use Encode;
+use POSIX            qw (strftime);
+
+sub byte2hex
+{
+  my $input = shift;
+  return unpack ("H*", $input);
+}
+
+sub hex2byte
+{
+  my $input = shift;
+  return pack ("H*", $input);
+}
+
+sub pad
+{
+  my $n = shift;
+  my $size = shift;
+
+  return (~$n + 1) & ($size - 1);
+}
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word      = shift;
+  my $salt      = shift;
+  my $user      = shift // "user";
+  my $realm     = shift // "realm";
+  my $checksum  = shift;
+  my $edata2    = shift;
+
+  my $mysalt = uc $realm;
+  $mysalt = $mysalt . $user;
+
+  # first we generate the 'seed'
+  my $iter = 4096;
+  my $pbkdf2 = Crypt::PBKDF2->new
+  (
+    hash_class => 'HMACSHA1',
+    iterations => $iter,
+    output_len => 32
+  );
+
+  my $b_seed = $pbkdf2->PBKDF2 ($mysalt, $word);
+
+  printf "seed: %s\n", byte2hex($b_seed);
+
+  # we can precompute this
+  my $b_kerberos_nfolded = hex2byte('6b65726265726f737b9b5b2b93132b93');
+
+  my $b_iv = hex2byte('0' x 32);
+
+  # 'key_bytes' will be the AES key used to generate 'ki' (for final hmac-sha1)
+  # and 'ke' (AES key to decrypt/encrypt the ticket)
+  my $cbc       = Crypt::Mode::CBC->new ('AES', 0);
+
+  my $b_key_bytes = $cbc->encrypt ($b_kerberos_nfolded, $b_seed, $b_iv);
+
+  $b_key_bytes = $b_key_bytes . $cbc->encrypt ($b_key_bytes, $b_seed, $b_iv);
+
+  printf "key_bytes: %s\n", byte2hex($b_key_bytes);
+
+  # precomputed stuff
+  my $b_nfolded1 = hex2byte('62dc6e371a63a80958ac562b15404ac5');
+  my $b_nfolded2 = hex2byte('b5b0582c14b6500aad56ab55aa80556a');
+
+  my $b_ki = $cbc->encrypt ($b_nfolded1, $b_key_bytes, $b_iv);
+
+  $b_ki = $b_ki . $cbc->encrypt ($b_ki, $b_key_bytes, $b_iv);
+
+  my $b_ke = $cbc->encrypt ($b_nfolded2, $b_key_bytes, $b_iv);
+
+  $b_ke = $b_ke . $cbc->encrypt ($b_ke, $b_key_bytes, $b_iv);
+
+  printf "ki: %s\n", byte2hex($b_ki);
+  printf "ke: %s\n", byte2hex($b_ke);
+
+  my $cleartext_ticket = '6381b03081ada00703050050a00000a11b3019a003020117a1'.
+    '12041058e0d77776e8b8e03991f2966939222aa2171b154d594b5242544553542e434f4e5'.
+    '44f534f2e434f4da3133011a003020102a10a30081b067472616e6365a40b3009a0030201'.
+    '01a1020400a511180f32303136303231353134343735305aa611180f32303136303231353'.
+    '134343735305aa711180f32303136303231363030343735305aa811180f32303136303232'.
+    '323134343735305a';
+
+  if (defined $edata2)
+  {
+    my $len_last_block  = length($edata2) % 32;
+
+    my $tmp = $len_last_block + 32;
+
+    my $b_truncated_enc_ticket = hex2byte (substr $edata2, 0, -$tmp);
+
+    my $b_last_block = hex2byte (substr $edata2, -$len_last_block);
+
+    my $b_n_1_block = hex2byte (substr(substr($edata2, -$tmp), 0, 32));
+
+    my $b_truncated_ticket_decrypted = $cbc->decrypt ($b_truncated_enc_ticket, $b_ke, $b_iv);
+
+    my $truncated_ticket_decrypted = byte2hex($b_truncated_ticket_decrypted);
+
+    my $check_correct  = ((substr ($truncated_ticket_decrypted, 32, 4) eq "6381" && substr ($truncated_ticket_decrypted, 38, 2) eq "30") ||
+                          (substr ($truncated_ticket_decrypted, 32, 4) eq "6382")) &&
+                         ((substr ($truncated_ticket_decrypted, 48, 6) eq "030500") ||
+                          (substr ($truncated_ticket_decrypted, 48, 8) eq "050307A0"));
+
+    if ($check_correct == 1)
+    {
+      my $b_n_2 = substr $b_truncated_enc_ticket, -16;
+
+      my $b_n_1_decrypted = $cbc->decrypt ($b_n_1_block, $b_ke, $b_iv);
+
+      my $b_last_plain = substr $b_n_1_decrypted, 0, $len_last_block/2;
+
+      $b_last_plain =  $b_last_plain ^ $b_last_block;
+
+      my $omitted = substr $b_n_1_decrypted,  -(16 - $len_last_block/2);
+
+      my $b_n_1 = $b_last_block . $omitted;
+
+      $b_n_1 = $cbc->decrypt ($b_n_1, $b_ke, $b_iv);
+
+      $b_n_1 = $b_n_1 ^ $b_n_2;
+
+      my $b_cleartext_ticket = $b_truncated_ticket_decrypted . $b_n_1 . $b_last_plain;
+
+      $cleartext_ticket = byte2hex($b_cleartext_ticket);
+    }
+    else # validation failed
+    {
+      # fake/wrong ticket (otherwise if we just decrypt/encrypt we end
+      #up with false positives all the time)
+      $cleartext_ticket = "0" x (length ($cleartext_ticket) + 32);
+    }
+  }
+
+  if (defined $checksum)
+  {
+    $checksum = pack ("H*", $checksum);
+  }
+  else
+  {
+    if (!defined $edata2)
+    {
+      my $nonce = unpack ("H*", random_bytes (16));
+
+      $cleartext_ticket = $nonce . $cleartext_ticket;
+    }
+      # we have what is required to compute checksum
+    $checksum = hmac_sha1 (hex2byte($cleartext_ticket), $b_ki);
+
+    $checksum = substr $checksum, 0, 12;
+  }
+
+  my $len_cleartext_last_block = length($cleartext_ticket)%32;
+  my $cleartext_last_block = substr $cleartext_ticket, -$len_cleartext_last_block;
+
+  my $padding = pad(length($cleartext_ticket), 32);
+
+  my $b_cleartext_last_block_padded = hex2byte($cleartext_last_block . '0' x $padding);
+
+  # we will encrypt until n-1 block (included)
+  my $truncated_cleartext_ticket = substr $cleartext_ticket, 0, -$len_cleartext_last_block;
+
+  my $b_truncated_enc_ticket = $cbc->encrypt (hex2byte($truncated_cleartext_ticket), $b_ke, $b_iv);
+
+  my $b_enc_ticket_n_1_block= substr $b_truncated_enc_ticket, -16;
+
+  my $b_enc_last_block = substr $b_enc_ticket_n_1_block, 0, $len_cleartext_last_block/2;
+
+  # we now craft the new n-1 block
+  my $tmp = $b_enc_ticket_n_1_block ^ $b_cleartext_last_block_padded;
+
+  $b_enc_ticket_n_1_block = $cbc->encrypt ($tmp, $b_ke, $b_iv);
+
+  $tmp = substr $b_truncated_enc_ticket, 0, -16;
+
+  $edata2 = $tmp . $b_enc_ticket_n_1_block . $b_enc_last_block;
+
+  my $tmp_hash = sprintf ('$krb5tgs$18$%s$%s$%s$%s', $user, $realm, unpack ("H*", $checksum), unpack ("H*", $edata2));
+
+  return $tmp_hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @data = split ('\$', $hash);
+
+  return unless scalar @data == 7;
+
+  shift @data;
+
+  my $signature = shift @data;
+  my $algorithm = shift @data;
+  my $user      = shift @data;
+  my $realm     = shift @data;
+  my $checksum  = shift @data;
+  my $edata2    = shift @data;
+
+  return unless ($signature eq "krb5tgs");
+  return unless ($algorithm eq "18");
+  return unless (length ($checksum) == 24);
+  return unless (length ($edata2) >= 64);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, undef, $user, $realm, $checksum, $edata2);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Hi,
this PR adds 2 new formats:

- krb5tgs encryption type 17 (AES128-CTS-HMAC-SHA1-96);
- krb5tgs encryption type 18 (AES256-CTS-HMAC-SHA1-96).

The jtr implementation should also be there soon (cc @kholia) :+1:

# Issues related

This addresses issue #1384. Furthermore, #1386 being a subset of the algorithms implemented within this PR, it would be trivial to create such a new hash format and also close this issue (I'll do it later). Finally, this implementation could also permit to close #959 as same algorithms are involved... Later again :wink:

# How does it work

**(not so) TL;DR:** within a Windows Active Directory environment, registered services (as MsSQL or so) rely on a domain account in order to be functional.
This domain account should be a service account but administrators can provided whichever account they want provided that it has sufficient rights.
Such specific accounts are easily identifiable by their LDAP attribute _servicePrincipalName_ (SPN) and can be listed by any authenticated user (whatever are his rights in the domain).
Furthermore any authenticated can request a TGS ticket for these accounts (/invoke [Wikipedia](https://en.wikipedia.org/wiki/Kerberos_(protocol))). Nevertheless, if one can request such tickets, it does not mean that he would be able to impersonate these accounts.
Indeed, the important part, assuring that a user submitting a ticket is its legit owner, is encrypted with a key which is constructed from a secret only known by the legit account which is... its domain account password :wink: . This attack is known as "Kerberoast" and was discovered by **Tim Medin**.

So, having a valid domain user account, you can request tickets of accounts having a SPN and try to retrieve the password of concerned accounts :blush:

# Algorithms details
Active Directory offers 4 algorithms to generate the encryption key:
- DES (disabled by default, not really usefull)
- RC4-HMAC-MD5 (enctype 23)
- AES128-CTS-HMAC-SHA1-96 (enctype 17) - with some nice **4096** iterations count PBKDF2 HMAC-SHA1 ...
- AES256-CTS-HMAC-SHA1-96 (enctype 18) - same number of algo/iterations

I had already implemented enctype 23 back in the days but enctype 17 and 18 were missing, so here they are!

# How can I haz ticketz?

Back in the days I coded a private tool [(kerberom)](https://github.com/Synacktiv/kerberom) based on the amazing [impacket](https://github.com/SecureAuthCorp/impacket) from @asolino. Then other tools became public and the attack is now within the impacket suite (_GetUserSPNs.py_).
The sole interest of _kerberom_ now is that it can be built as a Windows binary (it also supports Windows implicit authentication, which is really useful when you've managed to compromise a user account but don't have his password, as in phishing campains during redteam assessments for example)... but I also plan to implement this in _GetUserSPNs.py_...
So, you should use _GetUserSPNs.py_ from impacket in order to get these hashes! (if you have the password/hash of an authenticated user, of course, otherwise _kerberom_).
All you have to do is wait for this PR SecureAuthCorp/impacket#584 to be accepted :wink:

# Countermeasures

Guys... we are in 2019... you should now use Managed Service Accounts. If not possible, create a dedicated domain account having a **random** password!
There are also other mechanisms, but these 2 are sufficient enough and easy to set-up :+1: 

# Performances

Provided a rig of 8 GTX 1080Ti:

```
Hashmode: 13100 - Kerberos 5 TGS-REP etype 23 (RC4-HMAC-MD5)
Speed.#*.........:  3120.7 MH/s

Hashmode: 19600 - Kerberos 5 TGS-REP etype 17 (AES128-CTS-HMAC-SHA1-96)
(Iterations: 4095)
Speed.#*.........:  8643.4 kH/s

Hashmode: 19700 - Kerberos 5 TGS-REP etype 18 (AES256-CTS-HMAC-SHA1-96)
(Iterations: 4095)
Speed.#*.........:  4290.3 kH/s
```
The performances are not good compared to the RC4 algorithm, but meh you know... PBKDF2, AES, etc.
Anyway, these are still pretty good performances regarding involved alogirthms + iterations count (less than 5 minutes on enctype 17 to complete a 1.4GB dictionary!)

# Further reading

@harmj0y and @PyroTek3 described all the mechanisms involved in these kinds of attacks. They also give a lot of insights on Active Directory on a global basis. I highly recommend you to read their awesome blogs ([harmj0y's one](https://blog.harmj0y.net/) and [PyroTek3's one](https://adsecurity.org/)) whether you are a beginner or a confirmed Windows administrator/pentester.
If you are not afraid of _Croissant's black magic_ I also recommend you to read some papers of the almighty Aurélien Bordes, pioneer in all this ([here](https://www.sstic.org/media/SSTIC2007/SSTIC-actes/Secrets_d_authentification_sous_Windows/SSTIC2007-Article-Secrets_d_authentification_sous_Windows-bordes.pdf) and [here](https://www.sstic.org/media/SSTIC2014/SSTIC-actes/secrets_dauthentification_pisode_ii__kerberos_cont/SSTIC2014-Article-secrets_dauthentification_pisode_ii__kerberos_contre-attaque-bordes_2.pdf))

I hope you have all the information you need to Kerberoast a bit now :wink:

Cheers!

PS: a big thanks to @skelsec who provided the algorithm and convinced me to implement it in hashcat as I was being lazy...
PS2: a big thanks to @jsteube for the insights on the new hashcat architecture I was not familiar with! This project is awesome and formats are really easy to implement now!