### PR TITLE
outfile remove: fix hash parsing

### DIFF
--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -230,7 +230,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
           {
             void *tmps = hcmalloc (hashconfig->tmp_size);
 
-            parser_status = module_ctx->module_hash_decode_potfile (hashconfig, hash_buf.digest, hash_buf.salt, hash_buf.esalt, hash_buf.hook_salt, hash_buf.hash_info, line_buf, line_len - 1, tmps);
+            parser_status = module_ctx->module_hash_decode_potfile (hashconfig, hash_buf.digest, hash_buf.salt, hash_buf.esalt, hash_buf.hook_salt, hash_buf.hash_info, line_buf, line_hash_len, tmps);
 
             hcfree (tmps);
           }
@@ -238,7 +238,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
           {
             // "normal" case: hash in the outfile is the same as the hash in the original hash file
 
-            parser_status = module_ctx->module_hash_decode (hashconfig, hash_buf.digest, hash_buf.salt, hash_buf.esalt, hash_buf.hook_salt, hash_buf.hash_info, line_buf, line_len - 1);
+            parser_status = module_ctx->module_hash_decode (hashconfig, hash_buf.digest, hash_buf.salt, hash_buf.esalt, hash_buf.hook_salt, hash_buf.hash_info, line_buf, line_hash_len);
           }
 
           if (parser_status != PARSER_OK) continue;


### PR DESCRIPTION
The feature to add cracks to hashcat.outfiles/ wasn't working correctly with the latest betas because the hash:pass was not split correctly and therefore not correctly passed to the parsing function. The whole line was passed instead of only the hash.
This should fix the problem of splitting the lines and therefore correctly parsing the outfiles.

Thanks