### PR TITLE
Introduce _cleanup_fclose_ to automatically fclose opened files

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -94,4 +94,10 @@ int  generic_salt_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, const u8 
 
 int input_tokenizer (const u8 *input_buf, const int input_len, token_t *token);
 
+static inline void hc_fclose(FILE **f)
+{
+    fclose(*f);
+}
+
+#define _cleanup_fclose_ __attribute__((cleanup(hc_fclose)))
 #endif // _SHARED_H

--- a/src/brain.c
+++ b/src/brain.c
@@ -539,7 +539,7 @@ u64 brain_compute_attack_wordlist (const char *filename)
 
   char buf[FBUFSZ];
 
-  FILE *fd = fopen (filename, "rb");
+  FILE *fd _cleanup_fclose_ = fopen (filename, "rb");
 
   while (!feof (fd))
   {
@@ -547,8 +547,6 @@ u64 brain_compute_attack_wordlist (const char *filename)
 
     XXH64_update (state, buf, nread);
   }
-
-  fclose (fd);
 
   const u64 hash = XXH64_digest (state);
 
@@ -609,7 +607,7 @@ u32 brain_auth_challenge (void)
 
   static const char *urandom = "/dev/urandom";
 
-  FILE *fd = fopen (urandom, "rb");
+  FILE *fd _cleanup_fclose_ = fopen (urandom, "rb");
 
   if (fd == NULL)
   {
@@ -622,12 +620,8 @@ u32 brain_auth_challenge (void)
   {
     brain_logging (stderr, 0, "%s: %s\n", urandom, strerror (errno));
 
-    fclose (fd);
-
     return val;
   }
-
-  fclose (fd);
 
   #endif
 
@@ -1595,7 +1589,7 @@ bool brain_server_read_hash_dump (brain_server_db_hash_t *brain_server_db_hash, 
     return false;
   }
 
-  FILE *fd = fopen (file, "rb");
+  FILE *fd _cleanup_fclose_ = fopen (file, "rb");
 
   if (fd == NULL)
   {
@@ -1611,8 +1605,6 @@ bool brain_server_read_hash_dump (brain_server_db_hash_t *brain_server_db_hash, 
     {
       brain_logging (stderr, 0, "%s\n", MSG_ENOMEM);
 
-      fclose (fd);
-
       return false;
     }
 
@@ -1622,16 +1614,12 @@ bool brain_server_read_hash_dump (brain_server_db_hash_t *brain_server_db_hash, 
     {
       brain_logging (stderr, 0, "%s: only %" PRIu64 " bytes read\n", file, (u64) nread * sizeof (brain_server_hash_long_t));
 
-      fclose (fd);
-
       return false;
     }
 
     brain_server_db_hash->long_cnt = temp_cnt;
 
     brain_server_db_hash->write_hashes = false;
-
-    fclose (fd);
   }
 
   const double ms = hc_timer_get (timer_dump);
@@ -1651,7 +1639,7 @@ bool brain_server_write_hash_dump (brain_server_db_hash_t *brain_server_db_hash,
 
   // write to file
 
-  FILE *fd = fopen (file, "wb");
+  FILE *fd _cleanup_fclose_ = fopen (file, "wb");
 
   if (fd == NULL)
   {
@@ -1667,12 +1655,8 @@ bool brain_server_write_hash_dump (brain_server_db_hash_t *brain_server_db_hash,
     {
       brain_logging (stderr, 0, "%s: only %" PRIu64 " bytes written\n", file, (u64) nwrite * sizeof (brain_server_hash_long_t));
 
-      fclose (fd);
-
       return false;
     }
-
-    fclose (fd);
 
     brain_server_db_hash->write_hashes = false;
   }
@@ -1794,7 +1778,7 @@ bool brain_server_read_attack_dump (brain_server_db_attack_t *brain_server_db_at
     return false;
   }
 
-  FILE *fd = fopen (file, "rb");
+  FILE *fd _cleanup_fclose_ = fopen (file, "rb");
 
   if (fd == NULL)
   {
@@ -1810,8 +1794,6 @@ bool brain_server_read_attack_dump (brain_server_db_attack_t *brain_server_db_at
     {
       brain_logging (stderr, 0, "%s\n", MSG_ENOMEM);
 
-      fclose (fd);
-
       return false;
     }
 
@@ -1821,16 +1803,12 @@ bool brain_server_read_attack_dump (brain_server_db_attack_t *brain_server_db_at
     {
       brain_logging (stderr, 0, "%s: only %" PRIu64 " bytes read\n", file, (u64) nread * sizeof (brain_server_attack_long_t));
 
-      fclose (fd);
-
       return false;
     }
 
     brain_server_db_attack->long_cnt = temp_cnt;
 
     brain_server_db_attack->write_attacks = false;
-
-    fclose (fd);
   }
 
   const double ms = hc_timer_get (timer_dump);
@@ -1850,7 +1828,7 @@ bool brain_server_write_attack_dump (brain_server_db_attack_t *brain_server_db_a
 
   // write to file
 
-  FILE *fd = fopen (file, "wb");
+  FILE *fd _cleanup_fclose_ = fopen (file, "wb");
 
   if (fd == NULL)
   {
@@ -1868,12 +1846,8 @@ bool brain_server_write_attack_dump (brain_server_db_attack_t *brain_server_db_a
     {
       brain_logging (stderr, 0, "%s: only %" PRIu64 " bytes written\n", file, (u64) nwrite * sizeof (brain_server_attack_long_t));
 
-      fclose (fd);
-
       return false;
     }
-
-    fclose (fd);
 
     brain_server_db_attack->write_attacks = false;
   }

--- a/src/combinator.c
+++ b/src/combinator.c
@@ -60,8 +60,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         return -1;
       }
 
-      FILE *fp1 = NULL;
-      FILE *fp2 = NULL;
+      FILE *fp1 _cleanup_fclose_ = NULL;
+      FILE *fp2 _cleanup_fclose_ = NULL;
 
       if ((fp1 = fopen (dictfile1, "rb")) == NULL)
       {
@@ -73,8 +73,6 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
       if ((fp2 = fopen (dictfile2, "rb")) == NULL)
       {
         event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
-
-        fclose (fp1);
 
         return -1;
       }
@@ -89,18 +87,12 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile1);
 
-        fclose (fp1);
-        fclose (fp2);
-
         return -1;
       }
 
       if (words1_cnt == 0)
       {
         event_log_error (hashcat_ctx, "%s: empty file.", dictfile1);
-
-        fclose (fp1);
-        fclose (fp2);
 
         return -1;
       }
@@ -115,9 +107,6 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile2);
 
-        fclose (fp1);
-        fclose (fp2);
-
         return -1;
       }
 
@@ -125,14 +114,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
       {
         event_log_error (hashcat_ctx, "%s: empty file.", dictfile2);
 
-        fclose (fp1);
-        fclose (fp2);
-
         return -1;
       }
-
-      fclose (fp1);
-      fclose (fp2);
 
       combinator_ctx->dict1 = dictfile1;
       combinator_ctx->dict2 = dictfile2;
@@ -169,8 +152,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
           return -1;
         }
 
-        FILE *fp1 = NULL;
-        FILE *fp2 = NULL;
+        FILE *fp1 _cleanup_fclose_ = NULL;
+        FILE *fp2 _cleanup_fclose_ = NULL;
 
         if ((fp1 = fopen (dictfile1, "rb")) == NULL)
         {
@@ -182,8 +165,6 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         if ((fp2 = fopen (dictfile2, "rb")) == NULL)
         {
           event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
-
-          fclose (fp1);
 
           return -1;
         }
@@ -198,18 +179,12 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile1);
 
-          fclose (fp1);
-          fclose (fp2);
-
           return -1;
         }
 
         if (words1_cnt == 0)
         {
           event_log_error (hashcat_ctx, "%s: empty file.", dictfile1);
-
-          fclose (fp1);
-          fclose (fp2);
 
           return -1;
         }
@@ -224,9 +199,6 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile2);
 
-          fclose (fp1);
-          fclose (fp2);
-
           return -1;
         }
 
@@ -234,14 +206,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         {
           event_log_error (hashcat_ctx, "%s: empty file.", dictfile2);
 
-          fclose (fp1);
-          fclose (fp2);
-
           return -1;
         }
-
-        fclose (fp1);
-        fclose (fp2);
 
         combinator_ctx->dict1 = dictfile1;
         combinator_ctx->dict2 = dictfile2;
@@ -306,8 +272,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
           return -1;
         }
 
-        FILE *fp1 = NULL;
-        FILE *fp2 = NULL;
+        FILE *fp1 _cleanup_fclose_ = NULL;
+        FILE *fp2 _cleanup_fclose_ = NULL;
 
         if ((fp1 = fopen (dictfile1, "rb")) == NULL)
         {
@@ -319,8 +285,6 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         if ((fp2 = fopen (dictfile2, "rb")) == NULL)
         {
           event_log_error (hashcat_ctx, "%s: %s", dictfile2, strerror (errno));
-
-          fclose (fp1);
 
           return -1;
         }
@@ -335,18 +299,12 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile1);
 
-          fclose (fp1);
-          fclose (fp2);
-
           return -1;
         }
 
         if (words1_cnt == 0)
         {
           event_log_error (hashcat_ctx, "%s: empty file.", dictfile1);
-
-          fclose (fp1);
-          fclose (fp2);
 
           return -1;
         }
@@ -361,9 +319,6 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile2);
 
-          fclose (fp1);
-          fclose (fp2);
-
           return -1;
         }
 
@@ -371,14 +326,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         {
           event_log_error (hashcat_ctx, "%s: empty file.", dictfile2);
 
-          fclose (fp1);
-          fclose (fp2);
-
           return -1;
         }
-
-        fclose (fp1);
-        fclose (fp2);
 
         combinator_ctx->dict1 = dictfile1;
         combinator_ctx->dict2 = dictfile2;
@@ -405,7 +354,7 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
           return -1;
         }
 
-        FILE *fp = NULL;
+        FILE *fp _cleanup_fclose_;
 
         if ((fp = fopen (dictfile, "rb")) == NULL)
         {
@@ -424,12 +373,8 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile);
 
-          fclose (fp);
-
           return -1;
         }
-
-        fclose (fp);
 
         combinator_ctx->combs_cnt  = words_cnt;
         combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_LEFT;

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -582,7 +582,7 @@ static void mp_setup_sys (cs_t *mp_sys)
 
 static int mp_setup_usr (hashcat_ctx_t *hashcat_ctx, cs_t *mp_sys, cs_t *mp_usr, const char *buf, const u32 userindex)
 {
-  FILE *fp = fopen (buf, "rb");
+  FILE *fp _cleanup_fclose_ = fopen (buf, "rb");
 
   if (fp == NULL) // feof() in case if file is empty
   {
@@ -600,12 +600,8 @@ static int mp_setup_usr (hashcat_ctx_t *hashcat_ctx, cs_t *mp_sys, cs_t *mp_usr,
     {
       event_log_error (hashcat_ctx, "%s: Custom charset file is too large.", buf);
 
-      fclose (fp);
-
       return -1;
     }
-
-    fclose (fp);
 
     if (nread == 0)
     {
@@ -710,7 +706,7 @@ static int sp_setup_tbl (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  FILE *fd = fopen (hcstat, "rb");
+  FILE *fd _cleanup_fclose_ = fopen (hcstat, "rb");
 
   if (fd == NULL)
   {
@@ -727,14 +723,10 @@ static int sp_setup_tbl (hashcat_ctx_t *hashcat_ctx)
   {
     event_log_error (hashcat_ctx, "%s: Could not read data.", hcstat);
 
-    fclose (fd);
-
     hcfree (inbuf);
 
     return -1;
   }
-
-  fclose (fd);
 
   u8 *outbuf = (u8 *) hcmalloc (SP_FILESZ);
 
@@ -1460,7 +1452,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
             if (hc_path_is_file (arg) == true)
             {
-              FILE *mask_fp = fopen (arg, "r");
+              FILE *mask_fp _cleanup_fclose_ = fopen (arg, "r");
 
               if (mask_fp == NULL)
               {
@@ -1494,17 +1486,12 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
                 const int rc = mask_append (hashcat_ctx, mask_buf, prepend_buf);
 
-                if (rc == -1)
-                {
-                  fclose (mask_fp);
+                if (rc == -1) return -1;
 
-                  return -1;
-                }
               }
 
               hcfree (line_buf);
 
-              fclose (mask_fp);
             }
             else
             {
@@ -1553,7 +1540,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
       {
         mask_ctx->mask_from_file = true;
 
-        FILE *mask_fp = fopen (arg, "r");
+        FILE *mask_fp _cleanup_fclose_ = fopen (arg, "r");
 
         if (mask_fp == NULL)
         {
@@ -1587,17 +1574,12 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
           const int rc = mask_append (hashcat_ctx, mask_buf, prepend_buf);
 
-          if (rc == -1)
-          {
-            fclose (mask_fp);
+          if (rc == -1) return -1;
 
-            return -1;
-          }
         }
 
         hcfree (line_buf);
 
-        fclose (mask_fp);
       }
       else
       {
@@ -1627,7 +1609,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
       {
         mask_ctx->mask_from_file = true;
 
-        FILE *mask_fp = fopen (arg, "r");
+        FILE *mask_fp _cleanup_fclose_ = fopen (arg, "r");
 
         if (mask_fp == NULL)
         {
@@ -1661,17 +1643,10 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
           const int rc = mask_append (hashcat_ctx, mask_buf, prepend_buf);
 
-          if (rc == -1)
-          {
-            fclose (mask_fp);
+          if (rc == -1) return -1;
 
-            return -1;
-          }
         }
-
         hcfree (line_buf);
-
-        fclose (mask_fp);
       }
       else
       {

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -155,7 +155,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
     for (int j = 0; j < out_cnt; j++)
     {
-      FILE *fp = fopen (out_info[j].file_name, "rb");
+      FILE *fp _cleanup_fclose_ = fopen (out_info[j].file_name, "rb");
 
       if (fp == NULL) continue;
 
@@ -163,12 +163,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
       struct stat outfile_stat;
 
-      if (fstat (fileno (fp), &outfile_stat))
-      {
-        fclose (fp);
-
-        continue;
-      }
+      if (fstat (fileno (fp), &outfile_stat)) continue;
 
       if (outfile_stat.st_ctime > out_info[j].ctime)
       {
@@ -310,8 +305,6 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
       out_info[j].seek = ftello (fp);
 
       //hc_thread_mutex_unlock (status_ctx->mux_display);
-
-      fclose (fp);
 
       if (status_ctx->shutdown_inner == true) break;
     }

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -16,15 +16,13 @@ static int check_running_process (hashcat_ctx_t *hashcat_ctx)
 
   char *pidfile_filename = pidfile_ctx->filename;
 
-  FILE *fp = fopen (pidfile_filename, "rb");
+  FILE *fp _cleanup_fclose_ = fopen (pidfile_filename, "rb");
 
   if (fp == NULL) return 0;
 
   pidfile_data_t *pd = (pidfile_data_t *) hcmalloc (sizeof (pidfile_data_t));
 
   const size_t nread = hc_fread (pd, sizeof (pidfile_data_t), 1, fp);
-
-  fclose (fp);
 
   if (nread != 1)
   {
@@ -124,7 +122,7 @@ static int write_pidfile (hashcat_ctx_t *hashcat_ctx)
 
   char *pidfile_filename = pidfile_ctx->filename;
 
-  FILE *fp = fopen (pidfile_filename, "wb");
+  FILE *fp _cleanup_fclose_ = fopen (pidfile_filename, "wb");
 
   if (fp == NULL)
   {
@@ -136,8 +134,6 @@ static int write_pidfile (hashcat_ctx_t *hashcat_ctx)
   hc_fwrite (pd, sizeof (pidfile_data_t), 1, fp);
 
   fflush (fp);
-
-  fclose (fp);
 
   return 0;
 }

--- a/src/restore.c
+++ b/src/restore.c
@@ -54,7 +54,7 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
 
   char *eff_restore_file = restore_ctx->eff_restore_file;
 
-  FILE *fp = fopen (eff_restore_file, "rb");
+  FILE *fp _cleanup_fclose_ = fopen (eff_restore_file, "rb");
 
   if (fp == NULL)
   {
@@ -69,8 +69,6 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
   {
     event_log_error (hashcat_ctx, "Cannot read %s", eff_restore_file);
 
-    fclose (fp);
-
     return -1;
   }
 
@@ -80,16 +78,12 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
   {
     event_log_error (hashcat_ctx, "Unusually low number of arguments (argc) within restore file %s", eff_restore_file);
 
-    fclose (fp);
-
     return -1;
   }
 
   if (rd->argc > 250) // some upper bound check is always good (with some dirs/dicts it could be a large string)
   {
     event_log_error (hashcat_ctx, "Unusually high number of arguments (argc) within restore file %s", eff_restore_file);
-
-    fclose (fp);
 
     return -1;
   }
@@ -104,8 +98,6 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
     {
       event_log_error (hashcat_ctx, "Cannot read %s", eff_restore_file);
 
-      fclose (fp);
-
       return -1;
     }
 
@@ -117,8 +109,6 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
   }
 
   hcfree (buf);
-
-  fclose (fp);
 
   if (hc_path_exist (rd->cwd) == false)
   {
@@ -203,7 +193,7 @@ static int write_restore (hashcat_ctx_t *hashcat_ctx)
 
   char *new_restore_file = restore_ctx->new_restore_file;
 
-  FILE *fp = fopen (new_restore_file, "wb");
+  FILE *fp _cleanup_fclose_ = fopen (new_restore_file, "wb");
 
   if (fp == NULL)
   {
@@ -215,8 +205,6 @@ static int write_restore (hashcat_ctx_t *hashcat_ctx)
   if (setvbuf (fp, NULL, _IONBF, 0))
   {
     event_log_error (hashcat_ctx, "setvbuf file '%s': %s", new_restore_file, strerror (errno));
-
-    fclose (fp);
 
     return -1;
   }
@@ -233,8 +221,6 @@ static int write_restore (hashcat_ctx_t *hashcat_ctx)
   fflush (fp);
 
   fsync (fileno (fp));
-
-  fclose (fp);
 
   rd->masks_pos = 0;
   rd->dicts_pos = 0;

--- a/src/rp.c
+++ b/src/rp.c
@@ -733,7 +733,7 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
 
     char *rp_file = user_options->rp_files[i];
 
-    FILE *fp = NULL;
+    FILE *fp _cleanup_fclose_ = NULL;
 
     u32 rule_line = 0;
 
@@ -792,8 +792,6 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
 
       kernel_rules_cnt++;
     }
-
-    fclose (fp);
 
     all_kernel_rules_cnt[i] = kernel_rules_cnt;
     all_kernel_rules_buf[i] = kernel_rules_buf;

--- a/src/shared.c
+++ b/src/shared.c
@@ -347,13 +347,11 @@ bool hc_path_has_bom (const char *path)
 {
   u8 buf[8] = { 0 };
 
-  FILE *fp = fopen (path, "rb");
+  FILE *fp _cleanup_fclose_ = fopen (path, "rb");
 
   if (fp == NULL) return false;
 
   const size_t nread = fread (buf, 1, sizeof (buf), fp);
-
-  fclose (fp);
 
   if (nread < 1) return false;
 
@@ -608,20 +606,13 @@ bool hc_same_files (char *file1, char *file2)
 
     int do_check = 0;
 
-    FILE *fp;
+    FILE *fp _cleanup_fclose_;
 
     fp = fopen (file1, "r");
 
     if (fp)
     {
-      if (fstat (fileno (fp), &tmpstat_file1))
-      {
-        fclose (fp);
-
-        return false;
-      }
-
-      fclose (fp);
+      if (fstat (fileno (fp), &tmpstat_file1)) return false;
 
       do_check++;
     }
@@ -630,14 +621,7 @@ bool hc_same_files (char *file1, char *file2)
 
     if (fp)
     {
-      if (fstat (fileno (fp), &tmpstat_file2))
-      {
-        fclose (fp);
-
-        return false;
-      }
-
-      fclose (fp);
+      if (fstat (fileno (fp), &tmpstat_file2)) return false;
 
       do_check++;
     }

--- a/src/stdout.c
+++ b/src/stdout.c
@@ -67,7 +67,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
 
   if (filename)
   {
-    FILE *fp = fopen (filename, "ab");
+    FILE *fp _cleanup_fclose_ = fopen (filename, "ab");
 
     if (fp == NULL)
     {
@@ -78,8 +78,6 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
 
     if (lock_file (fp) == -1)
     {
-      fclose (fp);
-
       event_log_error (hashcat_ctx, "%s: %s", filename, strerror (errno));
 
       return -1;

--- a/src/straight.c
+++ b/src/straight.c
@@ -70,7 +70,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
         logfile_sub_var_string ("rulefile", user_options->rp_files[i]);
       }
 
-      FILE *fd = fopen (straight_ctx->dict, "rb");
+      FILE *fd _cleanup_fclose_ = fopen (straight_ctx->dict, "rb");
 
       if (fd == NULL)
       {
@@ -80,8 +80,6 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
       }
 
       const int rc = count_words (hashcat_ctx, fd, straight_ctx->dict, &status_ctx->words_cnt);
-
-      fclose (fd);
 
       if (rc == -1)
       {
@@ -105,7 +103,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
     if (combinator_ctx->combs_mode == COMBINATOR_MODE_BASE_LEFT)
     {
-      FILE *fd = fopen (combinator_ctx->dict1, "rb");
+      FILE *fd _cleanup_fclose_ = fopen (combinator_ctx->dict1, "rb");
 
       if (fd == NULL)
       {
@@ -116,8 +114,6 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       const int rc = count_words (hashcat_ctx, fd, combinator_ctx->dict1, &status_ctx->words_cnt);
 
-      fclose (fd);
-
       if (rc == -1)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", combinator_ctx->dict1);
@@ -127,7 +123,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
     }
     else if (combinator_ctx->combs_mode == COMBINATOR_MODE_BASE_RIGHT)
     {
-      FILE *fd = fopen (combinator_ctx->dict2, "rb");
+      FILE *fd _cleanup_fclose_ = fopen (combinator_ctx->dict2, "rb");
 
       if (fd == NULL)
       {
@@ -137,8 +133,6 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
       }
 
       const int rc = count_words (hashcat_ctx, fd, combinator_ctx->dict2, &status_ctx->words_cnt);
-
-      fclose (fd);
 
       if (rc == -1)
       {
@@ -173,7 +167,7 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
     logfile_sub_string (straight_ctx->dict);
     logfile_sub_string (mask_ctx->mask);
 
-    FILE *fd = fopen (straight_ctx->dict, "rb");
+    FILE *fd _cleanup_fclose_ = fopen (straight_ctx->dict, "rb");
 
     if (fd == NULL)
     {
@@ -183,8 +177,6 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
     }
 
     const int rc = count_words (hashcat_ctx, fd, straight_ctx->dict, &status_ctx->words_cnt);
-
-    fclose (fd);
 
     if (rc == -1)
     {

--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -68,7 +68,7 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
   hc_asprintf (&tuning_db_file, "%s/%s", folder_config->shared_dir, TUNING_DB_FILE);
 
-  FILE *fp = fopen (tuning_db_file, "rb");
+  FILE *fp _cleanup_fclose_ = fopen (tuning_db_file, "rb");
 
   if (fp == NULL)
   {
@@ -269,8 +269,6 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
   }
 
   hcfree (buf);
-
-  fclose (fp);
 
   // todo: print loaded 'cnt' message
 


### PR DESCRIPTION
fclose is called in multiple if statements that return. We can use the
cleanup attribute to handle this automatically.

Needs testing. Posting for comments.