### PR TITLE
added support for $electrum$3 hashes (-m 16600)

### DIFF
--- a/OpenCL/m16600_a0-optimized.cl
+++ b/OpenCL/m16600_a0-optimized.cl
@@ -398,6 +398,27 @@ KERNEL_FQ void m16600_m04 (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+    }
   }
 }
 
@@ -781,6 +802,27 @@ KERNEL_FQ void m16600_s04 (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
       }
     }
   }

--- a/OpenCL/m16600_a0-pure.cl
+++ b/OpenCL/m16600_a0-pure.cl
@@ -212,6 +212,27 @@ KERNEL_FQ void m16600_mxx (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+    }
   }
 }
 
@@ -401,6 +422,27 @@ KERNEL_FQ void m16600_sxx (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
       }
     }
   }

--- a/OpenCL/m16600_a1-optimized.cl
+++ b/OpenCL/m16600_a1-optimized.cl
@@ -454,6 +454,27 @@ KERNEL_FQ void m16600_m04 (KERN_ATTR_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+    }
   }
 }
 
@@ -895,6 +916,27 @@ KERNEL_FQ void m16600_s04 (KERN_ATTR_ESALT (electrum_wallet_t))
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
       }
     }
   }

--- a/OpenCL/m16600_a1-pure.cl
+++ b/OpenCL/m16600_a1-pure.cl
@@ -208,6 +208,27 @@ KERNEL_FQ void m16600_mxx (KERN_ATTR_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+    }
   }
 }
 
@@ -395,6 +416,27 @@ KERNEL_FQ void m16600_sxx (KERN_ATTR_ESALT (electrum_wallet_t))
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
       }
     }
   }

--- a/OpenCL/m16600_a3-optimized.cl
+++ b/OpenCL/m16600_a3-optimized.cl
@@ -316,6 +316,27 @@ DECLSPEC void m16600 (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a 
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+    }
   }
 }
 

--- a/OpenCL/m16600_a3-pure.cl
+++ b/OpenCL/m16600_a3-pure.cl
@@ -221,6 +221,27 @@ KERNEL_FQ void m16600_mxx (KERN_ATTR_VECTOR_ESALT (electrum_wallet_t))
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
       }
     }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+    }
   }
 }
 
@@ -421,6 +442,27 @@ KERNEL_FQ void m16600_sxx (KERN_ATTR_VECTOR_ESALT (electrum_wallet_t))
       if (atomic_inc (&hashes_shown[digests_offset]) == 0)
       {
         mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+
+    if (esalt_bufs[digests_offset].salt_type == 3)
+    {
+      // check PKCS7 padding (either 13 times 0x0d or 12 times 0x0c at the end, we only check 12 bytes, it's enough):
+
+      if ((out[1] == 0x0c0c0c0c) && (out[2] == 0x0c0c0c0c) && (out[3] == 0x0c0c0c0c))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
+      }
+
+      if ((out[1] == 0x0d0d0d0d) && (out[2] == 0x0d0d0d0d) && (out[3] == 0x0d0d0d0d))
+      {
+        if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+        {
+          mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+        }
       }
     }
   }

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -16,6 +16,7 @@
 - Added hash-mode: Open Document Format (ODF) 1.1 (SHA-1, Blowfish)
 - Added hash-mode: Java Object hashCode()
 - Added hash-mode: Blockchain, My Wallet, Second Password (SHA256)
+- Added hash-mode: Electrum Wallet (Salt-Type 3)
 - Added hash-mode: Android Backup
 - Added hash-mode: QNX /etc/shadow (MD5)
 - Added hash-mode: QNX /etc/shadow (SHA256)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -262,7 +262,7 @@ NVIDIA GPUs require "NVIDIA Driver" (418.56 or later)
 - Blockchain, My Wallet
 - Blockchain, My Wallet, V2
 - Blockchain, My Wallet, Second Password (SHA256)
-- Electrum Wallet (Salt-Type 1-2)
+- Electrum Wallet (Salt-Type 1-3)
 - KeePass 1 (AES/Twofish) and KeePass 2 (AES)
 - JKS Java Key Store Private Keys (SHA1)
 - Ethereum Wallet, PBKDF2-HMAC-SHA256

--- a/src/modules/module_16600.c
+++ b/src/modules/module_16600.c
@@ -17,7 +17,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_8;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_PASSWORD_MANAGER;
-static const char *HASH_NAME      = "Electrum Wallet (Salt-Type 1-2)";
+static const char *HASH_NAME      = "Electrum Wallet (Salt-Type 1-3)";
 static const u64   KERN_TYPE      = 16600;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_PRECOMPUTE_INIT;
@@ -105,7 +105,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u32 salt_type = hc_strtoul ((const char *) salt_type_pos, NULL, 10);
 
-  if ((salt_type == 1) || (salt_type == 2))
+  if ((salt_type == 1) || (salt_type == 2) || (salt_type == 3))
   {
     // all ok
   }


### PR DESCRIPTION
This pull requests adds support for the missing Salt-Type 3 for $electrum$3 hashes . It still uses the kernels for -m 16600 because the overall algorithm is the same (just the final compare check is different).

Thanks a lot