### PR TITLE
Fix issue with pkzip hashes which have a larger offset value to be printed correctly

### DIFF
--- a/OpenCL/m17200_a0-pure.cl
+++ b/OpenCL/m17200_a0-pure.cl
@@ -126,8 +126,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17200_a1-pure.cl
+++ b/OpenCL/m17200_a1-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17200_a3-pure.cl
+++ b/OpenCL/m17200_a3-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17210_a0-pure.cl
+++ b/OpenCL/m17210_a0-pure.cl
@@ -126,8 +126,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17210_a1-pure.cl
+++ b/OpenCL/m17210_a1-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17210_a3-pure.cl
+++ b/OpenCL/m17210_a3-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17220_a0-pure.cl
+++ b/OpenCL/m17220_a0-pure.cl
@@ -126,8 +126,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17220_a1-pure.cl
+++ b/OpenCL/m17220_a1-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17220_a3-pure.cl
+++ b/OpenCL/m17220_a3-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17230_a0-pure.cl
+++ b/OpenCL/m17230_a0-pure.cl
@@ -126,8 +126,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17230_a1-pure.cl
+++ b/OpenCL/m17230_a1-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/OpenCL/m17230_a3-pure.cl
+++ b/OpenCL/m17230_a3-pure.cl
@@ -124,8 +124,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -119,8 +119,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -119,8 +119,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -119,8 +119,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -119,8 +119,8 @@ struct pkzip_hash
   u32 compressed_length;
   u32 uncompressed_length;
   u32 crc32;
-  u8  offset;
-  u8  additional_offset;
+  u32 offset;
+  u32 additional_offset;
   u8  compression_type;
   u32 data_length;
   u16 checksum_from_crc;


### PR DESCRIPTION
These hashes with offsets larger than 0xff are now printed the same way as they were on input.