### PR TITLE
Added parser message for pkzip hashes which have unsupported compression type for kernel

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -512,6 +512,7 @@ typedef enum parser_rc
   PARSER_TOKEN_ENCODING       = -34,
   PARSER_TOKEN_LENGTH         = -35,
   PARSER_INSUFFICIENT_ENTROPY = -36,
+  PARSER_PKZIP_CT_UNMATCHED   = -37,
   PARSER_UNKNOWN_ERROR        = -255
 
 } parser_rc_t;

--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -248,7 +248,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   p = strtok(NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
   pkzip->hash.compression_type = atoi(p);
-  if (pkzip->hash.compression_type != 8) return PARSER_HASH_VALUE;
+  if (pkzip->hash.compression_type != 8) return PARSER_PKZIP_CT_UNMATCHED;
 
   p = strtok(NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -248,7 +248,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   p = strtok(NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
   pkzip->hash.compression_type = atoi(p);
-  if (pkzip->hash.compression_type != 0) return PARSER_HASH_VALUE;
+  if (pkzip->hash.compression_type != 0) return PARSER_PKZIP_CT_UNMATCHED;
 
   p = strtok(NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -250,7 +250,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     p = strtok(NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
     pkzip->hashes[i].compression_type = atoi(p);
-    if (pkzip->hashes[i].compression_type != 8) return PARSER_HASH_VALUE;
+    if (pkzip->hashes[i].compression_type != 8) return PARSER_PKZIP_CT_UNMATCHED;
 
     p = strtok(NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -251,7 +251,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     p = strtok(NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
     pkzip->hashes[i].compression_type = atoi(p);
-    if (pkzip->hashes[i].compression_type != 8) return PARSER_HASH_VALUE;
+    if (pkzip->hashes[i].compression_type != 8) return PARSER_PKZIP_CT_UNMATCHED;
 
     p = strtok(NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;

--- a/src/shared.c
+++ b/src/shared.c
@@ -49,6 +49,7 @@ static const char *PA_033 = "Invalid hccapx message pair";
 static const char *PA_034 = "Token encoding exception";
 static const char *PA_035 = "Token length exception";
 static const char *PA_036 = "Insufficient entropy exception";
+static const char *PA_037 = "Hash contains unsupported compression type for current mode";
 static const char *PA_255 = "Unknown error";
 
 static const char *OPTI_STR_OPTIMIZED_KERNEL     = "Optimized-Kernel";
@@ -973,6 +974,7 @@ const char *strparser (const u32 parser_status)
     case PARSER_TOKEN_ENCODING:       return PA_034;
     case PARSER_TOKEN_LENGTH:         return PA_035;
     case PARSER_INSUFFICIENT_ENTROPY: return PA_036;
+    case PARSER_PKZIP_CT_UNMATCHED:   return PA_037;
   }
 
   return PA_255;


### PR DESCRIPTION
This allows users to note easily that they used the wrong kernel for the hash.