### PR TITLE
Added check for current pkzip inflate limitation to parser

### DIFF
--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -108,6 +108,7 @@ static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$1*1*2*0*e3*1c5*eda7a8de*0*28*8*e3*eda7*5096*a9fc1f4e951c8fb3031a6f903e5f4e3211c8fdc4671547bf77f6f682afbfcc7475d83898985621a7af9bccd1349d1976500a68c48f630b7f22d7a0955524d768e34868880461335417ddd149c65a917c0eb0a4bf7224e24a1e04cf4ace5eef52205f4452e66ded937db9545f843a68b1e84a2e933cc05fb36d3db90e6c5faf1bee2249fdd06a7307849902a8bb24ec7e8a0886a4544ca47979a9dfeefe034bdfc5bd593904cfe9a5309dd199d337d3183f307c2cb39622549a5b9b8b485b7949a4803f63f67ca427a0640ad3793a519b2476c52198488e3e2e04cac202d624fb7d13c2*$/pkzip2$";
 
 #define MAX_DATA (16 * 1024 * 1024)
+#define MAX_LEN  (32 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -229,6 +230,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     if (pkzip->hash.compressed_length > MAX_DATA * 4)
     {
       return PARSER_TOKEN_LENGTH;
+    }
+    if (pkzip->hash.uncompressed_length > MAX_LEN)
+    {
+      return PARSER_HASH_LENGTH;
     }
 
     p = strtok(NULL, "*");

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -108,6 +108,7 @@ static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$3*1*1*0*8*24*a425*8827*d1730095cd829e245df04ebba6c52c0573d49d3bbeab6cb385b7fa8a28dcccd3098bfdd7*1*0*8*24*2a74*882a*51281ac874a60baedc375ca645888d29780e20d4076edd1e7154a99bde982152a736311f*2*0*e3*1c5*eda7a8de*0*29*8*e3*eda7*5096*1455781b59707f5151139e018bdcfeebfc89bc37e372883a7ec0670a5eafc622feb338f9b021b6601a674094898a91beac70e41e675f77702834ca6156111a1bf7361bc9f3715d77dfcdd626634c68354c6f2e5e0a7b1e1ce84a44e632d0f6e36019feeab92fb7eac9dda8df436e287aafece95d042059a1b27d533c5eab62c1c559af220dc432f2eb1a38a70f29e8f3cb5a207704274d1e305d7402180fd47e026522792f5113c52a116d5bb25b67074ffd6f4926b221555234aabddc69775335d592d5c7d22462b75de1259e8342a9ba71cb06223d13c7f51f13be2ad76352c3b8ed*$/pkzip2$";
 
 #define MAX_DATA (16 * 1024 * 1024)
+#define MAX_LEN  (32 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -231,6 +232,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
       if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
+      }
+      if (pkzip->hashes[i].uncompressed_length > MAX_LEN)
+      {
+        return PARSER_HASH_LENGTH;
       }
 
       p = strtok(NULL, "*");

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -108,6 +108,7 @@ static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$3*1*1*0*0*24*3e2c*3ef8*0619e9d17ff3f994065b99b1fa8aef41c056edf9fa4540919c109742dcb32f797fc90ce0*1*0*8*24*431a*3f26*18e2461c0dbad89bd9cc763067a020c89b5e16195b1ac5fa7fb13bd246d000b6833a2988*2*0*23*17*1e3c1a16*2e4*2f*0*23*1e3c*3f2d*54ea4dbc711026561485bbd191bf300ae24fa0997f3779b688cdad323985f8d3bb8b0c*$/pkzip2$";
 
 #define MAX_DATA (16 * 1024 * 1024)
+#define MAX_LEN  (32 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -231,6 +232,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
       if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
+      }
+      if (pkzip->hashes[i].uncompressed_length > MAX_LEN)
+      {
+        return PARSER_HASH_LENGTH;
       }
 
       p = strtok(NULL, "*");


### PR DESCRIPTION
This enforces the parser to reject hashes which have uncompressed data larger than 32KB as there are currently issues with the inflate code beyond this size. In order to avoid any cracking activities with such hashes which are currently uncrackable, the parser will reject these until there is a patch available to support larger hashes.