### PR TITLE
PKZIP: improve decompression and allow up to 320KB data length

### DIFF
--- a/OpenCL/inc_zip_inflate.cl
+++ b/OpenCL/inc_zip_inflate.cl
@@ -180,7 +180,7 @@ typedef int mz_bool;
 
 typedef mz_uint64 tinfl_bit_buf_t;
 
-void memcpy(void *dest, const void *src, u32 n){
+DECLSPEC void memcpy(void *dest, const void *src, u32 n){
   char *csrc = (char *)src;
   char *cdest = (char *)dest;
   for (int i=0; i<n; i++){
@@ -189,7 +189,7 @@ void memcpy(void *dest, const void *src, u32 n){
 }
 
 
-void *memset(u8 *s, int c, u32 len){
+DECLSPEC void *memset(u8 *s, int c, u32 len){
   u8 *dst = s;
   while (len > 0) {
       *dst = (u8) c;
@@ -447,15 +447,15 @@ typedef struct mz_stream_s
 
 typedef mz_stream *mz_streamp;
 
+// hashcat-patched: not needed functions:
+// void miniz_def_free_func(void *opaque, void *address);
+// void *miniz_def_alloc_func(void *opaque, size_t items, size_t size);
+DECLSPEC int mz_inflate(mz_streamp pStream, int flush);
+DECLSPEC int mz_inflateEnd(mz_streamp pStream);
 
-void miniz_def_free_func(void *opaque, void *address);
-void *miniz_def_alloc_func(void *opaque, size_t items, size_t size);
-int mz_inflate(mz_streamp pStream, int flush);
-int mz_inflateEnd(mz_streamp pStream);
 
 
-
-int mz_inflateInit2(mz_streamp pStream, int window_bits, inflate_state*);
+DECLSPEC int mz_inflateInit2(mz_streamp pStream, int window_bits, inflate_state*);
 
 
 DECLSPEC const mz_uint8 pIn_xor_byte (const mz_uint8 c, mz_streamp pStream)

--- a/OpenCL/m17200_a0-pure.cl
+++ b/OpenCL/m17200_a0-pure.cl
@@ -325,22 +325,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -410,7 +410,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -550,7 +550,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -559,7 +559,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -788,7 +788,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -797,7 +797,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17200_a0-pure.cl
+++ b/OpenCL/m17200_a0-pure.cl
@@ -132,7 +132,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17200_a0-pure.cl
+++ b/OpenCL/m17200_a0-pure.cl
@@ -94,13 +94,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_rp.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -749,11 +749,11 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     // inflateinit2 is needed because otherwise it checks for headers by default
     mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-    int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+    int ret = hc_inflate (&infstream);
 
     while (ret == MZ_OK)
     {
-      ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      ret = hc_inflate (&infstream);
     }
 
     if (ret != MZ_STREAM_END) continue; // failed to inflate
@@ -975,11 +975,11 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     // inflateinit2 is needed because otherwise it checks for headers by default
     mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-    int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+    int ret = hc_inflate (&infstream);
 
     while (ret == MZ_OK)
     {
-      ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      ret = hc_inflate (&infstream);
     }
 
     if (ret != MZ_STREAM_END) continue; // failed to inflate

--- a/OpenCL/m17200_a1-pure.cl
+++ b/OpenCL/m17200_a1-pure.cl
@@ -323,22 +323,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -408,7 +408,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -548,7 +548,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -557,7 +557,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -790,7 +790,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -799,7 +799,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17200_a1-pure.cl
+++ b/OpenCL/m17200_a1-pure.cl
@@ -92,13 +92,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_simd.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -751,11 +751,11 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_ESALT (pkzip_t))
     // inflateinit2 is needed because otherwise it checks for headers by default
     mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-    int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+    int ret = hc_inflate (&infstream);
 
     while (ret == MZ_OK)
     {
-      ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      ret = hc_inflate (&infstream);
     }
 
     if (ret != MZ_STREAM_END) continue; // failed to inflate
@@ -981,11 +981,11 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_ESALT (pkzip_t))
     // inflateinit2 is needed because otherwise it checks for headers by default
     mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-    int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+    int ret = hc_inflate (&infstream);
 
     while (ret == MZ_OK)
     {
-      ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      ret = hc_inflate (&infstream);
     }
 
     if (ret != MZ_STREAM_END) continue; // failed to inflate

--- a/OpenCL/m17200_a1-pure.cl
+++ b/OpenCL/m17200_a1-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17200_a3-pure.cl
+++ b/OpenCL/m17200_a3-pure.cl
@@ -92,13 +92,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_simd.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -764,11 +764,11 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     // inflateinit2 is needed because otherwise it checks for headers by default
     mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-    int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+    int ret = hc_inflate (&infstream);
 
     while (ret == MZ_OK)
     {
-      ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      ret = hc_inflate (&infstream);
     }
 
     if (ret != MZ_STREAM_END) continue; // failed to inflate
@@ -1006,11 +1006,11 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     // inflateinit2 is needed because otherwise it checks for headers by default
     mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-    int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+    int ret = hc_inflate (&infstream);
 
     while (ret == MZ_OK)
     {
-      ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      ret = hc_inflate (&infstream);
     }
 
     if (ret != MZ_STREAM_END) continue; // failed to inflate

--- a/OpenCL/m17200_a3-pure.cl
+++ b/OpenCL/m17200_a3-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17200_a3-pure.cl
+++ b/OpenCL/m17200_a3-pure.cl
@@ -325,22 +325,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -409,7 +409,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -549,7 +549,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -558,7 +558,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -803,7 +803,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -812,7 +812,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17210_a0-pure.cl
+++ b/OpenCL/m17210_a0-pure.cl
@@ -241,7 +241,7 @@ KERNEL_FQ void m17210_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -250,7 +250,7 @@ KERNEL_FQ void m17210_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -480,7 +480,7 @@ KERNEL_FQ void m17210_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -489,7 +489,7 @@ KERNEL_FQ void m17210_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17210_a0-pure.cl
+++ b/OpenCL/m17210_a0-pure.cl
@@ -132,7 +132,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17210_a0-pure.cl
+++ b/OpenCL/m17210_a0-pure.cl
@@ -100,7 +100,7 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \

--- a/OpenCL/m17210_a1-pure.cl
+++ b/OpenCL/m17210_a1-pure.cl
@@ -239,7 +239,7 @@ KERNEL_FQ void m17210_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -248,7 +248,7 @@ KERNEL_FQ void m17210_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -480,7 +480,7 @@ KERNEL_FQ void m17210_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -489,7 +489,7 @@ KERNEL_FQ void m17210_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17210_a1-pure.cl
+++ b/OpenCL/m17210_a1-pure.cl
@@ -98,7 +98,7 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \

--- a/OpenCL/m17210_a1-pure.cl
+++ b/OpenCL/m17210_a1-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17210_a3-pure.cl
+++ b/OpenCL/m17210_a3-pure.cl
@@ -239,7 +239,7 @@ KERNEL_FQ void m17210_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -248,7 +248,7 @@ KERNEL_FQ void m17210_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -492,7 +492,7 @@ KERNEL_FQ void m17210_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -501,7 +501,7 @@ KERNEL_FQ void m17210_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hash.data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17210_a3-pure.cl
+++ b/OpenCL/m17210_a3-pure.cl
@@ -98,7 +98,7 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \

--- a/OpenCL/m17210_a3-pure.cl
+++ b/OpenCL/m17210_a3-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17220_a0-pure.cl
+++ b/OpenCL/m17220_a0-pure.cl
@@ -323,22 +323,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -408,7 +408,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -548,7 +548,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -557,7 +557,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -813,7 +813,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -822,7 +822,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17220_a0-pure.cl
+++ b/OpenCL/m17220_a0-pure.cl
@@ -94,13 +94,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_rp.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -750,11 +750,11 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
       // inflateinit2 is needed because otherwise it checks for headers by default
       mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-      int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      int ret = hc_inflate (&infstream);
 
       while (ret == MZ_OK)
       {
-        ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        ret = hc_inflate (&infstream);
       }
 
       if (ret != MZ_STREAM_END) break; // failed to inflate
@@ -1015,11 +1015,11 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
       // inflateinit2 is needed because otherwise it checks for headers by default
       mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-      int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      int ret = hc_inflate (&infstream);
 
       while (ret == MZ_OK)
       {
-        ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        ret = hc_inflate (&infstream);
       }
 
       if (ret != MZ_STREAM_END) break; // failed to inflate

--- a/OpenCL/m17220_a0-pure.cl
+++ b/OpenCL/m17220_a0-pure.cl
@@ -132,7 +132,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17220_a1-pure.cl
+++ b/OpenCL/m17220_a1-pure.cl
@@ -321,22 +321,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -406,7 +406,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -546,7 +546,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -555,7 +555,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -813,7 +813,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -822,7 +822,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17220_a1-pure.cl
+++ b/OpenCL/m17220_a1-pure.cl
@@ -92,13 +92,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_simd.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -750,11 +750,11 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_ESALT (pkzip_t))
       // inflateinit2 is needed because otherwise it checks for headers by default
       mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-      int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      int ret = hc_inflate (&infstream);
 
       while (ret == MZ_OK)
       {
-        ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        ret = hc_inflate (&infstream);
       }
 
       if (ret != MZ_STREAM_END) break; // failed to inflate
@@ -1017,11 +1017,11 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_ESALT (pkzip_t))
       // inflateinit2 is needed because otherwise it checks for headers by default
       mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-      int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      int ret = hc_inflate (&infstream);
 
       while (ret == MZ_OK)
       {
-        ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        ret = hc_inflate (&infstream);
       }
 
       if (ret != MZ_STREAM_END) break; // failed to inflate

--- a/OpenCL/m17220_a1-pure.cl
+++ b/OpenCL/m17220_a1-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17220_a3-pure.cl
+++ b/OpenCL/m17220_a3-pure.cl
@@ -321,22 +321,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -406,7 +406,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -546,7 +546,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -555,7 +555,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -825,7 +825,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -834,7 +834,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17220_a3-pure.cl
+++ b/OpenCL/m17220_a3-pure.cl
@@ -92,13 +92,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_simd.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -762,11 +762,11 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
       // inflateinit2 is needed because otherwise it checks for headers by default
       mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-      int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      int ret = hc_inflate (&infstream);
 
       while (ret == MZ_OK)
       {
-        ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        ret = hc_inflate (&infstream);
       }
 
       if (ret != MZ_STREAM_END) break; // failed to inflate
@@ -1041,11 +1041,11 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
       // inflateinit2 is needed because otherwise it checks for headers by default
       mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-      int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+      int ret = hc_inflate (&infstream);
 
       while (ret == MZ_OK)
       {
-        ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        ret = hc_inflate (&infstream);
       }
 
       if (ret != MZ_STREAM_END) break; // failed to inflate

--- a/OpenCL/m17220_a3-pure.cl
+++ b/OpenCL/m17220_a3-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17225_a0-pure.cl
+++ b/OpenCL/m17225_a0-pure.cl
@@ -94,13 +94,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_rp.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -759,11 +759,11 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
         // inflateinit2 is needed because otherwise it checks for headers by default
         mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-        int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        int ret = hc_inflate (&infstream);
 
         while (ret == MZ_OK)
         {
-          ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+          ret = hc_inflate (&infstream);
         }
 
         if (ret != MZ_STREAM_END) break; // failed to inflate
@@ -1087,11 +1087,11 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
         // inflateinit2 is needed because otherwise it checks for headers by default
         mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-        int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        int ret = hc_inflate (&infstream);
 
         while (ret == MZ_OK)
         {
-          ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+          ret = hc_inflate (&infstream);
         }
 
         if (ret != MZ_STREAM_END) break; // failed to inflate

--- a/OpenCL/m17225_a0-pure.cl
+++ b/OpenCL/m17225_a0-pure.cl
@@ -323,22 +323,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -408,7 +408,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -548,7 +548,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -557,7 +557,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -876,7 +876,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -885,7 +885,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17225_a0-pure.cl
+++ b/OpenCL/m17225_a0-pure.cl
@@ -132,7 +132,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17225_a1-pure.cl
+++ b/OpenCL/m17225_a1-pure.cl
@@ -321,22 +321,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -406,7 +406,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -546,7 +546,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -555,7 +555,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -875,7 +875,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -884,7 +884,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17225_a1-pure.cl
+++ b/OpenCL/m17225_a1-pure.cl
@@ -92,13 +92,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_simd.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -759,11 +759,11 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_ESALT (pkzip_t))
         // inflateinit2 is needed because otherwise it checks for headers by default
         mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-        int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        int ret = hc_inflate (&infstream);
 
         while (ret == MZ_OK)
         {
-          ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+          ret = hc_inflate (&infstream);
         }
 
         if (ret != MZ_STREAM_END) break; // failed to inflate
@@ -1088,11 +1088,11 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_ESALT (pkzip_t))
         // inflateinit2 is needed because otherwise it checks for headers by default
         mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-        int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        int ret = hc_inflate (&infstream);
 
         while (ret == MZ_OK)
         {
-          ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+          ret = hc_inflate (&infstream);
         }
 
         if (ret != MZ_STREAM_END) break; // failed to inflate

--- a/OpenCL/m17225_a1-pure.cl
+++ b/OpenCL/m17225_a1-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17225_a3-pure.cl
+++ b/OpenCL/m17225_a3-pure.cl
@@ -321,22 +321,22 @@ DECLSPEC int check_inflate_code2 (u8 *next)
   u32 ncode;
   u32 ncount[2];  // ends up being an array of 8 u8 count values.  But we can clear it, and later 'check' it with 2 u32 instructions.
   u8 *count;    // this will point to ncount array. NOTE, this is alignment required 'safe' for Sparc systems or others requiring alignment.
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32)next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3;  // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   hold >>= 3;  // we already processed 3 bits
   count = (u8*)ncount;
 
-  if (257+(hold&0x1F) > 286)
+  if (257 + (hold & 0x1F) > 286)
   {
     return 0;  // nlen, but we do not use it.
   }
   hold >>= 5;
-  if (1+(hold&0x1F) > 30)
+  if (1 + (hold & 0x1F) > 30)
   {
     return 0;    // ndist, but we do not use it.
   }
   hold >>= 5;
-  ncode = 4+(hold&0xF);
+  ncode = 4 + (hold & 0xF);
   hold >>= 4;
 
   // we have 15 bits left.
@@ -406,7 +406,7 @@ DECLSPEC int check_inflate_code1 (u8 *next, int left)
   u32 whave = 0, op, bits, hold,len;
   code here1;
 
-  hold = *next + (((u32)next[1])<<8) + (((u32)next[2])<<16) + (((u32)next[3])<<24);
+  hold = *next + (((u32) next[1]) << 8) + (((u32) next[2]) << 16) + (((u32) next[3]) << 24);
   next += 3; // we pre-increment when pulling it in the loop, thus we need to be 1 byte back.
   left -= 4;
   hold >>= 3;  // we already processed 3 bits
@@ -546,7 +546,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -555,7 +555,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -887,7 +887,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -896,7 +896,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17225_a3-pure.cl
+++ b/OpenCL/m17225_a3-pure.cl
@@ -92,13 +92,13 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #include "inc_simd.cl"
 
 #define MAX_LOCAL 512 // too much leaves no room for compiler optimizations, simply benchmark to find a good trade-off - make it as big as possible
-#define TMPSIZ    32
+#define TMPSIZ    (2 * TINFL_LZ_DICT_SIZE)
 
 #define CRC32(x,c,t) (((x) >> 8) ^ (t)[((x) ^ (c)) & 0xff])
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \
@@ -771,11 +771,11 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
         // inflateinit2 is needed because otherwise it checks for headers by default
         mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-        int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        int ret = hc_inflate (&infstream);
 
         while (ret == MZ_OK)
         {
-          ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+          ret = hc_inflate (&infstream);
         }
 
         if (ret != MZ_STREAM_END) break; // failed to inflate
@@ -1112,11 +1112,11 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
         // inflateinit2 is needed because otherwise it checks for headers by default
         mz_inflateInit2 (&infstream, -MAX_WBITS, &pStream);
 
-        int ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+        int ret = hc_inflate (&infstream);
 
         while (ret == MZ_OK)
         {
-          ret = mz_inflate (&infstream, Z_SYNC_FLUSH);
+          ret = hc_inflate (&infstream);
         }
 
         if (ret != MZ_STREAM_END) break; // failed to inflate

--- a/OpenCL/m17225_a3-pure.cl
+++ b/OpenCL/m17225_a3-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17230_a0-pure.cl
+++ b/OpenCL/m17230_a0-pure.cl
@@ -241,7 +241,7 @@ KERNEL_FQ void m17230_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -250,7 +250,7 @@ KERNEL_FQ void m17230_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -411,7 +411,7 @@ KERNEL_FQ void m17230_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -420,7 +420,7 @@ KERNEL_FQ void m17230_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17230_a0-pure.cl
+++ b/OpenCL/m17230_a0-pure.cl
@@ -132,7 +132,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17230_a0-pure.cl
+++ b/OpenCL/m17230_a0-pure.cl
@@ -100,7 +100,7 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \

--- a/OpenCL/m17230_a1-pure.cl
+++ b/OpenCL/m17230_a1-pure.cl
@@ -239,7 +239,7 @@ KERNEL_FQ void m17230_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -248,7 +248,7 @@ KERNEL_FQ void m17230_sxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -411,7 +411,7 @@ KERNEL_FQ void m17230_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -420,7 +420,7 @@ KERNEL_FQ void m17230_mxx (KERN_ATTR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17230_a1-pure.cl
+++ b/OpenCL/m17230_a1-pure.cl
@@ -98,7 +98,7 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \

--- a/OpenCL/m17230_a1-pure.cl
+++ b/OpenCL/m17230_a1-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m17230_a3-pure.cl
+++ b/OpenCL/m17230_a3-pure.cl
@@ -239,7 +239,7 @@ KERNEL_FQ void m17230_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -248,7 +248,7 @@ KERNEL_FQ void m17230_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -425,7 +425,7 @@ KERNEL_FQ void m17230_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   LOCAL_VK u32 l_data[MAX_LOCAL];
 
@@ -434,7 +434,7 @@ KERNEL_FQ void m17230_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
     l_data[i] = esalt_bufs[digests_offset].hashes[0].data[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m17230_a3-pure.cl
+++ b/OpenCL/m17230_a3-pure.cl
@@ -98,7 +98,7 @@ Related publication: https://scitepress.org/PublicationsDetail.aspx?ID=KLPzPqStp
 #define MSB(x)       ((x) >> 24)
 #define CONST        0x08088405
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 #define update_key012(k0,k1,k2,c,t)           \
 {                                             \

--- a/OpenCL/m17230_a3-pure.cl
+++ b/OpenCL/m17230_a3-pure.cl
@@ -130,7 +130,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/OpenCL/m20500_a0-pure.cl
+++ b/OpenCL/m20500_a0-pure.cl
@@ -172,7 +172,7 @@ KERNEL_FQ void m20500_sxx (KERN_ATTR_RULES ())
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -246,7 +246,7 @@ KERNEL_FQ void m20500_mxx (KERN_ATTR_RULES ())
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m20500_a1-pure.cl
+++ b/OpenCL/m20500_a1-pure.cl
@@ -170,7 +170,7 @@ KERNEL_FQ void m20500_sxx (KERN_ATTR_BASIC ())
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -246,7 +246,7 @@ KERNEL_FQ void m20500_mxx (KERN_ATTR_BASIC ())
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m20500_a3-pure.cl
+++ b/OpenCL/m20500_a3-pure.cl
@@ -266,7 +266,7 @@ KERNEL_FQ void m20500_sxx (KERN_ATTR_VECTOR ())
     l_icrc32tab[i] = icrc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 
@@ -380,7 +380,7 @@ KERNEL_FQ void m20500_mxx (KERN_ATTR_VECTOR ())
     l_crc32tab[i] = crc32tab[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m20510_a0-pure.cl
+++ b/OpenCL/m20510_a0-pure.cl
@@ -509,7 +509,7 @@ KERNEL_FQ void m20510_sxx (KERN_ATTR_RULES ())
     l_lsbk0_count1[i] = lsbk0_count1[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m20510_a1-pure.cl
+++ b/OpenCL/m20510_a1-pure.cl
@@ -507,7 +507,7 @@ KERNEL_FQ void m20510_sxx (KERN_ATTR_BASIC ())
     l_lsbk0_count1[i] = lsbk0_count1[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/OpenCL/m20510_a3-pure.cl
+++ b/OpenCL/m20510_a3-pure.cl
@@ -507,7 +507,7 @@ KERNEL_FQ void m20510_sxx (KERN_ATTR_VECTOR ())
     l_lsbk0_count1[i] = lsbk0_count1[i];
   }
 
-  SYNC_THREADS();
+  SYNC_THREADS ();
 
   if (gid >= gid_max) return;
 

--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -125,7 +125,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -186,91 +186,93 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   char input[line_len + 1];
   input[line_len] = '\0';
-  memcpy(&input, line_buf, line_len);
+  memcpy (&input, line_buf, line_len);
 
-  char *p = strtok(input, "*");
+  char *p = strtok (input, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  if (strncmp(p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp(p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
+  if (strncmp (p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp (p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
 
   pkzip->version = 1;
-  if(strlen(p) == 9) pkzip->version = 2;
+
+  if (strlen (p) == 9) pkzip->version = 2;
 
   char sub[2];
-  sub[0] = p[strlen(p) - 1];
+
+  sub[0] = p[strlen (p) - 1];
   sub[1] = '\0';
-  pkzip->hash_count = atoi(sub);
+  pkzip->hash_count = atoi (sub);
 
   // check here that the hash_count is valid for the attack type
-  if(pkzip->hash_count != 1) return PARSER_HASH_VALUE;
+  if (pkzip->hash_count != 1) return PARSER_HASH_VALUE;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->checksum_size = atoi(p);
+  pkzip->checksum_size = atoi (p);
   if (pkzip->checksum_size != 1 && pkzip->checksum_size != 2) return PARSER_HASH_LENGTH;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.data_type_enum = atoi(p);
+  pkzip->hash.data_type_enum = atoi (p);
   if (pkzip->hash.data_type_enum > 3) return PARSER_HASH_LENGTH;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.magic_type_enum = atoi(p);
+  pkzip->hash.magic_type_enum = atoi (p);
 
-  if(pkzip->hash.data_type_enum > 1)
+  if (pkzip->hash.data_type_enum > 1)
   {
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.compressed_length = strtoul(p, NULL, 16);
+    pkzip->hash.compressed_length = strtoul (p, NULL, 16);
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.uncompressed_length = strtoul(p, NULL, 16);
+    pkzip->hash.uncompressed_length = strtoul (p, NULL, 16);
     if (pkzip->hash.compressed_length > MAX_DATA)
     {
       return PARSER_TOKEN_LENGTH;
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    sscanf(p, "%x", &(pkzip->hash.crc32));
+    sscanf (p, "%x", &(pkzip->hash.crc32));
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.offset = strtoul(p, NULL, 16);
+    pkzip->hash.offset = strtoul (p, NULL, 16);
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.additional_offset = strtoul(p, NULL, 16);
+    pkzip->hash.additional_offset = strtoul (p, NULL, 16);
   }
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.compression_type = atoi(p);
+  pkzip->hash.compression_type = atoi (p);
   if (pkzip->hash.compression_type != 8) return PARSER_PKZIP_CT_UNMATCHED;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.data_length = strtoul(p, NULL, 16);
+  pkzip->hash.data_length = strtoul (p, NULL, 16);
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  sscanf(p, "%hx", &(pkzip->hash.checksum_from_crc));
-  if(pkzip->version == 2)
+  sscanf (p, "%hx", &(pkzip->hash.checksum_from_crc));
+  if (pkzip->version == 2)
   {
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    sscanf(p, "%hx", &(pkzip->hash.checksum_from_timestamp));
+    sscanf (p, "%hx", &(pkzip->hash.checksum_from_timestamp));
   }
   else
   {
     pkzip->hash.checksum_from_timestamp = pkzip->hash.checksum_from_crc;
   }
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
 
-  hex_to_binary(p, strlen(p), (char *) &(pkzip->hash.data));
+  hex_to_binary (p, strlen (p), (char *) &(pkzip->hash.data));
 
   // fake salt
   u32 *ptr = (u32 *) pkzip->hash.data;

--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -107,8 +107,7 @@ static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$1*1*2*0*e3*1c5*eda7a8de*0*28*8*e3*eda7*5096*a9fc1f4e951c8fb3031a6f903e5f4e3211c8fdc4671547bf77f6f682afbfcc7475d83898985621a7af9bccd1349d1976500a68c48f630b7f22d7a0955524d768e34868880461335417ddd149c65a917c0eb0a4bf7224e24a1e04cf4ace5eef52205f4452e66ded937db9545f843a68b1e84a2e933cc05fb36d3db90e6c5faf1bee2249fdd06a7307849902a8bb24ec7e8a0886a4544ca47979a9dfeefe034bdfc5bd593904cfe9a5309dd199d337d3183f307c2cb39622549a5b9b8b485b7949a4803f63f67ca427a0640ad3793a519b2476c52198488e3e2e04cac202d624fb7d13c2*$/pkzip2$";
 
-#define MAX_DATA (16 * 1024 * 1024)
-#define MAX_LEN  (32 * 1024)
+#define MAX_DATA (320 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -227,13 +226,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     p = strtok(NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
     pkzip->hash.uncompressed_length = strtoul(p, NULL, 16);
-    if (pkzip->hash.compressed_length > MAX_DATA * 4)
+    if (pkzip->hash.compressed_length > MAX_DATA)
     {
       return PARSER_TOKEN_LENGTH;
-    }
-    if (pkzip->hash.uncompressed_length > MAX_LEN)
-    {
-      return PARSER_HASH_LENGTH;
     }
 
     p = strtok(NULL, "*");

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -107,7 +107,7 @@ static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$1*1*2*0*1d1*1c5*eda7a8de*0*28*0*1d1*eda7*5096*1dea673da43d9fc7e2be1a1f4f664269fceb6cb88723a97408ae1fe07f774d31d1442ea8485081e63f919851ca0b7588d5e3442317fff19fe547a4ef97492ed75417c427eea3c4e146e16c100a2f8b6abd7e5988dc967e5a0e51f641401605d673630ea52ebb04da4b388489901656532c9aa474ca090dbac7cf8a21428d57b42a71da5f3d83fed927361e5d385ca8e480a6d42dea5b4bf497d3a24e79fc7be37c8d1721238cbe9e1ea3ae1eb91fc02aabdf33070d718d5105b70b3d7f3d2c28b3edd822e89a5abc0c8fee117c7fbfbfd4b4c8e130977b75cb0b1da080bfe1c0859e6483c42f459c8069d45a76220e046e6c2a2417392fd87e4aa4a2559eaab3baf78a77a1b94d8c8af16a977b4bb45e3da211838ad044f209428dba82666bf3d54d4eed82c64a9b3444a44746b9e398d0516a2596d84243b4a1d7e87d9843f38e45b6be67fd980107f3ad7b8453d87300e6c51ac9f5e3f6c3b702654440c543b1d808b62f7a313a83b31a6faaeedc2620de7057cd0df80f70346fe2d4dccc318f0b5ed128bcf0643e63d754bb05f53afb2b0fa90b34b538b2ad3648209dff587df4fa18698e4fa6d858ad44aa55d2bba3b08dfdedd3e28b8b7caf394d5d9d95e452c2ab1c836b9d74538c2f0d24b9b577*$/pkzip2$";
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -226,7 +226,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     p = strtok(NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
     pkzip->hash.uncompressed_length = strtoul(p, NULL, 16);
-    if (pkzip->hash.uncompressed_length > MAX_DATA * 4)
+    if (pkzip->hash.compressed_length > MAX_DATA)
     {
       return PARSER_TOKEN_LENGTH;
     }

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -125,7 +125,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -186,91 +186,92 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   char input[line_len + 1];
   input[line_len] = '\0';
-  memcpy(&input, line_buf, line_len);
+  memcpy (&input, line_buf, line_len);
 
-  char *p = strtok(input, "*");
+  char *p = strtok (input, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  if (strncmp(p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp(p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
+  if (strncmp (p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp (p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
 
   pkzip->version = 1;
-  if(strlen(p) == 9) pkzip->version = 2;
+
+  if (strlen (p) == 9) pkzip->version = 2;
 
   char sub[2];
-  sub[0] = p[strlen(p) - 1];
+  sub[0] = p[strlen (p) - 1];
   sub[1] = '\0';
-  pkzip->hash_count = atoi(sub);
+  pkzip->hash_count = atoi (sub);
 
   // check here that the hash_count is valid for the attack type
-  if(pkzip->hash_count != 1) return PARSER_HASH_VALUE;
+  if (pkzip->hash_count != 1) return PARSER_HASH_VALUE;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->checksum_size = atoi(p);
+  pkzip->checksum_size = atoi (p);
   if (pkzip->checksum_size != 1 && pkzip->checksum_size != 2) return PARSER_HASH_LENGTH;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.data_type_enum = atoi(p);
+  pkzip->hash.data_type_enum = atoi (p);
   if (pkzip->hash.data_type_enum > 3) return PARSER_HASH_LENGTH;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.magic_type_enum = atoi(p);
+  pkzip->hash.magic_type_enum = atoi (p);
 
-  if(pkzip->hash.data_type_enum > 1)
+  if (pkzip->hash.data_type_enum > 1)
   {
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.compressed_length = strtoul(p, NULL, 16);
+    pkzip->hash.compressed_length = strtoul (p, NULL, 16);
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.uncompressed_length = strtoul(p, NULL, 16);
+    pkzip->hash.uncompressed_length = strtoul (p, NULL, 16);
     if (pkzip->hash.compressed_length > MAX_DATA)
     {
       return PARSER_TOKEN_LENGTH;
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    sscanf(p, "%x", &(pkzip->hash.crc32));
+    sscanf (p, "%x", & (pkzip->hash.crc32));
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.offset = strtoul(p, NULL, 16);
+    pkzip->hash.offset = strtoul (p, NULL, 16);
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hash.additional_offset = strtoul(p, NULL, 16);
+    pkzip->hash.additional_offset = strtoul (p, NULL, 16);
   }
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.compression_type = atoi(p);
+  pkzip->hash.compression_type = atoi (p);
   if (pkzip->hash.compression_type != 0) return PARSER_PKZIP_CT_UNMATCHED;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->hash.data_length = strtoul(p, NULL, 16);
+  pkzip->hash.data_length = strtoul (p, NULL, 16);
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  sscanf(p, "%hx", &(pkzip->hash.checksum_from_crc));
-  if(pkzip->version == 2)
+  sscanf (p, "%hx", &(pkzip->hash.checksum_from_crc));
+  if (pkzip->version == 2)
   {
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    sscanf(p, "%hx", &(pkzip->hash.checksum_from_timestamp));
+    sscanf (p, "%hx", &(pkzip->hash.checksum_from_timestamp));
   }
   else
   {
     pkzip->hash.checksum_from_timestamp = pkzip->hash.checksum_from_crc;
   }
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
 
-  hex_to_binary(p, strlen(p), (char *) &(pkzip->hash.data));
+  hex_to_binary (p, strlen (p), (char *) &(pkzip->hash.data));
 
   // fake salt
   u32 *ptr = (u32 *) pkzip->hash.data;

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -125,7 +125,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -107,8 +107,7 @@ static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$3*1*1*0*8*24*a425*8827*d1730095cd829e245df04ebba6c52c0573d49d3bbeab6cb385b7fa8a28dcccd3098bfdd7*1*0*8*24*2a74*882a*51281ac874a60baedc375ca645888d29780e20d4076edd1e7154a99bde982152a736311f*2*0*e3*1c5*eda7a8de*0*29*8*e3*eda7*5096*1455781b59707f5151139e018bdcfeebfc89bc37e372883a7ec0670a5eafc622feb338f9b021b6601a674094898a91beac70e41e675f77702834ca6156111a1bf7361bc9f3715d77dfcdd626634c68354c6f2e5e0a7b1e1ce84a44e632d0f6e36019feeab92fb7eac9dda8df436e287aafece95d042059a1b27d533c5eab62c1c559af220dc432f2eb1a38a70f29e8f3cb5a207704274d1e305d7402180fd47e026522792f5113c52a116d5bb25b67074ffd6f4926b221555234aabddc69775335d592d5c7d22462b75de1259e8342a9ba71cb06223d13c7f51f13be2ad76352c3b8ed*$/pkzip2$";
 
-#define MAX_DATA (16 * 1024 * 1024)
-#define MAX_LEN  (32 * 1024)
+#define MAX_DATA (320 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -232,10 +231,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
       if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
-      }
-      if (pkzip->hashes[i].uncompressed_length > MAX_LEN)
-      {
-        return PARSER_HASH_LENGTH;
       }
 
       p = strtok(NULL, "*");

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -186,93 +186,94 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   char input[line_len + 1];
   input[line_len] = '\0';
-  memcpy(&input, line_buf, line_len);
+  memcpy (&input, line_buf, line_len);
 
-  char *p = strtok(input, "*");
+  char *p = strtok (input, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  if (strncmp(p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp(p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
+  if (strncmp (p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp (p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
 
   pkzip->version = 1;
-  if(strlen(p) == 9) pkzip->version = 2;
+
+  if (strlen (p) == 9) pkzip->version = 2;
 
   char sub[2];
-  sub[0] = p[strlen(p) - 1];
+  sub[0] = p[strlen (p) - 1];
   sub[1] = '\0';
-  pkzip->hash_count = atoi(sub);
+  pkzip->hash_count = atoi (sub);
 
   // check here that the hash_count is valid for the attack type
-  if(pkzip->hash_count > 8) return PARSER_HASH_VALUE;
+  if (pkzip->hash_count > 8) return PARSER_HASH_VALUE;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->checksum_size = atoi(p);
+  pkzip->checksum_size = atoi (p);
   if (pkzip->checksum_size != 1 && pkzip->checksum_size != 2) return PARSER_HASH_LENGTH;
 
-  for(int i = 0; i < pkzip->hash_count; i++)
+  for (int i = 0; i < pkzip->hash_count; i++)
   {
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].data_type_enum = atoi(p);
+    pkzip->hashes[i].data_type_enum = atoi (p);
     if (pkzip->hashes[i].data_type_enum > 3) return PARSER_HASH_LENGTH;
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].magic_type_enum = atoi(p);
+    pkzip->hashes[i].magic_type_enum = atoi (p);
 
-    if(pkzip->hashes[i].data_type_enum > 1)
+    if (pkzip->hashes[i].data_type_enum > 1)
     {
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].compressed_length = strtoul(p, NULL, 16);
+      pkzip->hashes[i].compressed_length = strtoul (p, NULL, 16);
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].uncompressed_length = strtoul(p, NULL, 16);
+      pkzip->hashes[i].uncompressed_length = strtoul (p, NULL, 16);
       if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
       }
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      sscanf(p, "%x", &(pkzip->hashes[i].crc32));
+      sscanf (p, "%x", &(pkzip->hashes[i].crc32));
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].offset = strtoul(p, NULL, 16);
+      pkzip->hashes[i].offset = strtoul (p, NULL, 16);
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].additional_offset = strtoul(p, NULL, 16);
+      pkzip->hashes[i].additional_offset = strtoul (p, NULL, 16);
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].compression_type = atoi(p);
+    pkzip->hashes[i].compression_type = atoi (p);
     if (pkzip->hashes[i].compression_type != 8) return PARSER_PKZIP_CT_UNMATCHED;
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].data_length = strtoul(p, NULL, 16);
+    pkzip->hashes[i].data_length = strtoul (p, NULL, 16);
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    sscanf(p, "%hx", &(pkzip->hashes[i].checksum_from_crc));
-    if(pkzip->version == 2)
+    sscanf (p, "%hx", &(pkzip->hashes[i].checksum_from_crc));
+    if (pkzip->version == 2)
     {
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      sscanf(p, "%hx", &(pkzip->hashes[i].checksum_from_timestamp));
+      sscanf (p, "%hx", &(pkzip->hashes[i].checksum_from_timestamp));
     }
     else
     {
       pkzip->hashes[i].checksum_from_timestamp = pkzip->hashes[i].checksum_from_crc;
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
 
-    hex_to_binary(p, strlen(p), (char *) &(pkzip->hashes[i].data));
+    hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
 
     // fake salt
     u32 *ptr = (u32 *) pkzip->hashes[i].data;

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -125,7 +125,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -107,8 +107,7 @@ static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$3*1*1*0*0*24*3e2c*3ef8*0619e9d17ff3f994065b99b1fa8aef41c056edf9fa4540919c109742dcb32f797fc90ce0*1*0*8*24*431a*3f26*18e2461c0dbad89bd9cc763067a020c89b5e16195b1ac5fa7fb13bd246d000b6833a2988*2*0*23*17*1e3c1a16*2e4*2f*0*23*1e3c*3f2d*54ea4dbc711026561485bbd191bf300ae24fa0997f3779b688cdad323985f8d3bb8b0c*$/pkzip2$";
 
-#define MAX_DATA (16 * 1024 * 1024)
-#define MAX_LEN  (32 * 1024)
+#define MAX_DATA (320 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -232,10 +231,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
       if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
-      }
-      if (pkzip->hashes[i].uncompressed_length > MAX_LEN)
-      {
-        return PARSER_HASH_LENGTH;
       }
 
       p = strtok(NULL, "*");

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -186,93 +186,94 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   char input[line_len + 1];
   input[line_len] = '\0';
-  memcpy(&input, line_buf, line_len);
+  memcpy (&input, line_buf, line_len);
 
-  char *p = strtok(input, "*");
+  char *p = strtok (input, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  if (strncmp(p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp(p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
+  if (strncmp (p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp (p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
 
   pkzip->version = 1;
-  if(strlen(p) == 9) pkzip->version = 2;
+
+  if (strlen (p) == 9) pkzip->version = 2;
 
   char sub[2];
-  sub[0] = p[strlen(p) - 1];
+  sub[0] = p[strlen (p) - 1];
   sub[1] = '\0';
-  pkzip->hash_count = atoi(sub);
+  pkzip->hash_count = atoi (sub);
 
   // check here that the hash_count is valid for the attack type
-  if(pkzip->hash_count > 8) return PARSER_HASH_VALUE;
+  if (pkzip->hash_count > 8) return PARSER_HASH_VALUE;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->checksum_size = atoi(p);
+  pkzip->checksum_size = atoi (p);
   if (pkzip->checksum_size != 1 && pkzip->checksum_size != 2) return PARSER_HASH_LENGTH;
 
-  for(int i = 0; i < pkzip->hash_count; i++)
+  for (int i = 0; i < pkzip->hash_count; i++)
   {
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].data_type_enum = atoi(p);
+    pkzip->hashes[i].data_type_enum = atoi (p);
     if (pkzip->hashes[i].data_type_enum > 3) return PARSER_HASH_LENGTH;
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].magic_type_enum = atoi(p);
+    pkzip->hashes[i].magic_type_enum = atoi (p);
 
-    if(pkzip->hashes[i].data_type_enum > 1)
+    if (pkzip->hashes[i].data_type_enum > 1)
     {
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].compressed_length = strtoul(p, NULL, 16);
+      pkzip->hashes[i].compressed_length = strtoul (p, NULL, 16);
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].uncompressed_length = strtoul(p, NULL, 16);
+      pkzip->hashes[i].uncompressed_length = strtoul (p, NULL, 16);
       if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
       }
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      sscanf(p, "%x", &(pkzip->hashes[i].crc32));
+      sscanf (p, "%x", &(pkzip->hashes[i].crc32));
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].offset = strtoul(p, NULL, 16);
+      pkzip->hashes[i].offset = strtoul (p, NULL, 16);
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].additional_offset = strtoul(p, NULL, 16);
+      pkzip->hashes[i].additional_offset = strtoul (p, NULL, 16);
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].compression_type = atoi(p);
+    pkzip->hashes[i].compression_type = atoi (p);
     if (pkzip->hashes[i].compression_type != 8 && pkzip->hashes[i].compression_type != 0) return PARSER_HASH_VALUE;
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].data_length = strtoul(p, NULL, 16);
+    pkzip->hashes[i].data_length = strtoul (p, NULL, 16);
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    sscanf(p, "%hx", &(pkzip->hashes[i].checksum_from_crc));
-    if(pkzip->version == 2)
+    sscanf (p, "%hx", &(pkzip->hashes[i].checksum_from_crc));
+    if (pkzip->version == 2)
     {
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      sscanf(p, "%hx", &(pkzip->hashes[i].checksum_from_timestamp));
+      sscanf (p, "%hx", &(pkzip->hashes[i].checksum_from_timestamp));
     }
     else
     {
       pkzip->hashes[i].checksum_from_timestamp = pkzip->hashes[i].checksum_from_crc;
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
 
-    hex_to_binary(p, strlen(p), (char *) &(pkzip->hashes[i].data));
+    hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
 
     // fake salt
     u32 *ptr = (u32 *) pkzip->hashes[i].data;

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -125,7 +125,7 @@ struct pkzip_hash
   u32 data_length;
   u16 checksum_from_crc;
   u16 checksum_from_timestamp;
-  u32 data[MAX_DATA];
+  u32 data[MAX_DATA / 4]; // a quarter because of the u32 type
 
 } __attribute__((packed));
 

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -107,7 +107,7 @@ static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$pkzip2$8*1*1*0*8*24*a425*8827*3bd479d541019c2f32395046b8fbca7e1dca218b9b5414975be49942c3536298e9cc939e*1*0*8*24*2a74*882a*537af57c30fd9fd4b3eefa9ce55b6bff3bbfada237a7c1dace8ebf3bb0de107426211da3*1*0*8*24*2a74*882a*5f406b4858d3489fd4a6a6788798ac9b924b5d0ca8b8e5a6371739c9edcfd28c82f75316*1*0*8*24*2a74*882a*1843aca546b2ea68bd844d1e99d4f74d86417248eb48dd5e956270e42a331c18ea13f5ed*1*0*8*24*2a74*882a*aca3d16543bbfb2e5d2659f63802e0fa5b33e0a1f8ae47334019b4f0b6045d3d8eda3af1*1*0*8*24*2a74*882a*fbe0efc9e10ae1fc9b169bd060470bf3e39f09f8d83bebecd5216de02b81e35fe7e7b2f2*1*0*8*24*2a74*882a*537886dbabffbb7cac77deb01dc84760894524e6966183b4478a4ef56f0c657375a235a1*1*0*8*24*eda7*5096*40eb30ef1ddd9b77b894ed46abf199b480f1e5614fde510855f92ae7b8026a11f80e4d5f*$/pkzip2$";
 
-#define MAX_DATA (16 * 1024 * 1024)
+#define MAX_DATA (320 * 1024)
 
 // this is required to force mingw to accept the packed attribute
 #pragma pack(push,1)
@@ -229,7 +229,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
       p = strtok(NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
       pkzip->hashes[i].uncompressed_length = strtoul(p, NULL, 16);
-      if (pkzip->hashes[i].compressed_length > MAX_DATA * 4)
+      if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
       }

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -186,94 +186,95 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   char input[line_len + 1];
   input[line_len] = '\0';
-  memcpy(&input, line_buf, line_len);
+  memcpy (&input, line_buf, line_len);
 
-  char *p = strtok(input, "*");
+  char *p = strtok (input, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  if (strncmp(p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp(p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
+  if (strncmp (p, SIGNATURE_PKZIP_V1, 7) != 0 && strncmp (p, SIGNATURE_PKZIP_V2, 8) != 0) return PARSER_SIGNATURE_UNMATCHED;
 
   pkzip->version = 1;
-  if(strlen(p) == 9) pkzip->version = 2;
+
+  if (strlen (p) == 9) pkzip->version = 2;
 
   char sub[2];
-  sub[0] = p[strlen(p) - 1];
+  sub[0] = p[strlen (p) - 1];
   sub[1] = '\0';
-  pkzip->hash_count = atoi(sub);
+  pkzip->hash_count = atoi (sub);
 
   // check here that the hash_count is valid for the attack type
-  if(pkzip->hash_count > 8) return PARSER_HASH_VALUE;
-  if(pkzip->hash_count < 3) return PARSER_HASH_VALUE;
+  if (pkzip->hash_count > 8) return PARSER_HASH_VALUE;
+  if (pkzip->hash_count < 3) return PARSER_HASH_VALUE;
 
-  p = strtok(NULL, "*");
+  p = strtok (NULL, "*");
   if (p == NULL) return PARSER_HASH_LENGTH;
-  pkzip->checksum_size = atoi(p);
+  pkzip->checksum_size = atoi (p);
   if (pkzip->checksum_size != 1 && pkzip->checksum_size != 2) return PARSER_HASH_LENGTH;
 
-  for(int i = 0; i < pkzip->hash_count; i++)
+  for (int i = 0; i < pkzip->hash_count; i++)
   {
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].data_type_enum = atoi(p);
+    pkzip->hashes[i].data_type_enum = atoi (p);
     if (pkzip->hashes[i].data_type_enum > 3) return PARSER_HASH_LENGTH;
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].magic_type_enum = atoi(p);
+    pkzip->hashes[i].magic_type_enum = atoi (p);
 
-    if(pkzip->hashes[i].data_type_enum > 1)
+    if (pkzip->hashes[i].data_type_enum > 1)
     {
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].compressed_length = strtoul(p, NULL, 16);
+      pkzip->hashes[i].compressed_length = strtoul (p, NULL, 16);
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].uncompressed_length = strtoul(p, NULL, 16);
+      pkzip->hashes[i].uncompressed_length = strtoul (p, NULL, 16);
       if (pkzip->hashes[i].compressed_length > MAX_DATA)
       {
         return PARSER_TOKEN_LENGTH;
       }
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      sscanf(p, "%x", &(pkzip->hashes[i].crc32));
+      sscanf (p, "%x", &(pkzip->hashes[i].crc32));
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].offset = strtoul(p, NULL, 16);
+      pkzip->hashes[i].offset = strtoul (p, NULL, 16);
 
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      pkzip->hashes[i].additional_offset = strtoul(p, NULL, 16);
+      pkzip->hashes[i].additional_offset = strtoul (p, NULL, 16);
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].compression_type = atoi(p);
+    pkzip->hashes[i].compression_type = atoi (p);
     if (pkzip->hashes[i].compression_type != 8 && pkzip->hashes[i].compression_type != 0) return PARSER_PKZIP_CT_UNMATCHED;
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    pkzip->hashes[i].data_length = strtoul(p, NULL, 16);
+    pkzip->hashes[i].data_length = strtoul (p, NULL, 16);
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
-    sscanf(p, "%hx", &(pkzip->hashes[i].checksum_from_crc));
-    if(pkzip->version == 2)
+    sscanf (p, "%hx", &(pkzip->hashes[i].checksum_from_crc));
+    if (pkzip->version == 2)
     {
-      p = strtok(NULL, "*");
+      p = strtok (NULL, "*");
       if (p == NULL) return PARSER_HASH_LENGTH;
-      sscanf(p, "%hx", &(pkzip->hashes[i].checksum_from_timestamp));
+      sscanf (p, "%hx", &(pkzip->hashes[i].checksum_from_timestamp));
     }
     else
     {
       pkzip->hashes[i].checksum_from_timestamp = pkzip->hashes[i].checksum_from_crc;
     }
 
-    p = strtok(NULL, "*");
+    p = strtok (NULL, "*");
     if (p == NULL) return PARSER_HASH_LENGTH;
 
-    hex_to_binary(p, strlen(p), (char *) &(pkzip->hashes[i].data));
+    hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
 
     // fake salt
     u32 *ptr = (u32 *) pkzip->hashes[i].data;


### PR DESCRIPTION
We recently (https://github.com/hashcat/hashcat/pull/2049) had to add a 32 KB limitation for our DEFLATE decompression (inflate) because the way we used the output buffer and dict/window size didn't allow more input/output.

With this patch I've added a new "style" of using tinfl_decompress () that is similar to the miniz examples mentioned here: https://github.com/tessel/miniz/blob/master/example5.c but with also this prerequisite in mind https://github.com/tessel/miniz/blob/dee3e1992f0abbe42c1871590f6f7246b517db46/example5.c#L35 i.e. the output buffer must be at least 2 times the dict dize i.e. 32 KB  * 2 = 64 KB.

I also had to limit the input of the "new" data that is provided to the inflator step-by-step to only 16 bytes (see https://github.com/hashcat/hashcat/pull/2053/files#diff-56ba797d1f59ee0e02be67cdebf1fb3eR1149) because my tests showed that (depending on the compression ratio/settings) an even very, very small input with that huge dict size (32 KB) can expand to a very large decompressed output.

The idea now is that we loop with 16 input bytes until we find an error or are done, while still computing the crc32 checksum within that loop.

I've discussed several of these ideas with @s3inlc (thank you very much !) and we have still some "other" open issues that can/should be considered in the future:
1. end of hash check $/pkzip2$ and data length specified vs real length checks
2. MAX_DATA vs HCBUFSIZ_LARGE check if there are multiple files in hash. Is MAX_DATA now correct?
3. ideally, use the "binary file" strategy for pkzip hashes instead of loading the hashes with fgetl ()
4. use snprintf () instead of sprintf () everywhere possible to avoid buffer overflows
5. the check (plain & 6) == 0 prevents several hashes to be cracked in my tests. remove this ?
6. do we need an additional maximum length check for inflate () output in OpenCL ? prevent something similar to zip bombs etc
7. document which version of miniz was used + link + what had to be changed to work with our OpenCL architecture (like DECLSPEC) and also add a note to docs/credits.txt
etc

one of the main problems is the way hashcat currently (normally, i.e. not the binary file approach) reads the hashes (with fgetl () ) and this prevents us from loading even larger hashes for now (fixed input and output buffer also for potfile and output file etc).

cc: @s3inlc 

Thank you all guys