### PR TITLE
Fix fatal OSX build errors

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -69,6 +69,7 @@ CC                      := clang
 SED                     := /usr/bin/sed
 SED_IN_PLACE            := -i ""
 PROD_VERS               := $(shell sw_vers -productVersion | cut -d. -f2)
+AR                      := /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar
 endif
 
 ifeq ($(UNAME),FreeBSD)

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,10 +66,10 @@ SED_IN_PLACE            := -i
 ifeq ($(UNAME),Darwin)
 CC                      := clang
 # the sed -i option of macOS requires a parameter for the backup file (we just use "")
+AR                      := /usr/bin/ar
 SED                     := /usr/bin/sed
 SED_IN_PLACE            := -i ""
 PROD_VERS               := $(shell sw_vers -productVersion | cut -d. -f2)
-AR                      := /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar
 endif
 
 ifeq ($(UNAME),FreeBSD)


### PR DESCRIPTION
Build on OSX fail if the default ar binary is used

```
$ make
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/affinity.c -o obj/affinity.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/autotune.c -o obj/autotune.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/backend.c -o obj/backend.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/benchmark.c -o obj/benchmark.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/bitmap.c -o obj/bitmap.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/bitops.c -o obj/bitops.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/combinator.c -o obj/combinator.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/common.c -o obj/common.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/convert.c -o obj/convert.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/cpt.c -o obj/cpt.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/cpu_crc32.c -o obj/cpu_crc32.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/debugfile.c -o obj/debugfile.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/dictstat.c -o obj/dictstat.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/dispatch.c -o obj/dispatch.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/dynloader.c -o obj/dynloader.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/event.c -o obj/event.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_ADL.c -o obj/ext_ADL.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_cuda.c -o obj/ext_cuda.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_nvapi.c -o obj/ext_nvapi.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_nvml.c -o obj/ext_nvml.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_nvrtc.c -o obj/ext_nvrtc.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_OpenCL.c -o obj/ext_OpenCL.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_sysfs.c -o obj/ext_sysfs.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/ext_lzma.c -o obj/ext_lzma.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/filehandling.c -o
obj/filehandling.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/folder.c -o obj/folder.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/hashcat.c -o obj/hashcat.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/hashes.c -o obj/hashes.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/hlfmt.c -o obj/hlfmt.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/hwmon.c -o obj/hwmon.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/induct.c -o obj/induct.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/interface.c -o obj/interface.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/keyboard_layout.c -o
obj/keyboard_layout.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/locking.c -o obj/locking.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/logfile.c -o obj/logfile.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/loopback.c -o obj/loopback.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/memory.c -o obj/memory.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/monitor.c -o obj/monitor.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/mpsp.c -o obj/mpsp.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/outfile_check.c -o
obj/outfile_check.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/outfile.c -o obj/outfile.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/pidfile.c -o obj/pidfile.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/potfile.c -o obj/potfile.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/restore.c -o obj/restore.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/rp.c -o obj/rp.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/rp_cpu.c -o obj/rp_cpu.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/selftest.c -o obj/selftest.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/slow_candidates.c -o
obj/slow_candidates.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/shared.c -o obj/shared.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/status.c -o obj/status.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/stdout.c -o obj/stdout.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/straight.c -o obj/straight.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/terminal.c -o obj/terminal.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/thread.c -o obj/thread.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/timer.c -o obj/timer.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/tuningdb.c -o obj/tuningdb.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/usage.c -o obj/usage.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/user_options.c -o
obj/user_options.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/wordlist.c -o obj/wordlist.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_general.c -o obj/emu_general.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_common.c -o
obj/emu_inc_common.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_platform.c -o
obj/emu_inc_platform.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_scalar.c -o
obj/emu_inc_scalar.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_simd.c -o
obj/emu_inc_simd.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_rp.c -o obj/emu_inc_rp.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_rp_optimized.c -o
obj/emu_inc_rp_optimized.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_truecrypt_crc32.c -o
obj/emu_inc_truecrypt_crc32.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_truecrypt_keyfile.c -o
obj/emu_inc_truecrypt_keyfile.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_truecrypt_xts.c -o
obj/emu_inc_truecrypt_xts.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_veracrypt_xts.c -o
obj/emu_inc_veracrypt_xts.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_md4.c -o
obj/emu_inc_hash_md4.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_md5.c -o
obj/emu_inc_hash_md5.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_ripemd160.c -o
obj/emu_inc_hash_ripemd160.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_sha1.c -o
obj/emu_inc_hash_sha1.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_sha256.c -o
obj/emu_inc_hash_sha256.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_sha384.c -o
obj/emu_inc_hash_sha384.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_sha512.c -o
obj/emu_inc_hash_sha512.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_streebog256.c -o
obj/emu_inc_hash_streebog256.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_hash_streebog512.c -o
obj/emu_inc_hash_streebog512.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_cipher_aes.c -o
obj/emu_inc_cipher_aes.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_cipher_camellia.c -o
obj/emu_inc_cipher_camellia.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_cipher_des.c -o
obj/emu_inc_cipher_des.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_cipher_kuznyechik.c -o
obj/emu_inc_cipher_kuznyechik.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_cipher_serpent.c -o
obj/emu_inc_cipher_serpent.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/emu_inc_cipher_twofish.c -o
obj/emu_inc_cipher_twofish.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/brain.c -o obj/brain.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME deps/LZMA-SDK/C/Alloc.c -o obj/Alloc.NATIVE.o
-fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME deps/LZMA-SDK/C/Lzma2Dec.c -o
obj/Lzma2Dec.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME deps/LZMA-SDK/C/LzmaDec.c -o
obj/LzmaDec.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME -Wno-implicit-fallthrough deps/zlib//adler32.c
-o obj/adler32.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME -Wno-implicit-fallthrough deps/zlib//crc32.c
-o obj/crc32.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME -Wno-implicit-fallthrough deps/zlib//zutil.c
-o obj/zutil.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME -Wno-implicit-fallthrough
deps/zlib//inftrees.c -o obj/inftrees.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME -Wno-implicit-fallthrough deps/zlib//inffast.c
-o obj/inffast.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME -Wno-implicit-fallthrough deps/zlib//inflate.c
-o obj/inflate.NATIVE.o -fpic
clang -c -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME deps/xxHash/xxhash.c -o obj/xxhash.NATIVE.o
-fpic
ar rcs obj/combined.NATIVE.a obj/affinity.NATIVE.o
obj/autotune.NATIVE.o obj/backend.NATIVE.o obj/benchmark.NATIVE.o
obj/bitmap.NATIVE.o obj/bitops.NATIVE.o obj/combinator.NATIVE.o
obj/common.NATIVE.o obj/convert.NATIVE.o obj/cpt.NATIVE.o
obj/cpu_crc32.NATIVE.o obj/debugfile.NATIVE.o obj/dictstat.NATIVE.o
obj/dispatch.NATIVE.o obj/dynloader.NATIVE.o obj/event.NATIVE.o
obj/ext_ADL.NATIVE.o obj/ext_cuda.NATIVE.o obj/ext_nvapi.NATIVE.o
obj/ext_nvml.NATIVE.o obj/ext_nvrtc.NATIVE.o obj/ext_OpenCL.NATIVE.o
obj/ext_sysfs.NATIVE.o obj/ext_lzma.NATIVE.o obj/filehandling.NATIVE.o
obj/folder.NATIVE.o obj/hashcat.NATIVE.o obj/hashes.NATIVE.o
obj/hlfmt.NATIVE.o obj/hwmon.NATIVE.o obj/induct.NATIVE.o
obj/interface.NATIVE.o obj/keyboard_layout.NATIVE.o
obj/locking.NATIVE.o obj/logfile.NATIVE.o obj/loopback.NATIVE.o
obj/memory.NATIVE.o obj/monitor.NATIVE.o obj/mpsp.NATIVE.o
obj/outfile_check.NATIVE.o obj/outfile.NATIVE.o obj/pidfile.NATIVE.o
obj/potfile.NATIVE.o obj/restore.NATIVE.o obj/rp.NATIVE.o
obj/rp_cpu.NATIVE.o obj/selftest.NATIVE.o obj/slow_candidates.NATIVE.o
obj/shared.NATIVE.o obj/status.NATIVE.o obj/stdout.NATIVE.o
obj/straight.NATIVE.o obj/terminal.NATIVE.o obj/thread.NATIVE.o
obj/timer.NATIVE.o obj/tuningdb.NATIVE.o obj/usage.NATIVE.o
obj/user_options.NATIVE.o obj/wordlist.NATIVE.o
obj/emu_general.NATIVE.o obj/emu_inc_common.NATIVE.o
obj/emu_inc_platform.NATIVE.o obj/emu_inc_scalar.NATIVE.o
obj/emu_inc_simd.NATIVE.o obj/emu_inc_rp.NATIVE.o
obj/emu_inc_rp_optimized.NATIVE.o obj/emu_inc_truecrypt_crc32.NATIVE.o
obj/emu_inc_truecrypt_keyfile.NATIVE.o
obj/emu_inc_truecrypt_xts.NATIVE.o obj/emu_inc_veracrypt_xts.NATIVE.o
obj/emu_inc_hash_md4.NATIVE.o obj/emu_inc_hash_md5.NATIVE.o
obj/emu_inc_hash_ripemd160.NATIVE.o obj/emu_inc_hash_sha1.NATIVE.o
obj/emu_inc_hash_sha256.NATIVE.o obj/emu_inc_hash_sha384.NATIVE.o
obj/emu_inc_hash_sha512.NATIVE.o obj/emu_inc_hash_streebog256.NATIVE.o
obj/emu_inc_hash_streebog512.NATIVE.o obj/emu_inc_cipher_aes.NATIVE.o
obj/emu_inc_cipher_camellia.NATIVE.o obj/emu_inc_cipher_des.NATIVE.o
obj/emu_inc_cipher_kuznyechik.NATIVE.o
obj/emu_inc_cipher_serpent.NATIVE.o
obj/emu_inc_cipher_twofish.NATIVE.o obj/brain.NATIVE.o
obj/Alloc.NATIVE.o obj/Lzma2Dec.NATIVE.o obj/LzmaDec.NATIVE.o
obj/adler32.NATIVE.o obj/crc32.NATIVE.o obj/zutil.NATIVE.o
obj/inftrees.NATIVE.o obj/inffast.NATIVE.o obj/inflate.NATIVE.o
obj/xxhash.NATIVE.o
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/main.c obj/combined.NATIVE.a -o hashcat
                 -framework OpenCL -lpthread -liconv
-DCOMPTIME=1560978081 -DVERSION_TAG=\"v5.1.0-1164-gad8b43ca\"
-DINSTALL_FOLDER=\"/usr/local/bin\"
-DSHARED_FOLDER=\"/usr/local/share/hashcat\"
-DDOCUMENT_FOLDER=\"/usr/local/share/doc/hashcat\"
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/modules/module_00000.c
obj/combined.NATIVE.a -o modules/module_00000.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/modules/module_00010.c
obj/combined.NATIVE.a -o modules/module_00010.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/modules/module_00011.c
obj/combined.NATIVE.a -o modules/module_00011.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/modules/module_00012.c
obj/combined.NATIVE.a -o modules/module_00012.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/modules/module_00020.c
obj/combined.NATIVE.a -o modules/module_00020.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/modules/module_00021.c
obj/combined.NATIVE.a -o modules/module_00021.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
clang    -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99
-Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib/
-Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash
-DMISSING_CLOCK_GETTIME src/modules/module_00022.c
obj/combined.NATIVE.a -o modules/module_00022.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
Undefined symbols for architecture x86_64:
  "_hex_to_u32", referenced from:
      _module_hash_decode in module_00000-48daae.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00000-48daae.o
  "_u32_to_hex", referenced from:
      _module_hash_encode in module_00000-48daae.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [modules/module_00000.so] Error 1
make: *** Waiting for unfinished jobs....
Undefined symbols for architecture x86_64:
  "_generic_salt_decode", referenced from:
      _module_hash_decode in module_00010-e4a26f.o
  "_generic_salt_encode", referenced from:
      _module_hash_encode in module_00010-e4a26f.o
  "_hex_to_u32", referenced from:
      _module_hash_decode in module_00010-e4a26f.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00010-e4a26f.o
  "_u32_to_hex", referenced from:
      _module_hash_encode in module_00010-e4a26f.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [modules/module_00010.so] Error 1
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
Undefined symbols for architecture x86_64:
  "_generic_salt_decode", referenced from:
      _module_hash_decode in module_00011-bf7932.o
  "_generic_salt_encode", referenced from:
      _module_hash_encode in module_00011-bf7932.o
  "_hex_to_u32", referenced from:
      _module_hash_decode in module_00011-bf7932.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00011-bf7932.o
  "_u32_to_hex", referenced from:
      _module_hash_encode in module_00011-bf7932.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
make: *** [modules/module_00011.so] Error 1
Undefined symbols for architecture x86_64:
  "_generic_salt_decode", referenced from:
      _module_hash_decode in module_00020-cd8d26.o
  "_generic_salt_encode", referenced from:
      _module_hash_encode in module_00020-cd8d26.o
  "_hex_to_u32", referenced from:
      _module_hash_decode in module_00020-cd8d26.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00020-cd8d26.o
  "_u32_to_hex", referenced from:
      _module_hash_encode in module_00020-cd8d26.o
ld: symbol(s) not found for architecture x86_64
Undefined symbols for architecture x86_64:
  "_generic_salt_decode", referenced from:
      _module_hash_decode in module_00012-e448ce.o
  "_generic_salt_encode", referenced from:
      _module_hash_encode in module_00012-e448ce.o
  "_hex_to_u32", referenced from:
      _module_hash_decode in module_00012-e448ce.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00012-e448ce.o
  "_u32_to_hex", referenced from:
      _module_hash_encode in module_00012-e448ce.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [modules/module_00020.so] Error 1
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [modules/module_00012.so] Error 1
Undefined symbols for architecture x86_64:
  "_generic_salt_decode", referenced from:
      _module_hash_decode in module_00021-5f32b0.o
  "_generic_salt_encode", referenced from:
      _module_hash_encode in module_00021-5f32b0.o
  "_hex_to_u32", referenced from:
      _module_hash_decode in module_00021-5f32b0.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00021-5f32b0.o
  "_u32_to_hex", referenced from:
      _module_hash_encode in module_00021-5f32b0.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [modules/module_00021.so] Error 1
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
Undefined symbols for architecture x86_64:
  "_base64_to_int", referenced from:
      _module_hash_decode in module_00022-bf7927.o
  "_byte_swap_32", referenced from:
      _module_hash_decode in module_00022-bf7927.o
      _module_hash_encode in module_00022-bf7927.o
  "_generic_salt_decode", referenced from:
      _module_hash_decode in module_00022-bf7927.o
  "_generic_salt_encode", referenced from:
      _module_hash_encode in module_00022-bf7927.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00022-bf7927.o
  "_int_to_base64", referenced from:
      _module_hash_encode in module_00022-bf7927.o
  "_v16a_from_v32", referenced from:
      _module_hash_encode in module_00022-bf7927.o
  "_v16b_from_v32", referenced from:
      _module_hash_encode in module_00022-bf7927.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [modules/module_00022.so] Error 1
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
Undefined symbols for architecture x86_64:
  "_backend_info", referenced from:
      _main in main-248d97.o
  "_backend_info_compact", referenced from:
      _main in main-248d97.o
  "_brain_server", referenced from:
      _main in main-248d97.o
  "_clear_prompt", referenced from:
      _event in main-248d97.o
  "_event_log_advice", referenced from:
      _event in main-248d97.o
  "_event_log_error", referenced from:
      _event in main-248d97.o
  "_event_log_info", referenced from:
      _event in main-248d97.o
  "_event_log_info_nn", referenced from:
      _event in main-248d97.o
  "_event_log_warning", referenced from:
      _event in main-248d97.o
  "_example_hashes", referenced from:
      _main in main-248d97.o
  "_format_timer_display", referenced from:
      _event in main-248d97.o
  "_goodbye_screen", referenced from:
      _main in main-248d97.o
  "_hashcat_destroy", referenced from:
      _main in main-248d97.o
  "_hashcat_init", referenced from:
      _main in main-248d97.o
  "_hashcat_session_destroy", referenced from:
      _main in main-248d97.o
  "_hashcat_session_execute", referenced from:
      _main in main-248d97.o
  "_hashcat_session_init", referenced from:
      _main in main-248d97.o
  "_hc_fwrite", referenced from:
      _event in main-248d97.o
      _main_log in main-248d97.o
  "_hccalloc", referenced from:
      _event in main-248d97.o
  "_hcfree", referenced from:
      _event in main-248d97.o
  "_hcmalloc", referenced from:
      _main in main-248d97.o
      _event in main-248d97.o
  "_send_prompt", referenced from:
      _event in main-248d97.o
  "_setup_console", referenced from:
      _main in main-248d97.o
  "_status_benchmark", referenced from:
      _event in main-248d97.o
  "_status_display", referenced from:
      _event in main-248d97.o
  "_status_progress", referenced from:
      _event in main-248d97.o
  "_status_speed", referenced from:
      _event in main-248d97.o
  "_stroptitype", referenced from:
      _event in main-248d97.o
  "_thread_keypress", referenced from:
      _event in main-248d97.o
  "_usage_big_print", referenced from:
      _main in main-248d97.o
  "_user_options_getopt", referenced from:
      _main in main-248d97.o
  "_user_options_info", referenced from:
      _main in main-248d97.o
  "_user_options_init", referenced from:
      _main in main-248d97.o
  "_user_options_sanity", referenced from:
      _main in main-248d97.o
  "_welcome_screen", referenced from:
      _main in main-248d97.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [hashcat] Error 1
matrix@Gabrieles-MacBook-Pro:~/github/a/hashcat$ clang    -W -Wall
-Wextra -Wno-enum-conversion -O2 -pipe -std=gnu99 -Iinclude/ -IOpenCL/
-Ideps/LZMA-SDK/C -Ideps/zlib/ -Ideps/OpenCL-Headers -DWITH_BRAIN
-Ideps/xxHash -DMISSING_CLOCK_GETTIME src/modules/module_00022.c
obj/combined.NATIVE.a -o modules/module_00022.so  -framework OpenCL
-lpthread -liconv -shared -fPIC -D
MODULE_INTERFACE_VERSION_CURRENT=520
ld: warning: ignoring file obj/combined.NATIVE.a, file was built for
archive which is not the architecture being linked (x86_64):
obj/combined.NATIVE.a
Undefined symbols for architecture x86_64:
  "_base64_to_int", referenced from:
      _module_hash_decode in module_00022-d08b61.o
  "_byte_swap_32", referenced from:
      _module_hash_decode in module_00022-d08b61.o
      _module_hash_encode in module_00022-d08b61.o
  "_generic_salt_decode", referenced from:
      _module_hash_decode in module_00022-d08b61.o
  "_generic_salt_encode", referenced from:
      _module_hash_encode in module_00022-d08b61.o
  "_input_tokenizer", referenced from:
      _module_hash_decode in module_00022-d08b61.o
  "_int_to_base64", referenced from:
      _module_hash_encode in module_00022-d08b61.o
  "_v16a_from_v32", referenced from:
      _module_hash_encode in module_00022-d08b61.o
  "_v16b_from_v32", referenced from:
      _module_hash_encode in module_00022-d08b61.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```