### PR TITLE
fix OpenCL compiler warning

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -1425,7 +1425,7 @@ DECLSPEC float hc_get_entropy (const u32 *buf, const int elems)
 {
   const int length = elems * 4;
 
-  float entropy = 0.0;
+  float entropy = 0.0f;
 
   #ifdef _unroll
   #pragma unroll


### PR DESCRIPTION
```
In file included from <program source>:12:
hashcat/OpenCL/inc_common.cl:1428:19: warning: double precision constant requires cl_khr_fp64, casting to single precision
  float entropy = 0.0;
```