### PR TITLE
allow up to 64 bytes of salt in module 01460

### DIFF
--- a/src/modules/module_01460.c
+++ b/src/modules/module_01460.c
@@ -16,6 +16,7 @@ static const u32   DGST_POS1      = 7;
 static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 6;
 static const u32   DGST_SIZE      = DGST_SIZE_4_8;
+static const u32   DGST_BLK_SIZE  = 64;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_RAW_HASH_AUTHENTICATED;
 static const char *HASH_NAME      = "HMAC-SHA256 (key = $salt)";
 static const u64   KERN_TYPE      = 1460;
@@ -40,6 +41,7 @@ u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
 u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
 u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+u32         module_salt_max       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_BLK_SIZE;   }
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
@@ -214,7 +216,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_pwdump_column            = MODULE_DEFAULT;
   module_ctx->module_pw_max                   = MODULE_DEFAULT;
   module_ctx->module_pw_min                   = MODULE_DEFAULT;
-  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = module_salt_max;
   module_ctx->module_salt_min                 = MODULE_DEFAULT;
   module_ctx->module_salt_type                = module_salt_type;
   module_ctx->module_separator                = MODULE_DEFAULT;


### PR DESCRIPTION
Test case hashes.txt:
```
1f9dba8e10e8155fd684ca4ee8b416004a0729fae9472316ac2d9bfff743d1bb:aa73150989391fe8ffdc19b930f6059d029a9442f4c7e0da2609afc1ccb0ef05f85d37de3774826de38eb2a4c058fc3b6bc872a4afc518d5e581a0a858c48a92
```

Invocation:
```
hashcat -m 1460 -a 3 --hex-salt --custom-charset1=hasct hashes.txt '?1?1?1?1?1?1?1'
```

Result before patch:
```
Hashfile 'hashes.txt' on line 1 [...]: Salt-length exception
```

Result after patch:
Successfully broken
```
1f9dba8e10e8155fd684ca4ee8b416004a0729fae9472316ac2d9bfff743d1bb:aa73150989391fe8ffdc19b930f6059d029a9442f4c7e0da2609afc1ccb0ef05f85d37de3774826de38eb2a4c058fc3b6bc872a4afc518d5e581a0a858c48a92:hashcat
```

### Further details

When generating a HMAC-SHA256, the algorithm's first few operations are like this (pseudo-code):

```
if (key.size_in_bytes > 64) {
  key = sha256(key)
}

if (key.size_in_bytes < 64) {
  key = pad_with_nulls_up_to_size(key, 64)
}

do_hmac_operation(key, payload)
```

This means for keys > 64 bytes, they get SHA256'd back down to 32 bytes, then padded with zeroes.

A simple fix for users who want to use > 64 bytes could be some documentation which instructs the user to simply hash their key (or Hashcat could do it by precomputing for them, but I don't see an easy way of fitting that into the existing code)