### PR TITLE
Add OSX HW Monitor initial support

### DIFF
--- a/include/ext_iokit.h
+++ b/include/ext_iokit.h
@@ -6,31 +6,33 @@
 #ifndef _EXT_IOKIT_H
 #define _EXT_IOKIT_H
 
-// key values
-#define SMC_KEY_CPU_TEMP "TC0P"
-#define SMC_KEY_GPU_TEMP "TG0P"
-#define SMC_KEY_GPU_INT_TEMP "TCGC"
-#define SMC_KEY_FAN0_RPM_CUR "F0Ac"
-
 #ifdef __APPLE__
 #include <IOKit/IOKitLib.h>
 
-#define VERSION "0.01"
+// Apple SMC Keys
+#define HM_IOKIT_SMC_SENSOR_GRAPHICS_HOT "SGHT"
+#define HM_IOKIT_SMC_CPU_PROXIMITY       "TC0P"
+#define HM_IOKIT_SMC_GPU_PROXIMITY       "TG0P"
+#define HM_IOKIT_SMC_PECI_GPU            "TCGC"
 
 #define KERNEL_INDEX_SMC 2
 
-#define SMC_CMD_READ_BYTES 5
-#define SMC_CMD_WRITE_BYTES 6
-#define SMC_CMD_READ_INDEX 8
-#define SMC_CMD_READ_KEYINFO 9
-#define SMC_CMD_READ_PLIMIT 11
-#define SMC_CMD_READ_VERS 12
-
-#define DATATYPE_FPE2 "fpe2"
-#define DATATYPE_UINT8 "ui8 "
+#define DATATYPE_FPE2   "fpe2"
+#define DATATYPE_UINT8  "ui8 "
 #define DATATYPE_UINT16 "ui16"
 #define DATATYPE_UINT32 "ui32"
-#define DATATYPE_SP78 "sp78"
+#define DATATYPE_SP78   "sp78"
+
+typedef enum
+{
+  SMC_CMD_READ_BYTES   =  5,
+  SMC_CMD_WRITE_BYTES  =  6,
+  SMC_CMD_READ_INDEX   =  8,
+  SMC_CMD_READ_KEYINFO =  9,
+  SMC_CMD_READ_PLIMIT  = 11,
+  SMC_CMD_READ_VERS    = 12
+
+} SMCCommands_t;
 
 typedef struct
 {
@@ -106,5 +108,7 @@ typedef struct hm_iokit_lib
 } hm_iokit_lib_t;
 
 typedef hm_iokit_lib_t IOKIT_PTR;
+
+int hm_IOKIT_SMCGetSensorGraphicHot (void *hashcat_ctx);
 
 #endif // _EXT_IOKIT_H

--- a/include/ext_iokit.h
+++ b/include/ext_iokit.h
@@ -1,0 +1,110 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifndef _EXT_IOKIT_H
+#define _EXT_IOKIT_H
+
+// key values
+#define SMC_KEY_CPU_TEMP "TC0P"
+#define SMC_KEY_GPU_TEMP "TG0P"
+#define SMC_KEY_GPU_INT_TEMP "TCGC"
+#define SMC_KEY_FAN0_RPM_CUR "F0Ac"
+
+#ifdef __APPLE__
+#include <IOKit/IOKitLib.h>
+
+#define VERSION "0.01"
+
+#define KERNEL_INDEX_SMC 2
+
+#define SMC_CMD_READ_BYTES 5
+#define SMC_CMD_WRITE_BYTES 6
+#define SMC_CMD_READ_INDEX 8
+#define SMC_CMD_READ_KEYINFO 9
+#define SMC_CMD_READ_PLIMIT 11
+#define SMC_CMD_READ_VERS 12
+
+#define DATATYPE_FPE2 "fpe2"
+#define DATATYPE_UINT8 "ui8 "
+#define DATATYPE_UINT16 "ui16"
+#define DATATYPE_UINT32 "ui32"
+#define DATATYPE_SP78 "sp78"
+
+typedef struct
+{
+  char   major;
+  char   minor;
+  char   build;
+  char   reserved[1];
+  UInt16 release;
+
+} SMCKeyData_vers_t;
+
+typedef struct
+{
+  UInt16 version;
+  UInt16 length;
+  UInt32 cpuPLimit;
+  UInt32 gpuPLimit;
+  UInt32 memPLimit;
+
+} SMCKeyData_pLimitData_t;
+
+typedef struct
+{
+  UInt32 dataSize;
+  UInt32 dataType;
+
+  char   dataAttributes;
+
+} SMCKeyData_keyInfo_t;
+
+typedef char SMCBytes_t[32];
+
+typedef struct
+{
+  UInt32 key;
+
+  SMCKeyData_vers_t vers;
+  SMCKeyData_pLimitData_t pLimitData;
+  SMCKeyData_keyInfo_t keyInfo;
+
+  char   result;
+  char   status;
+  char   data8;
+
+  UInt32       data32;
+  SMCBytes_t   bytes;
+
+} SMCKeyData_t;
+
+typedef char UInt32Char_t[5];
+
+typedef struct
+{
+  UInt32Char_t key;
+  UInt32       dataSize;
+  UInt32Char_t dataType;
+  SMCBytes_t   bytes;
+
+} SMCVal_t;
+
+#endif // __APPLE__
+
+typedef int HM_ADAPTER_IOKIT;
+
+typedef void *IOKIT_LIB;
+
+typedef struct hm_iokit_lib
+{
+  #if defined(__APPLE__)
+  io_connect_t conn;
+  #endif // __APPLE__
+
+} hm_iokit_lib_t;
+
+typedef hm_iokit_lib_t IOKIT_PTR;
+
+#endif // _EXT_IOKIT_H

--- a/include/types.h
+++ b/include/types.h
@@ -626,7 +626,7 @@ typedef enum user_options_defaults
   STDOUT_FLAG              = false,
   USAGE                    = false,
   USERNAME                 = false,
-  SHOW_VERSION             = false,
+  VERSION                  = false,
   WORDLIST_AUTOHEX_DISABLE = false,
   WORKLOAD_PROFILE         = 2,
 

--- a/include/types.h
+++ b/include/types.h
@@ -564,7 +564,11 @@ typedef enum user_options_defaults
   EXAMPLE_HASHES           = false,
   FORCE                    = false,
   HWMON_DISABLE            = false,
+  #if defined (__APPLE__)
+  HWMON_TEMP_ABORT         = 100,
+  #else
   HWMON_TEMP_ABORT         = 90,
+  #endif
   HASH_MODE                = 0,
   HCCAPX_MESSAGE_PAIR      = 0,
   HEX_CHARSET              = false,
@@ -622,7 +626,7 @@ typedef enum user_options_defaults
   STDOUT_FLAG              = false,
   USAGE                    = false,
   USERNAME                 = false,
-  VERSION                  = false,
+  SHOW_VERSION             = false,
   WORDLIST_AUTOHEX_DISABLE = false,
   WORKLOAD_PROFILE         = 2,
 
@@ -1441,6 +1445,7 @@ typedef struct backend_ctx
   bool                need_nvml;
   bool                need_nvapi;
   bool                need_sysfs;
+  bool                need_iokit;
 
   int                 comptime;
 
@@ -1481,6 +1486,7 @@ typedef enum kernel_workload
 #include "ext_nvapi.h"
 #include "ext_nvml.h"
 #include "ext_sysfs.h"
+#include "ext_iokit.h"
 
 typedef struct hm_attrs
 {
@@ -1488,6 +1494,7 @@ typedef struct hm_attrs
   HM_ADAPTER_NVML    nvml;
   HM_ADAPTER_NVAPI   nvapi;
   HM_ADAPTER_SYSFS   sysfs;
+  HM_ADAPTER_IOKIT   iokit;
 
   int od_version;
 
@@ -1512,6 +1519,7 @@ typedef struct hwmon_ctx
   void *hm_nvml;
   void *hm_nvapi;
   void *hm_sysfs;
+  void *hm_iokit;
 
   hm_attrs_t *hm_device;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -257,6 +257,7 @@ endif # FreeBSD
 ifeq ($(UNAME),Darwin)
 export MACOSX_DEPLOYMENT_TARGET=10.9
 CFLAGS_NATIVE           := $(CFLAGS)
+CFLAGS_NATIVE           += -DWITH_HWMON
 
 ifeq ($(shell test $(PROD_VERS) -le 11; echo $$?), 0)
 CFLAGS_NATIVE           += -DMISSING_CLOCK_GETTIME
@@ -264,6 +265,7 @@ endif
 
 LFLAGS_NATIVE           := $(LFLAGS)
 LFLAGS_NATIVE           += -framework OpenCL
+LFLAGS_NATIVE           += -framework IOKit
 LFLAGS_NATIVE           += -lpthread
 LFLAGS_NATIVE           += -liconv
 endif # Darwin
@@ -299,7 +301,7 @@ EMU_OBJS_ALL            += emu_inc_truecrypt_crc32 emu_inc_truecrypt_keyfile emu
 EMU_OBJS_ALL            += emu_inc_hash_md4 emu_inc_hash_md5 emu_inc_hash_ripemd160 emu_inc_hash_sha1 emu_inc_hash_sha256 emu_inc_hash_sha384 emu_inc_hash_sha512 emu_inc_hash_streebog256 emu_inc_hash_streebog512
 EMU_OBJS_ALL            += emu_inc_cipher_aes emu_inc_cipher_camellia emu_inc_cipher_des emu_inc_cipher_kuznyechik emu_inc_cipher_serpent emu_inc_cipher_twofish
 
-OBJS_ALL                := affinity autotune backend benchmark bitmap bitops combinator common convert cpt cpu_crc32 debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_nvapi ext_nvml ext_nvrtc ext_OpenCL ext_sysfs ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
+OBJS_ALL                := affinity autotune backend benchmark bitmap bitops combinator common convert cpt cpu_crc32 debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_nvapi ext_nvml ext_nvrtc ext_OpenCL ext_sysfs ext_iokit ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
 
 ifeq ($(ENABLE_BRAIN),1)
 OBJS_ALL                += brain

--- a/src/backend.c
+++ b/src/backend.c
@@ -5456,6 +5456,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
   bool need_nvml    = false;
   bool need_nvapi   = false;
   bool need_sysfs   = false;
+  bool need_iokit   = false;
 
   int backend_devices_idx = 0;
 
@@ -6207,22 +6208,32 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
         if (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU)
         {
-          if ((device_param->opencl_platform_vendor_id == VENDOR_ID_AMD) && (device_param->opencl_device_vendor_id == VENDOR_ID_AMD))
+          if (device_param->skipped == false)
           {
-            need_adl = true;
+            if ((device_param->opencl_platform_vendor_id == VENDOR_ID_AMD) && (device_param->opencl_device_vendor_id == VENDOR_ID_AMD))
+            {
+              need_adl = true;
 
-            #if defined (__linux__)
-            need_sysfs = true;
-            #endif
-          }
+              #if defined (__linux__)
+              need_sysfs = true;
+              #endif
+            }
 
-          if ((device_param->opencl_platform_vendor_id == VENDOR_ID_NV) && (device_param->opencl_device_vendor_id == VENDOR_ID_NV))
-          {
-            need_nvml = true;
+            if ((device_param->opencl_platform_vendor_id == VENDOR_ID_NV) && (device_param->opencl_device_vendor_id == VENDOR_ID_NV))
+            {
+              need_nvml = true;
 
-            #if defined (_WIN) || defined (__CYGWIN__)
-            need_nvapi = true;
-            #endif
+              #if defined (_WIN) || defined (__CYGWIN__)
+              need_nvapi = true;
+              #endif
+            }
+
+            if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
+            {
+              #if defined (__APPLE__)
+              need_iokit = true;
+              #endif
+            }
           }
         }
 
@@ -6679,6 +6690,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
   backend_ctx->need_nvml    = need_nvml;
   backend_ctx->need_nvapi   = need_nvapi;
   backend_ctx->need_sysfs   = need_sysfs;
+  backend_ctx->need_iokit   = need_iokit;
 
   backend_ctx->comptime     = comptime;
 
@@ -6727,6 +6739,7 @@ void backend_ctx_devices_destroy (hashcat_ctx_t *hashcat_ctx)
   backend_ctx->need_nvml   = false;
   backend_ctx->need_nvapi  = false;
   backend_ctx->need_sysfs  = false;
+  backend_ctx->need_iokit  = false;
 }
 
 void backend_ctx_devices_sync_tuning (hashcat_ctx_t *hashcat_ctx)

--- a/src/ext_iokit.c
+++ b/src/ext_iokit.c
@@ -1,0 +1,7 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "ext_iokit.h"

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -122,7 +122,7 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
 
         if ((backend_ctx->devices_param[backend_devices_idx].opencl_device_type & CL_DEVICE_TYPE_GPU) == 0) continue;
 
-        const int temperature = hm_get_temperature_with_devices_idx (hashcat_ctx, backend_devices_idx);
+        int temperature = hm_get_temperature_with_devices_idx (hashcat_ctx, backend_devices_idx);
 
         if (temperature > (int) user_options->hwmon_temp_abort)
         {

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -130,6 +130,20 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
 
           myabort (hashcat_ctx);
         }
+        #if defined (__APPLE__)
+        // experimental feature, check the "Sensor Graphic Hot" sensor through IOKIT/SMC to catch a GPU overtemp alarm
+        else if (temperature > (int) (user_options->hwmon_temp_abort - 10))
+        {
+          if (hm_IOKIT_SMCGetSensorGraphicHot (hashcat_ctx) == 1)
+          {
+            event_log_error (hashcat_ctx, "hm_IOKIT_SMCGetSensorGraphicHot(): Sensor Graphics HoT, GPU Overtemp");
+
+            EVENT_DATA (EVENT_MONITOR_TEMP_ABORT, &backend_devices_idx, sizeof (int));
+
+            myabort (hashcat_ctx);
+          }
+        }
+        #endif
       }
 
       for (int backend_devices_idx = 0; backend_devices_idx < backend_ctx->backend_devices_cnt; backend_devices_idx++)

--- a/src/status.c
+++ b/src/status.c
@@ -1956,6 +1956,10 @@ char *status_get_hwmon_dev (const hashcat_ctx_t *hashcat_ctx, const int backend_
 {
   const backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
 
+  const hwmon_ctx_t   *hwmon_ctx   = hashcat_ctx->hwmon_ctx;
+
+  if (hwmon_ctx->enabled == false) return NULL;
+
   hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
 
   char *output_buf = (char *) hcmalloc (HCBUFSIZ_TINY);
@@ -2029,6 +2033,10 @@ int status_get_corespeed_dev (const hashcat_ctx_t *hashcat_ctx, const int backen
 {
   const backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
 
+  const hwmon_ctx_t   *hwmon_ctx   = hashcat_ctx->hwmon_ctx;
+
+  if (hwmon_ctx->enabled == false) return -1;
+
   hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
 
   if (device_param->skipped == true) return -1;
@@ -2049,6 +2057,10 @@ int status_get_corespeed_dev (const hashcat_ctx_t *hashcat_ctx, const int backen
 int status_get_memoryspeed_dev (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx)
 {
   const backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
+
+  const hwmon_ctx_t   *hwmon_ctx   = hashcat_ctx->hwmon_ctx;
+
+  if (hwmon_ctx->enabled == false) return -1;
 
   hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
 

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -250,7 +250,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->veracrypt_keyfiles        = NULL;
   user_options->veracrypt_pim_start       = 0;
   user_options->veracrypt_pim_stop        = 0;
-  user_options->version                   = SHOW_VERSION;
+  user_options->version                   = VERSION;
   user_options->wordlist_autohex_disable  = WORDLIST_AUTOHEX_DISABLE;
   user_options->workload_profile          = WORKLOAD_PROFILE;
   user_options->rp_files_cnt              = 0;

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -250,7 +250,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->veracrypt_keyfiles        = NULL;
   user_options->veracrypt_pim_start       = 0;
   user_options->veracrypt_pim_stop        = 0;
-  user_options->version                   = VERSION;
+  user_options->version                   = SHOW_VERSION;
   user_options->wordlist_autohex_disable  = WORDLIST_AUTOHEX_DISABLE;
   user_options->workload_profile          = WORKLOAD_PROFILE;
   user_options->rp_files_cnt              = 0;


### PR DESCRIPTION
Hi,
I found a way to enum the Apple GPU temperature and FAN speed (through IOKit Framework).
This patch it's only a proof of concept and I'm not handling the 3rd GPU presence for now.

I don't want to spend time to export the needed IOKit functions (like amd/nv) if this feature will not merged to the master branch.

Let me known :)