### PR TITLE
(mpsp) remove unused *rc* vars and cleanup

### DIFF
--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -1089,9 +1089,7 @@ static int mask_append (hashcat_ctx_t *hashcat_ctx, const char *mask, const char
         mask_truncated_next += snprintf (mask_truncated, 256, "%s,", prepend);
       }
 
-      const int rc_truncated_mask = mp_get_truncated_mask (hashcat_ctx, mask, strlen (mask), increment_len, mask_truncated_next);
-
-      if (rc_truncated_mask == -1)
+      if (mp_get_truncated_mask (hashcat_ctx, mask, strlen (mask), increment_len, mask_truncated_next) == -1)
       {
         hcfree (mask_truncated);
 
@@ -1111,7 +1109,7 @@ static int mask_append (hashcat_ctx_t *hashcat_ctx, const char *mask, const char
     {
       // this happens with maskfiles only
 
-      char *prepend_mask;
+      char *prepend_mask = NULL;
 
       hc_asprintf (&prepend_mask, "%s,%s", prepend, mask);
 
@@ -1123,9 +1121,7 @@ static int mask_append (hashcat_ctx_t *hashcat_ctx, const char *mask, const char
     }
     else
     {
-      const int rc = mask_append_final (hashcat_ctx, mask);
-
-      if (rc == -1) return -1;
+      if (mask_append_final (hashcat_ctx, mask) == -1) return -1;
     }
   }
 
@@ -1199,15 +1195,11 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
       {
         mask_ctx->mask = mask_ctx->masks[mask_ctx->masks_pos];
 
-        const int rc_mask_file = mask_ctx_parse_maskfile (hashcat_ctx);
-
-        if (rc_mask_file == -1) return -1;
+        if (mask_ctx_parse_maskfile (hashcat_ctx) == -1) return -1;
 
         mask_ctx->css_buf = (cs_t *) hccalloc (256, sizeof (cs_t));
 
-        const int rc_gen_css = mp_gen_css (hashcat_ctx, mask_ctx->mask, strlen (mask_ctx->mask), mask_ctx->mp_sys, mask_ctx->mp_usr, mask_ctx->css_buf, &mask_ctx->css_cnt);
-
-        if (rc_gen_css == -1) return -1;
+        if (mp_gen_css (hashcat_ctx, mask_ctx->mask, strlen (mask_ctx->mask), mask_ctx->mp_sys, mask_ctx->mp_usr, mask_ctx->css_buf, &mask_ctx->css_cnt) == -1) return -1;
 
         u32 uniq_tbls[SP_PW_MAX][CHARSIZ] = { { 0 } };
 
@@ -1215,32 +1207,24 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
         sp_tbl_to_css (mask_ctx->root_table_buf, mask_ctx->markov_table_buf, mask_ctx->root_css_buf, mask_ctx->markov_css_buf, user_options->markov_threshold, uniq_tbls);
 
-        const int rc_get_sum = sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &mask_ctx->bfs_cnt);
-
-        if (rc_get_sum == -1)
+        if (sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &mask_ctx->bfs_cnt) == -1)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of mask: %s", mask_ctx->mask);
 
           return -1;
         }
 
-        const int rc_update_mp = backend_session_update_mp (hashcat_ctx);
-
-        if (rc_update_mp == -1) return -1;
+        if (backend_session_update_mp (hashcat_ctx) == -1) return -1;
       }
       else
       {
         mask_ctx->mask = mask_ctx->masks[mask_ctx->masks_pos];
 
-        const int rc_mask_file = mask_ctx_parse_maskfile (hashcat_ctx);
-
-        if (rc_mask_file == -1) return -1;
+        if (mask_ctx_parse_maskfile (hashcat_ctx) == -1) return -1;
 
         mask_ctx->css_buf = (cs_t *) hccalloc (256, sizeof (cs_t));
 
-        const int rc_gen_css = mp_gen_css (hashcat_ctx, mask_ctx->mask, strlen (mask_ctx->mask), mask_ctx->mp_sys, mask_ctx->mp_usr, mask_ctx->css_buf, &mask_ctx->css_cnt);
-
-        if (rc_gen_css == -1) return -1;
+        if (mp_gen_css (hashcat_ctx, mask_ctx->mask, strlen (mask_ctx->mask), mask_ctx->mp_sys, mask_ctx->mp_usr, mask_ctx->css_buf, &mask_ctx->css_cnt) == -1) return -1;
 
         u32 uniq_tbls[SP_PW_MAX][CHARSIZ] = { { 0 } };
 
@@ -1248,40 +1232,30 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
         sp_tbl_to_css (mask_ctx->root_table_buf, mask_ctx->markov_table_buf, mask_ctx->root_css_buf, mask_ctx->markov_css_buf, user_options->markov_threshold, uniq_tbls);
 
-        const int rc_get_sum = sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &combinator_ctx->combs_cnt);
-
-        if (rc_get_sum == -1)
+        if (sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &combinator_ctx->combs_cnt) == -1) return -1;
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of mask: %s", mask_ctx->mask);
 
           return -1;
         }
 
-        const int rc_update_mp = backend_session_update_mp (hashcat_ctx);
-
-        if (rc_update_mp == -1) return -1;
+        if (backend_session_update_mp (hashcat_ctx) == -1) return -1;
       }
     }
 
-    const int rc_update_combinator = backend_session_update_combinator (hashcat_ctx);
-
-    if (rc_update_combinator == -1) return -1;
+    if (backend_session_update_combinator (hashcat_ctx) == -1) return -1;
   }
   else if (user_options_extra->attack_kern == ATTACK_KERN_BF)
   {
     mask_ctx->mask = mask_ctx->masks[mask_ctx->masks_pos];
 
-    const int rc_mask_file = mask_ctx_parse_maskfile (hashcat_ctx);
-
-    if (rc_mask_file == -1) return -1;
+    if (mask_ctx_parse_maskfile (hashcat_ctx) == -1) return -1;
 
     if (user_options->attack_mode == ATTACK_MODE_BF) // always true
     {
       mask_ctx->css_buf = (cs_t *) hccalloc (256, sizeof (cs_t));
 
-      const int rc_gen_css = mp_gen_css (hashcat_ctx, mask_ctx->mask, strlen (mask_ctx->mask), mask_ctx->mp_sys, mask_ctx->mp_usr, mask_ctx->css_buf, &mask_ctx->css_cnt);
-
-      if (rc_gen_css == -1) return -1;
+      if (mp_gen_css (hashcat_ctx, mask_ctx->mask, strlen (mask_ctx->mask), mask_ctx->mp_sys, mask_ctx->mp_usr, mask_ctx->css_buf, &mask_ctx->css_cnt) == -1) return -1;
 
       // special case for benchmark
 
@@ -1325,15 +1299,11 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       if (hashconfig->opts_type & OPTS_TYPE_PT_UTF16LE)
       {
-        const int rc = mp_css_utf16le_expand (hashcat_ctx);
-
-        if (rc == -1) return -1;
+        if (mp_css_utf16le_expand (hashcat_ctx) == -1) return -1;
       }
       else if (hashconfig->opts_type & OPTS_TYPE_PT_UTF16BE)
       {
-        const int rc = mp_css_utf16be_expand (hashcat_ctx);
-
-        if (rc == -1) return -1;
+        if (mp_css_utf16be_expand (hashcat_ctx) == -1) return -1;
       }
 
       u32 css_cnt_orig = mask_ctx->css_cnt;
@@ -1342,9 +1312,7 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
       {
         if (hashconfig->opti_type & OPTI_TYPE_APPENDED_SALT)
         {
-          const int rc = mp_css_append_salt (hashcat_ctx, &hashes->salts_buf[0]);
-
-          if (rc == -1) return -1;
+          if (mp_css_append_salt (hashcat_ctx, &hashes->salts_buf[0]) == -1) return -1;
         }
       }
 
@@ -1354,9 +1322,7 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       sp_tbl_to_css (mask_ctx->root_table_buf, mask_ctx->markov_table_buf, mask_ctx->root_css_buf, mask_ctx->markov_css_buf, user_options->markov_threshold, uniq_tbls);
 
-      const int rc_get_sum1 = sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &status_ctx->words_cnt);
-
-      if (rc_get_sum1 == -1)
+      if (sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &status_ctx->words_cnt) == -1)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of mask: %s", mask_ctx->mask);
 
@@ -1369,18 +1335,14 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
       mp_css_split_cnt (hashcat_ctx, css_cnt_orig, css_cnt_lr);
 
-      const int rc_get_sum2 = sp_get_sum (0, css_cnt_lr[1], mask_ctx->root_css_buf, &mask_ctx->bfs_cnt);
-
-      if (rc_get_sum2 == -1)
+      if (sp_get_sum (0, css_cnt_lr[1], mask_ctx->root_css_buf, &mask_ctx->bfs_cnt) == -1)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of mask: %s", mask_ctx->mask);
 
         return -1;
       }
 
-      const int rc_update_mp_rl = backend_session_update_mp_rl (hashcat_ctx, css_cnt_lr[0], css_cnt_lr[1]);
-
-      if (rc_update_mp_rl == -1) return -1;
+      if (backend_session_update_mp_rl (hashcat_ctx, css_cnt_lr[0], css_cnt_lr[1]) == -1) return -1;
     }
   }
 
@@ -1390,9 +1352,9 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 {
   const hashconfig_t         *hashconfig          = hashcat_ctx->hashconfig;
-        mask_ctx_t           *mask_ctx            = hashcat_ctx->mask_ctx;
   const user_options_extra_t *user_options_extra  = hashcat_ctx->user_options_extra;
   const user_options_t       *user_options        = hashcat_ctx->user_options;
+  mask_ctx_t                 *mask_ctx            = hashcat_ctx->mask_ctx;
 
   mask_ctx->enabled = false;
 
@@ -1411,9 +1373,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
   mask_ctx->root_table_buf   = (hcstat_table_t *) hccalloc (SP_ROOT_CNT,   sizeof (hcstat_table_t));
   mask_ctx->markov_table_buf = (hcstat_table_t *) hccalloc (SP_MARKOV_CNT, sizeof (hcstat_table_t));
 
-  const int rc_setup_tbl = sp_setup_tbl (hashcat_ctx);
-
-  if (rc_setup_tbl == -1) return -1;
+  if (sp_setup_tbl (hashcat_ctx) == -1) return -1;
 
   mask_ctx->root_css_buf   = (cs_t *) hccalloc (SP_PW_MAX,           sizeof (cs_t));
   mask_ctx->markov_css_buf = (cs_t *) hccalloc (SP_PW_MAX * CHARSIZ, sizeof (cs_t));
@@ -1431,10 +1391,10 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
   mp_setup_sys (mask_ctx->mp_sys);
 
-  if (user_options->custom_charset_1) { const int rc = mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_1, 0); if (rc == -1) return -1; }
-  if (user_options->custom_charset_2) { const int rc = mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_2, 1); if (rc == -1) return -1; }
-  if (user_options->custom_charset_3) { const int rc = mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_3, 2); if (rc == -1) return -1; }
-  if (user_options->custom_charset_4) { const int rc = mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_4, 3); if (rc == -1) return -1; }
+  if (user_options->custom_charset_1) { if (mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_1, 0) == -1) return -1; }
+  if (user_options->custom_charset_2) { if (mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_2, 1) == -1) return -1; }
+  if (user_options->custom_charset_3) { if (mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_3, 2) == -1) return -1; }
+  if (user_options->custom_charset_4) { if (mp_setup_usr (hashcat_ctx, mask_ctx->mp_sys, mask_ctx->mp_usr, user_options->custom_charset_4, 3) == -1) return -1; }
 
   if (user_options->attack_mode == ATTACK_MODE_BF)
   {
@@ -1446,9 +1406,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         if (hc_path_exist (arg) == false)
         {
-          const int rc = mask_append (hashcat_ctx, arg, NULL);
-
-          if (rc == -1) return -1;
+          if (mask_append (hashcat_ctx, arg, NULL) == -1) return -1;
         }
         else
         {
@@ -1492,9 +1450,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
                   mask_buf[-1] = 0;
                 }
 
-                const int rc = mask_append (hashcat_ctx, mask_buf, prepend_buf);
-
-                if (rc == -1)
+                if (mask_append (hashcat_ctx, mask_buf, prepend_buf) == -1)
                 {
                   hc_fclose (&mask_fp);
 
@@ -1519,18 +1475,14 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
       {
         const char *mask = DEF_MASK;
 
-        const int rc = mask_append (hashcat_ctx, mask, NULL);
-
-        if (rc == -1) return -1;
+        if (mask_append (hashcat_ctx, mask, NULL) == -1) return -1;
       }
     }
     else
     {
       const char *mask = hashconfig->benchmark_mask;
 
-      const int rc = mask_append (hashcat_ctx, mask, NULL);
-
-      if (rc == -1) return -1;
+      if (mask_append (hashcat_ctx, mask, NULL) == -1) return -1;
     }
   }
   else if (user_options->attack_mode == ATTACK_MODE_HYBRID1)
@@ -1543,9 +1495,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if (hc_path_exist (arg) == false)
     {
-      const int rc = mask_append (hashcat_ctx, arg, NULL);
-
-      if (rc == -1) return -1;
+      if (mask_append (hashcat_ctx, arg, NULL) == -1) return -1;
     }
     else
     {
@@ -1585,9 +1535,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
             mask_buf[-1] = 0;
           }
 
-          const int rc = mask_append (hashcat_ctx, mask_buf, prepend_buf);
-
-          if (rc == -1)
+          if (mask_append (hashcat_ctx, mask_buf, prepend_buf) == -1)
           {
             hc_fclose (&mask_fp);
 
@@ -1617,9 +1565,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
     if (hc_path_exist (arg) == false)
     {
-      const int rc = mask_append (hashcat_ctx, arg, NULL);
-
-      if (rc == -1) return -1;
+      if (mask_append (hashcat_ctx, arg, NULL) == -1) return -1;
     }
     else
     {
@@ -1659,9 +1605,7 @@ int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
             mask_buf[-1] = 0;
           }
 
-          const int rc = mask_append (hashcat_ctx, mask_buf, prepend_buf);
-
-          if (rc == -1)
+          if (mask_append (hashcat_ctx, mask_buf, prepend_buf) == -1)
           {
             hc_fclose (&mask_fp);
 


### PR DESCRIPTION
As the title, already discussed in #2075 