### PR TITLE
Fix buffer overflow in build_plain()

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -330,18 +330,22 @@ void check_hash (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pl
 
   // plain
 
-  u32 plain_buf[64] = { 0 };
+  u8 plain_buf[256+1];
 
-  u8 *plain_ptr = (u8 *) plain_buf;
+  memset (plain_buf, 0, sizeof (plain_buf));
+
+  u8 *plain_ptr = plain_buf;
   int plain_len = 0;
 
-  build_plain (hashcat_ctx, device_param, plain, plain_buf, &plain_len);
+  build_plain (hashcat_ctx, device_param, plain, (u32 *)plain_buf, &plain_len);
 
   if (module_ctx->module_build_plain_postprocess != MODULE_DEFAULT)
   {
-    u32 temp_buf[64] = { 0 };
+    u8 temp_buf[256+1] = { 0 };
 
-    const int temp_len = module_ctx->module_build_plain_postprocess (hashcat_ctx->hashconfig, hashcat_ctx->hashes, tmps, plain_buf, sizeof (plain_buf), plain_len, temp_buf, sizeof (temp_buf));
+    memset (temp_buf, 0, sizeof (temp_buf));
+
+    const int temp_len = module_ctx->module_build_plain_postprocess (hashcat_ctx->hashconfig, hashcat_ctx->hashes, tmps, (u32 *)plain_buf, sizeof (plain_buf), plain_len, (u32 *)temp_buf, sizeof (temp_buf));
 
     if (temp_len < (int) sizeof (plain_buf))
     {


### PR DESCRIPTION
Hi,

while debugging 20600 hash mode I found an buffer overflow.

```
==73675==ERROR: AddressSanitizer: stack-buffer-overflow on address
0x70000911b7e0 at pc 0x000100114efe bp 0x70000911a710 sp
0x70000911a708
WRITE of size 1 at 0x70000911b7e0 thread T12
    #0 0x100114efd in build_plain outfile.c:244
    #1 0x1000c5c1a in check_hash hashes.c:338
    #2 0x1000c817e in check_cracked hashes.c:544
    #3 0x10003db07 in run_cracker backend.c:4920
    #4 0x1000ae6da in calc dispatch.c:1581
    #5 0x1000a38f9 in thread_calc dispatch.c:1685
    #6 0x7fff7a6b4660 in _pthread_body (libsystem_pthread.dylib:x86_64+0x3660)
    #7 0x7fff7a6b450c in _pthread_start (libsystem_pthread.dylib:x86_64+0x350c)
    #8 0x7fff7a6b3bf8 in thread_start (libsystem_pthread.dylib:x86_64+0x2bf8)

Address 0x70000911b7e0 is located in stack of thread T12 at offset 288 in frame
    #0 0x1000c4eef in check_hash hashes.c:296

  This frame has 8 object(s):
    [32, 288) 'plain_buf' (line 333) <== Memory access at offset 288
overflows this variable
    [352, 356) 'plain_len' (line 336)
    [368, 624) 'temp_buf' (line 342)
    [688, 696) 'crackpos' (line 356)
    [720, 976) 'debug_rule_buf' (line 362)
    [1040, 1044) 'debug_rule_len' (line 363)
    [1056, 1312) 'debug_plain_ptr' (line 365)
    [1376, 1380) 'debug_plain_len' (line 366)
HINT: this may be a false positive if your program uses some custom
stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
Thread T12 created by T0 here:
    #0 0x100801ead in wrap_pthread_create
(libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4eead)
    #1 0x1000c08fc in inner2_loop hashcat.c:265
    #2 0x1000beaef in inner1_loop hashcat.c:409
    #3 0x1000bb8d0 in outer_loop hashcat.c:878
    #4 0x1000b85c4 in hashcat_session_execute hashcat.c:1280
    #5 0x100001b89 in main main.c:1160
    #6 0x7fff7a39c014 in start (libdyld.dylib:x86_64+0x1014)

``` 

This patch fix the bug :)