### PR TITLE
fix bug in mpsp

### DIFF
--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -1232,7 +1232,7 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
         sp_tbl_to_css (mask_ctx->root_table_buf, mask_ctx->markov_table_buf, mask_ctx->root_css_buf, mask_ctx->markov_css_buf, user_options->markov_threshold, uniq_tbls);
 
-        if (sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &combinator_ctx->combs_cnt) == -1) return -1;
+        if (sp_get_sum (0, mask_ctx->css_cnt, mask_ctx->root_css_buf, &combinator_ctx->combs_cnt) == -1)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of mask: %s", mask_ctx->mask);
 


### PR DESCRIPTION
Hi,
it's a clear (and my) error :) 

Without '-O' works but :

```
$ ./hashcat -t 32 -a 7 example0.hash ?a?a?a?a example.dict --quiet -O
Integer overflow detected in keyspace of mask: ?a?a?a?a
```
