### PR TITLE
Avoid -Waddress-of-packed-member warnings

### DIFF
--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -284,12 +284,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   hex_to_binary (p, strlen (p), (char *) &(pkzip->hash.data));
 
   // fake salt
-  u32 *ptr = (u32 *) pkzip->hash.data;
-
-  salt->salt_buf[0] = ptr[0];
-  salt->salt_buf[1] = ptr[1];
-  salt->salt_buf[2] = ptr[2];
-  salt->salt_buf[3] = ptr[3];
+  salt->salt_buf[0] = pkzip->hash.data[0];
+  salt->salt_buf[1] = pkzip->hash.data[1];
+  salt->salt_buf[2] = pkzip->hash.data[2];
+  salt->salt_buf[3] = pkzip->hash.data[3];
 
   salt->salt_len = 16;
 

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -283,12 +283,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   hex_to_binary (p, strlen (p), (char *) &(pkzip->hash.data));
 
   // fake salt
-  u32 *ptr = (u32 *) pkzip->hash.data;
-
-  salt->salt_buf[0] = ptr[0];
-  salt->salt_buf[1] = ptr[1];
-  salt->salt_buf[2] = ptr[2];
-  salt->salt_buf[3] = ptr[3];
+  salt->salt_buf[0] = pkzip->hash.data[0];
+  salt->salt_buf[1] = pkzip->hash.data[1];
+  salt->salt_buf[2] = pkzip->hash.data[2];
+  salt->salt_buf[3] = pkzip->hash.data[3];
 
   salt->salt_len = 16;
 

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -285,9 +285,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
 
     // fake salt
-    u32 *ptr = (u32 *) pkzip->hashes[i].data;
-
-    salt->salt_buf[i] = ptr[0];
+    salt->salt_buf[i] = pkzip->hashes[i].data[0];
 
     if (i == 0) digest[i] = pkzip->hashes[i].checksum_from_crc;
   }

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -285,9 +285,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
 
     // fake salt
-    u32 *ptr = (u32 *) pkzip->hashes[i].data;
-
-    salt->salt_buf[i] = ptr[0];
+    salt->salt_buf[i] = pkzip->hashes[i].data[0];
 
     if (i == 0) digest[i] = pkzip->hashes[i].checksum_from_crc;
   }

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -286,9 +286,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
 
     // fake salt
-    u32 *ptr = (u32 *) pkzip->hashes[i].data;
-
-    salt->salt_buf[i] = ptr[0];
+    salt->salt_buf[i] = pkzip->hashes[i].data[0];
 
     if (i == 0) digest[i] = pkzip->hashes[i].checksum_from_crc;
   }


### PR DESCRIPTION
Getting these warnings in GCC 9.1.0

As far as I checked, my changes didn't modify the compiled binaries