### PR TITLE
fixes #2208: -m 15200/12700 correctly validate "address" in decrypted data

### DIFF
--- a/OpenCL/m12700-pure.cl
+++ b/OpenCL/m12700-pure.cl
@@ -406,7 +406,7 @@ KERNEL_FQ void m12700_comp (KERN_ATTR_TMPS (mywallet_tmp_t))
     }
 
     // "addre
-    if ((pt[i + 0] == '"') && (pt[i + 1] == 'a') && (pt[i + 2] == 'd') && (pt[i + 3] == 'd') && (pt[i + 4] == 'r') && (pt[i + 5] == 'a'))
+    if ((pt[i + 0] == '"') && (pt[i + 1] == 'a') && (pt[i + 2] == 'd') && (pt[i + 3] == 'd') && (pt[i + 4] == 'r') && (pt[i + 5] == 'e'))
     {
       const u32 r0 = data[0];
       const u32 r1 = data[1];


### PR DESCRIPTION
As reported in #2208, the encrypted blockchain wallet data gets decrypted into "addre" but not "addra" (typo).

This problem resulted in false negatives, whenever the json data had "address" at the start, see https://github.com/hashcat/hashcat/issues/1937#issuecomment-469038973

Thanks