### PR TITLE
fixes #2214: -m 15200 = Blockchain allow large data similar to -m 12700 with hash copy

### DIFF
--- a/src/modules/module_15200.c
+++ b/src/modules/module_15200.c
@@ -93,13 +93,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[2]     = '$';
   token.len_min[2] = 1;
-  token.len_max[2] = 5;
+  token.len_max[2] = 6;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.sep[3]     = '$';
   token.len_min[3] = 64;
-  token.len_max[3] = 20000;
+  token.len_max[3] = 999999;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 


### PR DESCRIPTION
Similar to this one: https://github.com/hashcat/hashcat/commit/9fc193ce47d5be59460fb00ee26c80bae84fab96#diff-d3d21486db58c8a36a8326d073a16e99R143

if we use OPTS_TYPE_HASH_COPY, we should allow larger data buffers for the blockchain v2 hashes.

Thanks