### PR TITLE
fixes #2200: new WinZip tokenizer hex  data length problem

### DIFF
--- a/src/modules/module_13600.c
+++ b/src/modules/module_13600.c
@@ -162,7 +162,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.len_max[6] = 6;
   token.sep[6]     = '*';
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_DIGIT;
+                   | TOKEN_ATTR_VERIFY_HEX;
 
   token.len_min[7] = 0;
   token.len_max[7] = 16384;
@@ -233,7 +233,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *compress_length_pos = token.buf[6];
 
-  const u32 compress_length = hc_strtoul ((const char *) compress_length_pos, NULL, 10);
+  const u32 compress_length = hc_strtoul ((const char *) compress_length_pos, NULL, 16);
 
   zip2->compress_length = compress_length;
 
@@ -384,7 +384,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     sprintf (auth_tmp + j, "%02x", ptr[i]);
   }
 
-  const int line_len = snprintf (line_buf, line_size, "%s*%u*%u*%u*%s*%x*%u*%s*%s*%s",
+  const int line_len = snprintf (line_buf, line_size, "%s*%u*%u*%u*%s*%x*%x*%s*%s*%s",
     SIGNATURE_ZIP2_START,
     zip2->type,
     zip2->mode,

--- a/tools/test_modules/m13600.pm
+++ b/tools/test_modules/m13600.pm
@@ -94,7 +94,7 @@ sub module_generate_hash
 
   my $auth = hmac_hex ($data, $key_bin, \&sha1, 64);
 
-  my $hash = sprintf ('$zip2$*%u*%u*%u*%s*%s*%u*%s*%s*$/zip2$', $type, $mode, $magic, $salt, $verify_bytes, $compress_length, $data, substr ($auth, 0, 20));
+  my $hash = sprintf ('$zip2$*%u*%u*%u*%s*%s*%x*%s*%s*$/zip2$', $type, $mode, $magic, $salt, $verify_bytes, $compress_length, $data, substr ($auth, 0, 20));
 
   return $hash;
 }


### PR DESCRIPTION
in #2200 we noticed that the new tokenizer did not allow hexadecimal characters in the data length. This wasn't really a serious problem because we do not use that field (we use it only for the final hash encoding), but use the actual token.len[] instead (calculated field length)...

... but anyways, the problem is that the tokenizer (NOW, not release only beta of course) doesn't allow a-f in the data length field and therefore the hash is/was not accepted if and only if the hash length consisted of a...f hexadecimal characters to express the length.

also see: https://github.com/magnumripper/JohnTheRipper/blob/577b8873e3b7c9636685b387d2cbe2a89cc45115/src/zip2john.c#L76 (the length is always in hex according to the zip2john.c documentation).

This PR updates the 13600 module and the test module (to use hex, %x)

Thanks