### PR TITLE
minor: pip2 confirm uninstall fixed

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -59,7 +59,7 @@ ERRORS=$((ERRORS+$?))
 
 pip2 install pygost pycryptoplus
 
-pip2 -y uninstall pycryptodome
+pip2 uninstall -y pycryptodome
 
 ERRORS=$((ERRORS+$?))
 


### PR DESCRIPTION
The -y (confirm, accept, YES) for uninstalling the python module with pip2 must always come after the "uninstall" argument otherwise it gives an error.