### PR TITLE
Fix extra semicolon warnings

### DIFF
--- a/include/dynloader.h
+++ b/include/dynloader.h
@@ -28,46 +28,52 @@ hc_dynfunc_t hc_dlsym   (hc_dynlib_t handle, const char *symbol);
 #endif
 
 #define HC_LOAD_FUNC2(ptr,name,type,var,libname,noerr) \
-  ptr->name = (type) hc_dlsym (ptr->var, #name); \
-  if (noerr != -1) { \
-    if (!ptr->name) { \
-      if (noerr == 1) { \
-        event_log_error (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
-        return -1; \
-      } \
-      if (noerr != 1) { \
-        event_log_warning (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
-        return 0; \
+  do { \
+    ptr->name = (type) hc_dlsym (ptr->var, #name); \
+    if (noerr != -1) { \
+      if (!ptr->name) { \
+        if (noerr == 1) { \
+          event_log_error (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+          return -1; \
+        } \
+        if (noerr != 1) { \
+          event_log_warning (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+          return 0; \
+        } \
       } \
     } \
-  }
+  } while (0)
 
 #define HC_LOAD_FUNC(ptr,name,type,libname,noerr) \
-  ptr->name = (type) hc_dlsym (ptr->lib, #name); \
-  if (noerr != -1) { \
+  do { \
+    ptr->name = (type) hc_dlsym (ptr->lib, #name); \
+    if (noerr != -1) { \
+      if (!ptr->name) { \
+        if (noerr == 1) { \
+          event_log_error (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+          return -1; \
+        } \
+        if (noerr != 1) { \
+          event_log_warning (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+          return 0; \
+        } \
+      } \
+    } \
+  } while (0)
+
+#define HC_LOAD_ADDR(ptr,name,type,func,addr,libname,noerr) \
+  do { \
+    ptr->name = (type) (*ptr->func) (addr); \
     if (!ptr->name) { \
       if (noerr == 1) { \
-        event_log_error (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+        event_log_error (hashcat_ctx, "%s at address %08x is missing from %s shared library.", #name, addr, #libname); \
         return -1; \
       } \
       if (noerr != 1) { \
-        event_log_warning (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+        event_log_warning (hashcat_ctx, "%s at address %08x is missing from %s shared library.", #name, addr, #libname); \
         return 0; \
       } \
     } \
-  }
-
-#define HC_LOAD_ADDR(ptr,name,type,func,addr,libname,noerr) \
-  ptr->name = (type) (*ptr->func) (addr); \
-  if (!ptr->name) { \
-    if (noerr == 1) { \
-      event_log_error (hashcat_ctx, "%s at address %08x is missing from %s shared library.", #name, addr, #libname); \
-      return -1; \
-    } \
-    if (noerr != 1) { \
-      event_log_warning (hashcat_ctx, "%s at address %08x is missing from %s shared library.", #name, addr, #libname); \
-      return 0; \
-    } \
-  }
+  } while (0)
 
 #endif // _DYNALOADER_H

--- a/include/logfile.h
+++ b/include/logfile.h
@@ -14,25 +14,25 @@
 
 // logfile_append() checks for logfile_disable internally to make it easier from here
 
-#define logfile_top_msg(msg)                               logfile_append (hashcat_ctx, "%s\t%s",                  logfile_ctx->topid,                     (msg));
-#define logfile_sub_msg(msg)                               logfile_append (hashcat_ctx, "%s\t%s\t%s",              logfile_ctx->topid, logfile_ctx->subid, (msg));
-#define logfile_top_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%" PRIu64 "",     logfile_ctx->topid,                     (var), (u64)   (val));
-#define logfile_sub_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%s\t%" PRIu64 "", logfile_ctx->topid, logfile_ctx->subid, (var), (u64)   (val));
-#define logfile_top_var_uint(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%u",              logfile_ctx->topid,                     (var), (u32)   (val));
-#define logfile_sub_var_uint(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%s\t%u",          logfile_ctx->topid, logfile_ctx->subid, (var), (u32)   (val));
-#define logfile_top_var_char(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%c",              logfile_ctx->topid,                     (var), (char)  (val));
-#define logfile_sub_var_char(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%s\t%c",          logfile_ctx->topid, logfile_ctx->subid, (var), (char)  (val));
-#define logfile_top_var_string(var,val) if ((val) != NULL) logfile_append (hashcat_ctx, "%s\t%s\t%s",              logfile_ctx->topid,                     (var), (val));
-#define logfile_sub_var_string(var,val) if ((val) != NULL) logfile_append (hashcat_ctx, "%s\t%s\t%s\t%s",          logfile_ctx->topid, logfile_ctx->subid, (var), (val));
+#define logfile_top_msg(msg)                               logfile_append (hashcat_ctx, "%s\t%s",                  logfile_ctx->topid,                     (msg))
+#define logfile_sub_msg(msg)                               logfile_append (hashcat_ctx, "%s\t%s\t%s",              logfile_ctx->topid, logfile_ctx->subid, (msg))
+#define logfile_top_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%" PRIu64 "",     logfile_ctx->topid,                     (var), (u64)   (val))
+#define logfile_sub_var_uint64(var,val)                    logfile_append (hashcat_ctx, "%s\t%s\t%s\t%" PRIu64 "", logfile_ctx->topid, logfile_ctx->subid, (var), (u64)   (val))
+#define logfile_top_var_uint(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%u",              logfile_ctx->topid,                     (var), (u32)   (val))
+#define logfile_sub_var_uint(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%s\t%u",          logfile_ctx->topid, logfile_ctx->subid, (var), (u32)   (val))
+#define logfile_top_var_char(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%c",              logfile_ctx->topid,                     (var), (char)  (val))
+#define logfile_sub_var_char(var,val)                      logfile_append (hashcat_ctx, "%s\t%s\t%s\t%c",          logfile_ctx->topid, logfile_ctx->subid, (var), (char)  (val))
+#define logfile_top_var_string(var,val) if ((val) != NULL) logfile_append (hashcat_ctx, "%s\t%s\t%s",              logfile_ctx->topid,                     (var), (val))
+#define logfile_sub_var_string(var,val) if ((val) != NULL) logfile_append (hashcat_ctx, "%s\t%s\t%s\t%s",          logfile_ctx->topid, logfile_ctx->subid, (var), (val))
 
-#define logfile_top_uint(var)   logfile_top_var_uint   (#var, (var));
-#define logfile_sub_uint(var)   logfile_sub_var_uint   (#var, (var));
-#define logfile_top_uint64(var) logfile_top_var_uint64 (#var, (var));
-#define logfile_sub_uint64(var) logfile_sub_var_uint64 (#var, (var));
-#define logfile_top_char(var)   logfile_top_var_char   (#var, (var));
-#define logfile_sub_char(var)   logfile_sub_var_char   (#var, (var));
-#define logfile_top_string(var) logfile_top_var_string (#var, (var));
-#define logfile_sub_string(var) logfile_sub_var_string (#var, (var));
+#define logfile_top_uint(var)   logfile_top_var_uint   (#var, (var))
+#define logfile_sub_uint(var)   logfile_sub_var_uint   (#var, (var))
+#define logfile_top_uint64(var) logfile_top_var_uint64 (#var, (var))
+#define logfile_sub_uint64(var) logfile_sub_var_uint64 (#var, (var))
+#define logfile_top_char(var)   logfile_top_var_char   (#var, (var))
+#define logfile_sub_char(var)   logfile_sub_var_char   (#var, (var))
+#define logfile_top_string(var) logfile_top_var_string (#var, (var))
+#define logfile_sub_string(var) logfile_sub_var_string (#var, (var))
 
 void logfile_generate_topid (hashcat_ctx_t *hashcat_ctx);
 void logfile_generate_subid (hashcat_ctx_t *hashcat_ctx);

--- a/src/backend.c
+++ b/src/backend.c
@@ -921,19 +921,21 @@ int cuda_init (hashcat_ctx_t *hashcat_ctx)
   if (cuda->lib == NULL) return -1;
 
   #define HC_LOAD_FUNC_CUDA(ptr,name,cudaname,type,libname,noerr) \
-    ptr->name = (type) hc_dlsym ((ptr)->lib, #cudaname); \
-    if ((noerr) != -1) { \
-      if (!(ptr)->name) { \
-        if ((noerr) == 1) { \
-          event_log_error (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
-          return -1; \
-        } \
-        if ((noerr) != 1) { \
-          event_log_warning (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
-          return 0; \
+    do { \
+      ptr->name = (type) hc_dlsym ((ptr)->lib, #cudaname); \
+      if ((noerr) != -1) { \
+        if (!(ptr)->name) { \
+          if ((noerr) == 1) { \
+            event_log_error (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+            return -1; \
+          } \
+          if ((noerr) != 1) { \
+            event_log_warning (hashcat_ctx, "%s is missing from %s shared library.", #name, #libname); \
+            return 0; \
+          } \
         } \
       } \
-    }
+    } while (0)
 
   // finding the right symbol is a PITA, because of the _v2 suffix
   // a good reference is cuda.h itself
@@ -4877,7 +4879,7 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
   if (backend_ctx->ocl)
   {
     #define FREE_OPENCL_CTX_ON_ERROR          \
-    {                                         \
+    do {                                      \
       hcfree (opencl_platforms);              \
       hcfree (opencl_platforms_devices);      \
       hcfree (opencl_platforms_devices_cnt);  \
@@ -4885,7 +4887,7 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
       hcfree (opencl_platforms_vendor);       \
       hcfree (opencl_platforms_vendor_id);    \
       hcfree (opencl_platforms_version);      \
-    }
+    } while(0)
 
     cl_platform_id *opencl_platforms             = (cl_platform_id *) hccalloc (CL_PLATFORMS_MAX, sizeof (cl_platform_id));
     cl_uint         opencl_platforms_cnt         = 0;

--- a/src/cpu_crc32.c
+++ b/src/cpu_crc32.c
@@ -85,7 +85,7 @@ u32 cpu_crc32_buffer (const u8 *buf, const size_t length)
     crc = crc32tab[(crc ^ buf[pos]) & 0xff] ^ (crc >> 8);
   }
 
-  return crc ^ 0xffffffff;;
+  return crc ^ 0xffffffff;
 }
 
 int cpu_crc32 (const char *filename, u8 keytab[64])

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -518,22 +518,22 @@ static int nvml_init (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  HC_LOAD_FUNC(nvml, nvmlErrorString, NVML_ERROR_STRING, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlInit, NVML_INIT, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlShutdown, NVML_SHUTDOWN, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetCount, NVML_DEVICE_GET_COUNT, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetName, NVML_DEVICE_GET_NAME, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetHandleByIndex, NVML_DEVICE_GET_HANDLE_BY_INDEX, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetTemperature, NVML_DEVICE_GET_TEMPERATURE, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetFanSpeed, NVML_DEVICE_GET_FAN_SPEED, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetUtilizationRates, NVML_DEVICE_GET_UTILIZATION_RATES, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetClockInfo, NVML_DEVICE_GET_CLOCKINFO, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetTemperatureThreshold, NVML_DEVICE_GET_THRESHOLD, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetCurrPcieLinkGeneration, NVML_DEVICE_GET_CURRPCIELINKGENERATION, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetCurrPcieLinkWidth, NVML_DEVICE_GET_CURRPCIELINKWIDTH, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetCurrentClocksThrottleReasons, NVML_DEVICE_GET_CURRENTCLOCKSTHROTTLEREASONS, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetSupportedClocksThrottleReasons, NVML_DEVICE_GET_SUPPORTEDCLOCKSTHROTTLEREASONS, NVML, 0)
-  HC_LOAD_FUNC(nvml, nvmlDeviceGetPciInfo, NVML_DEVICE_GET_PCIINFO, NVML, 0)
+  HC_LOAD_FUNC(nvml, nvmlErrorString, NVML_ERROR_STRING, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlInit, NVML_INIT, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlShutdown, NVML_SHUTDOWN, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetCount, NVML_DEVICE_GET_COUNT, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetName, NVML_DEVICE_GET_NAME, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetHandleByIndex, NVML_DEVICE_GET_HANDLE_BY_INDEX, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetTemperature, NVML_DEVICE_GET_TEMPERATURE, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetFanSpeed, NVML_DEVICE_GET_FAN_SPEED, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetUtilizationRates, NVML_DEVICE_GET_UTILIZATION_RATES, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetClockInfo, NVML_DEVICE_GET_CLOCKINFO, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetTemperatureThreshold, NVML_DEVICE_GET_THRESHOLD, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetCurrPcieLinkGeneration, NVML_DEVICE_GET_CURRPCIELINKGENERATION, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetCurrPcieLinkWidth, NVML_DEVICE_GET_CURRPCIELINKWIDTH, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetCurrentClocksThrottleReasons, NVML_DEVICE_GET_CURRENTCLOCKSTHROTTLEREASONS, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetSupportedClocksThrottleReasons, NVML_DEVICE_GET_SUPPORTEDCLOCKSTHROTTLEREASONS, NVML, 0);
+  HC_LOAD_FUNC(nvml, nvmlDeviceGetPciInfo, NVML_DEVICE_GET_PCIINFO, NVML, 0);
 
   return 0;
 }
@@ -820,15 +820,15 @@ static int nvapi_init (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  HC_LOAD_FUNC(nvapi, nvapi_QueryInterface,             NVAPI_QUERYINTERFACE,             NVAPI,                0)
-  HC_LOAD_ADDR(nvapi, NvAPI_Initialize,                 NVAPI_INITIALIZE,                 nvapi_QueryInterface, 0x0150E828U, NVAPI, 0)
-  HC_LOAD_ADDR(nvapi, NvAPI_Unload,                     NVAPI_UNLOAD,                     nvapi_QueryInterface, 0xD22BDD7EU, NVAPI, 0)
-  HC_LOAD_ADDR(nvapi, NvAPI_GetErrorMessage,            NVAPI_GETERRORMESSAGE,            nvapi_QueryInterface, 0x6C2D048CU, NVAPI, 0)
-  HC_LOAD_ADDR(nvapi, NvAPI_EnumPhysicalGPUs,           NVAPI_ENUMPHYSICALGPUS,           nvapi_QueryInterface, 0xE5AC921FU, NVAPI, 0)
-  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetPerfPoliciesInfo,    NVAPI_GPU_GETPERFPOLICIESINFO,    nvapi_QueryInterface, 0x409D9841U, NVAPI, 0)
-  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetPerfPoliciesStatus,  NVAPI_GPU_GETPERFPOLICIESSTATUS,  nvapi_QueryInterface, 0x3D358A0CU, NVAPI, 0)
-  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetBusId,               NVAPI_GPU_GETBUSID,               nvapi_QueryInterface, 0x1BE0B8E5U, NVAPI, 0)
-  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetBusSlotId,           NVAPI_GPU_GETBUSSLOTID,           nvapi_QueryInterface, 0x2A0A350FU, NVAPI, 0)
+  HC_LOAD_FUNC(nvapi, nvapi_QueryInterface,             NVAPI_QUERYINTERFACE,             NVAPI,                0);
+  HC_LOAD_ADDR(nvapi, NvAPI_Initialize,                 NVAPI_INITIALIZE,                 nvapi_QueryInterface, 0x0150E828U, NVAPI, 0);
+  HC_LOAD_ADDR(nvapi, NvAPI_Unload,                     NVAPI_UNLOAD,                     nvapi_QueryInterface, 0xD22BDD7EU, NVAPI, 0);
+  HC_LOAD_ADDR(nvapi, NvAPI_GetErrorMessage,            NVAPI_GETERRORMESSAGE,            nvapi_QueryInterface, 0x6C2D048CU, NVAPI, 0);
+  HC_LOAD_ADDR(nvapi, NvAPI_EnumPhysicalGPUs,           NVAPI_ENUMPHYSICALGPUS,           nvapi_QueryInterface, 0xE5AC921FU, NVAPI, 0);
+  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetPerfPoliciesInfo,    NVAPI_GPU_GETPERFPOLICIESINFO,    nvapi_QueryInterface, 0x409D9841U, NVAPI, 0);
+  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetPerfPoliciesStatus,  NVAPI_GPU_GETPERFPOLICIESSTATUS,  nvapi_QueryInterface, 0x3D358A0CU, NVAPI, 0);
+  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetBusId,               NVAPI_GPU_GETBUSID,               nvapi_QueryInterface, 0x1BE0B8E5U, NVAPI, 0);
+  HC_LOAD_ADDR(nvapi, NvAPI_GPU_GetBusSlotId,           NVAPI_GPU_GETBUSSLOTID,           nvapi_QueryInterface, 0x2A0A350FU, NVAPI, 0);
 
   return 0;
 }
@@ -1045,27 +1045,27 @@ static int adl_init (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  HC_LOAD_FUNC(adl, ADL_Main_Control_Destroy, ADL_MAIN_CONTROL_DESTROY, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Main_Control_Create, ADL_MAIN_CONTROL_CREATE, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Adapter_NumberOfAdapters_Get, ADL_ADAPTER_NUMBEROFADAPTERS_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Adapter_AdapterInfo_Get, ADL_ADAPTER_ADAPTERINFO_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Display_DisplayInfo_Get, ADL_DISPLAY_DISPLAYINFO_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Adapter_ID_Get, ADL_ADAPTER_ID_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Adapter_VideoBiosInfo_Get, ADL_ADAPTER_VIDEOBIOSINFO_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive5_ThermalDevices_Enum, ADL_OVERDRIVE5_THERMALDEVICES_ENUM, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive5_Temperature_Get, ADL_OVERDRIVE5_TEMPERATURE_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive6_Temperature_Get, ADL_OVERDRIVE6_TEMPERATURE_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive5_CurrentActivity_Get, ADL_OVERDRIVE5_CURRENTACTIVITY_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive5_FanSpeedInfo_Get, ADL_OVERDRIVE5_FANSPEEDINFO_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive5_FanSpeed_Get, ADL_OVERDRIVE5_FANSPEED_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive6_FanSpeed_Get, ADL_OVERDRIVE6_FANSPEED_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Adapter_Active_Get, ADL_ADAPTER_ACTIVE_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive_Caps, ADL_OVERDRIVE_CAPS, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive6_Capabilities_Get, ADL_OVERDRIVE6_CAPABILITIES_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive6_StateInfo_Get, ADL_OVERDRIVE6_STATEINFO_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive6_CurrentStatus_Get, ADL_OVERDRIVE6_CURRENTSTATUS_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive6_TargetTemperatureData_Get, ADL_OVERDRIVE6_TARGETTEMPERATUREDATA_GET, ADL, 0)
-  HC_LOAD_FUNC(adl, ADL_Overdrive6_TargetTemperatureRangeInfo_Get, ADL_OVERDRIVE6_TARGETTEMPERATURERANGEINFO_GET, ADL, 0)
+  HC_LOAD_FUNC(adl, ADL_Main_Control_Destroy, ADL_MAIN_CONTROL_DESTROY, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Main_Control_Create, ADL_MAIN_CONTROL_CREATE, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Adapter_NumberOfAdapters_Get, ADL_ADAPTER_NUMBEROFADAPTERS_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Adapter_AdapterInfo_Get, ADL_ADAPTER_ADAPTERINFO_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Display_DisplayInfo_Get, ADL_DISPLAY_DISPLAYINFO_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Adapter_ID_Get, ADL_ADAPTER_ID_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Adapter_VideoBiosInfo_Get, ADL_ADAPTER_VIDEOBIOSINFO_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive5_ThermalDevices_Enum, ADL_OVERDRIVE5_THERMALDEVICES_ENUM, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive5_Temperature_Get, ADL_OVERDRIVE5_TEMPERATURE_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive6_Temperature_Get, ADL_OVERDRIVE6_TEMPERATURE_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive5_CurrentActivity_Get, ADL_OVERDRIVE5_CURRENTACTIVITY_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive5_FanSpeedInfo_Get, ADL_OVERDRIVE5_FANSPEEDINFO_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive5_FanSpeed_Get, ADL_OVERDRIVE5_FANSPEED_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive6_FanSpeed_Get, ADL_OVERDRIVE6_FANSPEED_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Adapter_Active_Get, ADL_ADAPTER_ACTIVE_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive_Caps, ADL_OVERDRIVE_CAPS, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive6_Capabilities_Get, ADL_OVERDRIVE6_CAPABILITIES_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive6_StateInfo_Get, ADL_OVERDRIVE6_STATEINFO_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive6_CurrentStatus_Get, ADL_OVERDRIVE6_CURRENTSTATUS_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive6_TargetTemperatureData_Get, ADL_OVERDRIVE6_TARGETTEMPERATUREDATA_GET, ADL, 0);
+  HC_LOAD_FUNC(adl, ADL_Overdrive6_TargetTemperatureRangeInfo_Get, ADL_OVERDRIVE6_TARGETTEMPERATURERANGEINFO_GET, ADL, 0);
 
   return 0;
 }
@@ -2247,12 +2247,12 @@ int hwmon_ctx_init (hashcat_ctx_t *hashcat_ctx)
   hm_attrs_t *hm_adapters_sysfs = (hm_attrs_t *) hccalloc (DEVICES_MAX, sizeof (hm_attrs_t));
 
   #define FREE_ADAPTERS         \
-  {                             \
+  do {                          \
     hcfree (hm_adapters_adl);   \
     hcfree (hm_adapters_nvapi); \
     hcfree (hm_adapters_nvml);  \
     hcfree (hm_adapters_sysfs); \
-  }
+  } while(0)
 
   if (backend_ctx->need_nvml == true)
   {

--- a/src/rp.c
+++ b/src/rp.c
@@ -218,8 +218,8 @@ int generate_random_rule (char rule_buf[RP_RULE_SIZE], const u32 rp_gen_func_min
 #define INCR_POS if (++rule_pos == rule_len) return (-1)
 
 #define SET_NAME(rule,val) (rule)->cmds[rule_cnt]  = ((val) & 0xff) <<  0
-#define SET_P0(rule,val)   INCR_POS; if (is_hex_notation (rule_buf, rule_len, rule_pos) == true) { (rule)->cmds[rule_cnt] |= (hex_convert (rule_buf[rule_pos + 3] & 0xff) <<  8) | (hex_convert (rule_buf[rule_pos + 2] & 0xff) << 12); rule_pos += 3; } else { (rule)->cmds[rule_cnt] |= ((val) & 0xff) <<  8; }
-#define SET_P1(rule,val)   INCR_POS; if (is_hex_notation (rule_buf, rule_len, rule_pos) == true) { (rule)->cmds[rule_cnt] |= (hex_convert (rule_buf[rule_pos + 3] & 0xff) << 16) | (hex_convert (rule_buf[rule_pos + 2] & 0xff) << 20); rule_pos += 3; } else { (rule)->cmds[rule_cnt] |= ((val) & 0xff) <<  16; }
+#define SET_P0(rule,val)   do { INCR_POS; if (is_hex_notation (rule_buf, rule_len, rule_pos) == true) { (rule)->cmds[rule_cnt] |= (hex_convert (rule_buf[rule_pos + 3] & 0xff) <<  8) | (hex_convert (rule_buf[rule_pos + 2] & 0xff) << 12); rule_pos += 3; } else { (rule)->cmds[rule_cnt] |= ((val) & 0xff) <<  8; } } while(0)
+#define SET_P1(rule,val)   do { INCR_POS; if (is_hex_notation (rule_buf, rule_len, rule_pos) == true) { (rule)->cmds[rule_cnt] |= (hex_convert (rule_buf[rule_pos + 3] & 0xff) << 16) | (hex_convert (rule_buf[rule_pos + 2] & 0xff) << 20); rule_pos += 3; } else { (rule)->cmds[rule_cnt] |= ((val) & 0xff) <<  16; } } while(0)
 #define GET_NAME(rule)     rule_cmd = (((rule)->cmds[rule_cnt] >>  0) & 0xff)
 #define GET_P0(rule)       INCR_POS; rule_buf[rule_pos] = (((rule)->cmds[rule_cnt] >>  8) & 0xff)
 #define GET_P1(rule)       INCR_POS; rule_buf[rule_pos] = (((rule)->cmds[rule_cnt] >> 16) & 0xff)


### PR DESCRIPTION
These macros don't need a ; but since ; is used, make the macros more
robust by enclosing them in a do while loop.

the dynloader diff looks weird. but it is correct.