### PR TITLE
Add Nexus legacy wallet support to -m 11300

### DIFF
--- a/OpenCL/m11300-pure.cl
+++ b/OpenCL/m11300-pure.cl
@@ -102,7 +102,7 @@ KERNEL_FQ void m11300_init (KERN_ATTR_TMPS_ESALT (bitcoin_wallet_tmp_t, bitcoin_
 
   sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
 
-  sha512_update_global_swap (&ctx, salt_bufs[salt_pos].salt_buf, salt_bufs[salt_pos].salt_len);
+  sha512_update_global_swap (&ctx, salt_bufs[salt_pos].salt_buf, 8);
 
   sha512_final (&ctx);
 
@@ -293,13 +293,6 @@ KERNEL_FQ void m11300_comp (KERN_ATTR_TMPS_ESALT (bitcoin_wallet_tmp_t, bitcoin_
   key[6] = h32_from_64_S (dgst[3]);
   key[7] = l32_from_64_S (dgst[3]);
 
-  u32 iv[4];
-
-  iv[0] = h32_from_64_S (dgst[4]);
-  iv[1] = l32_from_64_S (dgst[4]);
-  iv[2] = h32_from_64_S (dgst[5]);
-  iv[3] = l32_from_64_S (dgst[5]);
-
   #define KEYLEN 60
 
   u32 ks[KEYLEN];
@@ -308,10 +301,18 @@ KERNEL_FQ void m11300_comp (KERN_ATTR_TMPS_ESALT (bitcoin_wallet_tmp_t, bitcoin_
 
   u32 out[4];
 
-  for (u32 i = 0; i < esalt_bufs[digests_offset].cry_master_len; i += 16)
   {
-    u32 data[4];
+    u32 i = esalt_bufs[digests_offset].cry_master_len - 32;
 
+    u32 iv[4];
+    iv[0] = hc_swap32_S (esalt_bufs[digests_offset].cry_master_buf[(i / 4) + 0]);
+    iv[1] = hc_swap32_S (esalt_bufs[digests_offset].cry_master_buf[(i / 4) + 1]);
+    iv[2] = hc_swap32_S (esalt_bufs[digests_offset].cry_master_buf[(i / 4) + 2]);
+    iv[3] = hc_swap32_S (esalt_bufs[digests_offset].cry_master_buf[(i / 4) + 3]);
+
+    i += 16;
+
+    u32 data[4];
     data[0] = hc_swap32_S (esalt_bufs[digests_offset].cry_master_buf[(i / 4) + 0]);
     data[1] = hc_swap32_S (esalt_bufs[digests_offset].cry_master_buf[(i / 4) + 1]);
     data[2] = hc_swap32_S (esalt_bufs[digests_offset].cry_master_buf[(i / 4) + 2]);
@@ -323,17 +324,19 @@ KERNEL_FQ void m11300_comp (KERN_ATTR_TMPS_ESALT (bitcoin_wallet_tmp_t, bitcoin_
     out[1] ^= iv[1];
     out[2] ^= iv[2];
     out[3] ^= iv[3];
-
-    iv[0] = data[0];
-    iv[1] = data[1];
-    iv[2] = data[2];
-    iv[3] = data[3];
   }
 
-  if ((out[0] == 0x10101010)
-   && (out[1] == 0x10101010)
-   && (out[2] == 0x10101010)
-   && (out[3] == 0x10101010))
+  u32 pad;
+  if (salt_bufs[salt_pos].salt_len != 18) /* most wallets */
+  {
+    pad = 0x10101010;
+    if (out[0] != pad || out[1] != pad)
+      return;
+  } else { /* Nexus legacy wallet */
+    pad = 0x08080808;
+  }
+
+  if (out[2] == pad && out[3] == pad)
   {
     if (atomic_inc (&hashes_shown[digests_offset]) == 0)
     {


### PR DESCRIPTION
Related to #2219, this adds Nexus legacy wallet support to mode 11300, which amounts to two things:

1. Accept salt size of 36 hex characters, but treat it the same as 16 (only use first 16 hex characters) except it indicating this wallet type.

2. Expect different padding in the last AES block - 8 bytes of 0x08 instead of 16 bytes of 0x10 - because this wallet's full mkey size is 72 (which gives 8 modulo AES block size of 16) instead of the usual 32.

Test vector I used:

```
$bitcoin$64$6b0fbcd048e791edbab30408e14ee24cc51493b810afb61a1e59bc633993a093$36$74fc96a47606814567f02c7df532f6079cbd$169021$2$00$2$00
```

The password is "openwall". The test wallet was generated with `Nexus-Qt-Linux-0_2_0_5.tar.gz` and processed with current/work-in-progress revision of JtR's `bitcoin2john.py`. Older versions of that script would also process the wallet correctly, including for use with hashcat with this PR's changes, but they would include extraneous data. The above has placeholders in the last two fields, which are unneeded for password cracking.

While at it, I also changed a few things for all wallet types supported in this mode:

1. Instead of decrypting the full mkey (or whatever trailing portion of it is available in the input "hash"), decrypt only one final block using the previous block as IV. This is very slightly faster since it saves at least one AES block decryption (we keep at least two blocks in the "hash" since the penultimate block is needed as IV for the final block), although the difference is negligible given that it's done after having done (usually) thousands of iterations of SHA-512. As a side-effect of this change, the kernel now requires mkey size to be at least 32 bytes, whereas previously it could also handle 16, but I'm unaware of any wallet with mkey size less than 32. This side-effect is easy to avoid (just set IV like the code did before when the mkey size is 16 bytes) if there's any reason to.

2. Correct mkey length validation. Previously, the code checked for `% 16` giving zero, but that check worked on the number of hex characters, not bytes, whereas AES block size is 16 _bytes_. This is now changed to `% 32`, and now we also check that there are at least 64 hex characters (two AES blocks, which is required per the point above).

3. Allow 3-digit numbers for encoded mkey size, since the code previously allowed for up to 256 for the next field's length, and that's a 3-digit number. We could reduce that limit instead, which would also achieve consistency, but I saw no reason to. Nexus wallet's mkey size is 72 bytes, which is 144 hex characters. Our current `bitcoin2john.py` script would only encode the last 64 hex characters, but revisions from ~2+ years ago could encode the full 144.