### PR TITLE
formatting: remove extra whitespace in terminal.c

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1138,7 +1138,7 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
   event_log_info (hashcat_ctx,
     "Hash.Target......: %s",
     hashcat_status->hash_target);
-  
+
   if (user_options->force == true)
   {
     event_log_info (hashcat_ctx,
@@ -1152,7 +1152,8 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     "Time.Started.....: %s (%s)",
     hashcat_status->time_started_absolute,
     hashcat_status->time_started_relative);
-  }  
+  }
+
   if (user_options->force == true)
   {
     event_log_info (hashcat_ctx,
@@ -1167,7 +1168,7 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     hashcat_status->time_estimated_absolute,
     hashcat_status->time_estimated_relative);
   }
-  
+
   switch (hashcat_status->guess_mode)
   {
     case GUESS_MODE_STRAIGHT_FILE:


### PR DESCRIPTION
This little whitespace noise was introduced with #2230 and I suggest getting rid of it because it's not necessary here (we try to be very strict in such cases when it comes to formatting and extra spaces etc).

This is a minor formatting change without any major effects to the code.

Thanks