### PR TITLE
new PR for mode 21600, as discussed on previous thread for 12101 

### DIFF
--- a/OpenCL/m21600-pure.cl
+++ b/OpenCL/m21600-pure.cl
@@ -1,0 +1,353 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha512.cl"
+#endif
+
+#define COMPARE_S "inc_comp_single.cl"
+#define COMPARE_M "inc_comp_multi.cl"
+
+typedef struct pbkdf2_sha512_tmp
+{
+  u64  ipad[8];
+  u64  opad[8];
+
+  u64  dgst[16];
+  u64  out[16];
+
+} pbkdf2_sha512_tmp_t;
+
+typedef struct pbkdf2_sha512
+{
+  u32 salt_buf[64];
+  u32 hash_buf[64];
+  u32 salt_iter;
+  u32 salt_len;
+  u32 hash_len;
+
+} pbkdf2_sha512_t;
+
+DECLSPEC void hmac_sha512_run_V (u32x *w0, u32x *w1, u32x *w2, u32x *w3, u32x *w4, u32x *w5, u32x *w6, u32x *w7, u64x *ipad, u64x *opad, u64x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+  digest[5] = ipad[5];
+  digest[6] = ipad[6];
+  digest[7] = ipad[7];
+
+  sha512_transform_vector (w0, w1, w2, w3, w4, w5, w6, w7, digest);
+
+  w0[0] = h32_from_64 (digest[0]);
+  w0[1] = l32_from_64 (digest[0]);
+  w0[2] = h32_from_64 (digest[1]);
+  w0[3] = l32_from_64 (digest[1]);
+  w1[0] = h32_from_64 (digest[2]);
+  w1[1] = l32_from_64 (digest[2]);
+  w1[2] = h32_from_64 (digest[3]);
+  w1[3] = l32_from_64 (digest[3]);
+  w2[0] = h32_from_64 (digest[4]);
+  w2[1] = l32_from_64 (digest[4]);
+  w2[2] = h32_from_64 (digest[5]);
+  w2[3] = l32_from_64 (digest[5]);
+  w3[0] = h32_from_64 (digest[6]);
+  w3[1] = l32_from_64 (digest[6]);
+  w3[2] = h32_from_64 (digest[7]);
+  w3[3] = l32_from_64 (digest[7]);
+  w4[0] = 0x80000000;
+  w4[1] = 0;
+  w4[2] = 0;
+  w4[3] = 0;
+  w5[0] = 0;
+  w5[1] = 0;
+  w5[2] = 0;
+  w5[3] = 0;
+  w6[0] = 0;
+  w6[1] = 0;
+  w6[2] = 0;
+  w6[3] = 0;
+  w7[0] = 0;
+  w7[1] = 0;
+  w7[2] = 0;
+  w7[3] = (128 + 64) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+  digest[5] = opad[5];
+  digest[6] = opad[6];
+  digest[7] = opad[7];
+
+  sha512_transform_vector (w0, w1, w2, w3, w4, w5, w6, w7, digest);
+}
+
+KERNEL_FQ void m21600_init (KERN_ATTR_TMPS_ESALT (pbkdf2_sha512_tmp_t, pbkdf2_sha512_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  sha512_hmac_ctx_t sha512_hmac_ctx;
+
+  sha512_hmac_init_global_swap (&sha512_hmac_ctx, pws[gid].i, pws[gid].pw_len);
+
+  tmps[gid].ipad[0] = sha512_hmac_ctx.ipad.h[0];
+  tmps[gid].ipad[1] = sha512_hmac_ctx.ipad.h[1];
+  tmps[gid].ipad[2] = sha512_hmac_ctx.ipad.h[2];
+  tmps[gid].ipad[3] = sha512_hmac_ctx.ipad.h[3];
+  tmps[gid].ipad[4] = sha512_hmac_ctx.ipad.h[4];
+  tmps[gid].ipad[5] = sha512_hmac_ctx.ipad.h[5];
+  tmps[gid].ipad[6] = sha512_hmac_ctx.ipad.h[6];
+  tmps[gid].ipad[7] = sha512_hmac_ctx.ipad.h[7];
+
+  tmps[gid].opad[0] = sha512_hmac_ctx.opad.h[0];
+  tmps[gid].opad[1] = sha512_hmac_ctx.opad.h[1];
+  tmps[gid].opad[2] = sha512_hmac_ctx.opad.h[2];
+  tmps[gid].opad[3] = sha512_hmac_ctx.opad.h[3];
+  tmps[gid].opad[4] = sha512_hmac_ctx.opad.h[4];
+  tmps[gid].opad[5] = sha512_hmac_ctx.opad.h[5];
+  tmps[gid].opad[6] = sha512_hmac_ctx.opad.h[6];
+  tmps[gid].opad[7] = sha512_hmac_ctx.opad.h[7];
+
+  sha512_hmac_update_global_swap (&sha512_hmac_ctx, esalt_bufs[digests_offset].salt_buf, salt_bufs[salt_pos].salt_len);
+
+  for (u32 i = 0, j = 1; i < 8; i += 8, j += 1)
+  {
+    sha512_hmac_ctx_t sha512_hmac_ctx2 = sha512_hmac_ctx;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+    u32 w4[4];
+    u32 w5[4];
+    u32 w6[4];
+    u32 w7[4];
+
+    w0[0] = j;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+    w4[0] = 0;
+    w4[1] = 0;
+    w4[2] = 0;
+    w4[3] = 0;
+    w5[0] = 0;
+    w5[1] = 0;
+    w5[2] = 0;
+    w5[3] = 0;
+    w6[0] = 0;
+    w6[1] = 0;
+    w6[2] = 0;
+    w6[3] = 0;
+    w7[0] = 0;
+    w7[1] = 0;
+    w7[2] = 0;
+    w7[3] = 0;
+
+    sha512_hmac_update_128 (&sha512_hmac_ctx2, w0, w1, w2, w3, w4, w5, w6, w7, 4);
+
+    sha512_hmac_final (&sha512_hmac_ctx2);
+
+    tmps[gid].dgst[i + 0] = sha512_hmac_ctx2.opad.h[0];
+    tmps[gid].dgst[i + 1] = sha512_hmac_ctx2.opad.h[1];
+    tmps[gid].dgst[i + 2] = sha512_hmac_ctx2.opad.h[2];
+    tmps[gid].dgst[i + 3] = sha512_hmac_ctx2.opad.h[3];
+    tmps[gid].dgst[i + 4] = sha512_hmac_ctx2.opad.h[4];
+    tmps[gid].dgst[i + 5] = sha512_hmac_ctx2.opad.h[5];
+    tmps[gid].dgst[i + 6] = sha512_hmac_ctx2.opad.h[6];
+    tmps[gid].dgst[i + 7] = sha512_hmac_ctx2.opad.h[7];
+
+    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+    tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
+    tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
+    tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
+  }
+}
+
+KERNEL_FQ void m21600_loop (KERN_ATTR_TMPS_ESALT (pbkdf2_sha512_tmp_t, pbkdf2_sha512_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= gid_max) return;
+
+  u64x ipad[8];
+  u64x opad[8];
+
+  ipad[0] = pack64v (tmps, ipad, gid, 0);
+  ipad[1] = pack64v (tmps, ipad, gid, 1);
+  ipad[2] = pack64v (tmps, ipad, gid, 2);
+  ipad[3] = pack64v (tmps, ipad, gid, 3);
+  ipad[4] = pack64v (tmps, ipad, gid, 4);
+  ipad[5] = pack64v (tmps, ipad, gid, 5);
+  ipad[6] = pack64v (tmps, ipad, gid, 6);
+  ipad[7] = pack64v (tmps, ipad, gid, 7);
+
+  opad[0] = pack64v (tmps, opad, gid, 0);
+  opad[1] = pack64v (tmps, opad, gid, 1);
+  opad[2] = pack64v (tmps, opad, gid, 2);
+  opad[3] = pack64v (tmps, opad, gid, 3);
+  opad[4] = pack64v (tmps, opad, gid, 4);
+  opad[5] = pack64v (tmps, opad, gid, 5);
+  opad[6] = pack64v (tmps, opad, gid, 6);
+  opad[7] = pack64v (tmps, opad, gid, 7);
+
+  for (u32 i = 0; i < 8; i += 8)
+  {
+    u64x dgst[8];
+    u64x out[8];
+
+    dgst[0] = pack64v (tmps, dgst, gid, i + 0);
+    dgst[1] = pack64v (tmps, dgst, gid, i + 1);
+    dgst[2] = pack64v (tmps, dgst, gid, i + 2);
+    dgst[3] = pack64v (tmps, dgst, gid, i + 3);
+    dgst[4] = pack64v (tmps, dgst, gid, i + 4);
+    dgst[5] = pack64v (tmps, dgst, gid, i + 5);
+    dgst[6] = pack64v (tmps, dgst, gid, i + 6);
+    dgst[7] = pack64v (tmps, dgst, gid, i + 7);
+
+    out[0] = pack64v (tmps, out, gid, i + 0);
+    out[1] = pack64v (tmps, out, gid, i + 1);
+    out[2] = pack64v (tmps, out, gid, i + 2);
+    out[3] = pack64v (tmps, out, gid, i + 3);
+    out[4] = pack64v (tmps, out, gid, i + 4);
+    out[5] = pack64v (tmps, out, gid, i + 5);
+    out[6] = pack64v (tmps, out, gid, i + 6);
+    out[7] = pack64v (tmps, out, gid, i + 7);
+
+    for (u32 j = 0; j < loop_cnt; j++)
+    {
+      u32x w0[4];
+      u32x w1[4];
+      u32x w2[4];
+      u32x w3[4];
+      u32x w4[4];
+      u32x w5[4];
+      u32x w6[4];
+      u32x w7[4];
+
+      w0[0] = h32_from_64 (dgst[0]);
+      w0[1] = l32_from_64 (dgst[0]);
+      w0[2] = h32_from_64 (dgst[1]);
+      w0[3] = l32_from_64 (dgst[1]);
+      w1[0] = h32_from_64 (dgst[2]);
+      w1[1] = l32_from_64 (dgst[2]);
+      w1[2] = h32_from_64 (dgst[3]);
+      w1[3] = l32_from_64 (dgst[3]);
+      w2[0] = h32_from_64 (dgst[4]);
+      w2[1] = l32_from_64 (dgst[4]);
+      w2[2] = h32_from_64 (dgst[5]);
+      w2[3] = l32_from_64 (dgst[5]);
+      w3[0] = h32_from_64 (dgst[6]);
+      w3[1] = l32_from_64 (dgst[6]);
+      w3[2] = h32_from_64 (dgst[7]);
+      w3[3] = l32_from_64 (dgst[7]);
+      w4[0] = 0x80000000;
+      w4[1] = 0;
+      w4[2] = 0;
+      w4[3] = 0;
+      w5[0] = 0;
+      w5[1] = 0;
+      w5[2] = 0;
+      w5[3] = 0;
+      w6[0] = 0;
+      w6[1] = 0;
+      w6[2] = 0;
+      w6[3] = 0;
+      w7[0] = 0;
+      w7[1] = 0;
+      w7[2] = 0;
+      w7[3] = (128 + 64) * 8;
+
+      hmac_sha512_run_V (w0, w1, w2, w3, w4, w5, w6, w7, ipad, opad, dgst);
+
+      out[0] ^= dgst[0];
+      out[1] ^= dgst[1];
+      out[2] ^= dgst[2];
+      out[3] ^= dgst[3];
+      out[4] ^= dgst[4];
+      out[5] ^= dgst[5];
+      out[6] ^= dgst[6];
+      out[7] ^= dgst[7];
+    }
+
+    unpack64v (tmps, dgst, gid, i + 0, dgst[0]);
+    unpack64v (tmps, dgst, gid, i + 1, dgst[1]);
+    unpack64v (tmps, dgst, gid, i + 2, dgst[2]);
+    unpack64v (tmps, dgst, gid, i + 3, dgst[3]);
+    unpack64v (tmps, dgst, gid, i + 4, dgst[4]);
+    unpack64v (tmps, dgst, gid, i + 5, dgst[5]);
+    unpack64v (tmps, dgst, gid, i + 6, dgst[6]);
+    unpack64v (tmps, dgst, gid, i + 7, dgst[7]);
+
+    unpack64v (tmps, out, gid, i + 0, out[0]);
+    unpack64v (tmps, out, gid, i + 1, out[1]);
+    unpack64v (tmps, out, gid, i + 2, out[2]);
+    unpack64v (tmps, out, gid, i + 3, out[3]);
+    unpack64v (tmps, out, gid, i + 4, out[4]);
+    unpack64v (tmps, out, gid, i + 5, out[5]);
+    unpack64v (tmps, out, gid, i + 6, out[6]);
+    unpack64v (tmps, out, gid, i + 7, out[7]);
+  }
+}
+
+KERNEL_FQ void m21600_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha512_tmp_t, pbkdf2_sha512_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  const u64 lid = get_local_id (0);
+
+  const u64 a = tmps[gid].out[0];
+  const u64 b = tmps[gid].out[1];
+
+  const u32 r0 = l32_from_64_S (a);
+  const u32 r1 = h32_from_64_S (a);
+  const u32 r2 = l32_from_64_S (b);
+  const u32 r3 = h32_from_64_S (b);
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -54,6 +54,7 @@
 - Added hash-mode: sha256(md5($pass))
 - Added hash-mode: sha256(sha256_bin(pass))
 - Added hash-mode: sha256(sha256($pass).$salt)
+- Added hash-mode: pbkdf2(iter,20,sha512) (web2py variant)
 
 ##
 ## Bugs

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -78,4 +78,7 @@ Rick "Minga" Redman and KoreLogic <mingakore@gmail.com> (@CrackMeIfYouCan)
 Brandon Chalk <brandon@casaba.com> (@brandoncasaba)
 * Kerberos Pre-Auth 17/18 kernel module, ported from @Fist0urs TGS kernel modules
 
+Jamie Riden <jamie@blacktraffic.co.uk>
+* module_21600.c - web2py pbkdf2 variant
+
 !!! All the package maintainer of hashcat !!!

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -133,6 +133,7 @@ NVIDIA GPUs require "NVIDIA Driver" (418.56 or later) and "CUDA Toolkit" (10.1 o
 - PBKDF2-HMAC-SHA1
 - PBKDF2-HMAC-SHA256
 - PBKDF2-HMAC-SHA512
+- web2py variant of PBKDF2-HMAC-SHA512
 - scrypt
 - phpass
 - Ansible Vault

--- a/src/modules/module_21600.c
+++ b/src/modules/module_21600.c
@@ -1,0 +1,308 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_8_16;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_FRAMEWORK;
+static const char *HASH_NAME      = "web2py PBKDF2-HMAC-SHA512";
+static const u64   KERN_TYPE      = 21600;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_USES_BITS_64
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP ;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE ;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "mysecret";
+static const char *ST_HASH        = "pbkdf2(1000,20,sha512)$a2a2ca127df6bc19$77bb5a3d129e2ce710daaefeefef8356c4c827ff";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+static const char *SIGNATURE_WEB2PY = "pbkdf2";
+static const char *SIGNATURE_WEB2PY_PARAMS = "20,sha512)";
+
+typedef struct pbkdf2_sha512
+{
+  u32 salt_buf[64];
+  u32 hash_buf[64];
+  u32 salt_iter;
+  u32 salt_len;
+  u32 hash_len;
+
+} pbkdf2_sha512_t;
+
+typedef struct pbkdf2_sha512_tmp
+{
+  u64  ipad[8];
+  u64  opad[8];
+
+  u64  dgst[16];
+  u64  out[16];
+
+} pbkdf2_sha512_tmp_t;
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (pbkdf2_sha512_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (pbkdf2_sha512_tmp_t);
+
+  return tmp_size;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // this overrides the reductions of PW_MAX in case optimized kernel is selected
+  // IOW, even in optimized kernel mode it support length 256
+
+  const u32 pw_max = PW_MAX;
+
+  return pw_max;
+}
+
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  char *jit_build_options = NULL;
+
+  if (device_param->opencl_device_vendor_id == VENDOR_ID_AMD)
+  {
+    hc_asprintf (&jit_build_options, "-D NO_UNROLL");
+  }
+
+  return jit_build_options;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u64 *digest = (u64 *) digest_buf;
+
+  pbkdf2_sha512_t *pbkdf2_sha512 = (pbkdf2_sha512_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt  = 4;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_WEB2PY;
+
+  token.len_min[0] = 6;
+  token.len_max[0] = 6;
+  token.sep[0]     = '(';
+  token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // skip the rest 
+  token.sep[1]     = '$';
+  token.len_min[1] = 2;
+  token.len_max[1] = 280;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH ;
+
+  token.sep[2]     = '$';
+  token.len_min[2] = SALT_MIN;
+  token.len_max[2] = SALT_MAX;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH ;
+
+  token.len_min[3] = 16;
+  token.len_max[3] = 256;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // iteration count
+
+  const u8 *iter_pos = token.buf[0] + 7; 
+
+  u8* trail;
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, (char**) &trail, 10);
+
+  salt->salt_iter = iter - 1;
+
+  pbkdf2_sha512->salt_iter = salt->salt_iter;
+
+  // match "20,sha512" for next bit after the iterator
+  if (strncmp((const char*) trail+1,SIGNATURE_WEB2PY_PARAMS,10)!=0)
+  {
+      return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
+  // salt
+
+  const u8 *salt_pos = token.buf[2];
+  const int salt_len = token.len[2];
+
+  memcpy (pbkdf2_sha512->salt_buf, salt_pos, salt_len);
+
+  pbkdf2_sha512->salt_len=salt_len;
+
+  salt->salt_len = salt_len;
+
+  salt->salt_buf[0] = pbkdf2_sha512->salt_buf[0];
+  salt->salt_buf[1] = pbkdf2_sha512->salt_buf[1];
+  salt->salt_buf[2] = pbkdf2_sha512->salt_buf[2];
+  salt->salt_buf[3] = pbkdf2_sha512->salt_buf[3];
+  salt->salt_buf[4] = pbkdf2_sha512->salt_buf[4];
+  salt->salt_buf[5] = pbkdf2_sha512->salt_buf[5];
+  salt->salt_buf[6] = pbkdf2_sha512->salt_buf[6];
+  salt->salt_buf[7] = pbkdf2_sha512->salt_buf[7];
+
+  // hash
+
+  const u8 *hash_pos = token.buf[3];
+  const int hash_len = token.len[3];
+
+  digest[0] = hex_to_u64 (hash_pos +   0);
+  digest[1] = hex_to_u64 (hash_pos +  16);
+  digest[2] = hex_to_u64 (hash_pos +  32);
+  digest[3] = hex_to_u64 (hash_pos +  48);
+  digest[4] = hex_to_u64 (hash_pos +  64);
+  digest[5] = hex_to_u64 (hash_pos +  80);
+  digest[6] = hex_to_u64 (hash_pos +  96);
+  digest[7] = hex_to_u64 (hash_pos + 112);
+
+  digest[0] = byte_swap_64 (digest[0]);
+  digest[1] = byte_swap_64 (digest[1]);
+  digest[2] = byte_swap_64 (digest[2]);
+  digest[3] = byte_swap_64 (digest[3]);
+  digest[4] = byte_swap_64 (digest[4]);
+  digest[5] = byte_swap_64 (digest[5]);
+  digest[6] = byte_swap_64 (digest[6]);
+  digest[7] = byte_swap_64 (digest[7]);
+
+  memcpy (pbkdf2_sha512->hash_buf, hash_pos, hash_len);
+
+  pbkdf2_sha512->hash_len=hash_len;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+
+  pbkdf2_sha512_t *pbkdf2_sha512 = (pbkdf2_sha512_t *) esalt_buf;
+
+  int line_len = snprintf(line_buf, line_size, "pbkdf2(%d,20,sha512)$", pbkdf2_sha512->salt_iter+1);
+
+  u8 *salt_pos = (u8*) pbkdf2_sha512->salt_buf;
+
+  for (u32 i = 0; i < pbkdf2_sha512->salt_len; i++)
+  {
+    line_len += snprintf (line_buf + line_len, line_size, "%c", *salt_pos++);
+  }
+
+  line_len += snprintf (line_buf + line_len, line_size, "$");
+
+  u8 *hash_pos = (u8*) pbkdf2_sha512->hash_buf;
+  
+  for (u32 i = 0; i < pbkdf2_sha512->hash_len; i++)
+  {
+    line_len += snprintf (line_buf + line_len, line_size - line_len, "%c", *hash_pos++);
+  }
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m21600.pm
+++ b/tools/test_modules/m21600.pm
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use MIME::Base64 qw (encode_base64 decode_base64);
+use Crypt::PBKDF2;
+
+sub module_constraints { [[0, 256], [1, 15], [-1, -1], [-1, -1], [-1, -1]] }
+
+#pbkdf2(1000,20,sha512)$a2a2ca127df6bc19$77bb5a3d129e2ce710daaefeefef8356c4c827ff";
+
+sub module_generate_hash
+{
+  my $word       = shift;
+  my $salt       = shift;
+  my $iterations = shift // 1000;
+  my $out_len    = shift // 16;
+
+  my $pbkdf2 = Crypt::PBKDF2->new
+  (
+    hasher     => Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 512),
+    iterations => $iterations,
+    output_len => $out_len
+  );
+
+  my $digest = $pbkdf2->PBKDF2 ($salt, $word);
+  my $digest_hex = unpack "H*", $digest;
+
+  my $hash = sprintf ('pbkdf2(%i,20,sha512)$%s$%s', $iterations, $salt, $digest_hex);
+
+  return $hash;
+}
+
+#pbkdf2(1000,20,sha512)$a2a2ca127df6bc19$77bb5a3d129e2ce710daaefeefef8356c4c827ff";
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($digest, $word) = split (/:([^:]+)$/, $line);
+
+  return unless defined $digest;
+  return unless defined $word;
+
+  my ($intro, $salt, $hash_encoded) = split ('$', $digest);
+  my ($signature, $iterations, $len, $prf) = split (m/[\(\),]/, $digest);
+
+  return unless ($signature eq 'pbkdf2');
+  return unless ($prf eq 'sha512');
+  return unless defined $iterations;
+  return unless defined $hash_encoded;
+
+  my $hash = pack 'H*',$hash_encoded;
+
+  my $out_len = length ($hash);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $iterations, $out_len);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
My tests are passing in the previous tree, failing in the current one, but 12100, 21700 are also failing for me, so I wonder if it's a change that's been recently introduced? e.g. 

./tools/test.sh -m 12100 -a all -t all
[ test_1574610221 ] > Init test for hash type 12100.
[ test_1574610221 ] [ Type 12100, Attack 0, Mode single, Device-Type Gpu, Vector-Width 1 ] > Error : 0/8 not found, 8/8 not matched, 0/8 timeout
[ test_1574610221 ] [ Type 12100, Attack 0, Mode multi,  Device-Type Gpu, Vector-Width 1 ] > Error : 0/1 not found, 1/1 not matched, 0/1 timeout
[ test_1574610221 ] [ Type 12100, Attack 0, Mode single, Device-Type Gpu, Vector-Width 4 ] > Error : 0/8 not found, 8/8 not matched, 0/8 timeout
[ test_1574610221 ] [ Type 12100, Attack 0, Mode multi,  Device-Type Gpu, Vector-Width 4 ] > Error : 0/1 not found, 1/1 not matched, 0/1 timeout