### PR TITLE
electrum5: simplify zlib rejection check

### DIFF
--- a/OpenCL/m21800-pure.cl
+++ b/OpenCL/m21800-pure.cl
@@ -513,7 +513,7 @@ KERNEL_FQ void m21800_comp (KERN_ATTR_TMPS_ESALT (electrum_tmp_t, electrum_t))
 
   // early reject
 
-  if (buf[0] & 0x0006ffff != 0x00049c78) return; // allow 0b100 or 0b101 at the end of 3rd byte
+  if ((buf[0] & 0x0006ffff) != 0x00049c78) return; // allow 0b100 or 0b101 at the end of 3rd byte
 
   buf[1] ^= iv[1];
   buf[2] ^= iv[2];

--- a/OpenCL/m21800-pure.cl
+++ b/OpenCL/m21800-pure.cl
@@ -513,9 +513,7 @@ KERNEL_FQ void m21800_comp (KERN_ATTR_TMPS_ESALT (electrum_tmp_t, electrum_t))
 
   // early reject
 
-  u32 zlib_header = buf[0] & 0x0007ffff;
-
-  if ((zlib_header != 0x00049c78) && (zlib_header != 0x00059c78)) return;
+  if (buf[0] & 0x0006ffff != 0x00049c78) return; // allow 0b100 or 0b101 at the end of 3rd byte
 
   buf[1] ^= iv[1];
   buf[2] ^= iv[2];


### PR DESCRIPTION
This is just a cleaner/simplified version of the 0x04 or 0x05 from https://github.com/hashcat/hashcat/pull/2246.
My guess is that the compiler would optimize this itself, but let's just use this more compact code anyway.
Thanks