### PR TITLE
usage/help: use crack_pos everywhere instead of mixing crackpos w/ crack_pos

### DIFF
--- a/src/usage.c
+++ b/src/usage.c
@@ -162,7 +162,7 @@ static const char *const USAGE_BIG_POST_HASHMODES[] =
   "  5 | hash[:salt]:hex_plain",
   "  6 | plain:hex_plain",
   "  7 | hash[:salt]:plain:hex_plain",
-  "  8 | crackpos",
+  "  8 | crack_pos",
   "  9 | hash[:salt]:crack_pos",
   " 10 | plain:crack_pos",
   " 11 | hash[:salt]:plain:crack_pos",


### PR DESCRIPTION
We are actually currently discussing about a new way to let users set the --outfile-format and add timestamp to the format list... but for the time being I suggest to make this little change, since it seems to be a typo (or at least very weird that we are not consistently using the same term).

I think crack_pos should be preferred, because we also use hex_plain (with underscore). Furthermore, we have more formats using "crack_pos" versus "crackpos"... so the majority wins !? hehe

Thanks