### PR TITLE
PDF module: -m 10700 missing assignment of tmp_size

### DIFF
--- a/src/modules/module_10700.c
+++ b/src/modules/module_10700.c
@@ -108,25 +108,10 @@ u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED con
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
-  // OpenCL 1.2 pocl HSTR: pthread-x86_64-pc-linux-gnu-skylake: Segmentation fault
-  if (device_param->opencl_platform_vendor_id == VENDOR_ID_POCL)
-  {
-    return true;
-  }
-
   // l_opencl_p_18.1.0.013: password not found
   if (device_param->opencl_device_vendor_id == VENDOR_ID_INTEL_SDK)
   {
     if ((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0)
-    {
-      return true;
-    }
-  }
-
-  // amdgpu-pro-18.50-708488-ubuntu-18.04: Segmentation fault
-  if ((device_param->opencl_device_vendor_id == VENDOR_ID_AMD) && (device_param->has_vperm == false))
-  {
-    if ((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 1)
     {
       return true;
     }
@@ -139,12 +124,6 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
     {
       return true;
     }
-  }
-
-  // l_opencl_p_18.1.0.013.tgz: Segmentation fault
-  if ((device_param->opencl_device_vendor_id == VENDOR_ID_INTEL_SDK) && (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU))
-  {
-    return true;
   }
 
   return false;
@@ -402,7 +381,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_separator                = MODULE_DEFAULT;
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
-  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_tmp_size                 = module_tmp_size;
   module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }


### PR DESCRIPTION
The missing assignment of tmp_size is the culprit for crashes.

It still seems to NOT crack without -O (i.e. with the pure kernel, instead of the optimized kernel) with some drivers... we would need to investigate this separately... but this is definitely a serious bug that leads to wrong memory access etc. Luckily I've found this pretty quickly when investigating https://github.com/hashcat/hashcat/issues/2123 ... but there is still work to do to make pure kernels not-fail on some drivers (#2123 not yet completely fixed AFAIK).

Thanks