### PR TITLE
fixes #2009: padding problem in -m 13400 tests

### DIFF
--- a/tools/test_modules/m13400.pm
+++ b/tools/test_modules/m13400.pm
@@ -299,6 +299,8 @@ sub module_generate_hash
 
     $expected_bytes = $cipher->decrypt ($contents_hash);
 
+    $expected_bytes = substr ($expected_bytes . "\x00" x 32, 0, 32); # padding
+
     $hash = sprintf ('$keepass$*%d*%d*%d*%s*%s*%s*%s*%s%s',
           $version,
           $iteration,


### PR DESCRIPTION
We didn't really get much confirmation here https://github.com/hashcat/hashcat/issues/2009 , but the fix seems to work perfectly fine and everything is cracking with this approach.
There might be a slightly different approach possible... i.e. configuring the parameters/padding of the encryption/decryption call... , but it should actually work the same way and should produce different results.

Thanks 