### PR TITLE
tests: fixed new problem with -m 20510 and hash type ranges

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -2979,13 +2979,6 @@ if [ "${TYPE}" = "null" ]; then
   TYPE="Gpu"
 fi
 
-if [ "${HT}" -eq 20510 ]; then # special case for PKZIP Master Key
-  if [ "${MODE}" -eq 1 ]; then # if "multi" was forced we need to exit
-    echo "ERROR: -m 20510 = PKZIP Master Key can only be run with a single hash"
-    exit 1
-  fi
-fi
-
 if [ -n "${ARCHITECTURE}" ]; then
 
   BIN="${BIN}${ARCHITECTURE}"
@@ -3114,6 +3107,18 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
       elif [ "${hash_type}" -gt "${HT_MAX}" ]; then
         # we are done because hash_type is larger than range:
         break
+      fi
+    fi
+
+    if [ "${hash_type}" -eq 20510 ]; then # special case for PKZIP Master Key
+      if [ "${MODE}" -eq 1 ]; then # if "multi" was forced we need to skip it
+        if [ "${HT_MIN}" -lt "${HT_MAX}" ]; then
+          echo "WARNING: -m 20510 = PKZIP Master Key can only be run with a single hash"
+        else
+          echo "ERROR: -m 20510 = PKZIP Master Key can only be run with a single hash"
+        fi
+
+        continue
       fi
     fi
 


### PR DESCRIPTION
We recently introduced a new problem when adding -m 20510 tests by considering the variable $HT as a number, while it could also be a range/string whenever we use the hash type range feature when running tests (-m HT_MIN-HT_MAX).

This patch moves the sanity check for -m 20510 down a little bit and uses the $hash_type variable which is for sure a number, instead of $HT (which could be a range, for instance "0-100", for all hash types from MD5 to SHA1 etc).

Thank you so much, have a nice day