### PR TITLE
tests: prevent -m 20510 multi error message for -m all

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -3112,10 +3112,10 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
 
     if [ "${hash_type}" -eq 20510 ]; then # special case for PKZIP Master Key
       if [ "${MODE}" -eq 1 ]; then # if "multi" was forced we need to skip it
-        if [ "${HT_MIN}" -lt "${HT_MAX}" ]; then
-          echo "WARNING: -m 20510 = PKZIP Master Key can only be run with a single hash"
-        else
-          echo "ERROR: -m 20510 = PKZIP Master Key can only be run with a single hash"
+        if [ "${HT_MIN}" -eq 20510 ]; then
+          if [ "${HT_MAX}" -eq 20510 ]; then
+            echo "ERROR: -m 20510 = PKZIP Master Key can only be run with a single hash"
+          fi
         fi
 
         continue


### PR DESCRIPTION
This is a little follow-up fix (fix of the fix) for this recent commit: https://github.com/hashcat/hashcat/pull/2276

when testing with -m all (which is again a special mode 65535 internally) an error was shown (even if it shouldn't).

This PR should fix this.
Thx