### PR TITLE
Fixes #2267: added support for -m 22400 = AES Crypt (SHA256)

### DIFF
--- a/OpenCL/m22400-pure.cl
+++ b/OpenCL/m22400-pure.cl
@@ -1,0 +1,236 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha256.cl"
+#endif
+
+#define COMPARE_S "inc_comp_single.cl"
+#define COMPARE_M "inc_comp_multi.cl"
+
+typedef struct aescrypt
+{
+  u32 iv[4];
+  u32 key[8];
+
+} aescrypt_t;
+
+typedef struct aescrypt_tmp
+{
+  u32 dgst[8];
+  u32 pass[128];
+  u32 len;
+
+} aescrypt_tmp_t;
+
+KERNEL_FQ void m22400_init (KERN_ATTR_TMPS_ESALT (aescrypt_tmp_t, aescrypt_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  // salt:
+
+  u32 s[16] = { 0 }; // 64-byte aligned
+
+  s[0] = salt_bufs[salt_pos].salt_buf[0];
+  s[1] = salt_bufs[salt_pos].salt_buf[1];
+  s[2] = salt_bufs[salt_pos].salt_buf[2];
+  s[3] = salt_bufs[salt_pos].salt_buf[3];
+
+  // convert password to utf16le:
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  const u32 pw_len_utf16le = pw_len * 2;
+
+  u32 w[128] = { 0 };
+
+  for (u32 i = 0, j = 0; i < 64; i += 4, j += 8)
+  {
+    u32 in[4];
+
+    in[0] = pws[gid].i[i + 0];
+    in[1] = pws[gid].i[i + 1];
+    in[2] = pws[gid].i[i + 2];
+    in[3] = pws[gid].i[i + 3];
+
+    u32 out0[4];
+    u32 out1[4];
+
+    make_utf16le_S (in, out0, out1);
+
+    w[j + 0] = hc_swap32_S (out0[0]);
+    w[j + 1] = hc_swap32_S (out0[1]);
+    w[j + 2] = hc_swap32_S (out0[2]);
+    w[j + 3] = hc_swap32_S (out0[3]);
+
+    w[j + 4] = hc_swap32_S (out1[0]);
+    w[j + 5] = hc_swap32_S (out1[1]);
+    w[j + 6] = hc_swap32_S (out1[2]);
+    w[j + 7] = hc_swap32_S (out1[3]);
+  }
+
+  // sha256:
+
+  sha256_ctx_t ctx;
+
+  sha256_init   (&ctx);
+  sha256_update (&ctx, s, 32);
+  sha256_update (&ctx, w, pw_len_utf16le);
+  sha256_final  (&ctx);
+
+  // set tmps:
+
+  tmps[gid].dgst[0] = ctx.h[0];
+  tmps[gid].dgst[1] = ctx.h[1];
+  tmps[gid].dgst[2] = ctx.h[2];
+  tmps[gid].dgst[3] = ctx.h[3];
+  tmps[gid].dgst[4] = ctx.h[4];
+  tmps[gid].dgst[5] = ctx.h[5];
+  tmps[gid].dgst[6] = ctx.h[6];
+  tmps[gid].dgst[7] = ctx.h[7];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 128; i++)
+  {
+    tmps[gid].pass[i] = w[i];
+  }
+
+  tmps[gid].len = 32 + pw_len_utf16le;
+}
+
+KERNEL_FQ void m22400_loop (KERN_ATTR_TMPS_ESALT (aescrypt_tmp_t, aescrypt_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  // init
+
+  u32 w[144] = { 0 }; // we only need max 136*4, but it's 16-byte-aligned
+
+  w[0] = tmps[gid].dgst[0];
+  w[1] = tmps[gid].dgst[1];
+  w[2] = tmps[gid].dgst[2];
+  w[3] = tmps[gid].dgst[3];
+  w[4] = tmps[gid].dgst[4];
+  w[5] = tmps[gid].dgst[5];
+  w[6] = tmps[gid].dgst[6];
+  w[7] = tmps[gid].dgst[7];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < 128; i++)
+  {
+    w[8 + i] = tmps[gid].pass[i];
+  }
+
+  const u32 pw_len = tmps[gid].len;
+
+  // main loop
+
+  for (u32 i = 0; i < loop_cnt; i++)
+  {
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, w, pw_len);
+    sha256_final  (&ctx);
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+    w[4] = ctx.h[4];
+    w[5] = ctx.h[5];
+    w[6] = ctx.h[6];
+    w[7] = ctx.h[7];
+  }
+
+  tmps[gid].dgst[0] = w[0];
+  tmps[gid].dgst[1] = w[1];
+  tmps[gid].dgst[2] = w[2];
+  tmps[gid].dgst[3] = w[3];
+  tmps[gid].dgst[4] = w[4];
+  tmps[gid].dgst[5] = w[5];
+  tmps[gid].dgst[6] = w[6];
+  tmps[gid].dgst[7] = w[7];
+}
+
+KERNEL_FQ void m22400_comp (KERN_ATTR_TMPS_ESALT (aescrypt_tmp_t, aescrypt_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  // digest
+
+  u32 dgst[16] = { 0 };
+
+  dgst[0] = tmps[gid].dgst[0];
+  dgst[1] = tmps[gid].dgst[1];
+  dgst[2] = tmps[gid].dgst[2];
+  dgst[3] = tmps[gid].dgst[3];
+  dgst[4] = tmps[gid].dgst[4];
+  dgst[5] = tmps[gid].dgst[5];
+  dgst[6] = tmps[gid].dgst[6];
+  dgst[7] = tmps[gid].dgst[7];
+
+  // IV
+
+  u32 data[16] = { 0 };
+
+  data[ 0] = esalt_bufs[digests_offset].iv[0];
+  data[ 1] = esalt_bufs[digests_offset].iv[1];
+  data[ 2] = esalt_bufs[digests_offset].iv[2];
+  data[ 3] = esalt_bufs[digests_offset].iv[3];
+
+  // key
+
+  data[ 4] = esalt_bufs[digests_offset].key[0];
+  data[ 5] = esalt_bufs[digests_offset].key[1];
+  data[ 6] = esalt_bufs[digests_offset].key[2];
+  data[ 7] = esalt_bufs[digests_offset].key[3];
+  data[ 8] = esalt_bufs[digests_offset].key[4];
+  data[ 9] = esalt_bufs[digests_offset].key[5];
+  data[10] = esalt_bufs[digests_offset].key[6];
+  data[11] = esalt_bufs[digests_offset].key[7];
+
+  /*
+   * HMAC-SHA256:
+   */
+
+  sha256_hmac_ctx_t ctx;
+
+  sha256_hmac_init   (&ctx, dgst, 32);
+  sha256_hmac_update (&ctx, data, 48);
+  sha256_hmac_final  (&ctx);
+
+  const u32 r0 = ctx.opad.h[DGST_R0];
+  const u32 r1 = ctx.opad.h[DGST_R1];
+  const u32 r2 = ctx.opad.h[DGST_R2];
+  const u32 r3 = ctx.opad.h[DGST_R3];
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -21,6 +21,7 @@
 ## Algorithms
 ##
 
+- Added hash-mode: AES Crypt (SHA256)
 - Added hash-mode: Android Backup
 - Added hash-mode: AuthMe sha256
 - Added hash-mode: BitLocker

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -240,6 +240,7 @@ NVIDIA GPUs require "NVIDIA Driver" (418.56 or later) and "CUDA Toolkit" (10.1 o
 - Oracle Transportation Management (SHA256)
 - Huawei sha1(md5($pass).$salt)
 - AuthMe sha256
+- AES Crypt (SHA256)
 - BitLocker
 - eCryptfs
 - LUKS

--- a/src/modules/module_22400.c
+++ b/src/modules/module_22400.c
@@ -1,0 +1,325 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_8;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
+static const char *HASH_NAME      = "AES Crypt (SHA256)";
+static const u64   KERN_TYPE      = 22400;
+static const u32   OPTI_TYPE      = 0;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$aescrypt$1*efc648908ca7ec727f37f3316dfd885c*eff5c87a35545406a57b56de57bd0554*3a66401271aec08cbd10cf2070332214093a33f36bd0dced4a4bb09fab817184*6a3c49fea0cafb19190dc4bdadb787e73b1df244c51780beef912598bd3bdf7e";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+#define ITERATION_AESCRYPT 0x2000
+#define SALT_LEN_AESCRYPT  16
+#define IV_LEN_AESCRYPT    16
+#define KEY_LEN_AESCRYPT   32
+
+typedef struct aescrypt
+{
+  u32 iv[4];
+  u32 key[8];
+
+} aescrypt_t;
+
+typedef struct aescrypt_tmp
+{
+  u32 dgst[8];
+  u32 pass[128];
+  u32 len;
+
+} aescrypt_tmp_t;
+
+static const char *SIGNATURE_AESCRYPT = "$aescrypt$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (aescrypt_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (aescrypt_tmp_t);
+
+  return tmp_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  aescrypt_t *aescrypt = (aescrypt_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt  = 6;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_AESCRYPT;
+
+  token.len[0]     = 10;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '*';
+  token.len_min[1] = 1;
+  token.len_max[1] = 1;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[2]     = '*';
+  token.len_min[2] = 32;
+  token.len_max[2] = 32;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[3]     = '*';
+  token.len_min[3] = 32;
+  token.len_max[3] = 32;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[4]     = '*';
+  token.len_min[4] = 64;
+  token.len_max[4] = 64;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[5]     = '*';
+  token.len_min[5] = 64;
+  token.len_max[5] = 64;
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // version
+
+  const u8 *version_pos = token.buf[1];
+
+  const u32 version = hc_strtoul ((const char *) version_pos, NULL, 10);
+
+  if (version != 1) return PARSER_SALT_VALUE;
+
+  // salt
+
+  const u8 *salt_pos = token.buf[2];
+
+  salt->salt_buf[0] = hex_to_u32 (salt_pos +  0);
+  salt->salt_buf[1] = hex_to_u32 (salt_pos +  8);
+  salt->salt_buf[2] = hex_to_u32 (salt_pos + 16);
+  salt->salt_buf[3] = hex_to_u32 (salt_pos + 24);
+
+  salt->salt_buf[0] = byte_swap_32 (salt->salt_buf[0]);
+  salt->salt_buf[1] = byte_swap_32 (salt->salt_buf[1]);
+  salt->salt_buf[2] = byte_swap_32 (salt->salt_buf[2]);
+  salt->salt_buf[3] = byte_swap_32 (salt->salt_buf[3]);
+
+  salt->salt_len = SALT_LEN_AESCRYPT;
+
+  salt->salt_iter = ITERATION_AESCRYPT - 1;
+
+  // IV
+
+  const u8 *iv_pos = token.buf[3];
+
+  aescrypt->iv[0] = hex_to_u32 (iv_pos +  0);
+  aescrypt->iv[1] = hex_to_u32 (iv_pos +  8);
+  aescrypt->iv[2] = hex_to_u32 (iv_pos + 16);
+  aescrypt->iv[3] = hex_to_u32 (iv_pos + 24);
+
+  aescrypt->iv[0] = byte_swap_32 (aescrypt->iv[0]);
+  aescrypt->iv[1] = byte_swap_32 (aescrypt->iv[1]);
+  aescrypt->iv[2] = byte_swap_32 (aescrypt->iv[2]);
+  aescrypt->iv[3] = byte_swap_32 (aescrypt->iv[3]);
+
+  // key
+
+  const u8 *key_pos = token.buf[4];
+
+  for (u32 i = 0, j = 0; i < 8; i += 1, j += 8)
+  {
+    aescrypt->key[i] = hex_to_u32 (key_pos + j);
+
+    aescrypt->key[i] = byte_swap_32 (aescrypt->key[i]);
+  }
+
+  // digest
+
+  const u8 *hmac_pos = token.buf[5];
+
+  for (u32 i = 0, j = 0; i < 8; i += 1, j += 8)
+  {
+    digest[i] = hex_to_u32 (hmac_pos + j);
+
+    digest[i] = byte_swap_32 (digest[i]);
+  }
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  aescrypt_t *aescrypt = (aescrypt_t *) esalt_buf;
+
+  // salt
+
+  #define SALT_HEX_LEN SALT_LEN_AESCRYPT * 2 + 1
+
+  char salt_buf[SALT_HEX_LEN] = { 0 };
+
+  for (u32 i = 0, j = 0; i < SALT_LEN_AESCRYPT / 4; i += 1, j += 8)
+  {
+    snprintf (salt_buf + j, SALT_HEX_LEN - j, "%08x", salt->salt_buf[i]);
+  }
+
+  // iv
+
+  #define IV_HEX_LEN IV_LEN_AESCRYPT * 2 + 1
+
+  char iv_buf[IV_HEX_LEN] = { 0 };
+
+  for (u32 i = 0, j = 0; i < IV_LEN_AESCRYPT / 4; i += 1, j += 8)
+  {
+    snprintf (iv_buf + j, IV_HEX_LEN - j, "%08x", aescrypt->iv[i]);
+  }
+
+  // key
+
+  #define KEY_HEX_LEN KEY_LEN_AESCRYPT * 2 + 1
+
+  char key_buf[KEY_HEX_LEN] = { 0 };
+
+  for (u32 i = 0, j = 0; i < KEY_LEN_AESCRYPT / 4; i += 1, j += 8)
+  {
+    snprintf (key_buf + j, KEY_HEX_LEN - j, "%08x", aescrypt->key[i]);
+  }
+
+  // output
+
+  int line_len = snprintf (line_buf, line_size, "%s%i*%s*%s*%s*%08x%08x%08x%08x%08x%08x%08x%08x",
+    SIGNATURE_AESCRYPT,
+    1,
+    salt_buf,
+    iv_buf,
+    key_buf,
+    digest[0],
+    digest[1],
+    digest[2],
+    digest[3],
+    digest[4],
+    digest[5],
+    digest[6],
+    digest[7]);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/aescrypt2hashcat.pl
+++ b/tools/aescrypt2hashcat.pl
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+#
+# Helper functions
+#
+
+sub read_bytes
+{
+  my $handle = shift;
+  my $size   = shift;
+
+  my $data = "";
+
+  read ($handle, $data, $size);
+
+  # this function is very strict:
+  # it only returns something if all the bytes can be read
+
+  if (length ($data) != $size)
+  {
+    die "ERROR: Couldn't read data from the file. Maybe incorrect file format?\n";
+  }
+
+  return $data;
+}
+
+#
+# Start
+#
+
+if (scalar (@ARGV) != 1)
+{
+  die "usage: $0 file.txt.aes\n";
+}
+
+my $file_name = $ARGV[0];
+
+my $file_handle;
+
+if (! open ($file_handle, "<", $file_name))
+{
+  die "ERROR: Couldn't open file '$file_name'\n";
+}
+
+binmode ($file_handle);
+
+
+# Signature:
+
+my $signature = read_bytes ($file_handle, 3);
+
+if ($signature ne "AES")
+{
+  die "ERROR: The file doesn't seem to be a correct aescrypt file (signature mismatch)\n";
+}
+
+# Version
+
+my $version = read_bytes ($file_handle, 1);
+
+if ($version ne "\x02")
+{
+  die "ERROR: Currently only aescrypt file version 2 is supported by this script\n";
+}
+
+
+read_bytes ($file_handle, 1); # reservered/skip (normally should be just \x00)
+
+
+# Loop over the extensions until we got extension size 0
+
+my $extension_size = read_bytes ($file_handle, 2);
+
+while ($extension_size ne "\x00\x00")
+{
+  my $skip_size = unpack ("S>", $extension_size); # 16-bit lengths
+
+  read_bytes ($file_handle, $skip_size); # skip the extension
+
+  $extension_size = read_bytes ($file_handle, 2);
+}
+
+# IV (for KDF)
+
+my $iv = read_bytes ($file_handle, 16);
+
+
+# IV (encrypted IV for AES decryption)
+
+my $iv_enc = read_bytes ($file_handle, 16);
+
+
+# key_enc
+
+my $key_enc = read_bytes ($file_handle, 32);
+
+
+# HMAC
+
+my $hmac = read_bytes ($file_handle, 32);
+
+#
+# Hex conversion
+#
+
+$iv      = unpack ("H*", $iv);
+$iv_enc  = unpack ("H*", $iv_enc);
+$key_enc = unpack ("H*", $key_enc);
+$hmac    = unpack ("H*", $hmac);
+
+#
+# Final output
+#
+
+print sprintf ("\$aescrypt\$1*%s*%s*%s*%s\n", $iv, $iv_enc, $key_enc, $hmac);
+
+#
+# Cleanup
+#
+
+close ($file_handle);
+
+exit (0);

--- a/tools/test_modules/m22400.pm
+++ b/tools/test_modules/m22400.pm
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA  qw (sha256);
+use Digest::HMAC qw (hmac_hex);
+use Encode;
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $iv_aes  = shift // random_bytes (16);
+  my $key_aes = shift // random_bytes (32);
+
+  my $word_utf16le = encode ('UTF-16le', $word);
+
+  my $key = $salt . "\x00" x 16;
+
+  for (my $i = 0; $i < 8192; $i++)
+  {
+    $key = sha256 ($key . $word_utf16le);
+  }
+
+  my $digest = hmac_hex ($iv_aes . $key_aes, $key, \&sha256, 64);
+
+  # hex conversion:
+
+  my $salt_hex = unpack ("H*", $salt);
+  my $iv_hex   = unpack ("H*", $iv_aes);
+  my $key_hex  = unpack ("H*", $key_aes);
+
+  my $hash = sprintf ("\$aescrypt\$1*%s*%s*%s*%s", $salt_hex, $iv_hex, $key_hex, $digest);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @data = split ('\*', $hash);
+
+  return unless (scalar (@data) == 5);
+
+  my $signature = substr ($data[0], 0, 10);
+
+  return unless ($signature eq "\$aescrypt\$");
+
+  my $version = substr ($data[0], 10);
+
+  return unless ($version eq "1");
+
+  my $salt = $data[1];
+  my $iv   = $data[2];
+  my $key  = $data[3];
+
+  return unless (length ($salt) == 32); # hex lengths
+  return unless (length ($iv)   == 32);
+  return unless (length ($key)  == 64);
+
+  # binary conversion:
+
+  $salt = pack ("H*", $salt);
+  $iv   = pack ("H*", $iv);
+  $key  = pack ("H*", $key);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $iv, $key);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This PR adds support for -m 22400 = AES Crypt (SHA256) as requested in #2267 

We also add our own (perl) extraction script in tools/aescrypt2hashcat.pl such that the necessary data can easily be extracted from the encrypted .aes files (see https://aescrypt.com for more info about the format of the encrypted files themself).


our hash format starts with $aescrypt$  and an internal version number (for future use eventually if there are newer formats in the future, the current one is always 1).

After that comes the salt (or sometimes called IV in the aescrypt source) for the key-derivation-function KDF.
We have the AES_ENC_IV (encrypted) and AES_ENC_KEY (encrypted) after the salt and finally the HMAC (hmac-sha256 of the encrypted IV and encrypted key with the derived hash as the key).

more details of the format are explained in the link from #2267.

an example is (pass is hashcat):
```
$aescrypt$1*efc648908ca7ec727f37f3316dfd885c*eff5c87a35545406a57b56de57bd0554*3a66401271aec08cbd10cf2070332214093a33f36bd0dced4a4bb09fab817184*6a3c49fea0cafb19190dc4bdadb787e73b1df244c51780beef912598bd3bdf7e
```

Thank you very much