### PR TITLE
tests: fix return code check in attack_0 () function

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -500,9 +500,9 @@ function attack_0()
 
       output=$(echo "${pass}" | ./${BIN} ${OPTS} -a 0 -m ${hash_type} "${hash}" 2>&1)
 
-      pass=${pass_old}
-
       ret=${?}
+
+      pass=${pass_old}
 
       echo "${output}" >> "${OUTD}/logfull.txt"
 


### PR DESCRIPTION
The (quite new) problem here was that we have to check the return value $? immediately after the command, otherwise with the assignement in between them, we always get a value for the $ret variable of 0 (because assignments kind of never fail).

This problem was found just by chance... I think that was a very lucky find.

Thanks 