### PR TITLE
Fixes #1538: Added -m 22500 = MultiBit Classic .key (MD5)

### DIFF
--- a/OpenCL/m22500_a0-optimized.cl
+++ b/OpenCL/m22500_a0-optimized.cl
@@ -1,0 +1,1220 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp_optimized.h"
+#include "inc_rp_optimized.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+DECLSPEC int is_valid_bitcoinj_8 (const u8 v)
+{
+  // .abcdefghijklmnopqrstuvwxyz
+
+  if (v > (u8) 'z') return 0;
+  if (v < (u8) '.') return 0;
+
+  if ((v > (u8) '.') && (v < (u8) 'a')) return 0;
+
+  return 1;
+}
+
+KERNEL_FQ void m22500_m04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf[2];
+
+  salt_buf[0] = salt_bufs[salt_pos].salt_buf[0];
+  salt_buf[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    /**
+     * append salt
+     */
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf[0];
+    s0[1] = salt_buf[1];
+    s0[2] = 0x80;
+    s0[3] = 0;
+    s1[0] = 0;
+    s1[1] = 0;
+    s1[2] = 0;
+    s1[3] = 0;
+    s2[0] = 0;
+    s2[1] = 0;
+    s2[2] = 0;
+    s2[3] = 0;
+    s3[0] = 0;
+    s3[1] = 0;
+    s3[2] = 0;
+    s3[3] = 0;
+
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, out_len);
+
+    const u32x pw_salt_len = out_len + 8;
+
+    w0[0] |= s0[0];
+    w0[1] |= s0[1];
+    w0[2] |= s0[2];
+    w0[3] |= s0[3];
+    w1[0] |= s1[0];
+    w1[1] |= s1[1];
+    w1[2] |= s1[2];
+    w1[3] |= s1[3];
+    w2[0] |= s2[0];
+    w2[1] |= s2[1];
+    w2[2] |= s2[2];
+    w2[3] |= s2[3];
+    w3[0] |= s3[0];
+    w3[1] |= s3[1];
+    w3[2]  = pw_salt_len * 8;
+    w3[3]  = 0;
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 ukey[8];
+
+    ukey[0] = a;
+    ukey[1] = b;
+    ukey[2] = c;
+    ukey[3] = d;
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    const u32x dgst_pw_salt_len = 16 + pw_salt_len;
+
+    w3[3] = 0;
+    w3[2] = dgst_pw_salt_len * 8;
+    w3[1] = w2[1];
+    w3[0] = w2[0];
+    w2[3] = w1[3];
+    w2[2] = w1[2];
+    w2[1] = w1[1];
+    w2[0] = w1[0];
+    w1[3] = w0[3];
+    w1[2] = w0[2];
+    w1[1] = w0[1];
+    w1[0] = w0[0];
+    w0[3] = d;
+    w0[2] = c;
+    w0[1] = b;
+    w0[0] = a;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    ukey[4] = a;
+    ukey[5] = b;
+    ukey[6] = c;
+    ukey[7] = d;
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w0[0] = a;
+    w0[1] = b;
+    w0[2] = c;
+    w0[3] = d;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 iv[4];
+
+    iv[0] = a;
+    iv[1] = b;
+    iv[2] = c;
+    iv[3] = d;
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_m08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m22500_m16 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m22500_s04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf[2];
+
+  salt_buf[0] = salt_bufs[salt_pos].salt_buf[0];
+  salt_buf[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    /**
+     * append salt
+     */
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf[0];
+    s0[1] = salt_buf[1];
+    s0[2] = 0x80;
+    s0[3] = 0;
+    s1[0] = 0;
+    s1[1] = 0;
+    s1[2] = 0;
+    s1[3] = 0;
+    s2[0] = 0;
+    s2[1] = 0;
+    s2[2] = 0;
+    s2[3] = 0;
+    s3[0] = 0;
+    s3[1] = 0;
+    s3[2] = 0;
+    s3[3] = 0;
+
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, out_len);
+
+    const u32x pw_salt_len = out_len + 8;
+
+    w0[0] |= s0[0];
+    w0[1] |= s0[1];
+    w0[2] |= s0[2];
+    w0[3] |= s0[3];
+    w1[0] |= s1[0];
+    w1[1] |= s1[1];
+    w1[2] |= s1[2];
+    w1[3] |= s1[3];
+    w2[0] |= s2[0];
+    w2[1] |= s2[1];
+    w2[2] |= s2[2];
+    w2[3] |= s2[3];
+    w3[0] |= s3[0];
+    w3[1] |= s3[1];
+    w3[2]  = pw_salt_len * 8;
+    w3[3]  = 0;
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 ukey[8];
+
+    ukey[0] = a;
+    ukey[1] = b;
+    ukey[2] = c;
+    ukey[3] = d;
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    const u32x dgst_pw_salt_len = 16 + pw_salt_len;
+
+    w3[3] = 0;
+    w3[2] = dgst_pw_salt_len * 8;
+    w3[1] = w2[1];
+    w3[0] = w2[0];
+    w2[3] = w1[3];
+    w2[2] = w1[2];
+    w2[1] = w1[1];
+    w2[0] = w1[0];
+    w1[3] = w0[3];
+    w1[2] = w0[2];
+    w1[1] = w0[1];
+    w1[0] = w0[0];
+    w0[3] = d;
+    w0[2] = c;
+    w0[1] = b;
+    w0[0] = a;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    ukey[4] = a;
+    ukey[5] = b;
+    ukey[6] = c;
+    ukey[7] = d;
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w0[0] = a;
+    w0[1] = b;
+    w0[2] = c;
+    w0[3] = d;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 iv[4];
+
+    iv[0] = a;
+    iv[1] = b;
+    iv[2] = c;
+    iv[3] = d;
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_s08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m22500_s16 (KERN_ATTR_RULES ())
+{
+}

--- a/OpenCL/m22500_a0-pure.cl
+++ b/OpenCL/m22500_a0-pure.cl
@@ -1,0 +1,622 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp.h"
+#include "inc_rp.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_md5.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+DECLSPEC int is_valid_bitcoinj_8 (const u8 v)
+{
+  // .abcdefghijklmnopqrstuvwxyz
+
+  if (v > (u8) 'z') return 0;
+  if (v < (u8) '.') return 0;
+
+  if ((v > (u8) '.') && (v < (u8) 'a')) return 0;
+
+  return 1;
+}
+
+KERNEL_FQ void m22500_mxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * salt
+   */
+
+  u32 s[64] = { 0 };
+
+  s[0] = salt_bufs[salt_pos].salt_buf[0];
+  s[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    md5_ctx_t ctx;
+
+    md5_init   (&ctx);
+    md5_update (&ctx, tmp.i, tmp.pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 ukey[8];
+
+    ukey[0] = ctx.h[0];
+    ukey[1] = ctx.h[1];
+    ukey[2] = ctx.h[2];
+    ukey[3] = ctx.h[3];
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    u32 w[16] = { 0 }; // we need 64-bit alignment for md5_update ()
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+    md5_update (&ctx, tmp.i, tmp.pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    ukey[4] = ctx.h[0];
+    ukey[5] = ctx.h[1];
+    ukey[6] = ctx.h[2];
+    ukey[7] = ctx.h[3];
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+    md5_update (&ctx, tmp.i, tmp.pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 iv[4];
+
+    iv[0] = ctx.h[0];
+    iv[1] = ctx.h[1];
+    iv[2] = ctx.h[2];
+    iv[3] = ctx.h[3];
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_sxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * salt
+   */
+
+  u32 s[64] = { 0 };
+
+  s[0] = salt_bufs[salt_pos].salt_buf[0];
+  s[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    md5_ctx_t ctx;
+
+    md5_init   (&ctx);
+    md5_update (&ctx, tmp.i, tmp.pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 ukey[8];
+
+    ukey[0] = ctx.h[0];
+    ukey[1] = ctx.h[1];
+    ukey[2] = ctx.h[2];
+    ukey[3] = ctx.h[3];
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    u32 w[16] = { 0 }; // we need 64-bit alignment for md5_update ()
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+    md5_update (&ctx, tmp.i, tmp.pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    ukey[4] = ctx.h[0];
+    ukey[5] = ctx.h[1];
+    ukey[6] = ctx.h[2];
+    ukey[7] = ctx.h[3];
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+    md5_update (&ctx, tmp.i, tmp.pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 iv[4];
+
+    iv[0] = ctx.h[0];
+    iv[1] = ctx.h[1];
+    iv[2] = ctx.h[2];
+    iv[3] = ctx.h[3];
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}

--- a/OpenCL/m22500_a1-optimized.cl
+++ b/OpenCL/m22500_a1-optimized.cl
@@ -1,0 +1,1339 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_scalar.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+DECLSPEC int is_valid_bitcoinj_8 (const u8 v)
+{
+  // .abcdefghijklmnopqrstuvwxyz
+
+  if (v > (u8) 'z') return 0;
+  if (v < (u8) '.') return 0;
+
+  if ((v > (u8) '.') && (v < (u8) 'a')) return 0;
+
+  return 1;
+}
+
+KERNEL_FQ void m22500_m04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf[2];
+
+  salt_buf[0] = salt_bufs[salt_pos].salt_buf[0];
+  salt_buf[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * append salt
+     */
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf[0];
+    s0[1] = salt_buf[1];
+    s0[2] = 0x80;
+    s0[3] = 0;
+    s1[0] = 0;
+    s1[1] = 0;
+    s1[2] = 0;
+    s1[3] = 0;
+    s2[0] = 0;
+    s2[1] = 0;
+    s2[2] = 0;
+    s2[3] = 0;
+    s3[0] = 0;
+    s3[1] = 0;
+    s3[2] = 0;
+    s3[3] = 0;
+
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, pw_len);
+
+    const u32x pw_salt_len = pw_len + 8;
+
+    w0[0] |= s0[0];
+    w0[1] |= s0[1];
+    w0[2] |= s0[2];
+    w0[3] |= s0[3];
+    w1[0] |= s1[0];
+    w1[1] |= s1[1];
+    w1[2] |= s1[2];
+    w1[3] |= s1[3];
+    w2[0] |= s2[0];
+    w2[1] |= s2[1];
+    w2[2] |= s2[2];
+    w2[3] |= s2[3];
+    w3[0] |= s3[0];
+    w3[1] |= s3[1];
+    w3[2]  = pw_salt_len * 8;
+    w3[3]  = 0;
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 ukey[8];
+
+    ukey[0] = a;
+    ukey[1] = b;
+    ukey[2] = c;
+    ukey[3] = d;
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    const u32x dgst_pw_salt_len = 16 + pw_salt_len;
+
+    w3[3] = 0;
+    w3[2] = dgst_pw_salt_len * 8;
+    w3[1] = w2[1];
+    w3[0] = w2[0];
+    w2[3] = w1[3];
+    w2[2] = w1[2];
+    w2[1] = w1[1];
+    w2[0] = w1[0];
+    w1[3] = w0[3];
+    w1[2] = w0[2];
+    w1[1] = w0[1];
+    w1[0] = w0[0];
+    w0[3] = d;
+    w0[2] = c;
+    w0[1] = b;
+    w0[0] = a;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    ukey[4] = a;
+    ukey[5] = b;
+    ukey[6] = c;
+    ukey[7] = d;
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w0[0] = a;
+    w0[1] = b;
+    w0[2] = c;
+    w0[3] = d;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 iv[4];
+
+    iv[0] = a;
+    iv[1] = b;
+    iv[2] = c;
+    iv[3] = d;
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_m08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m22500_m16 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m22500_s04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf[2];
+
+  salt_buf[0] = salt_bufs[salt_pos].salt_buf[0];
+  salt_buf[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * append salt
+     */
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf[0];
+    s0[1] = salt_buf[1];
+    s0[2] = 0x80;
+    s0[3] = 0;
+    s1[0] = 0;
+    s1[1] = 0;
+    s1[2] = 0;
+    s1[3] = 0;
+    s2[0] = 0;
+    s2[1] = 0;
+    s2[2] = 0;
+    s2[3] = 0;
+    s3[0] = 0;
+    s3[1] = 0;
+    s3[2] = 0;
+    s3[3] = 0;
+
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, pw_len);
+
+    const u32x pw_salt_len = pw_len + 8;
+
+    w0[0] |= s0[0];
+    w0[1] |= s0[1];
+    w0[2] |= s0[2];
+    w0[3] |= s0[3];
+    w1[0] |= s1[0];
+    w1[1] |= s1[1];
+    w1[2] |= s1[2];
+    w1[3] |= s1[3];
+    w2[0] |= s2[0];
+    w2[1] |= s2[1];
+    w2[2] |= s2[2];
+    w2[3] |= s2[3];
+    w3[0] |= s3[0];
+    w3[1] |= s3[1];
+    w3[2]  = pw_salt_len * 8;
+    w3[3]  = 0;
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 ukey[8];
+
+    ukey[0] = a;
+    ukey[1] = b;
+    ukey[2] = c;
+    ukey[3] = d;
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    const u32x dgst_pw_salt_len = 16 + pw_salt_len;
+
+    w3[3] = 0;
+    w3[2] = dgst_pw_salt_len * 8;
+    w3[1] = w2[1];
+    w3[0] = w2[0];
+    w2[3] = w1[3];
+    w2[2] = w1[2];
+    w2[1] = w1[1];
+    w2[0] = w1[0];
+    w1[3] = w0[3];
+    w1[2] = w0[2];
+    w1[1] = w0[1];
+    w1[0] = w0[0];
+    w0[3] = d;
+    w0[2] = c;
+    w0[1] = b;
+    w0[0] = a;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    ukey[4] = a;
+    ukey[5] = b;
+    ukey[6] = c;
+    ukey[7] = d;
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w0[0] = a;
+    w0[1] = b;
+    w0[2] = c;
+    w0[3] = d;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 iv[4];
+
+    iv[0] = a;
+    iv[1] = b;
+    iv[2] = c;
+    iv[3] = d;
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_s08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m22500_s16 (KERN_ATTR_BASIC ())
+{
+}

--- a/OpenCL/m22500_a1-pure.cl
+++ b/OpenCL/m22500_a1-pure.cl
@@ -1,0 +1,632 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_md5.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+DECLSPEC int is_valid_bitcoinj_8 (const u8 v)
+{
+  // .abcdefghijklmnopqrstuvwxyz
+
+  if (v > (u8) 'z') return 0;
+  if (v < (u8) '.') return 0;
+
+  if ((v > (u8) '.') && (v < (u8) 'a')) return 0;
+
+  return 1;
+}
+
+KERNEL_FQ void m22500_mxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * salt
+   */
+
+  u32 s[64] = { 0 };
+
+  s[0] = salt_bufs[salt_pos].salt_buf[0];
+  s[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    md5_ctx_t ctx = ctx0;
+
+    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 ukey[8];
+
+    ukey[0] = ctx.h[0];
+    ukey[1] = ctx.h[1];
+    ukey[2] = ctx.h[2];
+    ukey[3] = ctx.h[3];
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    u32 w[16] = { 0 }; // we need 64-bit alignment for md5_update ()
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    ukey[4] = ctx.h[0];
+    ukey[5] = ctx.h[1];
+    ukey[6] = ctx.h[2];
+    ukey[7] = ctx.h[3];
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 iv[4];
+
+    iv[0] = ctx.h[0];
+    iv[1] = ctx.h[1];
+    iv[2] = ctx.h[2];
+    iv[3] = ctx.h[3];
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_sxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * salt
+   */
+
+  u32 s[64] = { 0 };
+
+  s[0] = salt_bufs[salt_pos].salt_buf[0];
+  s[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    md5_ctx_t ctx = ctx0;
+
+    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 ukey[8];
+
+    ukey[0] = ctx.h[0];
+    ukey[1] = ctx.h[1];
+    ukey[2] = ctx.h[2];
+    ukey[3] = ctx.h[3];
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    u32 w[16] = { 0 }; // we need 64-bit alignment for md5_update ()
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    ukey[4] = ctx.h[0];
+    ukey[5] = ctx.h[1];
+    ukey[6] = ctx.h[2];
+    ukey[7] = ctx.h[3];
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w[0] = ctx.h[0];
+    w[1] = ctx.h[1];
+    w[2] = ctx.h[2];
+    w[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, 16);
+
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 iv[4];
+
+    iv[0] = ctx.h[0];
+    iv[1] = ctx.h[1];
+    iv[2] = ctx.h[2];
+    iv[3] = ctx.h[3];
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}

--- a/OpenCL/m22500_a3-optimized.cl
+++ b/OpenCL/m22500_a3-optimized.cl
@@ -1,0 +1,1175 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+DECLSPEC int is_valid_bitcoinj_8 (const u8 v)
+{
+  // .abcdefghijklmnopqrstuvwxyz
+
+  if (v > (u8) 'z') return 0;
+  if (v < (u8) '.') return 0;
+
+  if ((v > (u8) '.') && (v < (u8) 'a')) return 0;
+
+  return 1;
+}
+
+DECLSPEC void m22500 (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a *s_te2, SHM_TYPE u32a *s_te3, SHM_TYPE u32a *s_te4, SHM_TYPE u32a *s_td0, SHM_TYPE u32a *s_td1, SHM_TYPE u32a *s_td2, SHM_TYPE u32a *s_td3, SHM_TYPE u32a *s_td4, u32 *w, const u32 pw_len, KERN_ATTR_VECTOR ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[4];
+
+  salt_buf0[0] = salt_bufs[salt_pos].salt_buf[0];
+  salt_buf0[1] = salt_bufs[salt_pos].salt_buf[1];
+  salt_buf0[2] = 0x80;
+  salt_buf0[3] = 0;
+
+  u32 salt_buf1[4] = { 0 };
+  u32 salt_buf2[4] = { 0 };
+  u32 salt_buf3[4] = { 0 };
+
+  const u32 pw_salt_len = pw_len + 8;
+
+  switch_buffer_by_offset_le_S (salt_buf0, salt_buf1, salt_buf2, salt_buf3, pw_len);
+
+  w[ 0] |= salt_buf0[0];
+  w[ 1] |= salt_buf0[1];
+  w[ 2] |= salt_buf0[2];
+  w[ 3] |= salt_buf0[3];
+  w[ 4] |= salt_buf1[0];
+  w[ 5] |= salt_buf1[1];
+  w[ 6] |= salt_buf1[2];
+  w[ 7] |= salt_buf1[3];
+  w[ 8] |= salt_buf2[0];
+  w[ 9] |= salt_buf2[1];
+  w[10] |= salt_buf2[2];
+  w[11] |= salt_buf2[3];
+  w[12] |= salt_buf3[0];
+  w[13] |= salt_buf3[1];
+  w[14]  = pw_salt_len * 8;
+  w[15]  = 0;
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * base
+   */
+
+  const u32 F_w0c00 =    0u + MD5C00;
+  const u32 F_w1c01 = w[ 1] + MD5C01;
+  const u32 F_w2c02 = w[ 2] + MD5C02;
+  const u32 F_w3c03 = w[ 3] + MD5C03;
+  const u32 F_w4c04 = w[ 4] + MD5C04;
+  const u32 F_w5c05 = w[ 5] + MD5C05;
+  const u32 F_w6c06 = w[ 6] + MD5C06;
+  const u32 F_w7c07 = w[ 7] + MD5C07;
+  const u32 F_w8c08 = w[ 8] + MD5C08;
+  const u32 F_w9c09 = w[ 9] + MD5C09;
+  const u32 F_wac0a = w[10] + MD5C0a;
+  const u32 F_wbc0b = w[11] + MD5C0b;
+  const u32 F_wcc0c = w[12] + MD5C0c;
+  const u32 F_wdc0d = w[13] + MD5C0d;
+  const u32 F_wec0e = w[14] + MD5C0e;
+  const u32 F_wfc0f = w[15] + MD5C0f;
+
+  const u32 G_w1c10 = w[ 1] + MD5C10;
+  const u32 G_w6c11 = w[ 6] + MD5C11;
+  const u32 G_wbc12 = w[11] + MD5C12;
+  const u32 G_w0c13 =    0u + MD5C13;
+  const u32 G_w5c14 = w[ 5] + MD5C14;
+  const u32 G_wac15 = w[10] + MD5C15;
+  const u32 G_wfc16 = w[15] + MD5C16;
+  const u32 G_w4c17 = w[ 4] + MD5C17;
+  const u32 G_w9c18 = w[ 9] + MD5C18;
+  const u32 G_wec19 = w[14] + MD5C19;
+  const u32 G_w3c1a = w[ 3] + MD5C1a;
+  const u32 G_w8c1b = w[ 8] + MD5C1b;
+  const u32 G_wdc1c = w[13] + MD5C1c;
+  const u32 G_w2c1d = w[ 2] + MD5C1d;
+  const u32 G_w7c1e = w[ 7] + MD5C1e;
+  const u32 G_wcc1f = w[12] + MD5C1f;
+
+  const u32 H_w5c20 = w[ 5] + MD5C20;
+  const u32 H_w8c21 = w[ 8] + MD5C21;
+  const u32 H_wbc22 = w[11] + MD5C22;
+  const u32 H_wec23 = w[14] + MD5C23;
+  const u32 H_w1c24 = w[ 1] + MD5C24;
+  const u32 H_w4c25 = w[ 4] + MD5C25;
+  const u32 H_w7c26 = w[ 7] + MD5C26;
+  const u32 H_wac27 = w[10] + MD5C27;
+  const u32 H_wdc28 = w[13] + MD5C28;
+  const u32 H_w0c29 =    0u + MD5C29;
+  const u32 H_w3c2a = w[ 3] + MD5C2a;
+  const u32 H_w6c2b = w[ 6] + MD5C2b;
+  const u32 H_w9c2c = w[ 9] + MD5C2c;
+  const u32 H_wcc2d = w[12] + MD5C2d;
+  const u32 H_wfc2e = w[15] + MD5C2e;
+  const u32 H_w2c2f = w[ 2] + MD5C2f;
+
+  const u32 I_w0c30 =    0u + MD5C30;
+  const u32 I_w7c31 = w[ 7] + MD5C31;
+  const u32 I_wec32 = w[14] + MD5C32;
+  const u32 I_w5c33 = w[ 5] + MD5C33;
+  const u32 I_wcc34 = w[12] + MD5C34;
+  const u32 I_w3c35 = w[ 3] + MD5C35;
+  const u32 I_wac36 = w[10] + MD5C36;
+  const u32 I_w1c37 = w[ 1] + MD5C37;
+  const u32 I_w8c38 = w[ 8] + MD5C38;
+  const u32 I_wfc39 = w[15] + MD5C39;
+  const u32 I_w6c3a = w[ 6] + MD5C3a;
+  const u32 I_wdc3b = w[13] + MD5C3b;
+  const u32 I_w4c3c = w[ 4] + MD5C3c;
+  const u32 I_wbc3d = w[11] + MD5C3d;
+  const u32 I_w2c3e = w[ 2] + MD5C3e;
+  const u32 I_w9c3f = w[ 9] + MD5C3f;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0, F_w0c00, MD5S00);
+    MD5_STEP0(MD5_Fo, d, a, b, c,     F_w1c01, MD5S01);
+    MD5_STEP0(MD5_Fo, c, d, a, b,     F_w2c02, MD5S02);
+    MD5_STEP0(MD5_Fo, b, c, d, a,     F_w3c03, MD5S03);
+    MD5_STEP0(MD5_Fo, a, b, c, d,     F_w4c04, MD5S00);
+    MD5_STEP0(MD5_Fo, d, a, b, c,     F_w5c05, MD5S01);
+    MD5_STEP0(MD5_Fo, c, d, a, b,     F_w6c06, MD5S02);
+    MD5_STEP0(MD5_Fo, b, c, d, a,     F_w7c07, MD5S03);
+    MD5_STEP0(MD5_Fo, a, b, c, d,     F_w8c08, MD5S00);
+    MD5_STEP0(MD5_Fo, d, a, b, c,     F_w9c09, MD5S01);
+    MD5_STEP0(MD5_Fo, c, d, a, b,     F_wac0a, MD5S02);
+    MD5_STEP0(MD5_Fo, b, c, d, a,     F_wbc0b, MD5S03);
+    MD5_STEP0(MD5_Fo, a, b, c, d,     F_wcc0c, MD5S00);
+    MD5_STEP0(MD5_Fo, d, a, b, c,     F_wdc0d, MD5S01);
+    MD5_STEP0(MD5_Fo, c, d, a, b,     F_wec0e, MD5S02);
+    MD5_STEP0(MD5_Fo, b, c, d, a,     F_wfc0f, MD5S03);
+
+    MD5_STEP0(MD5_Go, a, b, c, d,     G_w1c10, MD5S10);
+    MD5_STEP0(MD5_Go, d, a, b, c,     G_w6c11, MD5S11);
+    MD5_STEP0(MD5_Go, c, d, a, b,     G_wbc12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0, G_w0c13, MD5S13);
+    MD5_STEP0(MD5_Go, a, b, c, d,     G_w5c14, MD5S10);
+    MD5_STEP0(MD5_Go, d, a, b, c,     G_wac15, MD5S11);
+    MD5_STEP0(MD5_Go, c, d, a, b,     G_wfc16, MD5S12);
+    MD5_STEP0(MD5_Go, b, c, d, a,     G_w4c17, MD5S13);
+    MD5_STEP0(MD5_Go, a, b, c, d,     G_w9c18, MD5S10);
+    MD5_STEP0(MD5_Go, d, a, b, c,     G_wec19, MD5S11);
+    MD5_STEP0(MD5_Go, c, d, a, b,     G_w3c1a, MD5S12);
+    MD5_STEP0(MD5_Go, b, c, d, a,     G_w8c1b, MD5S13);
+    MD5_STEP0(MD5_Go, a, b, c, d,     G_wdc1c, MD5S10);
+    MD5_STEP0(MD5_Go, d, a, b, c,     G_w2c1d, MD5S11);
+    MD5_STEP0(MD5_Go, c, d, a, b,     G_w7c1e, MD5S12);
+    MD5_STEP0(MD5_Go, b, c, d, a,     G_wcc1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP0(MD5_H1, a, b, c, d,     H_w5c20, MD5S20);
+    MD5_STEP0(MD5_H2, d, a, b, c,     H_w8c21, MD5S21);
+    MD5_STEP0(MD5_H1, c, d, a, b,     H_wbc22, MD5S22);
+    MD5_STEP0(MD5_H2, b, c, d, a,     H_wec23, MD5S23);
+    MD5_STEP0(MD5_H1, a, b, c, d,     H_w1c24, MD5S20);
+    MD5_STEP0(MD5_H2, d, a, b, c,     H_w4c25, MD5S21);
+    MD5_STEP0(MD5_H1, c, d, a, b,     H_w7c26, MD5S22);
+    MD5_STEP0(MD5_H2, b, c, d, a,     H_wac27, MD5S23);
+    MD5_STEP0(MD5_H1, a, b, c, d,     H_wdc28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0, H_w0c29, MD5S21);
+    MD5_STEP0(MD5_H1, c, d, a, b,     H_w3c2a, MD5S22);
+    MD5_STEP0(MD5_H2, b, c, d, a,     H_w6c2b, MD5S23);
+    MD5_STEP0(MD5_H1, a, b, c, d,     H_w9c2c, MD5S20);
+    MD5_STEP0(MD5_H2, d, a, b, c,     H_wcc2d, MD5S21);
+    MD5_STEP0(MD5_H1, c, d, a, b,     H_wfc2e, MD5S22);
+    MD5_STEP0(MD5_H2, b, c, d, a,     H_w2c2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0, I_w0c30, MD5S30);
+    MD5_STEP0(MD5_I , d, a, b, c,     I_w7c31, MD5S31);
+    MD5_STEP0(MD5_I , c, d, a, b,     I_wec32, MD5S32);
+    MD5_STEP0(MD5_I , b, c, d, a,     I_w5c33, MD5S33);
+    MD5_STEP0(MD5_I , a, b, c, d,     I_wcc34, MD5S30);
+    MD5_STEP0(MD5_I , d, a, b, c,     I_w3c35, MD5S31);
+    MD5_STEP0(MD5_I , c, d, a, b,     I_wac36, MD5S32);
+    MD5_STEP0(MD5_I , b, c, d, a,     I_w1c37, MD5S33);
+    MD5_STEP0(MD5_I , a, b, c, d,     I_w8c38, MD5S30);
+    MD5_STEP0(MD5_I , d, a, b, c,     I_wfc39, MD5S31);
+    MD5_STEP0(MD5_I , c, d, a, b,     I_w6c3a, MD5S32);
+    MD5_STEP0(MD5_I , b, c, d, a,     I_wdc3b, MD5S33);
+    MD5_STEP0(MD5_I , a, b, c, d,     I_w4c3c, MD5S30);
+    MD5_STEP0(MD5_I , d, a, b, c,     I_wbc3d, MD5S31);
+    MD5_STEP0(MD5_I , c, d, a, b,     I_w2c3e, MD5S32);
+    MD5_STEP0(MD5_I , b, c, d, a,     I_w9c3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 ukey[8];
+
+    ukey[0] = a;
+    ukey[1] = b;
+    ukey[2] = c;
+    ukey[3] = d;
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    const u32x dgst_pw_salt_len = 16 + pw_salt_len;
+
+    u32x w0_t[4];
+    u32x w1_t[4];
+    u32x w2_t[4];
+    u32x w3_t[4];
+
+    w0_t[0] = a;
+    w0_t[1] = b;
+    w0_t[2] = c;
+    w0_t[3] = d;
+
+    w1_t[0] = w0;
+    w1_t[1] = w[1];
+    w1_t[2] = w[2];
+    w1_t[3] = w[3];
+
+    w2_t[0] = w[4];
+    w2_t[1] = w[5];
+    w2_t[2] = w[6];
+    w2_t[3] = w[7];
+
+    w3_t[0] = w[8];
+    w3_t[1] = w[9];
+    w3_t[2] = dgst_pw_salt_len * 8;
+    w3_t[3] = 0;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0_t[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0_t[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0_t[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1_t[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1_t[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1_t[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2_t[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2_t[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2_t[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3_t[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3_t[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3_t[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0_t[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1_t[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2_t[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1_t[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2_t[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3_t[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0_t[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2_t[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3_t[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0_t[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1_t[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3_t[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2_t[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2_t[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3_t[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0_t[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1_t[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1_t[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3_t[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0_t[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1_t[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2_t[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3_t[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0_t[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1_t[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3_t[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3_t[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0_t[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0_t[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2_t[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1_t[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3_t[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1_t[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2_t[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0_t[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2_t[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    ukey[4] = a;
+    ukey[5] = b;
+    ukey[6] = c;
+    ukey[7] = d;
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    w0_t[0] = a;
+    w0_t[1] = b;
+    w0_t[2] = c;
+    w0_t[3] = d;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0_t[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0_t[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0_t[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1_t[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1_t[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1_t[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2_t[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2_t[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2_t[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3_t[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3_t[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3_t[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0_t[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1_t[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2_t[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1_t[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2_t[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3_t[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0_t[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2_t[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3_t[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0_t[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1_t[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3_t[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2_t[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2_t[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3_t[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0_t[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1_t[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1_t[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3_t[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0_t[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1_t[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2_t[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3_t[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0_t[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1_t[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3_t[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3_t[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0_t[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0_t[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2_t[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1_t[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3_t[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1_t[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2_t[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0_t[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2_t[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u32 iv[4];
+
+    iv[0] = a;
+    iv[1] = b;
+    iv[2] = c;
+    iv[3] = d;
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_m04 (KERN_ATTR_VECTOR ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m22500 (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m22500_m08 (KERN_ATTR_VECTOR ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m22500 (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m22500_m16 (KERN_ATTR_VECTOR ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m22500 (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m22500_s04 (KERN_ATTR_VECTOR ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m22500 (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m22500_s08 (KERN_ATTR_VECTOR ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m22500 (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m22500_s16 (KERN_ATTR_VECTOR ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m22500 (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}

--- a/OpenCL/m22500_a3-pure.cl
+++ b/OpenCL/m22500_a3-pure.cl
@@ -1,0 +1,650 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+DECLSPEC int is_valid_bitcoinj_8 (const u8 v)
+{
+  // .abcdefghijklmnopqrstuvwxyz
+
+  if (v > (u8) 'z') return 0;
+  if (v < (u8) '.') return 0;
+
+  if ((v > (u8) '.') && (v < (u8) 'a')) return 0;
+
+  return 1;
+}
+
+KERNEL_FQ void m22500_mxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * salt
+   */
+
+  u32 s[64] = { 0 };
+
+  s[0] = salt_bufs[salt_pos].salt_buf[0];
+  s[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    md5_ctx_t ctx;
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 ukey[8];
+
+    ukey[0] = ctx.h[0];
+    ukey[1] = ctx.h[1];
+    ukey[2] = ctx.h[2];
+    ukey[3] = ctx.h[3];
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    u32 h[16] = { 0 }; // we need 64-bit alignment for md5_update ()
+
+    h[0] = ctx.h[0];
+    h[1] = ctx.h[1];
+    h[2] = ctx.h[2];
+    h[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, h, 16);
+    md5_update (&ctx, w, pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    ukey[4] = ctx.h[0];
+    ukey[5] = ctx.h[1];
+    ukey[6] = ctx.h[2];
+    ukey[7] = ctx.h[3];
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    h[0] = ctx.h[0];
+    h[1] = ctx.h[1];
+    h[2] = ctx.h[2];
+    h[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, h, 16);
+    md5_update (&ctx, w, pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 iv[4];
+
+    iv[0] = ctx.h[0];
+    iv[1] = ctx.h[1];
+    iv[2] = ctx.h[2];
+    iv[3] = ctx.h[3];
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m22500_sxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * salt
+   */
+
+  u32 s[64] = { 0 };
+
+  s[0] = salt_bufs[salt_pos].salt_buf[0];
+  s[1] = salt_bufs[salt_pos].salt_buf[1];
+
+  u32 data[8];
+
+  data[0] = salt_bufs[salt_pos].salt_buf[2];
+  data[1] = salt_bufs[salt_pos].salt_buf[3];
+  data[2] = salt_bufs[salt_pos].salt_buf[4];
+  data[3] = salt_bufs[salt_pos].salt_buf[5];
+  data[4] = salt_bufs[salt_pos].salt_buf[6];
+  data[5] = salt_bufs[salt_pos].salt_buf[7];
+  data[6] = salt_bufs[salt_pos].salt_buf[8];
+  data[7] = salt_bufs[salt_pos].salt_buf[9];
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    /**
+     * key1 = md5 ($pass . $salt):
+     */
+
+    md5_ctx_t ctx;
+
+    md5_init   (&ctx);
+    md5_update (&ctx, w, pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 ukey[8];
+
+    ukey[0] = ctx.h[0];
+    ukey[1] = ctx.h[1];
+    ukey[2] = ctx.h[2];
+    ukey[3] = ctx.h[3];
+
+    /**
+     * key2 = md5 ($key1 . $pass . $salt):
+     */
+
+    u32 h[16] = { 0 }; // we need 64-bit alignment for md5_update ()
+
+    h[0] = ctx.h[0];
+    h[1] = ctx.h[1];
+    h[2] = ctx.h[2];
+    h[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, h, 16);
+    md5_update (&ctx, w, pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    ukey[4] = ctx.h[0];
+    ukey[5] = ctx.h[1];
+    ukey[6] = ctx.h[2];
+    ukey[7] = ctx.h[3];
+
+    /**
+     * iv = md5 ($key2 . $pass . $salt):
+     */
+
+    h[0] = ctx.h[0];
+    h[1] = ctx.h[1];
+    h[2] = ctx.h[2];
+    h[3] = ctx.h[3];
+
+    md5_init   (&ctx);
+    md5_update (&ctx, h, 16);
+    md5_update (&ctx, w, pw_len);
+    md5_update (&ctx, s, 8);
+    md5_final  (&ctx);
+
+    u32 iv[4];
+
+    iv[0] = ctx.h[0];
+    iv[1] = ctx.h[1];
+    iv[2] = ctx.h[2];
+    iv[3] = ctx.h[3];
+
+    /**
+     * AES-256-CBC:
+     */
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    aes256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 encrypted[4];
+
+    encrypted[0] = data[0];
+    encrypted[1] = data[1];
+    encrypted[2] = data[2];
+    encrypted[3] = data[3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+
+    // first char of decrypted wallet data must be K, L, Q, 5, # or \n
+
+    const u32 first_byte = out[0] & 0xff;
+
+    if ((first_byte != 0x4b) && // K
+        (first_byte != 0x4c) && // L
+        (first_byte != 0x51) && // Q
+        (first_byte != 0x35) && // 5
+        (first_byte != 0x23) && // #
+        (first_byte != 0x0a))   // \n
+    {
+      continue;
+    }
+
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((first_byte == 0x4b) || // K => MultiBit Classic Wallet
+        (first_byte == 0x4c) || // L
+        (first_byte == 0x51) || // Q
+        (first_byte == 0x35))   // 5
+    {
+      // base58 check:
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      if (is_valid_base58_32 (out[0]) == 0) continue;
+      if (is_valid_base58_32 (out[1]) == 0) continue;
+      if (is_valid_base58_32 (out[2]) == 0) continue;
+      if (is_valid_base58_32 (out[3]) == 0) continue;
+    }
+    else if (first_byte == 0x0a) // \n => bitcoinj
+    {
+      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+
+      // check for "org." substring:
+
+      if ((out[0] & 0xffff0000) != 0x726f0000) continue; // "ro" (byte swapped)
+      if ((out[1] & 0x0000ffff) != 0x00002e67) continue; // ".g"
+
+      if (is_valid_bitcoinj_8 (out[1] >> 16) == 0) continue; // byte  6 (counting from 0)
+      if (is_valid_bitcoinj_8 (out[1] >> 24) == 0) continue; // byte  7
+
+      if (is_valid_bitcoinj_8 (out[2] >>  0) == 0) continue; // byte  8
+      if (is_valid_bitcoinj_8 (out[2] >>  8) == 0) continue; // byte  9
+      if (is_valid_bitcoinj_8 (out[2] >> 16) == 0) continue; // byte 10
+      if (is_valid_bitcoinj_8 (out[2] >> 24) == 0) continue; // byte 11
+
+      if (is_valid_bitcoinj_8 (out[3] >>  0) == 0) continue; // byte 12
+      if (is_valid_bitcoinj_8 (out[3] >>  8) == 0) continue; // byte 13
+    }
+    else // if (first_byte == 0x23) // # => KnCGroup Bitcoin Wallet
+    {
+      // Full string would be:
+      // "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      // check for "# KEEP YOUR PRIV" substring:
+
+      if (out[0] != 0x454b2023) continue; // "EK #" (byte swapped)
+      if (out[1] != 0x59205045) continue; // "Y PE"
+      if (out[2] != 0x2052554f) continue; // " RUO"
+      if (out[3] != 0x56495250) continue; // "VIRP"
+
+      iv[0] = encrypted[0];
+      iv[1] = encrypted[1];
+      iv[2] = encrypted[2];
+      iv[3] = encrypted[3];
+
+      encrypted[0] = data[4];
+      encrypted[1] = data[5];
+      encrypted[2] = data[6];
+      encrypted[3] = data[7];
+
+      aes256_decrypt (ks, encrypted, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      out[0] ^= iv[0];
+      out[1] ^= iv[1];
+      out[2] ^= iv[2];
+      out[3] ^= iv[3];
+
+      // check for "ATE KEYS SAFE! A" substring:
+
+      if (out[0] != 0x20455441) continue; // " ETA" (byte swapped)
+      if (out[1] != 0x5359454b) continue; // "SYEK"
+      if (out[2] != 0x46415320) continue; // "FAS "
+      if (out[3] != 0x41202145) continue; // "A !E"
+    }
+
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+    }
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -40,6 +40,7 @@
 - Added hash-mode: md5($salt.sha1($salt.$pass))
 - Added hash-mode: md5(sha1($pass).md5($pass).sha1($pass))
 - Added hash-mode: md5(sha1($salt).md5($pass))
+- Added hash-mode: MultiBit Classic .key (MD5)
 - Added hash-mode: Open Document Format (ODF) 1.1 (SHA-1, Blowfish)
 - Added hash-mode: Open Document Format (ODF) 1.2 (SHA-256, AES)
 - Added hash-mode: Oracle Transportation Management (SHA256)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -284,6 +284,7 @@ NVIDIA GPUs require "NVIDIA Driver" (418.56 or later) and "CUDA Toolkit" (9.0 or
 - Ethereum Pre-Sale Wallet, PBKDF2-HMAC-SHA256
 - Ethereum Wallet, PBKDF2-HMAC-SHA256
 - Ethereum Wallet, SCRYPT
+- MultiBit Classic .key (MD5)
 - 7-Zip
 - RAR3-hp
 - RAR5

--- a/src/modules/module_22500.c
+++ b/src/modules/module_22500.c
@@ -121,16 +121,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   salt->salt_buf[8] = hex_to_u32 (data_pos + 48);
   salt->salt_buf[9] = hex_to_u32 (data_pos + 56);
 
-  // TODO remove ?
-  // salt->salt_buf[2] = byte_swap_32 (salt->salt_buf[2]);
-  // salt->salt_buf[3] = byte_swap_32 (salt->salt_buf[3]);
-  // salt->salt_buf[4] = byte_swap_32 (salt->salt_buf[4]);
-  // salt->salt_buf[5] = byte_swap_32 (salt->salt_buf[5]);
-  // salt->salt_buf[6] = byte_swap_32 (salt->salt_buf[6]);
-  // salt->salt_buf[7] = byte_swap_32 (salt->salt_buf[7]);
-  // salt->salt_buf[8] = byte_swap_32 (salt->salt_buf[8]);
-  // salt->salt_buf[9] = byte_swap_32 (salt->salt_buf[9]);
-
   salt->salt_len = 40; // 8 + 32;
 
   // fake hash

--- a/src/modules/module_22500.c
+++ b/src/modules/module_22500.c
@@ -1,0 +1,236 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PASSWORD_MANAGER;
+static const char *HASH_NAME      = "MultiBit Classic .key (MD5)";
+static const u64   KERN_TYPE      = 22500;
+static const u32   OPTI_TYPE      = OPTI_TYPE_EARLY_SKIP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$multibit$1*e5912fe5c84af3d5*5f0391c219e8ef62c06505b1f6232858f5bcaa739c2b471d45dd0bd8345334de";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+static const char *SIGNATURE_MULTIBIT = "$multibit$";
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  u32 pw_max = PW_MAX;
+
+  if (optimized_kernel == true)
+  {
+    pw_max = 31; // 55 - 8 (salt) - 16 (key1/key2)
+  }
+
+  return pw_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  token_t token;
+
+  token.token_cnt  = 4;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_MULTIBIT;
+
+  token.len[0]     = 10;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '*';
+  token.len_min[1] = 1;
+  token.len_max[1] = 1;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[2]     = '*';
+  token.len_min[2] = 16;
+  token.len_max[2] = 16;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[3]     = '*';
+  token.len_min[3] = 64;
+  token.len_max[3] = 64;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // version
+
+  const u8 *version_pos = token.buf[1];
+
+  const u32 version = hc_strtoul ((const char *) version_pos, NULL, 10);
+
+  if (version != 1) return PARSER_SALT_VALUE;
+
+  // salt
+
+  const u8 *salt_pos = token.buf[2];
+
+  salt->salt_buf[0] = hex_to_u32 (salt_pos + 0);
+  salt->salt_buf[1] = hex_to_u32 (salt_pos + 8);
+
+  // data
+
+  const u8 *data_pos = token.buf[3];
+
+  salt->salt_buf[2] = hex_to_u32 (data_pos +  0);
+  salt->salt_buf[3] = hex_to_u32 (data_pos +  8);
+  salt->salt_buf[4] = hex_to_u32 (data_pos + 16);
+  salt->salt_buf[5] = hex_to_u32 (data_pos + 24);
+  salt->salt_buf[6] = hex_to_u32 (data_pos + 32);
+  salt->salt_buf[7] = hex_to_u32 (data_pos + 40);
+  salt->salt_buf[8] = hex_to_u32 (data_pos + 48);
+  salt->salt_buf[9] = hex_to_u32 (data_pos + 56);
+
+  // TODO remove ?
+  // salt->salt_buf[2] = byte_swap_32 (salt->salt_buf[2]);
+  // salt->salt_buf[3] = byte_swap_32 (salt->salt_buf[3]);
+  // salt->salt_buf[4] = byte_swap_32 (salt->salt_buf[4]);
+  // salt->salt_buf[5] = byte_swap_32 (salt->salt_buf[5]);
+  // salt->salt_buf[6] = byte_swap_32 (salt->salt_buf[6]);
+  // salt->salt_buf[7] = byte_swap_32 (salt->salt_buf[7]);
+  // salt->salt_buf[8] = byte_swap_32 (salt->salt_buf[8]);
+  // salt->salt_buf[9] = byte_swap_32 (salt->salt_buf[9]);
+
+  salt->salt_len = 40; // 8 + 32;
+
+  // fake hash
+
+  digest[0] = salt->salt_buf[2];
+  digest[1] = salt->salt_buf[3];
+  digest[2] = salt->salt_buf[4];
+  digest[3] = salt->salt_buf[5];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  int line_len = snprintf (line_buf, line_size, "%s%i*%08x%08x*%08x%08x%08x%08x%08x%08x%08x%08x",
+    SIGNATURE_MULTIBIT,
+    1,
+    byte_swap_32 (salt->salt_buf[0]),
+    byte_swap_32 (salt->salt_buf[1]),
+    byte_swap_32 (salt->salt_buf[2]),
+    byte_swap_32 (salt->salt_buf[3]),
+    byte_swap_32 (salt->salt_buf[4]),
+    byte_swap_32 (salt->salt_buf[5]),
+    byte_swap_32 (salt->salt_buf[6]),
+    byte_swap_32 (salt->salt_buf[7]),
+    byte_swap_32 (salt->salt_buf[8]),
+    byte_swap_32 (salt->salt_buf[9]));
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m22500.pm
+++ b/tools/test_modules/m22500.pm
@@ -1,0 +1,192 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::MD5 qw (md5);
+use Crypt::CBC;
+
+sub module_constraints { [[0, 256], [8, 8], [0, 31], [8, 8], [-1, -1]] }
+
+my $BASE58_CHARS   = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+my $BITCOINJ_CHARS = ".abcdefghijklmnopqrstuvwxyz";
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $data = shift;
+
+  my $word_salt = $word . $salt;
+
+  my $key1 = md5 (        $word_salt);
+  my $key2 = md5 ($key1 . $word_salt);
+  my $iv   = md5 ($key2 . $word_salt);
+
+  my $aes_cbc = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    iv          => $iv,
+    key         => $key1 . $key2,
+    keysize     => 32,
+    literal_key => 1,
+    header      => "none",
+    padding     => "none"
+  });
+
+  my $type = 0; # 0: MultiBit Classic MD5, 1: KnCGroup Bitcoin Wallet, 2: bitcoinj
+  my $key = "";
+
+  if (! defined ($data))
+  {
+    $type = random_number (0, 2);
+
+    if ($type == 0)
+    {
+      my @chars_at_start = ('K', 'L', 'Q', '5');
+
+      $data = $chars_at_start[random_number (0, scalar (@chars_at_start) - 1)];
+
+      for (my $i = 1; $i < 32; $i++)
+      {
+        $data .= substr ($BASE58_CHARS, random_number (0, length ($BASE58_CHARS) - 1), 1);
+      }
+    }
+    elsif ($type == 1)
+    {
+      $data  = "\n";
+      $data .= chr (random_number (0, 127));
+      $data .= "org.";
+
+      for (my $i = 6; $i < 32; $i++)
+      {
+        $data .= substr ($BITCOINJ_CHARS, random_number (0, length ($BITCOINJ_CHARS) - 1), 1);
+      }
+    }
+    elsif ($type == 2)
+    {
+      # Full string would be:
+      # "# KEEP YOUR PRIVATE KEYS SAFE! Anyone who can read this can spend your Bitcoins."
+
+      $data = '# KEEP YOUR PRIVATE KEYS SAFE! A';
+    }
+
+    $key = $aes_cbc->encrypt ($data);
+  }
+  else
+  {
+    $key = $aes_cbc->decrypt ($data);
+
+    # verification step:
+
+    # first char of $key must be K, L, Q, 5, # or \n
+
+    my $char_at_start = substr ($key, 0, 1);
+
+    if (($char_at_start eq 'K') ||
+        ($char_at_start eq 'L') ||
+        ($char_at_start eq 'Q') ||
+        ($char_at_start eq '5'))
+    {
+      my $error = 0;
+
+      for (my $i = 1; $i < 32; $i++) # start with 1 (we already checked first char)
+      {
+        my $c = substr ($key, $i, 1);
+
+        my $idx = index ($BASE58_CHARS, $c);
+
+        next if ($idx >= 0);
+
+        $error = 1;
+
+        last;
+      }
+
+      if ($error == 0)
+      {
+        $key = $data;
+      }
+    }
+    elsif ($char_at_start eq "\n") # bitcoinj
+    {
+      my $second_char = substr ($key, 1, 1);
+
+      if (ord ($second_char) < 128)
+      {
+        if (substr ($key, 2, 4) eq "org.")
+        {
+          my $error = 0;
+
+          for (my $i = 6; $i < 14; $i++) # start with 6 (we already checked first chars)
+          {
+            my $c = substr ($key, $i, 1);
+
+            my $idx = index ($BITCOINJ_CHARS, $c);
+
+            next if ($idx >= 0);
+
+            $error = 1;
+
+            last;
+          }
+
+          if ($error == 0)
+          {
+            $key = $data;
+          }
+        }
+      }
+    }
+    elsif ($char_at_start eq '#')  # KnCGroup Bitcoin Wallet
+    {
+      if (substr ($key, 0, 16) eq '# KEEP YOUR PRIV')
+      {
+        $key = $data;
+      }
+    }
+  }
+
+  my $hash = sprintf ("\$multibit\$1*%s*%s", unpack ("H*", $salt), unpack ("H*", $key));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless substr ($hash, 0, 12) eq '$multibit$1*';
+
+  $idx = index ($hash, '*', 12);
+
+  return unless $idx == 28;
+
+  my $salt_hex = substr ($hash, 12, 16); # 28 - 12 = 16
+  my $data_hex = substr ($hash, 29);
+
+  return unless length ($salt_hex) == 16;
+  return unless length ($data_hex) == 64;
+
+  my $salt = pack ("H*", $salt_hex);
+  my $data = pack ("H*", $data_hex);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $data);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This implements the MD5 variants (for MultiBit Bitcoin Wallet, bitcoinj and KnCGroup Bitcoin Wallet) of the MultiBit Classic .key (MD5) algorithm, see request #1538 .

MultiBit has some other variants too (see $multibit$2 and $multibit$3 from multibit2john.py), these other algorithms are currently NOT supported (yet).

The algorithm basically uses 3 calls of MD5 to generate the AES key and IV to decrypt some data.

Even if it is actually quite unlickely, the data length and missing base58check checksum from the JTR hash could make this format produce some false positives (again, very unlikely). I would still suggest running it with --keep-guessing and test the passwords manually with the MultiBit Wallet software.

Thank you very much