### PR TITLE
Added -m 7401 = MySQL $A$ (sha256crypt), closes #2305

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -41,6 +41,7 @@
 - Added hash-mode: md5(sha1($pass).md5($pass).sha1($pass))
 - Added hash-mode: md5(sha1($salt).md5($pass))
 - Added hash-mode: MultiBit Classic .key (MD5)
+- Added hash-mode: MySQL $A$ (sha256crypt)
 - Added hash-mode: Open Document Format (ODF) 1.1 (SHA-1, Blowfish)
 - Added hash-mode: Open Document Format (ODF) 1.2 (SHA-256, AES)
 - Added hash-mode: Oracle Transportation Management (SHA256)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -213,6 +213,7 @@ NVIDIA GPUs require "NVIDIA Driver" (418.56 or later) and "CUDA Toolkit" (9.0 or
 - Oracle T: Type (Oracle 12+)
 - MySQL323
 - MySQL4.1/MySQL5
+- MySQL $A$ (sha256crypt)
 - Sybase ASE
 - hMailServer
 - DNSSEC (NSEC3)

--- a/src/modules/module_07401.c
+++ b/src/modules/module_07401.c
@@ -1,0 +1,459 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_8;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_DATABASE_SERVER;
+static const char *HASH_NAME      = "MySQL $A$ (sha256crypt)";
+static const u64   KERN_TYPE      = 7400;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_ST_HEX;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$mysql$A$005*F9CC98CE08892924F50A213B6BC571A2C11778C5*625479393559393965414D45316477456B484F41316E64484742577A2E3162785353526B7554584647562F";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct sha256crypt_tmp
+{
+  u32 alt_result[8];
+  u32 p_bytes[64];
+  u32 s_bytes[64];
+
+} sha256crypt_tmp_t;
+
+static const u32   MULTIPLIER_MYSQL = 1000;
+static const char *SIGNATURE_MYSQL  = "$mysql$";
+
+static void sha256crypt_decode (u8 digest[32], const u8 buf[43])
+{
+  int l;
+
+  l  = itoa64_to_int (buf[ 0]) <<  0;
+  l |= itoa64_to_int (buf[ 1]) <<  6;
+  l |= itoa64_to_int (buf[ 2]) << 12;
+  l |= itoa64_to_int (buf[ 3]) << 18;
+
+  digest[ 0] = (l >> 16) & 0xff;
+  digest[10] = (l >>  8) & 0xff;
+  digest[20] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[ 4]) <<  0;
+  l |= itoa64_to_int (buf[ 5]) <<  6;
+  l |= itoa64_to_int (buf[ 6]) << 12;
+  l |= itoa64_to_int (buf[ 7]) << 18;
+
+  digest[21] = (l >> 16) & 0xff;
+  digest[ 1] = (l >>  8) & 0xff;
+  digest[11] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[ 8]) <<  0;
+  l |= itoa64_to_int (buf[ 9]) <<  6;
+  l |= itoa64_to_int (buf[10]) << 12;
+  l |= itoa64_to_int (buf[11]) << 18;
+
+  digest[12] = (l >> 16) & 0xff;
+  digest[22] = (l >>  8) & 0xff;
+  digest[ 2] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[12]) <<  0;
+  l |= itoa64_to_int (buf[13]) <<  6;
+  l |= itoa64_to_int (buf[14]) << 12;
+  l |= itoa64_to_int (buf[15]) << 18;
+
+  digest[ 3] = (l >> 16) & 0xff;
+  digest[13] = (l >>  8) & 0xff;
+  digest[23] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[16]) <<  0;
+  l |= itoa64_to_int (buf[17]) <<  6;
+  l |= itoa64_to_int (buf[18]) << 12;
+  l |= itoa64_to_int (buf[19]) << 18;
+
+  digest[24] = (l >> 16) & 0xff;
+  digest[ 4] = (l >>  8) & 0xff;
+  digest[14] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[20]) <<  0;
+  l |= itoa64_to_int (buf[21]) <<  6;
+  l |= itoa64_to_int (buf[22]) << 12;
+  l |= itoa64_to_int (buf[23]) << 18;
+
+  digest[15] = (l >> 16) & 0xff;
+  digest[25] = (l >>  8) & 0xff;
+  digest[ 5] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[24]) <<  0;
+  l |= itoa64_to_int (buf[25]) <<  6;
+  l |= itoa64_to_int (buf[26]) << 12;
+  l |= itoa64_to_int (buf[27]) << 18;
+
+  digest[ 6] = (l >> 16) & 0xff;
+  digest[16] = (l >>  8) & 0xff;
+  digest[26] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[28]) <<  0;
+  l |= itoa64_to_int (buf[29]) <<  6;
+  l |= itoa64_to_int (buf[30]) << 12;
+  l |= itoa64_to_int (buf[31]) << 18;
+
+  digest[27] = (l >> 16) & 0xff;
+  digest[ 7] = (l >>  8) & 0xff;
+  digest[17] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[32]) <<  0;
+  l |= itoa64_to_int (buf[33]) <<  6;
+  l |= itoa64_to_int (buf[34]) << 12;
+  l |= itoa64_to_int (buf[35]) << 18;
+
+  digest[18] = (l >> 16) & 0xff;
+  digest[28] = (l >>  8) & 0xff;
+  digest[ 8] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[36]) <<  0;
+  l |= itoa64_to_int (buf[37]) <<  6;
+  l |= itoa64_to_int (buf[38]) << 12;
+  l |= itoa64_to_int (buf[39]) << 18;
+
+  digest[ 9] = (l >> 16) & 0xff;
+  digest[19] = (l >>  8) & 0xff;
+  digest[29] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[40]) <<  0;
+  l |= itoa64_to_int (buf[41]) <<  6;
+  l |= itoa64_to_int (buf[42]) << 12;
+
+  digest[31] = (l >>  8) & 0xff;
+  digest[30] = (l >>  0) & 0xff;
+}
+
+static void sha256crypt_encode (const u8 digest[32], u8 buf[43])
+{
+  int l;
+
+  l = (digest[ 0] << 16) | (digest[10] << 8) | (digest[20] << 0);
+
+  buf[ 0] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 1] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 2] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 3] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[21] << 16) | (digest[ 1] << 8) | (digest[11] << 0);
+
+  buf[ 4] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 5] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 6] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 7] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[12] << 16) | (digest[22] << 8) | (digest[ 2] << 0);
+
+  buf[ 8] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 9] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[10] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[11] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[ 3] << 16) | (digest[13] << 8) | (digest[23] << 0);
+
+  buf[12] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[13] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[14] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[15] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[24] << 16) | (digest[ 4] << 8) | (digest[14] << 0);
+
+  buf[16] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[17] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[18] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[19] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[15] << 16) | (digest[25] << 8) | (digest[ 5] << 0);
+
+  buf[20] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[21] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[22] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[23] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[ 6] << 16) | (digest[16] << 8) | (digest[26] << 0);
+
+  buf[24] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[25] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[26] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[27] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[27] << 16) | (digest[ 7] << 8) | (digest[17] << 0);
+
+  buf[28] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[29] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[30] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[31] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[18] << 16) | (digest[28] << 8) | (digest[ 8] << 0);
+
+  buf[32] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[33] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[34] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[35] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l = (digest[ 9] << 16) | (digest[19] << 8) | (digest[29] << 0);
+
+  buf[36] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[37] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[38] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[39] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+
+  l =                  0 | (digest[31] << 8) | (digest[30] << 0);
+
+  buf[40] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[41] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[42] = int_to_itoa64 (l & 0x3f); //l >>= 6;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (sha256crypt_tmp_t);
+
+  return tmp_size;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  u32 pw_max = PW_MAX;
+
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  if (optimized_kernel == true)
+  {
+    pw_max = 15;
+  }
+
+  return pw_max;
+}
+
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  char *jit_build_options = NULL;
+
+  hc_asprintf (&jit_build_options, "-D NO_UNROLL");
+
+  return jit_build_options;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  token_t token;
+
+  token.token_cnt  = 5;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_MYSQL;
+
+  token.len[0]     = 7;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.len_min[1] = 1;
+  token.len_max[1] = 1;
+  token.sep[1]     = '$';
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  token.len_min[2] = 3;
+  token.len_max[2] = 3;
+  token.sep[2]     = '*';
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[3] = 40;
+  token.len_max[3] = 40;
+  token.sep[3]     = '*';
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[4] = 86;
+  token.len_max[4] = 86;
+  token.sep[4]     = '*';
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // version:
+
+  const u8 *version_pos = token.buf[1];
+
+  if (version_pos[0] != 'A') return (PARSER_SIGNATURE_UNMATCHED); // $A$
+
+  // cost factor:
+
+  const u8 *cost_pos = token.buf[2];
+
+  u32 cost_factor = hc_strtoul ((const char *) cost_pos, NULL, 10);
+
+  u32 salt_iter = cost_factor * MULTIPLIER_MYSQL;
+
+  // from: https://github.com/mysql/mysql-server/blob/4869291f7ee258e136ef03f5a50135fe7329ffb9/include/crypt_genhash_impl.h#L30-L31
+
+  if (salt_iter < 1000) return (PARSER_SALT_ITERATION);
+
+  // this check would probably be unsafe because it might change in the future:
+  // if (salt_iter > 5000) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = salt_iter;
+
+  const u8 *salt_pos = token.buf[3];
+  const int salt_len = token.len[3];
+
+  const bool parse_rc = generic_salt_decode (hashconfig, salt_pos, salt_len, (u8 *) salt->salt_buf, (int *) &salt->salt_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  const u8 *hash_pos = token.buf[4];
+  const int hash_len = token.len[4];
+
+  u8 tmp_dgst[100] = { 0 };
+
+  const int dgst_len = hex_decode ((const u8 *) hash_pos, hash_len, (u8 *) tmp_dgst);
+
+  if (dgst_len != 43) return (PARSER_HASH_ENCODING);
+
+  sha256crypt_decode ((u8 *) digest, tmp_dgst);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  // digest:
+
+  u8 dgst[100] = { 0 };
+
+  sha256crypt_encode ((u8 *) digest_buf, dgst);
+
+  // yeah, this is weird: we use hex-encoding for base64-encoded salt
+  // this has to do with missing MySQL function to decode/encode this variant of base64
+
+  u8 hex_dgst[100] = { 0 };
+
+  hex_encode (dgst, 43, hex_dgst);
+
+  uppercase (hex_dgst, 86); // cosmetic
+
+  // salt:
+
+  u8 hex_salt[SALT_MAX * 2] = { 0 };
+
+  const int salt_len = generic_salt_encode (hashconfig, (const u8 *) salt->salt_buf, (const int) salt->salt_len, hex_salt);
+
+  hex_salt[salt_len] = 0;
+
+  uppercase (hex_salt, 40); // cosmetic
+
+  const int cost = salt->salt_iter / MULTIPLIER_MYSQL;
+
+  int line_len = snprintf (line_buf, line_size, "$mysql$A$%03i*%s*%s", cost, hex_salt, hex_dgst);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}


### PR DESCRIPTION
This pull request implements the new sha256crypt variant of the MySQL (Database) hashes... it is actually just like -m 7400 but with a salt length of 20 bytes (and hash encoding is different, see https://github.com/hashcat/hashcat/issues/2305).

The hash format uses $mysql$A$ as a signature+version and the salt and digest in hexadecimal (there is a caveat, because the digest is actually double-encoded... it is converted to hex to make the hash format look nicer, but the input/digest itself is already base64 encoded with the "normal" sha256crypt base64 table, non-standard).
For discussion about the format see https://github.com/hashcat/hashcat/issues/2305

The hashes can be retrieved with this SQL query:

```
use mysql;

SELECT user, CONCAT('$mysql',LEFT(authentication_string,6),'*',INSERT(HEX(SUBSTR(authentication_string,8)),41,0,'*')) AS hash FROM user WHERE plugin = 'caching_sha2_password' AND authentication_string NOT LIKE '%INVALIDSALTANDPASSWORD%';
```

Thanks