### PR TITLE
update the number of supported hash types in docs/readme.txt

### DIFF
--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -41,7 +41,7 @@ NVIDIA GPUs require "NVIDIA Driver" (418.56 or later) and "CUDA Toolkit" (9.0 or
 - Supports automatic keyspace ordering markov-chains
 - Built-in benchmarking system
 - Integrated thermal watchdog
-- 200+ Hash-types implemented with performance in mind
+- 300+ Hash-types implemented with performance in mind
 
 ##
 ## Hash-Types


### PR DESCRIPTION
This is just a cosmetic update.

We now support **over 300** hash algorithms. Hurray !  congraz

BTW: this is how I found it out (as reference for the future):
```
hashcat --help | grep '^ [ 0-9]* | [^|]* | [^|]*$' | wc -l
```

or just:
```
ls src/modules/*.c | wc -l
```