### PR TITLE
update number of supported hash types in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## *hashcat* ##
 
-**hashcat** is the world's fastest and most advanced password recovery utility, supporting five unique modes of attack for over 200 highly-optimized hashing algorithms. hashcat currently supports CPUs, GPUs, and other hardware accelerators on Linux, Windows, and macOS, and has facilities to help enable distributed password cracking.
+**hashcat** is the world's fastest and most advanced password recovery utility, supporting five unique modes of attack for over 300 highly-optimized hashing algorithms. hashcat currently supports CPUs, GPUs, and other hardware accelerators on Linux, Windows, and macOS, and has facilities to help enable distributed password cracking.
 
 ### License ###
 


### PR DESCRIPTION
This is actually just a follow up of https://github.com/hashcat/hashcat/pull/2308 . I didn't remember that we have this number also mentioned in README.md . Now it should be up to date everywhere.

Thanks