### PR TITLE
Fix debugedit - canonicalization unexpectedly shrank by one character

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -112,25 +112,25 @@ LIBRARY_DEV_FOLDER      ?= $(LIBRARY_DEV_ROOT_FOLDER)/hashcat
 ifeq ($(USE_SYSTEM_LZMA),0)
 DEPS_LZMA_PATH          := deps/LZMA-SDK/C
 else
-DEPS_LZMA_PATH          := $(LIBRARY_DEV_ROOT_FOLDER)/
+DEPS_LZMA_PATH          := $(LIBRARY_DEV_ROOT_FOLDER)
 endif
 
 ifeq ($(USE_SYSTEM_ZLIB),0)
-DEPS_ZLIB_PATH          := deps/zlib/
+DEPS_ZLIB_PATH          := deps/zlib
 else
-DEPS_ZLIB_PATH          := $(LIBRARY_DEV_ROOT_FOLDER)/
+DEPS_ZLIB_PATH          := $(LIBRARY_DEV_ROOT_FOLDER)
 endif
 
 ifeq ($(USE_SYSTEM_OPENCL),0)
 DEPS_OPENCL_PATH        := deps/OpenCL-Headers
 else
-DEPS_OPENCL_PATH        := $(LIBRARY_DEV_ROOT_FOLDER)/
+DEPS_OPENCL_PATH        := $(LIBRARY_DEV_ROOT_FOLDER)
 endif
 
 ifeq ($(USE_SYSTEM_XXHASH),0)
 DEPS_XXHASH_PATH        := deps/xxHash
 else
-DEPS_XXHASH_PATH        := $(LIBRARY_DEV_ROOT_FOLDER)/
+DEPS_XXHASH_PATH        := $(LIBRARY_DEV_ROOT_FOLDER)
 endif
 
 ##


### PR DESCRIPTION
Hello,
As some paths in the src/Makefile are containing trailing slash "/", this is causing that during compile time some sources get referenced with double "//" in the path. On RHEL7 this causing issue to debugedit and is reported as error during the RPM package build.

Please consider adding this patch to prevent issue with debugedit on RHEL7
if path during compilation contains // in the reference to the file, the debugedit then reports unexpected difference.

This is the sample error messahe from RHEL7 build:
extracting debug info from /builddir/build/BUILDROOT/hashcat-5.1.0-7.20200220git398e068.el7.x86_64/usr/lib64/libhashcat.so.5.1.0
/usr/lib/rpm/debugedit: canonicalization unexpectedly shrank by one character

https://download.copr.fedorainfracloud.org/results/rebus/infosec-rebus/epel-7-x86_64/01248605-hashcat/build.log.gz

diff -ru hashcat-398e06878d6e36460bcd00283d847c723a162be3/src/Makefile hashcat-398e06878d6e36460bcd00283d847c723a162be3.new/src/Makefile

Best regards
Michal Ambroz