### PR TITLE
solve $telegram$1 format conflict with JTR

### DIFF
--- a/src/modules/module_22301.c
+++ b/src/modules/module_22301.c
@@ -27,7 +27,7 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE;
 static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
 static const char *ST_PASS        = "hashcat";
-static const char *ST_HASH        = "$telegram$1*518c001aeb3b4ae96c6173be4cebe60a85f67b1e087b045935849e2f815b5e41*25184098058621950709328221838128";
+static const char *ST_HASH        = "$telegram$0*518c001aeb3b4ae96c6173be4cebe60a85f67b1e087b045935849e2f815b5e41*25184098058621950709328221838128";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -84,7 +84,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *version_pos = token.buf[1];
 
-  if (version_pos[0] != '1') return (PARSER_SALT_VALUE);
+  if (version_pos[0] != '0') return (PARSER_SALT_VALUE);
 
   const u8 *hash_pos = token.buf[2];
 
@@ -162,7 +162,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const int line_len = snprintf (line_buf, line_size, "%s%i*%08x%08x%08x%08x%08x%08x%08x%08x*%08x%08x%08x%08x",
     SIGNATURE_TELEGRAM,
-    1,
+    0,
     tmp[0],
     tmp[1],
     tmp[2],

--- a/tools/test_modules/m22301.pm
+++ b/tools/test_modules/m22301.pm
@@ -21,7 +21,7 @@ sub module_generate_hash
 
   my $digest = sha256_hex ($salt_bin . $word . $salt_bin);
 
-  my $hash = sprintf ("\$telegram\$1*%s*%s", $digest, $salt);
+  my $hash = sprintf ("\$telegram\$0*%s*%s", $digest, $salt);
 
   return $hash;
 }
@@ -40,7 +40,7 @@ sub module_verify_hash
 
   my $version = substr ($data[0], 10);
 
-  return unless ($version eq "1");
+  return unless ($version eq "0");
 
   my $digest = $data[1];
   my $salt   = $data[2];


### PR DESCRIPTION
We have recently added the mobile client Telegram APP algorithm to hashcat with https://github.com/hashcat/hashcat/pull/2282 .
Unfortunately nobody mentioned that there are 2 different algorithms in use (see the discussion in here: https://hashcat.net/forum/thread-8888-post-47765.html#pid47765).

The problem is that JTR already uses $telegram$1... for the Desktop algorithm, while it uses a dynamic format for the other mode (for which I suggest using $telegram$0 in hashcat).

The hash format basically remains the same as mentioned in here: https://github.com/hashcat/hashcat/pull/2282 , just using $telegram$0 as the signature+version number.

I've think we can't and shouldn't use $telegram$2 because it might probably give a further conflict in the future if any new format will be implemented in hc/jtr .

Thanks