### PR TITLE
make -m 21200 more generic (accept all supported salt len)

### DIFF
--- a/src/modules/module_21200.c
+++ b/src/modules/module_21200.c
@@ -60,8 +60,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.len_min[1] = 19;
-  token.len_max[1] = 19;
+  token.len_min[1] = SALT_MIN;
+  token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   if (hashconfig->opts_type & OPTS_TYPE_ST_HEX)

--- a/tools/test_modules/m21200.pm
+++ b/tools/test_modules/m21200.pm
@@ -11,12 +11,12 @@ use warnings;
 use Digest::MD5 qw (md5_hex);
 use Digest::SHA qw (sha1_hex);
 
-sub module_constraints { [[0, 256], [19, 19], [0, 55], [-1, -1], [-1, -1]] }
+sub module_constraints { [[0, 256], [0, 256], [0, 55], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
   my $word = shift;
-  my $salt = random_hex_string (19, 19);
+  my $salt = shift;
 
   my $digest = md5_hex (sha1_hex ($salt) . md5_hex ($word));
 

--- a/tools/test_modules/m21300.pm
+++ b/tools/test_modules/m21300.pm
@@ -11,17 +11,12 @@ use warnings;
 use Digest::MD5 qw (md5_hex);
 use Digest::SHA qw (sha1_hex);
 
-sub module_constraints { [[0, 256], [1, 256], [0, 55], [-1, -1], [-1, -1]] }
+sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [0, 55]] }
 
 sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-
-  if (length $salt == 0)
-  {
-    $salt = random_hex_string (1, 256);
-  }
 
   my $digest = md5_hex ($salt . sha1_hex ($salt . $word));
 


### PR DESCRIPTION
There was a bug in -m 21200 which limited the salt lenght to only exactly 19 bytes. Since this is a generic format, I suggest to change the module code and tests (as within the PR). Thanks