### PR TITLE
fixes #2339: problem with --hex-salt fixed

### DIFF
--- a/src/modules/module_00040.c
+++ b/src/modules/module_00040.c
@@ -29,7 +29,7 @@ static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_PT_ADD80
                                   | OPTS_TYPE_PT_ADDBITS14
                                   | OPTS_TYPE_PT_UTF16LE;
-static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "23a8a90599fc5d0d15265d4d3b565f6e:58802707";
 

--- a/src/modules/module_04710.c
+++ b/src/modules/module_04710.c
@@ -27,7 +27,7 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_PT_ADD80
                                   | OPTS_TYPE_PT_ADDBITS14;
-static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "53c724b7f34f09787ed3f1b316215fc35c789504:hashcat1";
 

--- a/src/modules/module_20710.c
+++ b/src/modules/module_20710.c
@@ -28,7 +28,7 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
                                   | OPTS_TYPE_PT_ADD80
                                   | OPTS_TYPE_PT_ADDBITS15;
-static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "bfede293ecf6539211a7305ea218b9f3f608953130405cda9eaba6fb6250f824:7218532375810603";
 

--- a/src/modules/module_21200.c
+++ b/src/modules/module_21200.c
@@ -27,7 +27,7 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_PT_ADD80
                                   | OPTS_TYPE_PT_ADDBITS14;
-static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "e69b7a7fe1bf2ad9ef116f79551ee919:baa038987e582431a6d";
 

--- a/src/modules/module_21300.c
+++ b/src/modules/module_21300.c
@@ -27,7 +27,7 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_PT_ADD80
                                   | OPTS_TYPE_PT_ADDBITS14;
-static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "799dc7d9aa4d3f404cc21a4936dbdcde:68617368636174"; //6d455b6e8945bebfd0a5878eaa201523:hashcat"; //c8f4f1202e7aaebb14e49903ca973d39:943038186";
 


### PR DESCRIPTION
To fix #2339 , I would suggest to use SALT_TYPE_GENERIC everywhere possible to allow the use of --hex-salt again with these hash types (we use generic_salt_encode () and generic_salt_decode () in these modules already, so the only thing that needs to be replaced is SALT_TYPE_EMBEDDED with  SALT_TYPE_GENERIC).

Thank you and all the best