### PR TITLE
Allow module_hash_binary_parse to report a fatal error

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1296,9 +1296,13 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
         {
           hashes_cnt = hashes_parsed;
         }
-        else
+        else if (hashes_parsed == 0)
         {
           event_log_warning (hashcat_ctx, "Hashfile '%s': %s", hashes->hashfile, strerror (errno));
+        }
+        else
+        {
+          event_log_warning (hashcat_ctx, "Hashfile '%s': %s", hashes->hashfile, strparser (hashes_parsed));
         }
       }
       else

--- a/src/modules/module_14600.c
+++ b/src/modules/module_14600.c
@@ -235,6 +235,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   hash_t *hashes_buf = hashes->hashes_buf;
 
   int hashes_cnt = 0;
+  int last_error = 0;
 
   for (int keyslot_idx = 0; keyslot_idx < LUKS_NUMKEYS; keyslot_idx++)
   {
@@ -246,12 +247,23 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
 
     const int parser_status = module_hash_decode (hashconfig, hash->digest, hash->salt, hash->esalt, hash->hook_salt, hash->hash_info, hashes->hashfile, strlen (hashes->hashfile));
 
-    if (parser_status != PARSER_OK) continue;
+    if (parser_status != PARSER_OK)
+    {
+      last_error = parser_status;
+      continue;
+    }
 
     hashes_cnt++;
   }
 
-  return hashes_cnt;
+  if (hashes_cnt == 0)
+  {
+    return last_error;
+  }
+  else
+  {
+    return hashes_cnt;
+  }
 }
 
 u64 module_kern_type_dynamic (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info)


### PR DESCRIPTION
If module_hash_binary_parse is completely unable to successfully parse out
any hashes, up until now the output has been

```
Hashfile 'foo': Success
```

which is less than helpful.

This patch allows (but does not require) m_h_binary_parse to report a useful
error response, by returning a negative value.  Modules which continue to
return '0 hashes' will get the same less-than-useful behaviour they always
hace.

I've also modified the LUKS module to report a useful error, as a proof of
concept.

Further expansions on this could include:

* Applying similar behaviour to module_hash_binary_count, so it too can
  report errors when trying to count hashes.  This would require more
  co-ordinated change, because m_h_binary_count already uses -1 to indicate
  a system error.

* Allow and encourage modules to print their own errors and warnings during
  parsing.  This would allow for situations where a single hash in a
  multi-hash file could be reported as malformed, without having to fail the
  whole parse.  However, implementing this would, I expect, require modules
  to have access to `hashcat_ctx`, which...  yeah.  Not so straightforward.