### PR TITLE
Add some more generic error messages

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -534,6 +534,10 @@ typedef enum parser_rc
   PARSER_TOKEN_LENGTH         = -35,
   PARSER_INSUFFICIENT_ENTROPY = -36,
   PARSER_PKZIP_CT_UNMATCHED   = -37,
+  PARSER_KEY_SIZE             = -38,
+  PARSER_BLOCK_SIZE           = -39,
+  PARSER_CIPHER               = -40,
+  PARSER_FILE_SIZE            = -41,
   PARSER_UNKNOWN_ERROR        = -255
 
 } parser_rc_t;

--- a/src/shared.c
+++ b/src/shared.c
@@ -53,6 +53,10 @@ static const char *PA_034 = "Token encoding exception";
 static const char *PA_035 = "Token length exception";
 static const char *PA_036 = "Insufficient entropy exception";
 static const char *PA_037 = "Hash contains unsupported compression type for current mode";
+static const char *PA_038 = "Invalid key size";
+static const char *PA_039 = "Invalid block size";
+static const char *PA_040 = "Invalid or unsupported cipher";
+static const char *PA_041 = "Invalid filesize";
 static const char *PA_255 = "Unknown error";
 
 static const char *OPTI_STR_OPTIMIZED_KERNEL     = "Optimized-Kernel";
@@ -1002,6 +1006,10 @@ const char *strparser (const u32 parser_status)
     case PARSER_TOKEN_LENGTH:         return PA_035;
     case PARSER_INSUFFICIENT_ENTROPY: return PA_036;
     case PARSER_PKZIP_CT_UNMATCHED:   return PA_037;
+    case PARSER_KEY_SIZE:             return PA_038;
+    case PARSER_BLOCK_SIZE:           return PA_039;
+    case PARSER_CIPHER:               return PA_040;
+    case PARSER_FILE_SIZE:            return PA_041;
   }
 
   return PA_255;


### PR DESCRIPTION
These are almost all taken from error messages that are specific to one particular module, and turned into generic errors that can be used for any module.  It seemed like a better idea to provide generic messages than to encourage infinite proliferation of error codes (which would probably end up blowing the 255 value threshold sooner or later).  It doesn't seem necessary to provide module-specific error messages for things like "Invalid <X> filesize", since users should already know what sort of file they're asking to be parsed.

These error messages are required for better parsing failure reporting for my PKCS#1 module.

I haven't cleaned up existing uses of module-specific error messages, because that would change existing behaviour, but I can certainly do that (in this or another PR) if it should be deemed proper.