### PR TITLE
Fix POSIX temporary directory semantics

### DIFF
--- a/src/folder.c
+++ b/src/folder.c
@@ -462,9 +462,24 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
   {
     char *tmp;
 
-    hc_asprintf (&tmp, "TMP=%s", cpath_real);
+    #if defined (_POSIX)
+    // Setting TMP may break POSIX temporary directory semantics
+    // Fix it by setting the POSIX-ly correct TMPDIR if it is not already set
+    if (getenv ("TMPDIR") == NULL) {
+      if (getenv("TMP") != NULL) {
+        // TMP was specified in the environment, promote it to TMPDIR
+        hc_asprintf (&tmp, "TMPDIR=%s", getenv("TMP"));
+        putenv (tmp);
+        hcfree (tmp);
+      } else {
+        putenv ("TMPDIR=/tmp");
+      }
+    }
+    #endif
 
+    hc_asprintf (&tmp, "TMP=%s", cpath_real);
     putenv (tmp);
+    hcfree (tmp);
   }
 
   #if defined (_WIN)


### PR DESCRIPTION
This change sets the value of `TMPDIR` on POSIX systems to restore correct temporary directory semantics when overwriting `TMP` as a workaround for poor OpenCL implementations. It is an attempt to address #2379. 

When setting `TMP` to a non-writable directory, ROCm 3.3.0 breaks on a Void Linux installation because the OpenCL compiler tries to write temporary files to `$TMP` unless the POSIX-ly correct `TMPDIR` is set (`TMPDIR` supersedes `TMP` in this instance). The patch makes the following behavior changes *only* for POSIX systems:
1. If `TMPDIR` is already set, do nothing; otherwise,
2. If `TMP` is set before it is overridden in hashcat, copy the original value of `TMP` to the `TMPDIR` environment value; otherwise,
3. Enforce an explicit default `TMPDIR=/tmp` to restore expected POSIX temporary directory behavior.

I have no idea if `TMPDIR` supersedes `TMP` on these broken OpenCL implementations because I have none to test. If so, this probably negates the workaround. However, if the broken implementations tend to be on Windows, maybe this isn't an issue anyway.

If any OpenCL implementations break as a result of this change, I recommend adding something like a `--broken-opencl` command argument that would need to be specified before employing the `TMP` overwrite hack. That way, temporary directory semantics won't be broken by default.