### PR TITLE
fixes #2383: added -m 22700 = MultiBit HD (scrypt)

### DIFF
--- a/OpenCL/m22700-pure.cl
+++ b/OpenCL/m22700-pure.cl
@@ -1,0 +1,705 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_hash_sha256.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+#define COMPARE_S "inc_comp_single.cl"
+#define COMPARE_M "inc_comp_multi.cl"
+
+// fixed MultiBit salt (not a bug)
+
+#define MULTIBIT_S0 0x35510380
+#define MULTIBIT_S1 0x75a3b0c5
+
+#define MULTIBIT_IV0 0x1f3944a3
+#define MULTIBIT_IV1 0xb3118353
+#define MULTIBIT_IV2 0x16865429
+#define MULTIBIT_IV3 0x3e7289c4
+
+typedef struct
+{
+  #ifndef SCRYPT_TMP_ELEM
+  #define SCRYPT_TMP_ELEM 1
+  #endif
+
+  uint4 P[SCRYPT_TMP_ELEM];
+
+} scrypt_tmp_t;
+
+DECLSPEC int is_valid_bitcoinj_8 (const u8 v)
+{
+  // .abcdefghijklmnopqrstuvwxyz
+
+  if (v > (u8) 'z') return 0;
+  if (v < (u8) '.') return 0;
+
+  if ((v > (u8) '.') && (v < (u8) 'a')) return 0;
+
+  return 1;
+}
+
+DECLSPEC int is_valid_bitcoinj (const u32 *w)
+{
+  if ((w[0] & 0x000000ff) != 0x0000000a) return 0;
+
+  if ((w[0] & 0x0000ff00)  > 0x00007f00) return 0;
+
+  // check for "org." substring:
+
+  if ((w[0] & 0xffff0000) != 0x726f0000) return 0;
+  if ((w[1] & 0x0000ffff) != 0x00002e67) return 0;
+
+  if (is_valid_bitcoinj_8 (w[1] >> 16) == 0) return 0;
+  if (is_valid_bitcoinj_8 (w[1] >> 24) == 0) return 0;
+
+  if (is_valid_bitcoinj_8 (w[2] >>  0) == 0) return 0;
+  if (is_valid_bitcoinj_8 (w[2] >>  8) == 0) return 0;
+  if (is_valid_bitcoinj_8 (w[2] >> 16) == 0) return 0;
+  if (is_valid_bitcoinj_8 (w[2] >> 24) == 0) return 0;
+
+  if (is_valid_bitcoinj_8 (w[3] >>  0) == 0) return 0;
+  if (is_valid_bitcoinj_8 (w[3] >>  8) == 0) return 0;
+
+  return 1;
+}
+
+#ifdef IS_CUDA
+
+inline __device__ uint4 operator &  (const uint4  a, const u32   b) { return make_uint4 ((a.x &  b  ), (a.y &  b  ), (a.z &  b  ), (a.w &  b  ));  }
+inline __device__ uint4 operator << (const uint4  a, const u32   b) { return make_uint4 ((a.x << b  ), (a.y << b  ), (a.z << b  ), (a.w << b  ));  }
+inline __device__ uint4 operator >> (const uint4  a, const u32   b) { return make_uint4 ((a.x >> b  ), (a.y >> b  ), (a.z >> b  ), (a.w >> b  ));  }
+inline __device__ uint4 operator +  (const uint4  a, const uint4 b) { return make_uint4 ((a.x +  b.x), (a.y +  b.y), (a.z +  b.z), (a.w +  b.w));  }
+inline __device__ uint4 operator ^  (const uint4  a, const uint4 b) { return make_uint4 ((a.x ^  b.x), (a.y ^  b.y), (a.z ^  b.z), (a.w ^  b.w));  }
+inline __device__ uint4 operator |  (const uint4  a, const uint4 b) { return make_uint4 ((a.x |  b.x), (a.y |  b.y), (a.z |  b.z), (a.w |  b.w));  }
+inline __device__ void  operator ^= (      uint4 &a, const uint4 b) {                     a.x ^= b.x;   a.y ^= b.y;   a.z ^= b.z;   a.w ^= b.w;    }
+
+inline __device__ uint4 rotate (const uint4 a, const int n)
+{
+  return ((a << n) | ((a >> (32 - n))));
+}
+
+#endif
+
+DECLSPEC uint4 hc_swap32_4 (uint4 v)
+{
+  return (rotate ((v & 0x00FF00FF), 24u) | rotate ((v & 0xFF00FF00),  8u));
+}
+
+#define GET_SCRYPT_CNT(r,p) (2 * (r) * 16 * (p))
+#define GET_SMIX_CNT(r,N)   (2 * (r) * 16 * (N))
+#define GET_STATE_CNT(r)    (2 * (r) * 16)
+
+#define SCRYPT_CNT  GET_SCRYPT_CNT (SCRYPT_R, SCRYPT_P)
+#define SCRYPT_CNT4 (SCRYPT_CNT / 4)
+#define STATE_CNT   GET_STATE_CNT  (SCRYPT_R)
+#define STATE_CNT4  (STATE_CNT / 4)
+
+#define ADD_ROTATE_XOR(r,i1,i2,s) (r) ^= rotate ((i1) + (i2), (s));
+
+#ifdef IS_CUDA
+
+#define SALSA20_2R()                        \
+{                                           \
+  ADD_ROTATE_XOR (X1, X0, X3,  7);          \
+  ADD_ROTATE_XOR (X2, X1, X0,  9);          \
+  ADD_ROTATE_XOR (X3, X2, X1, 13);          \
+  ADD_ROTATE_XOR (X0, X3, X2, 18);          \
+                                            \
+  X1 = make_uint4 (X1.w, X1.x, X1.y, X1.z); \
+  X2 = make_uint4 (X2.z, X2.w, X2.x, X2.y); \
+  X3 = make_uint4 (X3.y, X3.z, X3.w, X3.x); \
+                                            \
+  ADD_ROTATE_XOR (X3, X0, X1,  7);          \
+  ADD_ROTATE_XOR (X2, X3, X0,  9);          \
+  ADD_ROTATE_XOR (X1, X2, X3, 13);          \
+  ADD_ROTATE_XOR (X0, X1, X2, 18);          \
+                                            \
+  X1 = make_uint4 (X1.y, X1.z, X1.w, X1.x); \
+  X2 = make_uint4 (X2.z, X2.w, X2.x, X2.y); \
+  X3 = make_uint4 (X3.w, X3.x, X3.y, X3.z); \
+}
+#else
+#define SALSA20_2R()                        \
+{                                           \
+  ADD_ROTATE_XOR (X1, X0, X3,  7);          \
+  ADD_ROTATE_XOR (X2, X1, X0,  9);          \
+  ADD_ROTATE_XOR (X3, X2, X1, 13);          \
+  ADD_ROTATE_XOR (X0, X3, X2, 18);          \
+                                            \
+  X1 = X1.s3012;                            \
+  X2 = X2.s2301;                            \
+  X3 = X3.s1230;                            \
+                                            \
+  ADD_ROTATE_XOR (X3, X0, X1,  7);          \
+  ADD_ROTATE_XOR (X2, X3, X0,  9);          \
+  ADD_ROTATE_XOR (X1, X2, X3, 13);          \
+  ADD_ROTATE_XOR (X0, X1, X2, 18);          \
+                                            \
+  X1 = X1.s1230;                            \
+  X2 = X2.s2301;                            \
+  X3 = X3.s3012;                            \
+}
+#endif
+
+#define SALSA20_8_XOR() \
+{                       \
+  R0 = R0 ^ Y0;         \
+  R1 = R1 ^ Y1;         \
+  R2 = R2 ^ Y2;         \
+  R3 = R3 ^ Y3;         \
+                        \
+  uint4 X0 = R0;        \
+  uint4 X1 = R1;        \
+  uint4 X2 = R2;        \
+  uint4 X3 = R3;        \
+                        \
+  SALSA20_2R ();        \
+  SALSA20_2R ();        \
+  SALSA20_2R ();        \
+  SALSA20_2R ();        \
+                        \
+  R0 = R0 + X0;         \
+  R1 = R1 + X1;         \
+  R2 = R2 + X2;         \
+  R3 = R3 + X3;         \
+}
+
+DECLSPEC void salsa_r (uint4 *TI)
+{
+  uint4 R0 = TI[STATE_CNT4 - 4];
+  uint4 R1 = TI[STATE_CNT4 - 3];
+  uint4 R2 = TI[STATE_CNT4 - 2];
+  uint4 R3 = TI[STATE_CNT4 - 1];
+
+  uint4 TO[STATE_CNT4];
+
+  int idx_y  = 0;
+  int idx_r1 = 0;
+  int idx_r2 = SCRYPT_R * 4;
+
+  for (int i = 0; i < SCRYPT_R; i++)
+  {
+    uint4 Y0;
+    uint4 Y1;
+    uint4 Y2;
+    uint4 Y3;
+
+    Y0 = TI[idx_y++];
+    Y1 = TI[idx_y++];
+    Y2 = TI[idx_y++];
+    Y3 = TI[idx_y++];
+
+    SALSA20_8_XOR ();
+
+    TO[idx_r1++] = R0;
+    TO[idx_r1++] = R1;
+    TO[idx_r1++] = R2;
+    TO[idx_r1++] = R3;
+
+    Y0 = TI[idx_y++];
+    Y1 = TI[idx_y++];
+    Y2 = TI[idx_y++];
+    Y3 = TI[idx_y++];
+
+    SALSA20_8_XOR ();
+
+    TO[idx_r2++] = R0;
+    TO[idx_r2++] = R1;
+    TO[idx_r2++] = R2;
+    TO[idx_r2++] = R3;
+  }
+
+  #pragma unroll
+  for (int i = 0; i < STATE_CNT4; i++)
+  {
+    TI[i] = TO[i];
+  }
+}
+
+DECLSPEC void scrypt_smix (uint4 *X, uint4 *T, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3)
+{
+  #define Coord(xd4,y,z) (((xd4) * ySIZE * zSIZE) + ((y) * zSIZE) + (z))
+  #define CO Coord(xd4,y,z)
+
+  const u32 ySIZE = SCRYPT_N / SCRYPT_TMTO;
+  const u32 zSIZE = STATE_CNT4;
+
+  const u32 x = get_global_id (0);
+
+  const u32 xd4 = x / 4;
+  const u32 xm4 = x & 3;
+
+  GLOBAL_AS uint4 *V;
+
+  switch (xm4)
+  {
+    case 0: V = V0; break;
+    case 1: V = V1; break;
+    case 2: V = V2; break;
+    case 3: V = V3; break;
+  }
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < STATE_CNT4; i += 4)
+  {
+    #ifdef IS_CUDA
+    T[0] = make_uint4 (X[i + 0].x, X[i + 1].y, X[i + 2].z, X[i + 3].w);
+    T[1] = make_uint4 (X[i + 1].x, X[i + 2].y, X[i + 3].z, X[i + 0].w);
+    T[2] = make_uint4 (X[i + 2].x, X[i + 3].y, X[i + 0].z, X[i + 1].w);
+    T[3] = make_uint4 (X[i + 3].x, X[i + 0].y, X[i + 1].z, X[i + 2].w);
+    #else
+    T[0] = (uint4) (X[i + 0].x, X[i + 1].y, X[i + 2].z, X[i + 3].w);
+    T[1] = (uint4) (X[i + 1].x, X[i + 2].y, X[i + 3].z, X[i + 0].w);
+    T[2] = (uint4) (X[i + 2].x, X[i + 3].y, X[i + 0].z, X[i + 1].w);
+    T[3] = (uint4) (X[i + 3].x, X[i + 0].y, X[i + 1].z, X[i + 2].w);
+    #endif
+
+    X[i + 0] = T[0];
+    X[i + 1] = T[1];
+    X[i + 2] = T[2];
+    X[i + 3] = T[3];
+  }
+
+  for (u32 y = 0; y < ySIZE; y++)
+  {
+    for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
+
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r (X);
+  }
+
+  for (u32 i = 0; i < SCRYPT_N; i++)
+  {
+    const u32 k = X[zSIZE - 4].x & (SCRYPT_N - 1);
+
+    const u32 y = k / SCRYPT_TMTO;
+
+    const u32 km = k - (y * SCRYPT_TMTO);
+
+    for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
+
+    for (u32 i = 0; i < km; i++) salsa_r (T);
+
+    for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
+
+    salsa_r (X);
+  }
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u32 i = 0; i < STATE_CNT4; i += 4)
+  {
+    #ifdef IS_CUDA
+    T[0] = make_uint4 (X[i + 0].x, X[i + 3].y, X[i + 2].z, X[i + 1].w);
+    T[1] = make_uint4 (X[i + 1].x, X[i + 0].y, X[i + 3].z, X[i + 2].w);
+    T[2] = make_uint4 (X[i + 2].x, X[i + 1].y, X[i + 0].z, X[i + 3].w);
+    T[3] = make_uint4 (X[i + 3].x, X[i + 2].y, X[i + 1].z, X[i + 0].w);
+    #else
+    T[0] = (uint4) (X[i + 0].x, X[i + 3].y, X[i + 2].z, X[i + 1].w);
+    T[1] = (uint4) (X[i + 1].x, X[i + 0].y, X[i + 3].z, X[i + 2].w);
+    T[2] = (uint4) (X[i + 2].x, X[i + 1].y, X[i + 0].z, X[i + 3].w);
+    T[3] = (uint4) (X[i + 3].x, X[i + 2].y, X[i + 1].z, X[i + 0].w);
+    #endif
+
+    X[i + 0] = T[0];
+    X[i + 1] = T[1];
+    X[i + 2] = T[2];
+    X[i + 3] = T[3];
+  }
+}
+
+KERNEL_FQ void m22700_init (KERN_ATTR_TMPS (scrypt_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  // convert password to utf16be:
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  const u32 pw_len_utf16be = pw_len * 2;
+
+  u32 w[128] = { 0 };
+
+  for (u32 i = 0, j = 0; i < 64; i += 4, j += 8)
+  {
+    u32 in[4];
+
+    in[0] = pws[gid].i[i + 0];
+    in[1] = pws[gid].i[i + 1];
+    in[2] = pws[gid].i[i + 2];
+    in[3] = pws[gid].i[i + 3];
+
+    u32 out0[4];
+    u32 out1[4];
+
+    make_utf16be_S (in, out0, out1);
+
+    w[j + 0] = out0[0];
+    w[j + 1] = out0[1];
+    w[j + 2] = out0[2];
+    w[j + 3] = out0[3];
+    w[j + 4] = out1[0];
+    w[j + 5] = out1[1];
+    w[j + 6] = out1[2];
+    w[j + 7] = out1[3];
+  }
+
+  sha256_hmac_ctx_t sha256_hmac_ctx;
+
+  sha256_hmac_init_swap (&sha256_hmac_ctx, w, pw_len_utf16be);
+
+  u32 s0[4] = { 0 };
+  u32 s1[4] = { 0 };
+  u32 s2[4] = { 0 };
+  u32 s3[4] = { 0 };
+
+  s0[0] = MULTIBIT_S0;
+  s0[1] = MULTIBIT_S1;
+
+  sha256_hmac_update_64 (&sha256_hmac_ctx, s0, s1, s2, s3, 8);
+
+  for (u32 i = 0, j = 1, k = 0; i < SCRYPT_CNT; i += 8, j += 1, k += 2)
+  {
+    sha256_hmac_ctx_t sha256_hmac_ctx2 = sha256_hmac_ctx;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = j;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_update_64 (&sha256_hmac_ctx2, w0, w1, w2, w3, 4);
+
+    sha256_hmac_final (&sha256_hmac_ctx2);
+
+    u32 digest[8];
+
+    digest[0] = sha256_hmac_ctx2.opad.h[0];
+    digest[1] = sha256_hmac_ctx2.opad.h[1];
+    digest[2] = sha256_hmac_ctx2.opad.h[2];
+    digest[3] = sha256_hmac_ctx2.opad.h[3];
+    digest[4] = sha256_hmac_ctx2.opad.h[4];
+    digest[5] = sha256_hmac_ctx2.opad.h[5];
+    digest[6] = sha256_hmac_ctx2.opad.h[6];
+    digest[7] = sha256_hmac_ctx2.opad.h[7];
+
+    #ifdef IS_CUDA
+    const uint4 tmp0 = make_uint4 (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = make_uint4 (digest[4], digest[5], digest[6], digest[7]);
+    #else
+    const uint4 tmp0 = (uint4) (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = (uint4) (digest[4], digest[5], digest[6], digest[7]);
+    #endif
+
+    tmps[gid].P[k + 0] = tmp0;
+    tmps[gid].P[k + 1] = tmp1;
+  }
+}
+
+KERNEL_FQ void m22700_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  GLOBAL_AS uint4 *d_scrypt0_buf = (GLOBAL_AS uint4 *) d_extra0_buf;
+  GLOBAL_AS uint4 *d_scrypt1_buf = (GLOBAL_AS uint4 *) d_extra1_buf;
+  GLOBAL_AS uint4 *d_scrypt2_buf = (GLOBAL_AS uint4 *) d_extra2_buf;
+  GLOBAL_AS uint4 *d_scrypt3_buf = (GLOBAL_AS uint4 *) d_extra3_buf;
+
+  uint4 X[STATE_CNT4];
+  uint4 T[STATE_CNT4];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int z = 0; z < STATE_CNT4; z++) X[z] = hc_swap32_4 (tmps[gid].P[z]);
+
+  scrypt_smix (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf);
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int z = 0; z < STATE_CNT4; z++) tmps[gid].P[z] = hc_swap32_4 (X[z]);
+
+  #if SCRYPT_P >= 1
+  for (int i = STATE_CNT4; i < SCRYPT_CNT4; i += STATE_CNT4)
+  {
+    for (int z = 0; z < STATE_CNT4; z++) X[z] = hc_swap32_4 (tmps[gid].P[i + z]);
+
+    scrypt_smix (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf);
+
+    for (int z = 0; z < STATE_CNT4; z++) tmps[gid].P[i + z] = hc_swap32_4 (X[z]);
+  }
+  #endif
+}
+
+KERNEL_FQ void m22700_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * 2nd pbkdf2, creates B
+   */
+
+  // convert password to utf16be:
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  const u32 pw_len_utf16be = pw_len * 2;
+
+  u32 w[128] = { 0 };
+
+  for (u32 i = 0, j = 0; i < 64; i += 4, j += 8)
+  {
+    u32 in[4];
+
+    in[0] = pws[gid].i[i + 0];
+    in[1] = pws[gid].i[i + 1];
+    in[2] = pws[gid].i[i + 2];
+    in[3] = pws[gid].i[i + 3];
+
+    u32 out0[4];
+    u32 out1[4];
+
+    make_utf16be_S (in, out0, out1);
+
+    w[j + 0] = out0[0];
+    w[j + 1] = out0[1];
+    w[j + 2] = out0[2];
+    w[j + 3] = out0[3];
+    w[j + 4] = out1[0];
+    w[j + 5] = out1[1];
+    w[j + 6] = out1[2];
+    w[j + 7] = out1[3];
+  }
+
+  sha256_hmac_ctx_t ctx;
+
+  sha256_hmac_init_swap (&ctx, w, pw_len_utf16be);
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  for (u32 l = 0; l < SCRYPT_CNT4; l += 4)
+  {
+    uint4 tmp;
+
+    tmp = tmps[gid].P[l + 0];
+
+    w0[0] = tmp.x;
+    w0[1] = tmp.y;
+    w0[2] = tmp.z;
+    w0[3] = tmp.w;
+
+    tmp = tmps[gid].P[l + 1];
+
+    w1[0] = tmp.x;
+    w1[1] = tmp.y;
+    w1[2] = tmp.z;
+    w1[3] = tmp.w;
+
+    tmp = tmps[gid].P[l + 2];
+
+    w2[0] = tmp.x;
+    w2[1] = tmp.y;
+    w2[2] = tmp.z;
+    w2[3] = tmp.w;
+
+    tmp = tmps[gid].P[l + 3];
+
+    w3[0] = tmp.x;
+    w3[1] = tmp.y;
+    w3[2] = tmp.z;
+    w3[3] = tmp.w;
+
+    sha256_hmac_update_64 (&ctx, w0, w1, w2, w3, 64);
+  }
+
+  w0[0] = 1;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  sha256_hmac_update_64 (&ctx, w0, w1, w2, w3, 4);
+
+  sha256_hmac_final (&ctx);
+
+  // AES256-CBC decrypt with IV from salt buffer (dynamic, alternative 1):
+
+  u32 key[8];
+
+  key[0] = ctx.opad.h[0];
+  key[1] = ctx.opad.h[1];
+  key[2] = ctx.opad.h[2];
+  key[3] = ctx.opad.h[3];
+  key[4] = ctx.opad.h[4];
+  key[5] = ctx.opad.h[5];
+  key[6] = ctx.opad.h[6];
+  key[7] = ctx.opad.h[7];
+
+  #define KEYLEN 60
+
+  u32 ks[KEYLEN];
+
+  AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+  u32 iv[4];
+
+  iv[0] = salt_bufs[salt_pos].salt_buf[0];
+  iv[1] = salt_bufs[salt_pos].salt_buf[1];
+  iv[2] = salt_bufs[salt_pos].salt_buf[2];
+  iv[3] = salt_bufs[salt_pos].salt_buf[3];
+
+  u32 enc[4];
+
+  enc[0] = salt_bufs[salt_pos].salt_buf[4];
+  enc[1] = salt_bufs[salt_pos].salt_buf[5];
+  enc[2] = salt_bufs[salt_pos].salt_buf[6];
+  enc[3] = salt_bufs[salt_pos].salt_buf[7];
+
+  u32 dec[4];
+
+  aes256_decrypt (ks, enc, dec, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  dec[0] ^= iv[0];
+  dec[1] ^= iv[1];
+  dec[2] ^= iv[2];
+  dec[3] ^= iv[3];
+
+  if (is_valid_bitcoinj (dec) == 1)
+  {
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, 0, 0, 0);
+    }
+
+    return;
+  }
+
+  // alternative 2 (second block, fixed IV):
+
+  enc[0] = salt_bufs[salt_pos].salt_buf[ 8];
+  enc[1] = salt_bufs[salt_pos].salt_buf[ 9];
+  enc[2] = salt_bufs[salt_pos].salt_buf[10];
+  enc[3] = salt_bufs[salt_pos].salt_buf[11];
+
+  aes256_decrypt (ks, enc, dec, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  dec[0] ^= MULTIBIT_IV0;
+  dec[1] ^= MULTIBIT_IV1;
+  dec[2] ^= MULTIBIT_IV2;
+  dec[3] ^= MULTIBIT_IV3;
+
+  if (is_valid_bitcoinj (dec) == 1)
+  {
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, 0, 0, 0);
+    }
+
+    return;
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -41,6 +41,7 @@
 - Added hash-mode: md5(sha1($pass).md5($pass).sha1($pass))
 - Added hash-mode: md5(sha1($salt).md5($pass))
 - Added hash-mode: MultiBit Classic .key (MD5)
+- Added hash-mode: MultiBit HD (scrypt)
 - Added hash-mode: MySQL $A$ (sha256crypt)
 - Added hash-mode: Open Document Format (ODF) 1.1 (SHA-1, Blowfish)
 - Added hash-mode: Open Document Format (ODF) 1.2 (SHA-256, AES)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -286,6 +286,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - Ethereum Wallet, PBKDF2-HMAC-SHA256
 - Ethereum Wallet, SCRYPT
 - MultiBit Classic .key (MD5)
+- MultiBit HD (scrypt)
 - 7-Zip
 - RAR3-hp
 - RAR5

--- a/hashcat.hctune
+++ b/hashcat.hctune
@@ -365,3 +365,5 @@ GeForce_GTX_TITAN                               3       9900    2       A       
 
 DEVICE_TYPE_CPU                                 *       15700   1       1       1
 DEVICE_TYPE_GPU                                 *       15700   1       1       1
+DEVICE_TYPE_CPU                                 *       22700   1       1       1
+DEVICE_TYPE_GPU                                 *       22700   1       1       1

--- a/src/modules/module_22700.c
+++ b/src/modules/module_22700.c
@@ -1,0 +1,443 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include <inttypes.h>
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PASSWORD_MANAGER;
+static const char *HASH_NAME      = "MultiBit HD (scrypt)";
+static const u64   KERN_TYPE      = 22700;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_PT_UTF16BE
+                                  | OPTS_TYPE_SELF_TEST_DISABLE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$multibit$2*2e311aa2cc5ec99f7073cacc8a2d1938*e3ad782e7f92d66a3cdfaec43a46be29*5d1cabd4f4a50ba125f88c47027fff9b";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+static const char *SIGNATURE_MULTIBIT = "$multibit$";
+static const u32   SCRYPT_N           = 16384;
+static const u32   SCRYPT_R           =     8;
+static const u32   SCRYPT_P           =     1;
+
+// limit scrypt accel otherwise we hurt ourself when calculating the scrypt tmto
+// 16 is actually a bit low, we may need to change this depending on user response
+
+static const u32   SCRYPT_MAX_ACCEL   = 16;
+static const u32   SCRYPT_MAX_THREADS = 16;
+
+u32 module_kernel_accel_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_accel_min = 1;
+
+  return kernel_accel_min;
+}
+
+u32 module_kernel_accel_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_accel_max = (user_options->kernel_accel_chgd == true) ? user_options->kernel_accel : SCRYPT_MAX_ACCEL;
+
+  return kernel_accel_max;
+}
+
+u32 module_kernel_loops_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_min = 1;
+
+  return kernel_loops_min;
+}
+
+u32 module_kernel_loops_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_max = 1;
+
+  return kernel_loops_max;
+}
+
+u32 module_kernel_threads_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_threads_min = 1;
+
+  return kernel_threads_min;
+}
+
+u32 module_kernel_threads_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // limit scrypt accel otherwise we hurt ourself when calculating the scrypt tmto
+  // 16 is actually a bit low, we may need to change this depending on user response
+
+  const u32 kernel_threads_max = (user_options->kernel_threads_chgd == true) ? user_options->kernel_threads : SCRYPT_MAX_THREADS;
+
+  return kernel_threads_max;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // this overrides the reductions of PW_MAX in case optimized kernel is selected
+  // IOW, even in optimized kernel mode it support length 256
+
+  const u32 pw_max = PW_MAX;
+
+  return pw_max;
+}
+
+u64 module_extra_buffer_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // we need to set the self-test hash settings to pass the self-test
+  // the decoder for the self-test is called after this function
+
+  const u32 scrypt_N = SCRYPT_N;
+  const u32 scrypt_r = SCRYPT_R;
+
+  const u64 kernel_power_max = (u64)(device_param->device_processors * hashconfig->kernel_threads_max * hashconfig->kernel_accel_max);
+
+  u32 tmto_start = 1;
+  u32 tmto_stop  = 6;
+
+  if (user_options->scrypt_tmto)
+  {
+    tmto_start = user_options->scrypt_tmto;
+    tmto_stop  = user_options->scrypt_tmto;
+  }
+
+  // size_pws
+
+  const u64 size_pws = kernel_power_max * sizeof (pw_t);
+
+  const u64 size_pws_amp = size_pws;
+
+  // size_pws_comp
+
+  const u64 size_pws_comp = kernel_power_max * (sizeof (u32) * 64);
+
+  // size_pws_idx
+
+  const u64 size_pws_idx = (kernel_power_max + 1) * sizeof (pw_idx_t);
+
+  // size_tmps
+
+  const u64 size_tmps = kernel_power_max * hashconfig->tmp_size;
+
+  // size_hooks
+
+  const u64 size_hooks = kernel_power_max * hashconfig->hook_size;
+
+  const u64 scrypt_extra_space
+    = device_param->size_bfs
+    + device_param->size_combs
+    + device_param->size_digests
+    + device_param->size_esalts
+    + device_param->size_markov_css
+    + device_param->size_plains
+    + device_param->size_results
+    + device_param->size_root_css
+    + device_param->size_rules
+    + device_param->size_rules_c
+    + device_param->size_salts
+    + device_param->size_shown
+    + device_param->size_tm
+    + device_param->size_st_digests
+    + device_param->size_st_salts
+    + device_param->size_st_esalts
+    + size_pws
+    + size_pws_amp
+    + size_pws_comp
+    + size_pws_idx
+    + size_tmps
+    + size_hooks;
+
+  bool not_enough_memory = true;
+
+  u64 size_scrypt = 0;
+
+  u32 tmto;
+
+  for (tmto = tmto_start; tmto <= tmto_stop; tmto++)
+  {
+    size_scrypt = (128 * scrypt_r) * scrypt_N;
+
+    size_scrypt /= 1u << tmto;
+
+    size_scrypt *= kernel_power_max;
+
+    if ((size_scrypt / 4) > device_param->device_maxmem_alloc) continue;
+
+    if ((size_scrypt + scrypt_extra_space) > device_param->device_available_mem) continue;
+
+    not_enough_memory = false;
+
+    break;
+  }
+
+  if (not_enough_memory == true) return -1;
+
+  return size_scrypt;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = 0; // we'll add some later
+
+  return tmp_size;
+}
+
+u64 module_extra_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes)
+{
+  // we need to set the self-test hash settings to pass the self-test
+  // the decoder for the self-test is called after this function
+
+  const u32 scrypt_r = SCRYPT_R;
+  const u32 scrypt_p = SCRYPT_P;
+
+  const u64 tmp_size = (u64)(128 * scrypt_r * scrypt_p);
+
+  return tmp_size;
+}
+
+bool module_jit_cache_disable (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  return true;
+}
+
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  const u32 scrypt_N = SCRYPT_N;
+  const u32 scrypt_r = SCRYPT_R;
+  const u32 scrypt_p = SCRYPT_P;
+
+  const u64 extra_buffer_size = device_param->extra_buffer_size;
+
+  const u64 kernel_power_max = (u64)(device_param->device_processors * hashconfig->kernel_threads_max * hashconfig->kernel_accel_max);
+
+  const u64 size_scrypt = (u64)(128 * scrypt_r * scrypt_N);
+
+  const u64 scrypt_tmto_final = (kernel_power_max * size_scrypt) / extra_buffer_size;
+
+  const u64 tmp_size = (u64)(128 * scrypt_r * scrypt_p);
+
+  char *jit_build_options = NULL;
+
+  hc_asprintf (&jit_build_options, "-DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%" PRIu64 " -DSCRYPT_TMP_ELEM=%" PRIu64,
+    SCRYPT_N,
+    SCRYPT_R,
+    SCRYPT_P,
+    scrypt_tmto_final,
+    tmp_size / 16);
+
+  return jit_build_options;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  token_t token;
+
+  token.token_cnt  = 5;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_MULTIBIT;
+
+  token.len[0]     = 10;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.len_min[1] = 1;
+  token.len_max[1] = 1;
+  token.sep[1]     = '*';
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[2] = 32;
+  token.len_max[2] = 32;
+  token.sep[2]     = '*';
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[3] = 32;
+  token.len_max[3] = 32;
+  token.sep[3]     = '*';
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len[4]     = 32;
+  token.attr[4]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // scrypt settings
+
+  salt->scrypt_N = SCRYPT_N;
+  salt->scrypt_r = SCRYPT_R;
+  salt->scrypt_p = SCRYPT_P;
+
+  // version
+
+  const u8 *version_pos = token.buf[1];
+
+  if (version_pos[0] != (u8) '2') return (PARSER_SIGNATURE_UNMATCHED);
+
+  // IV
+
+  const u8 *iv_pos = token.buf[2];
+
+  salt->salt_buf[ 0] = hex_to_u32 (iv_pos +  0);
+  salt->salt_buf[ 1] = hex_to_u32 (iv_pos +  8);
+  salt->salt_buf[ 2] = hex_to_u32 (iv_pos + 16);
+  salt->salt_buf[ 3] = hex_to_u32 (iv_pos + 24);
+
+  // block1
+
+  const u8 *b1_pos = token.buf[3];
+
+  salt->salt_buf[ 4] = hex_to_u32 (b1_pos +  0);
+  salt->salt_buf[ 5] = hex_to_u32 (b1_pos +  8);
+  salt->salt_buf[ 6] = hex_to_u32 (b1_pos + 16);
+  salt->salt_buf[ 7] = hex_to_u32 (b1_pos + 24);
+
+  // block2
+
+  const u8 *b2_pos = token.buf[4];
+
+  salt->salt_buf[ 8] = hex_to_u32 (b2_pos +  0);
+  salt->salt_buf[ 9] = hex_to_u32 (b2_pos +  8);
+  salt->salt_buf[10] = hex_to_u32 (b2_pos + 16);
+  salt->salt_buf[11] = hex_to_u32 (b2_pos + 24);
+
+  salt->salt_len  = 48;
+  salt->salt_iter =  1;
+
+  // fake digest:
+
+  digest[0] = salt->salt_buf[4];
+  digest[1] = salt->salt_buf[5];
+  digest[2] = salt->salt_buf[6];
+  digest[3] = salt->salt_buf[7];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const int line_len = snprintf (line_buf, line_size, "%s%u*%08x%08x%08x%08x*%08x%08x%08x%08x*%08x%08x%08x%08x",
+    SIGNATURE_MULTIBIT,
+    2,
+    byte_swap_32 (salt->salt_buf[ 0]),
+    byte_swap_32 (salt->salt_buf[ 1]),
+    byte_swap_32 (salt->salt_buf[ 2]),
+    byte_swap_32 (salt->salt_buf[ 3]),
+    byte_swap_32 (salt->salt_buf[ 4]),
+    byte_swap_32 (salt->salt_buf[ 5]),
+    byte_swap_32 (salt->salt_buf[ 6]),
+    byte_swap_32 (salt->salt_buf[ 7]),
+    byte_swap_32 (salt->salt_buf[ 8]),
+    byte_swap_32 (salt->salt_buf[ 9]),
+    byte_swap_32 (salt->salt_buf[10]),
+    byte_swap_32 (salt->salt_buf[11]));
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = module_extra_buffer_size;
+  module_ctx->module_extra_tmp_size           = module_extra_tmp_size;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = module_jit_cache_disable;
+  module_ctx->module_kernel_accel_max         = module_kernel_accel_max;
+  module_ctx->module_kernel_accel_min         = module_kernel_accel_min;
+  module_ctx->module_kernel_loops_max         = module_kernel_loops_max;
+  module_ctx->module_kernel_loops_min         = module_kernel_loops_min;
+  module_ctx->module_kernel_threads_max       = module_kernel_threads_max;
+  module_ctx->module_kernel_threads_min       = module_kernel_threads_min;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m22700.pm
+++ b/tools/test_modules/m22700.pm
@@ -1,0 +1,194 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Crypt::ScryptKDF qw (scrypt_raw);
+use Encode;
+use Crypt::CBC;
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+my $SCRYPT_N = 16384;
+my $SCRYPT_R =     8;
+my $SCRYPT_P =     1;
+
+my $FIXED_SALT = pack ("H*", "3551038075a3b0c5");
+my $FIXED_IV   = pack ("H*", "a344391f538311b329548616c489723e");
+
+my $BITCOINJ_CHARS = ".abcdefghijklmnopqrstuvwxyz";
+
+sub verify_bitcoinj
+{
+  my $data = shift;
+
+  my $first_char = substr ($data, 0, 1);
+
+  return 0 if ($first_char ne "\n");
+
+  my $second_char = substr ($data, 1, 1);
+
+  return 0 if (ord ($second_char) >= 128);
+
+  return 0 if (substr ($data, 2, 4) ne "org.");
+
+  for (my $i = 6; $i < 14; $i++) # start with 6 (we already checked first chars)
+  {
+    my $c = substr ($data, $i, 1);
+
+    my $idx = index ($BITCOINJ_CHARS, $c);
+
+    next if ($idx >= 0);
+
+    return 0; # fail
+  }
+
+  return 1; # success
+}
+
+sub module_generate_hash
+{
+  my $word   = shift;
+  my $iv     = shift;
+  my $block1 = shift;
+  my $block2 = shift;
+
+  my $word_utf16be = encode ('UTF-16BE', $word);
+
+  my $key = scrypt_raw ($word_utf16be, $FIXED_SALT, $SCRYPT_N, $SCRYPT_R, $SCRYPT_P, 32);
+
+  my $aes_cbc1 = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    iv          => $iv,
+    key         => $key,
+    keysize     => 32,
+    literal_key => 1,
+    header      => "none",
+    padding     => "none"
+  });
+
+  my $aes_cbc2 = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    iv          => $FIXED_IV,
+    key         => $key,
+    keysize     => 32,
+    literal_key => 1,
+    header      => "none",
+    padding     => "none"
+  });
+
+  my $data_block1 = "";
+  my $data_block2 = "";
+
+  if (defined ($block1)) # verify
+  {
+    # note: we need to try both alternatives (if the first fails)
+
+    my $data_dec = $aes_cbc1->decrypt ($block1);
+
+    if (verify_bitcoinj ($data_dec) == 1)
+    {
+      $data_block1 = $block1;
+      $data_block2 = $block2;
+    }
+    else
+    {
+      # else: ALTERNATIVE 2 (block 2, fixed IV):
+
+      $data_dec = $aes_cbc2->decrypt ($block2);
+
+      if (verify_bitcoinj ($data_dec) == 1)
+      {
+        $data_block1 = $block1;
+        $data_block2 = $block2;
+      }
+    }
+  }
+  else
+  {
+    my $data = "";
+
+    $data .= "\n";
+    $data .= chr (random_number (0, 127));
+    $data .= "org.";
+
+    for (my $i = 6; $i < 16; $i++)
+    {
+      $data .= substr ($BITCOINJ_CHARS, random_number (0, length ($BITCOINJ_CHARS) - 1), 1);
+    }
+
+    my $random_alternative = random_number (0, 1);
+
+    my $data_enc = "";
+
+    if ($random_alternative == 0)
+    {
+      $data_block1 = $aes_cbc1->encrypt ($data);
+      $data_block2 = $iv; # fake
+    }
+    else
+    {
+      $data_block1 = $iv; # fake
+      $data_block2 = $aes_cbc2->encrypt ($data);
+    }
+  }
+
+  my $hash = sprintf ("\$multibit\$2*%s*%s*%s", unpack ("H*", $iv), unpack ("H*", $data_block1), unpack ("H*", $data_block2));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  return unless (substr ($line, 0, 12) eq '$multibit$2*');
+
+  # split hash and word:
+
+  my $idx1 = index ($line, ":", 12);
+
+  return if $idx1 < 1;
+
+  my $hash = substr ($line,  0, $idx1);
+  my $word = substr ($line, $idx1 + 1);
+
+  # IV:
+
+  my $idx2 = index ($hash, "*", 12);
+
+  my $iv = substr ($hash, 12, $idx2 - 12);
+
+  # block 1:
+
+  $idx1 = index ($hash, "*", $idx2 + 1);
+
+  my $block1 = substr ($hash, $idx2 + 1, $idx1 - $idx2 - 1);
+
+  # block 2:
+
+  my $block2 = substr ($hash, $idx1 + 1);
+
+  return unless $iv     =~ m/^[0-9a-fA-F]{32}$/;
+  return unless $block1 =~ m/^[0-9a-fA-F]{32}$/;
+  return unless $block2 =~ m/^[0-9a-fA-F]{32}$/;
+
+  # hex to binary/raw:
+
+  $iv     = pack ("H*", $iv);
+  $block1 = pack ("H*", $block1);
+  $block2 = pack ("H*", $block2);
+
+  $word = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word, $iv, $block1, $block2);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This adds the new algorithm (hash type) that was requested in #2383 :
-m 22700 = MultiBit HD (scrypt)

The details of the algorithm are also explained in #2383 (utf16be, pbkdf2 with fixed salt, AES256-CBC decryption and bitcoinj string verification).

Since it involves scrypt, it will probably best work with modern OpenCL-compatible CPUs (Intel Core or Xeon etc), but this of course depends on what (and the amount of) hardware you have etc (normally systems have or could have multiple GPUs, but only a few CPUs etc).

It is needless to say that this is a very slow algorithm (by design), made to be difficult to "brute-force"/crack on GPUs... but if you have a small dict file or a good knowledge how the password could look like, the addition of this new hash type could help you. I hope so, because it was again a lot of work to implement it.

Thanks a lot