### PR TITLE
fixes possible off-by-one verification problem with -m 22500 = MultiBit Classic

### DIFF
--- a/OpenCL/m22500_a0-optimized.cl
+++ b/OpenCL/m22500_a0-optimized.cl
@@ -554,7 +554,7 @@ KERNEL_FQ void m22500_m04 (KERN_ATTR_RULES ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 
@@ -1149,7 +1149,7 @@ KERNEL_FQ void m22500_s04 (KERN_ATTR_RULES ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 

--- a/OpenCL/m22500_a0-pure.cl
+++ b/OpenCL/m22500_a0-pure.cl
@@ -263,7 +263,7 @@ KERNEL_FQ void m22500_mxx (KERN_ATTR_RULES ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 
@@ -559,7 +559,7 @@ KERNEL_FQ void m22500_sxx (KERN_ATTR_RULES ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 

--- a/OpenCL/m22500_a1-optimized.cl
+++ b/OpenCL/m22500_a1-optimized.cl
@@ -613,7 +613,7 @@ KERNEL_FQ void m22500_m04 (KERN_ATTR_BASIC ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 
@@ -1268,7 +1268,7 @@ KERNEL_FQ void m22500_s04 (KERN_ATTR_BASIC ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 

--- a/OpenCL/m22500_a1-pure.cl
+++ b/OpenCL/m22500_a1-pure.cl
@@ -267,7 +267,7 @@ KERNEL_FQ void m22500_mxx (KERN_ATTR_BASIC ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 
@@ -569,7 +569,7 @@ KERNEL_FQ void m22500_sxx (KERN_ATTR_BASIC ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 

--- a/OpenCL/m22500_a3-optimized.cl
+++ b/OpenCL/m22500_a3-optimized.cl
@@ -542,7 +542,7 @@ DECLSPEC void m22500 (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a 
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 

--- a/OpenCL/m22500_a3-pure.cl
+++ b/OpenCL/m22500_a3-pure.cl
@@ -276,7 +276,7 @@ KERNEL_FQ void m22500_mxx (KERN_ATTR_VECTOR ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 
@@ -587,7 +587,7 @@ KERNEL_FQ void m22500_sxx (KERN_ATTR_VECTOR ())
     }
     else if (first_byte == 0x0a) // \n => bitcoinj
     {
-      if ((out[0] & 0x0000ff00)  > 0x00007e00) continue; // second_byte
+      if ((out[0] & 0x0000ff00)  > 0x00007f00) continue; // second_byte
 
       // check for "org." substring:
 


### PR DESCRIPTION
While implementing the algorithm mentioned in https://github.com/hashcat/hashcat/issues/2383 with commit https://github.com/hashcat/hashcat/pull/2388 , I think I've found a possible off-by-one verification problem...

if we look for instance at the JTR code over here: https://github.com/magnumripper/JohnTheRipper/blob/4442241b4c3ec6421499b527213cda4a470b8837/src/multibit_fmt_plug.c#L259
we can see that up to value 128 is supported, while we only allowed up to 127 by mistake..

In theory this could lead to false negatives, but from my experience the values are very, very low in all of my example hashes....

Anyway, it's better to fix it now, because also the new -m 22700 = MultiBit HD (scrypt) algorithm allows the full range now.

Thanks