### PR TITLE
use our safe free () wrapper hcfree whenever possible

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -182,8 +182,8 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
   {
     event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
 
-    free (new_hashfile);
-    free (old_hashfile);
+    hcfree (new_hashfile);
+    hcfree (old_hashfile);
 
     return -1;
   }
@@ -194,8 +194,8 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
     event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
 
-    free (new_hashfile);
-    free (old_hashfile);
+    hcfree (new_hashfile);
+    hcfree (old_hashfile);
 
     return -1;
   }
@@ -256,8 +256,8 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
 
     event_log_error (hashcat_ctx, "%s: %s", new_hashfile, strerror (errno));
 
-    free (new_hashfile);
-    free (old_hashfile);
+    hcfree (new_hashfile);
+    hcfree (old_hashfile);
 
     return -1;
   }
@@ -270,8 +270,8 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
   {
     event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %s", hashfile, old_hashfile, strerror (errno));
 
-    free (new_hashfile);
-    free (old_hashfile);
+    hcfree (new_hashfile);
+    hcfree (old_hashfile);
 
     return -1;
   }
@@ -282,16 +282,16 @@ int save_hash (hashcat_ctx_t *hashcat_ctx)
   {
     event_log_error (hashcat_ctx, "Rename file '%s' to '%s': %s", new_hashfile, hashfile, strerror (errno));
 
-    free (new_hashfile);
-    free (old_hashfile);
+    hcfree (new_hashfile);
+    hcfree (old_hashfile);
 
     return -1;
   }
 
   unlink (old_hashfile);
 
-  free (new_hashfile);
-  free (old_hashfile);
+  hcfree (new_hashfile);
+  hcfree (old_hashfile);
 
   return 0;
 }

--- a/src/hlfmt.c
+++ b/src/hlfmt.c
@@ -374,7 +374,7 @@ u32 hlfmt_detect (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, u32 max_check)
     hashlist_format = i;
   }
 
-  free (formats_cnt);
+  hcfree (formats_cnt);
 
   return hashlist_format;
 }

--- a/src/modules/module_06211.c
+++ b/src/modules/module_06211.c
@@ -199,7 +199,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06212.c
+++ b/src/modules/module_06212.c
@@ -199,7 +199,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06213.c
+++ b/src/modules/module_06213.c
@@ -197,7 +197,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06221.c
+++ b/src/modules/module_06221.c
@@ -181,7 +181,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06222.c
+++ b/src/modules/module_06222.c
@@ -181,7 +181,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06223.c
+++ b/src/modules/module_06223.c
@@ -179,7 +179,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06231.c
+++ b/src/modules/module_06231.c
@@ -180,7 +180,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06232.c
+++ b/src/modules/module_06232.c
@@ -180,7 +180,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06233.c
+++ b/src/modules/module_06233.c
@@ -180,7 +180,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06241.c
+++ b/src/modules/module_06241.c
@@ -193,7 +193,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06242.c
+++ b/src/modules/module_06242.c
@@ -193,7 +193,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_06243.c
+++ b/src/modules/module_06243.c
@@ -193,7 +193,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13711.c
+++ b/src/modules/module_13711.c
@@ -209,7 +209,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13712.c
+++ b/src/modules/module_13712.c
@@ -209,7 +209,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13713.c
+++ b/src/modules/module_13713.c
@@ -209,7 +209,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13721.c
+++ b/src/modules/module_13721.c
@@ -210,7 +210,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13722.c
+++ b/src/modules/module_13722.c
@@ -210,7 +210,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13723.c
+++ b/src/modules/module_13723.c
@@ -210,7 +210,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13731.c
+++ b/src/modules/module_13731.c
@@ -209,7 +209,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13732.c
+++ b/src/modules/module_13732.c
@@ -209,7 +209,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13733.c
+++ b/src/modules/module_13733.c
@@ -209,7 +209,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13741.c
+++ b/src/modules/module_13741.c
@@ -211,7 +211,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13742.c
+++ b/src/modules/module_13742.c
@@ -211,7 +211,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13743.c
+++ b/src/modules/module_13743.c
@@ -211,7 +211,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13751.c
+++ b/src/modules/module_13751.c
@@ -228,7 +228,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13752.c
+++ b/src/modules/module_13752.c
@@ -228,7 +228,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13753.c
+++ b/src/modules/module_13753.c
@@ -228,7 +228,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13761.c
+++ b/src/modules/module_13761.c
@@ -230,7 +230,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13762.c
+++ b/src/modules/module_13762.c
@@ -230,7 +230,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13763.c
+++ b/src/modules/module_13763.c
@@ -230,7 +230,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13771.c
+++ b/src/modules/module_13771.c
@@ -213,7 +213,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13772.c
+++ b/src/modules/module_13772.c
@@ -213,7 +213,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/modules/module_13773.c
+++ b/src/modules/module_13773.c
@@ -213,7 +213,7 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       keyfile = strtok_r ((char *) NULL, ",", &saveptr);
     }
 
-    free (keyfiles);
+    hcfree (keyfiles);
   }
 
   // keyboard layout mapping

--- a/src/shared.c
+++ b/src/shared.c
@@ -507,7 +507,7 @@ void setup_environment_variables (const folder_config_t *folder_config)
 
     putenv (display);
 
-    free (display);
+    hcfree (display);
   }
   else
   {

--- a/src/status.c
+++ b/src/status.c
@@ -323,7 +323,7 @@ char *status_get_hash_target (const hashcat_ctx_t *hashcat_ctx)
 
       tmp_buf2[tmp_len] = 0;
 
-      free (tmp_buf);
+      hcfree (tmp_buf);
 
       return tmp_buf2;
     }
@@ -343,7 +343,7 @@ char *status_get_hash_target (const hashcat_ctx_t *hashcat_ctx)
 
     char *tmp_buf2 = strdup (tmp_buf);
 
-    free (tmp_buf);
+    hcfree (tmp_buf);
 
     return tmp_buf2;
   }
@@ -1097,14 +1097,14 @@ char *status_get_time_estimated_relative (const hashcat_ctx_t *hashcat_ctx)
 
       snprintf (display, HCBUFSIZ_TINY, "%s; Runtime limited: %s", tmp_display, display_left);
 
-      free (display_left);
+      hcfree (display_left);
     }
     else
     {
       snprintf (display, HCBUFSIZ_TINY, "%s; Runtime limit exceeded", tmp_display);
     }
 
-    free (tmp_display);
+    hcfree (tmp_display);
   }
 
   return display;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1068,7 +1068,7 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
   printf (" \"rejected\": %" PRIu64 ",", hashcat_status->progress_rejected);
   printf (" \"devices\": [");
 
-  free (target_json_encoded);
+  hcfree (target_json_encoded);
 
   int device_num = 0;
 


### PR DESCRIPTION
I've noticed just after we merged the JSON fix from https://github.com/hashcat/hashcat/pull/2395/files that we often forget to use hcfree () instead of free ().

I think we should just stick to use hcfree () whenever possible, even if it's mainly just to be safer and for consistency. Thank you very much