### PR TITLE
luks: remove self-test example hash

### DIFF
--- a/src/modules/module_14600.c
+++ b/src/modules/module_14600.c
@@ -26,8 +26,8 @@ static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_SELF_TEST_DISABLE
                                   | OPTS_TYPE_BINARY_HASHFILE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
-static const char *ST_PASS        = "hashcat";
-static const char *ST_HASH        = "tbd";
+static const char *ST_PASS        = NULL;
+static const char *ST_HASH        = NULL;
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }


### PR DESCRIPTION
This is a new problem introduced with https://github.com/hashcat/hashcat/commit/33579ae3db34a84bc26e01589925707b370d4f33 to the -m 14600 = LUKS hash type: 
without this fix an error was shown that the filesize of the luks container was not correct.

I would suggest to just remove the example hash data (pass + hash) for now, since we don't have a good/full example that we want to embed directly into the LUKS hashcat module. I also think it's not necessary to have an example directly embedded for such complicated hash types... the users could just go here: https://hashcat.net/wiki/example_hashes to see some examples.

Thx