### PR TITLE
-m 21000 = BitShares fix for different vector width

### DIFF
--- a/OpenCL/m21000_a3-pure.cl
+++ b/OpenCL/m21000_a3-pure.cl
@@ -66,22 +66,22 @@ KERNEL_FQ void m21000_mxx (KERN_ATTR_VECTOR ())
 
     u32x final[32] = { 0 };
 
-    final[ 0] = h32_from_64_S (ctx0.h[0]);
-    final[ 1] = l32_from_64_S (ctx0.h[0]);
-    final[ 2] = h32_from_64_S (ctx0.h[1]);
-    final[ 3] = l32_from_64_S (ctx0.h[1]);
-    final[ 4] = h32_from_64_S (ctx0.h[2]);
-    final[ 5] = l32_from_64_S (ctx0.h[2]);
-    final[ 6] = h32_from_64_S (ctx0.h[3]);
-    final[ 7] = l32_from_64_S (ctx0.h[3]);
-    final[ 8] = h32_from_64_S (ctx0.h[4]);
-    final[ 9] = l32_from_64_S (ctx0.h[4]);
-    final[10] = h32_from_64_S (ctx0.h[5]);
-    final[11] = l32_from_64_S (ctx0.h[5]);
-    final[12] = h32_from_64_S (ctx0.h[6]);
-    final[13] = l32_from_64_S (ctx0.h[6]);
-    final[14] = h32_from_64_S (ctx0.h[7]);
-    final[15] = l32_from_64_S (ctx0.h[7]);
+    final[ 0] = h32_from_64 (ctx0.h[0]);
+    final[ 1] = l32_from_64 (ctx0.h[0]);
+    final[ 2] = h32_from_64 (ctx0.h[1]);
+    final[ 3] = l32_from_64 (ctx0.h[1]);
+    final[ 4] = h32_from_64 (ctx0.h[2]);
+    final[ 5] = l32_from_64 (ctx0.h[2]);
+    final[ 6] = h32_from_64 (ctx0.h[3]);
+    final[ 7] = l32_from_64 (ctx0.h[3]);
+    final[ 8] = h32_from_64 (ctx0.h[4]);
+    final[ 9] = l32_from_64 (ctx0.h[4]);
+    final[10] = h32_from_64 (ctx0.h[5]);
+    final[11] = l32_from_64 (ctx0.h[5]);
+    final[12] = h32_from_64 (ctx0.h[6]);
+    final[13] = l32_from_64 (ctx0.h[6]);
+    final[14] = h32_from_64 (ctx0.h[7]);
+    final[15] = l32_from_64 (ctx0.h[7]);
 
     sha512_update_vector (&ctx, final, 64);
 
@@ -160,22 +160,22 @@ KERNEL_FQ void m21000_sxx (KERN_ATTR_VECTOR ())
 
     u32x final[32] = { 0 };
 
-    final[ 0] = h32_from_64_S (ctx0.h[0]);
-    final[ 1] = l32_from_64_S (ctx0.h[0]);
-    final[ 2] = h32_from_64_S (ctx0.h[1]);
-    final[ 3] = l32_from_64_S (ctx0.h[1]);
-    final[ 4] = h32_from_64_S (ctx0.h[2]);
-    final[ 5] = l32_from_64_S (ctx0.h[2]);
-    final[ 6] = h32_from_64_S (ctx0.h[3]);
-    final[ 7] = l32_from_64_S (ctx0.h[3]);
-    final[ 8] = h32_from_64_S (ctx0.h[4]);
-    final[ 9] = l32_from_64_S (ctx0.h[4]);
-    final[10] = h32_from_64_S (ctx0.h[5]);
-    final[11] = l32_from_64_S (ctx0.h[5]);
-    final[12] = h32_from_64_S (ctx0.h[6]);
-    final[13] = l32_from_64_S (ctx0.h[6]);
-    final[14] = h32_from_64_S (ctx0.h[7]);
-    final[15] = l32_from_64_S (ctx0.h[7]);
+    final[ 0] = h32_from_64 (ctx0.h[0]);
+    final[ 1] = l32_from_64 (ctx0.h[0]);
+    final[ 2] = h32_from_64 (ctx0.h[1]);
+    final[ 3] = l32_from_64 (ctx0.h[1]);
+    final[ 4] = h32_from_64 (ctx0.h[2]);
+    final[ 5] = l32_from_64 (ctx0.h[2]);
+    final[ 6] = h32_from_64 (ctx0.h[3]);
+    final[ 7] = l32_from_64 (ctx0.h[3]);
+    final[ 8] = h32_from_64 (ctx0.h[4]);
+    final[ 9] = l32_from_64 (ctx0.h[4]);
+    final[10] = h32_from_64 (ctx0.h[5]);
+    final[11] = l32_from_64 (ctx0.h[5]);
+    final[12] = h32_from_64 (ctx0.h[6]);
+    final[13] = l32_from_64 (ctx0.h[6]);
+    final[14] = h32_from_64 (ctx0.h[7]);
+    final[15] = l32_from_64 (ctx0.h[7]);
 
     sha512_update_vector (&ctx, final, 64);
 


### PR DESCRIPTION
The pure OpenCL kernel for `-m 21000 = BitShares v0.x - sha512(sha512_bin(pass))` did contain a new problem that made the compiler complain about the vector vs scalar types etc... our own h32_from_64_S () can't be used with vectors, we need to use h32_from_64 ()

Thx

BTW: I've accidentally found this problem while investigating some POCL errors in regards to this issue: https://github.com/hashcat/hashcat/issues/2398   