### PR TITLE
fixes #2413: documentation of rule "*" was incorrect

### DIFF
--- a/docs/rules.txt
+++ b/docs/rules.txt
@@ -28,7 +28,7 @@
 #define RULE_OP_MANGLE_DUPECHAR_ALL     'q' // duplicate all chars. ex: hello -> hheelllloo
 #define RULE_OP_MANGLE_SWITCH_FIRST     'k' // switches the first 2 chars. ex: hello -> ehllo
 #define RULE_OP_MANGLE_SWITCH_LAST      'K' // switches the last 2 chars.  ex: hello -> helol
-#define RULE_OP_MANGLE_SWITCH_AT        '*' // switches the first 2 chars after pos N. ex: hello -> hlelo
+#define RULE_OP_MANGLE_SWITCH_AT        '*' // switches char at pos N with char at pos M. ex: hello -> holle
 #define RULE_OP_MANGLE_CHR_SHIFTL       'L' // bitwise shift left char at pos N.  ex: hello0 -> hello`
 #define RULE_OP_MANGLE_CHR_SHIFTR       'R' // bitwise shift right char at pos N. ex: hello` -> hello0
 #define RULE_OP_MANGLE_CHR_INCR         '+' // bytewise increase at pos N. ex: hello0 -> hello1
@@ -42,7 +42,7 @@
 
 /* With -j or -k only */
 
-#define RULE_OP_MANGLE_EXTRACT_MEMORY   'X' // insert substring delimited by N and M into current word at position I
+#define RULE_OP_MANGLE_EXTRACT_MEMORY   'X' // insert substring delimited by N and M into current word at pos I
 #define RULE_OP_MANGLE_APPEND_MEMORY    '4' // insert the word saved by 'M' at the end of current word
 #define RULE_OP_MANGLE_PREPEND_MEMORY   '6' // insert the word saved by 'M' at the beginning of current word
 #define RULE_OP_MEMORIZE_WORD           'M' // memorize current word
@@ -52,9 +52,9 @@
 #define RULE_OP_REJECT_EQUAL            '_' // reject plains of length not equal to N
 #define RULE_OP_REJECT_CONTAIN          '!' // reject plains that contain char X
 #define RULE_OP_REJECT_NOT_CONTAIN      '/' // reject plains that do not contain char X
-#define RULE_OP_REJECT_EQUAL_FIRST      '(' // reject plains that do not contain char X at first position
-#define RULE_OP_REJECT_EQUAL_LAST       ')' // reject plains that do not contain char X at last position
-#define RULE_OP_REJECT_EQUAL_AT         '=' // reject plains that do not contain char X at position N
+#define RULE_OP_REJECT_EQUAL_FIRST      '(' // reject plains that do not contain char X at first pos
+#define RULE_OP_REJECT_EQUAL_LAST       ')' // reject plains that do not contain char X at last pos
+#define RULE_OP_REJECT_EQUAL_AT         '=' // reject plains that do not contain char X at pos N
 #define RULE_OP_REJECT_CONTAINS         '%' // reject plains that contain char X less than N times
 #define RULE_OP_REJECT_MEMORY           'Q' // reject plains that match the plain saved (see M), i.e. if unchanged
-#define RULE_LAST_REJECTED_SAVED_POS    'p' // position of the character last found with '/' or '%'
+#define RULE_LAST_REJECTED_SAVED_POS    'p' // pos of the character last found with '/' or '%'


### PR DESCRIPTION
This fixes the documentation problem mentioned in #2413 : the swap rule was explained incorrectly.

I've also replaced every "position" by "pos" to make it more concise and consistent with other descriptions/explanations.