### PR TITLE
fixes #2365: NSEC3 dot replace and empty salt/domain fix

### DIFF
--- a/OpenCL/m08300_a0-optimized.cl
+++ b/OpenCL/m08300_a0-optimized.cl
@@ -16,6 +16,113 @@
 #include "inc_hash_sha1.cl"
 #endif
 
+const u32 replace_dots (u32 *w, const u32 idx, const u32 old_len, const u32 pw_len)
+{
+  const u32 min_len = idx << 4; // 2 ^ 4 = 16 for each u32 w[4]
+
+  if (pw_len <= min_len) return 0;
+
+  const u32 max_len = pw_len - min_len - 1;
+
+  const u32 start_pos = (max_len < 15) ? max_len : 15;
+
+  u32 cur_len = old_len;
+
+  for (int pos = (int) start_pos; pos >= 0; pos--)
+  {
+    const u32 div = pos  / 4;
+    const u32 mod = pos  & 3;
+    const u32 sht = mod << 3;
+
+    if (((w[div] >> sht) & 0xff) == 0x2e) // '.'
+    {
+      w[div] += (cur_len - 0x2e) << sht;
+
+      cur_len = 0;
+    }
+    else
+    {
+      cur_len++;
+    }
+  }
+
+  return cur_len;
+}
+
+const u32 replace_dot_by_len (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len)
+{
+  u32 cur_len = 0;
+
+  // loop over w3...w0 (4 * 16 = 64 bytes):
+
+  cur_len = replace_dots (w3, 3, cur_len, pw_len);
+  cur_len = replace_dots (w2, 2, cur_len, pw_len);
+  cur_len = replace_dots (w1, 1, cur_len, pw_len);
+  cur_len = replace_dots (w0, 0, cur_len, pw_len);
+
+  return cur_len;
+}
+
+#define REPLACE_DOT_BY_LEN_VECT(n)                                             \
+  if (out_len.s##n > 0)                                                        \
+  {                                                                            \
+    u32 tmp0[4];                                                               \
+                                                                               \
+    tmp0[0] = w0_t[0].s##n;                                                    \
+    tmp0[1] = w0_t[1].s##n;                                                    \
+    tmp0[2] = w0_t[2].s##n;                                                    \
+    tmp0[3] = w0_t[3].s##n;                                                    \
+                                                                               \
+    u32 tmp1[4];                                                               \
+                                                                               \
+    tmp1[0] = w1_t[0].s##n;                                                    \
+    tmp1[1] = w1_t[1].s##n;                                                    \
+    tmp1[2] = w1_t[2].s##n;                                                    \
+    tmp1[3] = w1_t[3].s##n;                                                    \
+                                                                               \
+    u32 tmp2[4];                                                               \
+                                                                               \
+    tmp2[0] = w2_t[0].s##n;                                                    \
+    tmp2[1] = w2_t[1].s##n;                                                    \
+    tmp2[2] = w2_t[2].s##n;                                                    \
+    tmp2[3] = w2_t[3].s##n;                                                    \
+                                                                               \
+    u32 tmp3[4];                                                               \
+                                                                               \
+    tmp3[0] = w3_t[0].s##n;                                                    \
+    tmp3[1] = w3_t[1].s##n;                                                    \
+    tmp3[2] = w3_t[2].s##n;                                                    \
+    tmp3[3] = w3_t[3].s##n;                                                    \
+                                                                               \
+    const u32 len = replace_dot_by_len (tmp0, tmp1, tmp2, tmp3, out_len.s##n); \
+                                                                               \
+    switch_buffer_by_offset_le_S (tmp0, tmp1, tmp2, tmp3, 1);                  \
+                                                                               \
+    tmp0[0] |= len & 0xff;                                                     \
+                                                                               \
+    w0_t[0].s##n = tmp0[0];                                                    \
+    w0_t[1].s##n = tmp0[1];                                                    \
+    w0_t[2].s##n = tmp0[2];                                                    \
+    w0_t[3].s##n = tmp0[3];                                                    \
+                                                                               \
+    w1_t[0].s##n = tmp1[0];                                                    \
+    w1_t[1].s##n = tmp1[1];                                                    \
+    w1_t[2].s##n = tmp1[2];                                                    \
+    w1_t[3].s##n = tmp1[3];                                                    \
+                                                                               \
+    w2_t[0].s##n = tmp2[0];                                                    \
+    w2_t[1].s##n = tmp2[1];                                                    \
+    w2_t[2].s##n = tmp2[2];                                                    \
+    w2_t[3].s##n = tmp2[3];                                                    \
+                                                                               \
+    w3_t[0].s##n = tmp3[0];                                                    \
+    w3_t[1].s##n = tmp3[1];                                                    \
+    w3_t[2].s##n = tmp3[2];                                                    \
+    w3_t[3].s##n = tmp3[3];                                                    \
+                                                                               \
+    out_len.s##n++;                                                            \
+  }
+
 KERNEL_FQ void m08300_m04 (KERN_ATTR_RULES ())
 {
   /**
@@ -91,7 +198,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_RULES ())
     u32x w2[4] = { 0 };
     u32x w3[4] = { 0 };
 
-    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+    u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
 
     /**
      * salt
@@ -119,9 +226,44 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_RULES ())
     w3_t[2] = w3[2];
     w3_t[3] = w3[3];
 
-    switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+    // replace "." with the length:
 
-    w0_t[0] |= out_len & 0xff;
+    #if VECT_SIZE == 1
+      if (out_len > 0)
+      {
+        const u32 len = replace_dot_by_len (w0_t, w1_t, w2_t, w3_t, out_len);
+
+        switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+
+        w0_t[0] |= len & 0xff;
+
+        out_len++;
+      }
+    #endif
+    #if VECT_SIZE >= 2
+      REPLACE_DOT_BY_LEN_VECT (0)
+      REPLACE_DOT_BY_LEN_VECT (1)
+    #endif
+    #if VECT_SIZE >= 4
+      REPLACE_DOT_BY_LEN_VECT (2)
+      REPLACE_DOT_BY_LEN_VECT (3)
+    #endif
+    #if VECT_SIZE >= 8
+      REPLACE_DOT_BY_LEN_VECT (4)
+      REPLACE_DOT_BY_LEN_VECT (5)
+      REPLACE_DOT_BY_LEN_VECT (6)
+      REPLACE_DOT_BY_LEN_VECT (7)
+    #endif
+    #if VECT_SIZE >= 16
+      REPLACE_DOT_BY_LEN_VECT (8)
+      REPLACE_DOT_BY_LEN_VECT (9)
+      REPLACE_DOT_BY_LEN_VECT (a)
+      REPLACE_DOT_BY_LEN_VECT (b)
+      REPLACE_DOT_BY_LEN_VECT (c)
+      REPLACE_DOT_BY_LEN_VECT (d)
+      REPLACE_DOT_BY_LEN_VECT (e)
+      REPLACE_DOT_BY_LEN_VECT (f)
+    #endif
 
     u32x s0[4];
     u32x s1[4];
@@ -145,7 +287,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_RULES ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + out_len);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, out_len);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -181,7 +323,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_RULES ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + out_len + domain_len + 1);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, out_len + domain_len + 1);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -219,7 +361,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_RULES ())
     w3_t[0] = hc_swap32 (w3_t[0]);
     w3_t[1] = hc_swap32 (w3_t[1]);
     w3_t[2] = 0;
-    w3_t[3] = (1 + out_len + domain_len + 1 + salt_len) * 8;
+    w3_t[3] = (out_len + domain_len + 1 + salt_len) * 8;
 
     u32x digest[5];
 
@@ -360,7 +502,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_RULES ())
     u32x w2[4] = { 0 };
     u32x w3[4] = { 0 };
 
-    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+    u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
 
     /**
      * salt
@@ -388,9 +530,44 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_RULES ())
     w3_t[2] = w3[2];
     w3_t[3] = w3[3];
 
-    switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+    // replace "." with the length:
 
-    w0_t[0] |= out_len & 0xff;
+    #if VECT_SIZE == 1
+      if (out_len > 0)
+      {
+        const u32 len = replace_dot_by_len (w0_t, w1_t, w2_t, w3_t, out_len);
+
+        switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+
+        w0_t[0] |= len & 0xff;
+
+        out_len++;
+      }
+    #endif
+    #if VECT_SIZE >= 2
+      REPLACE_DOT_BY_LEN_VECT (0)
+      REPLACE_DOT_BY_LEN_VECT (1)
+    #endif
+    #if VECT_SIZE >= 4
+      REPLACE_DOT_BY_LEN_VECT (2)
+      REPLACE_DOT_BY_LEN_VECT (3)
+    #endif
+    #if VECT_SIZE >= 8
+      REPLACE_DOT_BY_LEN_VECT (4)
+      REPLACE_DOT_BY_LEN_VECT (5)
+      REPLACE_DOT_BY_LEN_VECT (6)
+      REPLACE_DOT_BY_LEN_VECT (7)
+    #endif
+    #if VECT_SIZE >= 16
+      REPLACE_DOT_BY_LEN_VECT (8)
+      REPLACE_DOT_BY_LEN_VECT (9)
+      REPLACE_DOT_BY_LEN_VECT (a)
+      REPLACE_DOT_BY_LEN_VECT (b)
+      REPLACE_DOT_BY_LEN_VECT (c)
+      REPLACE_DOT_BY_LEN_VECT (d)
+      REPLACE_DOT_BY_LEN_VECT (e)
+      REPLACE_DOT_BY_LEN_VECT (f)
+    #endif
 
     u32x s0[4];
     u32x s1[4];
@@ -414,7 +591,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_RULES ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + out_len);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, out_len);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -450,7 +627,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_RULES ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + out_len + domain_len + 1);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, out_len + domain_len + 1);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -488,7 +665,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_RULES ())
     w3_t[0] = hc_swap32 (w3_t[0]);
     w3_t[1] = hc_swap32 (w3_t[1]);
     w3_t[2] = 0;
-    w3_t[3] = (1 + out_len + domain_len + 1 + salt_len) * 8;
+    w3_t[3] = (out_len + domain_len + 1 + salt_len) * 8;
 
     u32x digest[5];
 

--- a/OpenCL/m08300_a0-pure.cl
+++ b/OpenCL/m08300_a0-pure.cl
@@ -67,11 +67,36 @@ KERNEL_FQ void m08300_mxx (KERN_ATTR_RULES ())
 
     sha1_init (&ctx1);
 
-    ctx1.w0[0] = (tmp.pw_len & 0xff) << 24;
+    // replace "." with the length:
 
-    ctx1.len = 1;
+    if (tmp.pw_len > 0)
+    {
+      u32 len = 0;
 
-    sha1_update_swap (&ctx1, tmp.i, tmp.pw_len);
+      for (int pos = tmp.pw_len - 1; pos >= 0; pos--)
+      {
+        const u32 div = pos  / 4;
+        const u32 mod = pos  & 3;
+        const u32 sht = mod << 3;
+
+        if (((tmp.i[div] >> sht) & 0xff) == 0x2e) // '.'
+        {
+          tmp.i[div] += (len - 0x2e) << sht;
+
+          len = 0;
+
+          continue;
+        }
+
+        len++;
+      }
+
+      ctx1.w0[0] = (len & 0xff) << 24;
+
+      ctx1.len = 1;
+
+      sha1_update_swap (&ctx1, tmp.i, tmp.pw_len);
+    }
 
     sha1_update (&ctx1, s_pc, salt_len_pc + 1);
 
@@ -186,11 +211,36 @@ KERNEL_FQ void m08300_sxx (KERN_ATTR_RULES ())
 
     sha1_init (&ctx1);
 
-    ctx1.w0[0] = (tmp.pw_len & 0xff) << 24;
+    // replace "." with the length:
 
-    ctx1.len = 1;
+    if (tmp.pw_len > 0)
+    {
+      u32 len = 0;
 
-    sha1_update_swap (&ctx1, tmp.i, tmp.pw_len);
+      for (int pos = tmp.pw_len - 1; pos >= 0; pos--)
+      {
+        const u32 div = pos  / 4;
+        const u32 mod = pos  & 3;
+        const u32 sht = mod << 3;
+
+        if (((tmp.i[div] >> sht) & 0xff) == 0x2e) // '.'
+        {
+          tmp.i[div] += (len - 0x2e) << sht;
+
+          len = 0;
+
+          continue;
+        }
+
+        len++;
+      }
+
+      ctx1.w0[0] = (len & 0xff) << 24;
+
+      ctx1.len = 1;
+
+      sha1_update_swap (&ctx1, tmp.i, tmp.pw_len);
+    }
 
     sha1_update (&ctx1, s_pc, salt_len_pc + 1);
 

--- a/OpenCL/m08300_a1-optimized.cl
+++ b/OpenCL/m08300_a1-optimized.cl
@@ -14,6 +14,113 @@
 #include "inc_hash_sha1.cl"
 #endif
 
+const u32 replace_dots (u32 *w, const u32 idx, const u32 old_len, const u32 pw_len)
+{
+  const u32 min_len = idx << 4; // 2 ^ 4 = 16 for each u32 w[4]
+
+  if (pw_len <= min_len) return 0;
+
+  const u32 max_len = pw_len - min_len - 1;
+
+  const u32 start_pos = (max_len < 15) ? max_len : 15;
+
+  u32 cur_len = old_len;
+
+  for (int pos = (int) start_pos; pos >= 0; pos--)
+  {
+    const u32 div = pos  / 4;
+    const u32 mod = pos  & 3;
+    const u32 sht = mod << 3;
+
+    if (((w[div] >> sht) & 0xff) == 0x2e) // '.'
+    {
+      w[div] += (cur_len - 0x2e) << sht;
+
+      cur_len = 0;
+    }
+    else
+    {
+      cur_len++;
+    }
+  }
+
+  return cur_len;
+}
+
+const u32 replace_dot_by_len (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len)
+{
+  u32 cur_len = 0;
+
+  // loop over w3...w0 (4 * 16 = 64 bytes):
+
+  cur_len = replace_dots (w3, 3, cur_len, pw_len);
+  cur_len = replace_dots (w2, 2, cur_len, pw_len);
+  cur_len = replace_dots (w1, 1, cur_len, pw_len);
+  cur_len = replace_dots (w0, 0, cur_len, pw_len);
+
+  return cur_len;
+}
+
+#define REPLACE_DOT_BY_LEN_VECT(n)                                            \
+  if (pw_len.s##n > 0)                                                        \
+  {                                                                           \
+    u32 tmp0[4];                                                              \
+                                                                              \
+    tmp0[0] = w0_t[0].s##n;                                                   \
+    tmp0[1] = w0_t[1].s##n;                                                   \
+    tmp0[2] = w0_t[2].s##n;                                                   \
+    tmp0[3] = w0_t[3].s##n;                                                   \
+                                                                              \
+    u32 tmp1[4];                                                              \
+                                                                              \
+    tmp1[0] = w1_t[0].s##n;                                                   \
+    tmp1[1] = w1_t[1].s##n;                                                   \
+    tmp1[2] = w1_t[2].s##n;                                                   \
+    tmp1[3] = w1_t[3].s##n;                                                   \
+                                                                              \
+    u32 tmp2[4];                                                              \
+                                                                              \
+    tmp2[0] = w2_t[0].s##n;                                                   \
+    tmp2[1] = w2_t[1].s##n;                                                   \
+    tmp2[2] = w2_t[2].s##n;                                                   \
+    tmp2[3] = w2_t[3].s##n;                                                   \
+                                                                              \
+    u32 tmp3[4];                                                              \
+                                                                              \
+    tmp3[0] = w3_t[0].s##n;                                                   \
+    tmp3[1] = w3_t[1].s##n;                                                   \
+    tmp3[2] = w3_t[2].s##n;                                                   \
+    tmp3[3] = w3_t[3].s##n;                                                   \
+                                                                              \
+    const u32 len = replace_dot_by_len (tmp0, tmp1, tmp2, tmp3, pw_len.s##n); \
+                                                                              \
+    switch_buffer_by_offset_le_S (tmp0, tmp1, tmp2, tmp3, 1);                 \
+                                                                              \
+    tmp0[0] |= len & 0xff;                                                    \
+                                                                              \
+    w0_t[0].s##n = tmp0[0];                                                   \
+    w0_t[1].s##n = tmp0[1];                                                   \
+    w0_t[2].s##n = tmp0[2];                                                   \
+    w0_t[3].s##n = tmp0[3];                                                   \
+                                                                              \
+    w1_t[0].s##n = tmp1[0];                                                   \
+    w1_t[1].s##n = tmp1[1];                                                   \
+    w1_t[2].s##n = tmp1[2];                                                   \
+    w1_t[3].s##n = tmp1[3];                                                   \
+                                                                              \
+    w2_t[0].s##n = tmp2[0];                                                   \
+    w2_t[1].s##n = tmp2[1];                                                   \
+    w2_t[2].s##n = tmp2[2];                                                   \
+    w2_t[3].s##n = tmp2[3];                                                   \
+                                                                              \
+    w3_t[0].s##n = tmp3[0];                                                   \
+    w3_t[1].s##n = tmp3[1];                                                   \
+    w3_t[2].s##n = tmp3[2];                                                   \
+    w3_t[3].s##n = tmp3[3];                                                   \
+                                                                              \
+    pw_len.s##n++;                                                            \
+  }
+
 KERNEL_FQ void m08300_m04 (KERN_ATTR_BASIC ())
 {
   /**
@@ -86,7 +193,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_BASIC ())
   {
     const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
 
-    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+    u32x pw_len = (pw_l_len + pw_r_len) & 63;
 
     /**
      * concat password candidate
@@ -177,9 +284,44 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_BASIC ())
     w3_t[2] = w3[2];
     w3_t[3] = w3[3];
 
-    switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+    // replace "." with the length:
 
-    w0_t[0] |= pw_len & 0xff;
+    #if VECT_SIZE == 1
+      if (pw_len > 0)
+      {
+        const u32 len = replace_dot_by_len (w0_t, w1_t, w2_t, w3_t, pw_len);
+
+        switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+
+        w0_t[0] |= len & 0xff;
+
+        pw_len++;
+      }
+    #endif
+    #if VECT_SIZE >= 2
+      REPLACE_DOT_BY_LEN_VECT (0)
+      REPLACE_DOT_BY_LEN_VECT (1)
+    #endif
+    #if VECT_SIZE >= 4
+      REPLACE_DOT_BY_LEN_VECT (2)
+      REPLACE_DOT_BY_LEN_VECT (3)
+    #endif
+    #if VECT_SIZE >= 8
+      REPLACE_DOT_BY_LEN_VECT (4)
+      REPLACE_DOT_BY_LEN_VECT (5)
+      REPLACE_DOT_BY_LEN_VECT (6)
+      REPLACE_DOT_BY_LEN_VECT (7)
+    #endif
+    #if VECT_SIZE >= 16
+      REPLACE_DOT_BY_LEN_VECT (8)
+      REPLACE_DOT_BY_LEN_VECT (9)
+      REPLACE_DOT_BY_LEN_VECT (a)
+      REPLACE_DOT_BY_LEN_VECT (b)
+      REPLACE_DOT_BY_LEN_VECT (c)
+      REPLACE_DOT_BY_LEN_VECT (d)
+      REPLACE_DOT_BY_LEN_VECT (e)
+      REPLACE_DOT_BY_LEN_VECT (f)
+    #endif
 
     u32x s0[4];
     u32x s1[4];
@@ -203,7 +345,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_BASIC ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + pw_len);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, pw_len);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -239,7 +381,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_BASIC ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + pw_len + domain_len + 1);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, pw_len + domain_len + 1);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -277,7 +419,7 @@ KERNEL_FQ void m08300_m04 (KERN_ATTR_BASIC ())
     w3_t[0] = hc_swap32 (w3_t[0]);
     w3_t[1] = hc_swap32 (w3_t[1]);
     w3_t[2] = 0;
-    w3_t[3] = (1 + pw_len + domain_len + 1 + salt_len) * 8;
+    w3_t[3] = (pw_len + domain_len + 1 + salt_len) * 8;
 
     u32x digest[5];
 
@@ -415,7 +557,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_BASIC ())
   {
     const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
 
-    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+    u32x pw_len = (pw_l_len + pw_r_len) & 63;
 
     /**
      * concat password candidate
@@ -506,9 +648,44 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_BASIC ())
     w3_t[2] = w3[2];
     w3_t[3] = w3[3];
 
-    switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+    // replace "." with the length:
 
-    w0_t[0] |= pw_len & 0xff;
+    #if VECT_SIZE == 1
+      if (pw_len > 0)
+      {
+        const u32 len = replace_dot_by_len (w0_t, w1_t, w2_t, w3_t, pw_len);
+
+        switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, 1);
+
+        w0_t[0] |= len & 0xff;
+
+        pw_len++;
+      }
+    #endif
+    #if VECT_SIZE >= 2
+      REPLACE_DOT_BY_LEN_VECT (0)
+      REPLACE_DOT_BY_LEN_VECT (1)
+    #endif
+    #if VECT_SIZE >= 4
+      REPLACE_DOT_BY_LEN_VECT (2)
+      REPLACE_DOT_BY_LEN_VECT (3)
+    #endif
+    #if VECT_SIZE >= 8
+      REPLACE_DOT_BY_LEN_VECT (4)
+      REPLACE_DOT_BY_LEN_VECT (5)
+      REPLACE_DOT_BY_LEN_VECT (6)
+      REPLACE_DOT_BY_LEN_VECT (7)
+    #endif
+    #if VECT_SIZE >= 16
+      REPLACE_DOT_BY_LEN_VECT (8)
+      REPLACE_DOT_BY_LEN_VECT (9)
+      REPLACE_DOT_BY_LEN_VECT (a)
+      REPLACE_DOT_BY_LEN_VECT (b)
+      REPLACE_DOT_BY_LEN_VECT (c)
+      REPLACE_DOT_BY_LEN_VECT (d)
+      REPLACE_DOT_BY_LEN_VECT (e)
+      REPLACE_DOT_BY_LEN_VECT (f)
+    #endif
 
     u32x s0[4];
     u32x s1[4];
@@ -532,7 +709,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_BASIC ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + pw_len);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, pw_len);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -568,7 +745,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_BASIC ())
     s3[2] = 0;
     s3[3] = 0;
 
-    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, 1 + pw_len + domain_len + 1);
+    switch_buffer_by_offset_le_VV (s0, s1, s2, s3, pw_len + domain_len + 1);
 
     w0_t[0] |= s0[0];
     w0_t[1] |= s0[1];
@@ -606,7 +783,7 @@ KERNEL_FQ void m08300_s04 (KERN_ATTR_BASIC ())
     w3_t[0] = hc_swap32 (w3_t[0]);
     w3_t[1] = hc_swap32 (w3_t[1]);
     w3_t[2] = 0;
-    w3_t[3] = (1 + pw_len + domain_len + 1 + salt_len) * 8;
+    w3_t[3] = (pw_len + domain_len + 1 + salt_len) * 8;
 
     u32x digest[5];
 

--- a/OpenCL/m08300_a3-optimized.cl
+++ b/OpenCL/m08300_a3-optimized.cl
@@ -14,6 +14,110 @@
 #include "inc_hash_sha1.cl"
 #endif
 
+const u32 replace_dots (u32 *w, const u32 idx, const u32 old_len, const u32 pw_len)
+{
+  const u32 min_len = idx << 4; // 2 ^ 4 = 16 for each u32 w[4]
+
+  if (pw_len <= min_len) return 0;
+
+  const u32 max_len = pw_len - min_len - 1;
+
+  const u32 start_pos = (max_len < 15) ? max_len : 15;
+
+  u32 cur_len = old_len;
+
+  for (int pos = (int) start_pos; pos >= 0; pos--)
+  {
+    const u32 div = pos / 4;
+    const u32 mod = pos & 3;
+    const u32 sht = (3 - mod) << 3;
+
+    if (((w[div] >> sht) & 0xff) == 0x2e) // '.'
+    {
+      w[div] += (cur_len - 0x2e) << sht;
+
+      cur_len = 0;
+    }
+    else
+    {
+      cur_len++;
+    }
+  }
+
+  return cur_len;
+}
+
+const u32 replace_dot_by_len (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len)
+{
+  u32 cur_len = 0;
+
+  // loop over w3...w0 (4 * 16 = 64 bytes):
+
+  cur_len = replace_dots (w3, 3, cur_len, pw_len);
+  cur_len = replace_dots (w2, 2, cur_len, pw_len);
+  cur_len = replace_dots (w1, 1, cur_len, pw_len);
+  cur_len = replace_dots (w0, 0, cur_len, pw_len);
+
+  return cur_len;
+}
+
+#define REPLACE_DOT_BY_LEN_VECT(n)                                       \
+  {                                                                      \
+    u32 tmp0[4];                                                         \
+                                                                         \
+    tmp0[0] = w0_t[0].s##n;                                              \
+    tmp0[1] = w0_t[1].s##n;                                              \
+    tmp0[2] = w0_t[2].s##n;                                              \
+    tmp0[3] = w0_t[3].s##n;                                              \
+                                                                         \
+    u32 tmp1[4];                                                         \
+                                                                         \
+    tmp1[0] = w1_t[0].s##n;                                              \
+    tmp1[1] = w1_t[1].s##n;                                              \
+    tmp1[2] = w1_t[2].s##n;                                              \
+    tmp1[3] = w1_t[3].s##n;                                              \
+                                                                         \
+    u32 tmp2[4];                                                         \
+                                                                         \
+    tmp2[0] = w2_t[0].s##n;                                              \
+    tmp2[1] = w2_t[1].s##n;                                              \
+    tmp2[2] = w2_t[2].s##n;                                              \
+    tmp2[3] = w2_t[3].s##n;                                              \
+                                                                         \
+    u32 tmp3[4];                                                         \
+                                                                         \
+    tmp3[0] = w3_t[0].s##n;                                              \
+    tmp3[1] = w3_t[1].s##n;                                              \
+    tmp3[2] = w3_t[2].s##n;                                              \
+    tmp3[3] = w3_t[3].s##n;                                              \
+                                                                         \
+    const u32 len = replace_dot_by_len (tmp0, tmp1, tmp2, tmp3, pw_len); \
+                                                                         \
+    switch_buffer_by_offset_be_S (tmp0, tmp1, tmp2, tmp3, 1);            \
+                                                                         \
+    tmp0[0] |= (len & 0xff) << 24;                                       \
+                                                                         \
+    w0_t[0].s##n = tmp0[0];                                              \
+    w0_t[1].s##n = tmp0[1];                                              \
+    w0_t[2].s##n = tmp0[2];                                              \
+    w0_t[3].s##n = tmp0[3];                                              \
+                                                                         \
+    w1_t[0].s##n = tmp1[0];                                              \
+    w1_t[1].s##n = tmp1[1];                                              \
+    w1_t[2].s##n = tmp1[2];                                              \
+    w1_t[3].s##n = tmp1[3];                                              \
+                                                                         \
+    w2_t[0].s##n = tmp2[0];                                              \
+    w2_t[1].s##n = tmp2[1];                                              \
+    w2_t[2].s##n = tmp2[2];                                              \
+    w2_t[3].s##n = tmp2[3];                                              \
+                                                                         \
+    w3_t[0].s##n = tmp3[0];                                              \
+    w3_t[1].s##n = tmp3[1];                                              \
+    w3_t[2].s##n = tmp3[2];                                              \
+    w3_t[3].s##n = tmp3[3];                                              \
+  }
+
 DECLSPEC void m08300m (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KERN_ATTR_BASIC ())
 {
   /**
@@ -168,9 +272,40 @@ DECLSPEC void m08300m (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
     w3_t[2] = w3[2];
     w3_t[3] = w3[3];
 
-    switch_buffer_by_offset_be (w0_t, w1_t, w2_t, w3_t, 1);
+    // replace "." with the length:
 
-    w0_t[0] |= (pw_len & 0xff) << 24;
+    #if VECT_SIZE == 1
+      const u32 len = replace_dot_by_len (w0_t, w1_t, w2_t, w3_t, pw_len);
+
+      switch_buffer_by_offset_be (w0_t, w1_t, w2_t, w3_t, 1);
+
+      w0_t[0] |= (len & 0xff) << 24;
+    #endif
+    #if VECT_SIZE >= 2
+      REPLACE_DOT_BY_LEN_VECT (0)
+      REPLACE_DOT_BY_LEN_VECT (1)
+    #endif
+    #if VECT_SIZE >= 4
+      REPLACE_DOT_BY_LEN_VECT (2)
+      REPLACE_DOT_BY_LEN_VECT (3)
+    #endif
+    #if VECT_SIZE >= 8
+      REPLACE_DOT_BY_LEN_VECT (4)
+      REPLACE_DOT_BY_LEN_VECT (5)
+      REPLACE_DOT_BY_LEN_VECT (6)
+      REPLACE_DOT_BY_LEN_VECT (7)
+    #endif
+    #if VECT_SIZE >= 16
+      REPLACE_DOT_BY_LEN_VECT (8)
+      REPLACE_DOT_BY_LEN_VECT (9)
+      REPLACE_DOT_BY_LEN_VECT (a)
+      REPLACE_DOT_BY_LEN_VECT (b)
+      REPLACE_DOT_BY_LEN_VECT (c)
+      REPLACE_DOT_BY_LEN_VECT (d)
+      REPLACE_DOT_BY_LEN_VECT (e)
+      REPLACE_DOT_BY_LEN_VECT (f)
+    #endif
+
     w3_t[2]  = 0;
     w3_t[3]  = (1 + pw_len + domain_len + 1 + salt_len) * 8;
 
@@ -388,9 +523,40 @@ DECLSPEC void m08300s (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
     w3_t[2] = w3[2];
     w3_t[3] = w3[3];
 
-    switch_buffer_by_offset_be (w0_t, w1_t, w2_t, w3_t, 1);
+    // replace "." with the length:
 
-    w0_t[0] |= (pw_len & 0xff) << 24;
+    #if VECT_SIZE == 1
+      const u32 len = replace_dot_by_len (w0_t, w1_t, w2_t, w3_t, pw_len);
+
+      switch_buffer_by_offset_be (w0_t, w1_t, w2_t, w3_t, 1);
+
+      w0_t[0] |= (len & 0xff) << 24;
+    #endif
+    #if VECT_SIZE >= 2
+      REPLACE_DOT_BY_LEN_VECT (0)
+      REPLACE_DOT_BY_LEN_VECT (1)
+    #endif
+    #if VECT_SIZE >= 4
+      REPLACE_DOT_BY_LEN_VECT (2)
+      REPLACE_DOT_BY_LEN_VECT (3)
+    #endif
+    #if VECT_SIZE >= 8
+      REPLACE_DOT_BY_LEN_VECT (4)
+      REPLACE_DOT_BY_LEN_VECT (5)
+      REPLACE_DOT_BY_LEN_VECT (6)
+      REPLACE_DOT_BY_LEN_VECT (7)
+    #endif
+    #if VECT_SIZE >= 16
+      REPLACE_DOT_BY_LEN_VECT (8)
+      REPLACE_DOT_BY_LEN_VECT (9)
+      REPLACE_DOT_BY_LEN_VECT (a)
+      REPLACE_DOT_BY_LEN_VECT (b)
+      REPLACE_DOT_BY_LEN_VECT (c)
+      REPLACE_DOT_BY_LEN_VECT (d)
+      REPLACE_DOT_BY_LEN_VECT (e)
+      REPLACE_DOT_BY_LEN_VECT (f)
+    #endif
+
     w3_t[2]  = 0;
     w3_t[3]  = (1 + pw_len + domain_len + 1 + salt_len) * 8;
 

--- a/OpenCL/m08300_a3-pure.cl
+++ b/OpenCL/m08300_a3-pure.cl
@@ -14,6 +14,17 @@
 #include "inc_hash_sha1.cl"
 #endif
 
+#define REPLACE_DOT_BY_LEN(n)                  \
+  if (((tmp[div].s##n >> sht) & 0xff) == 0x2e) \
+  {                                            \
+    tmp[div].s##n += (len.s##n - 0x2e) << sht; \
+    len.s##n = 0;                              \
+  }                                            \
+  else                                         \
+  {                                            \
+    len.s##n++;                                \
+  }
+
 KERNEL_FQ void m08300_mxx (KERN_ATTR_VECTOR ())
 {
   /**
@@ -76,11 +87,66 @@ KERNEL_FQ void m08300_mxx (KERN_ATTR_VECTOR ())
 
     sha1_init_vector (&ctx1);
 
-    ctx1.w0[0] = (pw_len & 0xff) << 24;
+    // replace "." with the length:
+
+    u32x tmp[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      tmp[idx] = w[idx];
+    }
+
+    u32x len = 0;
+
+    for (int pos = pw_len - 1; pos >= 0; pos--)
+    {
+      const u32 div = pos / 4;
+      const u32 mod = pos & 3;
+      const u32 sht = (3 - mod) << 3;
+
+      #if VECT_SIZE == 1
+        if (((tmp[div] >> sht) & 0xff) == 0x2e) // '.'
+        {
+          tmp[div] += (len - 0x2e) << sht;
+
+          len = 0;
+        }
+        else
+        {
+          len++;
+        }
+      #endif
+      #if VECT_SIZE >= 2
+        REPLACE_DOT_BY_LEN (0)
+        REPLACE_DOT_BY_LEN (1)
+      #endif
+      #if VECT_SIZE >= 4
+        REPLACE_DOT_BY_LEN (2)
+        REPLACE_DOT_BY_LEN (3)
+      #endif
+      #if VECT_SIZE >= 8
+        REPLACE_DOT_BY_LEN (4)
+        REPLACE_DOT_BY_LEN (5)
+        REPLACE_DOT_BY_LEN (6)
+        REPLACE_DOT_BY_LEN (7)
+      #endif
+      #if VECT_SIZE >= 16
+        REPLACE_DOT_BY_LEN (8)
+        REPLACE_DOT_BY_LEN (9)
+        REPLACE_DOT_BY_LEN (a)
+        REPLACE_DOT_BY_LEN (b)
+        REPLACE_DOT_BY_LEN (c)
+        REPLACE_DOT_BY_LEN (d)
+        REPLACE_DOT_BY_LEN (e)
+        REPLACE_DOT_BY_LEN (f)
+      #endif
+    }
+
+    ctx1.w0[0] = (len & 0xff) << 24;
 
     ctx1.len = 1;
 
-    sha1_update_vector (&ctx1, w, pw_len);
+    sha1_update_vector (&ctx1, tmp, pw_len);
 
     sha1_update_vector (&ctx1, s_pc, salt_len_pc + 1);
 
@@ -206,11 +272,66 @@ KERNEL_FQ void m08300_sxx (KERN_ATTR_VECTOR ())
 
     sha1_init_vector (&ctx1);
 
-    ctx1.w0[0] = (pw_len & 0xff) << 24;
+    // replace "." with the length:
+
+    u32x tmp[64];
+
+    for (int i = 0; i < 64; i++)
+    {
+      tmp[i] = w[i];
+    }
+
+    u32x len = 0;
+
+    for (int pos = pw_len - 1; pos >= 0; pos--)
+    {
+      const u32 div = pos / 4;
+      const u32 mod = pos & 3;
+      const u32 sht = (3 - mod) << 3;
+
+      #if VECT_SIZE == 1
+        if (((tmp[div] >> sht) & 0xff) == 0x2e) // '.'
+        {
+          tmp[div] += (len - 0x2e) << sht;
+
+          len = 0;
+        }
+        else
+        {
+          len++;
+        }
+      #endif
+      #if VECT_SIZE >= 2
+        REPLACE_DOT_BY_LEN (0)
+        REPLACE_DOT_BY_LEN (1)
+      #endif
+      #if VECT_SIZE >= 4
+        REPLACE_DOT_BY_LEN (2)
+        REPLACE_DOT_BY_LEN (3)
+      #endif
+      #if VECT_SIZE >= 8
+        REPLACE_DOT_BY_LEN (4)
+        REPLACE_DOT_BY_LEN (5)
+        REPLACE_DOT_BY_LEN (6)
+        REPLACE_DOT_BY_LEN (7)
+      #endif
+      #if VECT_SIZE >= 16
+        REPLACE_DOT_BY_LEN (8)
+        REPLACE_DOT_BY_LEN (9)
+        REPLACE_DOT_BY_LEN (a)
+        REPLACE_DOT_BY_LEN (b)
+        REPLACE_DOT_BY_LEN (c)
+        REPLACE_DOT_BY_LEN (d)
+        REPLACE_DOT_BY_LEN (e)
+        REPLACE_DOT_BY_LEN (f)
+      #endif
+    }
+
+    ctx1.w0[0] = (len & 0xff) << 24;
 
     ctx1.len = 1;
 
-    sha1_update_vector (&ctx1, w, pw_len);
+    sha1_update_vector (&ctx1, tmp, pw_len);
 
     sha1_update_vector (&ctx1, s_pc, salt_len_pc + 1);
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -83,6 +83,7 @@
 - Fixed cracking multiple Office hashes (modes 9500, 9600) with the same salt
 - Fixed cracking of Blockchain, My Wallet (V1 and V2) hashes with unexpected decrypted data
 - Fixed cracking of Cisco-PIX and Cisco-ASA MD5 passwords in mask-attack mode if mask > length 16
+- Fixed cracking of DNSSEC (NSEC3) hashes by replacing all dots in the passwords with lengths
 - Fixed cracking of Electrum Wallet Salt-Type 2 hashes
 - Fixed cracking of NetNTLMv1 passwords in mask-attack mode if mask > length 16 (optimized kernels only)
 - Fixed cracking of VeraCrypt Streebog-512 hashes (CPU only)

--- a/src/modules/module_08300.c
+++ b/src/modules/module_08300.c
@@ -56,7 +56,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   token.sep[1]     = ':';
-  token.len_min[1] = 1;
+  token.len_min[1] = 0;
   token.len_max[1] = 32;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
@@ -104,9 +104,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 *salt_buf_pc_ptr = (u8 *) salt->salt_buf_pc;
 
-  memcpy (salt_buf_pc_ptr, domain_pos, domain_len);
+  if (domain_len > 0)
+  {
+    if (domain_pos[0] != '.') return (PARSER_SALT_VALUE);
 
-  if (salt_buf_pc_ptr[0] != '.') return (PARSER_SALT_VALUE);
+    memcpy (salt_buf_pc_ptr, domain_pos, domain_len);
+  }
 
   u8 *len_ptr = salt_buf_pc_ptr;
 

--- a/tools/test_modules/m08300.pm
+++ b/tools/test_modules/m08300.pm
@@ -11,7 +11,11 @@ use warnings;
 use Net::DNS::RR::NSEC3;
 use Net::DNS::SEC;
 
-sub module_constraints { [[1, 256], [-1, -1], [1, 55], [-1, -1], [-1, -1]] }
+# we need to restict the pure password length for the test module to 63 bytes,
+# because we can't have any string (including the pass) of over 63 bytes without "."
+
+# sub module_constraints { [[1, 256], [-1, -1], [1, 55], [-1, -1], [-1, -1]] }
+sub module_constraints { [[1, 63], [-1, -1], [1, 55], [-1, -1], [-1, -1]] }
 
 sub get_random_dnssec_salt
 {
@@ -38,7 +42,14 @@ sub module_generate_hash
 
   if (length $salt == 0)
   {
-    $salt = get_random_dnssec_salt ();
+    if (int (rand (10)) == 0)
+    {
+      $salt = ":";
+    }
+    else
+    {
+      $salt = get_random_dnssec_salt ();
+    }
   }
 
   my ($domain, $salt_hex) = split (":", $salt);


### PR DESCRIPTION
Fixes the problem(s) mentioned in #2365 : 
1. problem that passwords could contain dots that need to be replaced by the length of the following part
2. allow empty domain, empty password and empty salt
3. fixed test module (we can't allow longer than 63 hashes without dots).

Thx