### PR TITLE
fixes #2410: added -m 2300x = SecureZIP

### DIFF
--- a/OpenCL/inc_cipher_aes.cl
+++ b/OpenCL/inc_cipher_aes.cl
@@ -1040,6 +1040,389 @@ DECLSPEC void aes128_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u
   out[3] = hc_swap32_S (out[3]);
 }
 
+// 192 bit key
+
+DECLSPEC void aes192_ExpandKey (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3)
+{
+  ks[ 0] = ukey[0];
+  ks[ 1] = ukey[1];
+  ks[ 2] = ukey[2];
+  ks[ 3] = ukey[3];
+  ks[ 4] = ukey[4];
+  ks[ 5] = ukey[5];
+  ks[ 6] = ks[ 0] ^ 0x01000000
+                  ^ (s_te2[(ks[ 5] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[ 5] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[ 5] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[ 5] >> 24) & 0xff] & 0x000000ff);
+  ks[ 7] = ks[ 1] ^ ks[ 6];
+  ks[ 8] = ks[ 2] ^ ks[ 7];
+  ks[ 9] = ks[ 3] ^ ks[ 8];
+  ks[10] = ks[ 4] ^ ks[ 9];
+  ks[11] = ks[ 5] ^ ks[10];
+  ks[12] = ks[ 6] ^ 0x02000000
+                  ^ (s_te2[(ks[11] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[11] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[11] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[11] >> 24) & 0xff] & 0x000000ff);
+  ks[13] = ks[ 7] ^ ks[12];
+  ks[14] = ks[ 8] ^ ks[13];
+  ks[15] = ks[ 9] ^ ks[14];
+  ks[16] = ks[10] ^ ks[15];
+  ks[17] = ks[11] ^ ks[16];
+  ks[18] = ks[12] ^ 0x04000000
+                  ^ (s_te2[(ks[17] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[17] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[17] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[17] >> 24) & 0xff] & 0x000000ff);
+  ks[19] = ks[13] ^ ks[18];
+  ks[20] = ks[14] ^ ks[19];
+  ks[21] = ks[15] ^ ks[20];
+  ks[22] = ks[16] ^ ks[21];
+  ks[23] = ks[17] ^ ks[22];
+  ks[24] = ks[18] ^ 0x08000000
+                  ^ (s_te2[(ks[23] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[23] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[23] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[23] >> 24) & 0xff] & 0x000000ff);
+  ks[25] = ks[19] ^ ks[24];
+  ks[26] = ks[20] ^ ks[25];
+  ks[27] = ks[21] ^ ks[26];
+  ks[28] = ks[22] ^ ks[27];
+  ks[29] = ks[23] ^ ks[28];
+  ks[30] = ks[24] ^ 0x10000000
+                  ^ (s_te2[(ks[29] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[29] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[29] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[29] >> 24) & 0xff] & 0x000000ff);
+  ks[31] = ks[25] ^ ks[30];
+  ks[32] = ks[26] ^ ks[31];
+  ks[33] = ks[27] ^ ks[32];
+  ks[34] = ks[28] ^ ks[33];
+  ks[35] = ks[29] ^ ks[34];
+  ks[36] = ks[30] ^ 0x20000000
+                  ^ (s_te2[(ks[35] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[35] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[35] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[35] >> 24) & 0xff] & 0x000000ff);
+  ks[37] = ks[31] ^ ks[36];
+  ks[38] = ks[32] ^ ks[37];
+  ks[39] = ks[33] ^ ks[38];
+  ks[40] = ks[34] ^ ks[39];
+  ks[41] = ks[35] ^ ks[40];
+  ks[42] = ks[36] ^ 0x40000000
+                  ^ (s_te2[(ks[41] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[41] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[41] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[41] >> 24) & 0xff] & 0x000000ff);
+  ks[43] = ks[37] ^ ks[42];
+  ks[44] = ks[38] ^ ks[43];
+  ks[45] = ks[39] ^ ks[44];
+  ks[46] = ks[40] ^ ks[45];
+  ks[47] = ks[41] ^ ks[46];
+  ks[48] = ks[42] ^ 0x80000000
+                  ^ (s_te2[(ks[47] >> 16) & 0xff] & 0xff000000)
+                  ^ (s_te3[(ks[47] >>  8) & 0xff] & 0x00ff0000)
+                  ^ (s_te0[(ks[47] >>  0) & 0xff] & 0x0000ff00)
+                  ^ (s_te1[(ks[47] >> 24) & 0xff] & 0x000000ff);
+  ks[49] = ks[43] ^ ks[48];
+  ks[50] = ks[44] ^ ks[49];
+  ks[51] = ks[45] ^ ks[50];
+}
+
+DECLSPEC void aes192_InvertKey (u32 *ks, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3)
+{
+  u32 temp;
+
+  temp = ks[ 0]; ks[ 0] = ks[48]; ks[48] = temp;
+  temp = ks[ 1]; ks[ 1] = ks[49]; ks[49] = temp;
+  temp = ks[ 2]; ks[ 2] = ks[50]; ks[50] = temp;
+  temp = ks[ 3]; ks[ 3] = ks[51]; ks[51] = temp;
+  temp = ks[ 4]; ks[ 4] = ks[44]; ks[44] = temp;
+  temp = ks[ 5]; ks[ 5] = ks[45]; ks[45] = temp;
+  temp = ks[ 6]; ks[ 6] = ks[46]; ks[46] = temp;
+  temp = ks[ 7]; ks[ 7] = ks[47]; ks[47] = temp;
+  temp = ks[ 8]; ks[ 8] = ks[40]; ks[40] = temp;
+  temp = ks[ 9]; ks[ 9] = ks[41]; ks[41] = temp;
+  temp = ks[10]; ks[10] = ks[42]; ks[42] = temp;
+  temp = ks[11]; ks[11] = ks[43]; ks[43] = temp;
+  temp = ks[12]; ks[12] = ks[36]; ks[36] = temp;
+  temp = ks[13]; ks[13] = ks[37]; ks[37] = temp;
+  temp = ks[14]; ks[14] = ks[38]; ks[38] = temp;
+  temp = ks[15]; ks[15] = ks[39]; ks[39] = temp;
+  temp = ks[16]; ks[16] = ks[32]; ks[32] = temp;
+  temp = ks[17]; ks[17] = ks[33]; ks[33] = temp;
+  temp = ks[18]; ks[18] = ks[34]; ks[34] = temp;
+  temp = ks[19]; ks[19] = ks[35]; ks[35] = temp;
+  temp = ks[20]; ks[20] = ks[28]; ks[28] = temp;
+  temp = ks[21]; ks[21] = ks[29]; ks[29] = temp;
+  temp = ks[22]; ks[22] = ks[30]; ks[30] = temp;
+  temp = ks[23]; ks[23] = ks[31]; ks[31] = temp;
+
+  ks[ 4] = s_td0[s_te1[(ks[ 4] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[ 4] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[ 4] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[ 4] >>  0) & 0xff] & 0xff];
+  ks[ 5] = s_td0[s_te1[(ks[ 5] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[ 5] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[ 5] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[ 5] >>  0) & 0xff] & 0xff];
+  ks[ 6] = s_td0[s_te1[(ks[ 6] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[ 6] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[ 6] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[ 6] >>  0) & 0xff] & 0xff];
+  ks[ 7] = s_td0[s_te1[(ks[ 7] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[ 7] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[ 7] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[ 7] >>  0) & 0xff] & 0xff];
+  ks[ 8] = s_td0[s_te1[(ks[ 8] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[ 8] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[ 8] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[ 8] >>  0) & 0xff] & 0xff];
+  ks[ 9] = s_td0[s_te1[(ks[ 9] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[ 9] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[ 9] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[ 9] >>  0) & 0xff] & 0xff];
+  ks[10] = s_td0[s_te1[(ks[10] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[10] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[10] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[10] >>  0) & 0xff] & 0xff];
+  ks[11] = s_td0[s_te1[(ks[11] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[11] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[11] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[11] >>  0) & 0xff] & 0xff];
+  ks[12] = s_td0[s_te1[(ks[12] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[12] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[12] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[12] >>  0) & 0xff] & 0xff];
+  ks[13] = s_td0[s_te1[(ks[13] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[13] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[13] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[13] >>  0) & 0xff] & 0xff];
+  ks[14] = s_td0[s_te1[(ks[14] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[14] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[14] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[14] >>  0) & 0xff] & 0xff];
+  ks[15] = s_td0[s_te1[(ks[15] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[15] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[15] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[15] >>  0) & 0xff] & 0xff];
+  ks[16] = s_td0[s_te1[(ks[16] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[16] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[16] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[16] >>  0) & 0xff] & 0xff];
+  ks[17] = s_td0[s_te1[(ks[17] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[17] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[17] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[17] >>  0) & 0xff] & 0xff];
+  ks[18] = s_td0[s_te1[(ks[18] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[18] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[18] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[18] >>  0) & 0xff] & 0xff];
+  ks[19] = s_td0[s_te1[(ks[19] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[19] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[19] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[19] >>  0) & 0xff] & 0xff];
+  ks[20] = s_td0[s_te1[(ks[20] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[20] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[20] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[20] >>  0) & 0xff] & 0xff];
+  ks[21] = s_td0[s_te1[(ks[21] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[21] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[21] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[21] >>  0) & 0xff] & 0xff];
+  ks[22] = s_td0[s_te1[(ks[22] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[22] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[22] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[22] >>  0) & 0xff] & 0xff];
+  ks[23] = s_td0[s_te1[(ks[23] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[23] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[23] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[23] >>  0) & 0xff] & 0xff];
+  ks[24] = s_td0[s_te1[(ks[24] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[24] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[24] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[24] >>  0) & 0xff] & 0xff];
+  ks[25] = s_td0[s_te1[(ks[25] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[25] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[25] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[25] >>  0) & 0xff] & 0xff];
+  ks[26] = s_td0[s_te1[(ks[26] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[26] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[26] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[26] >>  0) & 0xff] & 0xff];
+  ks[27] = s_td0[s_te1[(ks[27] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[27] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[27] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[27] >>  0) & 0xff] & 0xff];
+  ks[28] = s_td0[s_te1[(ks[28] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[28] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[28] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[28] >>  0) & 0xff] & 0xff];
+  ks[29] = s_td0[s_te1[(ks[29] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[29] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[29] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[29] >>  0) & 0xff] & 0xff];
+  ks[30] = s_td0[s_te1[(ks[30] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[30] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[30] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[30] >>  0) & 0xff] & 0xff];
+  ks[31] = s_td0[s_te1[(ks[31] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[31] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[31] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[31] >>  0) & 0xff] & 0xff];
+  ks[32] = s_td0[s_te1[(ks[32] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[32] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[32] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[32] >>  0) & 0xff] & 0xff];
+  ks[33] = s_td0[s_te1[(ks[33] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[33] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[33] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[33] >>  0) & 0xff] & 0xff];
+  ks[34] = s_td0[s_te1[(ks[34] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[34] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[34] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[34] >>  0) & 0xff] & 0xff];
+  ks[35] = s_td0[s_te1[(ks[35] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[35] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[35] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[35] >>  0) & 0xff] & 0xff];
+  ks[36] = s_td0[s_te1[(ks[36] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[36] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[36] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[36] >>  0) & 0xff] & 0xff];
+  ks[37] = s_td0[s_te1[(ks[37] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[37] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[37] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[37] >>  0) & 0xff] & 0xff];
+  ks[38] = s_td0[s_te1[(ks[38] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[38] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[38] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[38] >>  0) & 0xff] & 0xff];
+  ks[39] = s_td0[s_te1[(ks[39] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[39] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[39] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[39] >>  0) & 0xff] & 0xff];
+  ks[40] = s_td0[s_te1[(ks[40] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[40] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[40] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[40] >>  0) & 0xff] & 0xff];
+  ks[41] = s_td0[s_te1[(ks[41] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[41] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[41] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[41] >>  0) & 0xff] & 0xff];
+  ks[42] = s_td0[s_te1[(ks[42] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[42] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[42] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[42] >>  0) & 0xff] & 0xff];
+  ks[43] = s_td0[s_te1[(ks[43] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[43] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[43] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[43] >>  0) & 0xff] & 0xff];
+  ks[44] = s_td0[s_te1[(ks[44] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[44] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[44] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[44] >>  0) & 0xff] & 0xff];
+  ks[45] = s_td0[s_te1[(ks[45] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[45] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[45] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[45] >>  0) & 0xff] & 0xff];
+  ks[46] = s_td0[s_te1[(ks[46] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[46] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[46] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[46] >>  0) & 0xff] & 0xff];
+  ks[47] = s_td0[s_te1[(ks[47] >> 24) & 0xff] & 0xff] ^ s_td1[s_te1[(ks[47] >> 16) & 0xff] & 0xff] ^ s_td2[s_te1[(ks[47] >>  8) & 0xff] & 0xff] ^ s_td3[s_te1[(ks[47] >>  0) & 0xff] & 0xff];
+}
+
+DECLSPEC void aes192_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3)
+{
+  u32 ukey_s[6];
+
+  ukey_s[0] = hc_swap32_S (ukey[0]);
+  ukey_s[1] = hc_swap32_S (ukey[1]);
+  ukey_s[2] = hc_swap32_S (ukey[2]);
+  ukey_s[3] = hc_swap32_S (ukey[3]);
+  ukey_s[4] = hc_swap32_S (ukey[4]);
+  ukey_s[5] = hc_swap32_S (ukey[5]);
+
+  aes192_ExpandKey (ks, ukey_s, s_te0, s_te1, s_te2, s_te3);
+}
+
+DECLSPEC void aes192_set_decrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3)
+{
+  u32 ukey_s[6];
+
+  ukey_s[0] = hc_swap32_S (ukey[0]);
+  ukey_s[1] = hc_swap32_S (ukey[1]);
+  ukey_s[2] = hc_swap32_S (ukey[2]);
+  ukey_s[3] = hc_swap32_S (ukey[3]);
+  ukey_s[4] = hc_swap32_S (ukey[4]);
+  ukey_s[5] = hc_swap32_S (ukey[5]);
+
+  aes192_ExpandKey (ks, ukey_s, s_te0, s_te1, s_te2, s_te3);
+
+  aes192_InvertKey (ks, s_te1, s_td0, s_td1, s_td2, s_td3);
+}
+
+DECLSPEC void aes192_encrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 in_s[4];
+
+  in_s[0] = hc_swap32_S (in[0]);
+  in_s[1] = hc_swap32_S (in[1]);
+  in_s[2] = hc_swap32_S (in[2]);
+  in_s[3] = hc_swap32_S (in[3]);
+
+  u32 s0 = in_s[0] ^ ks[0];
+  u32 s1 = in_s[1] ^ ks[1];
+  u32 s2 = in_s[2] ^ ks[2];
+  u32 s3 = in_s[3] ^ ks[3];
+
+  u32 t0;
+  u32 t1;
+  u32 t2;
+  u32 t3;
+
+  t0 = s_te0[s0 >> 24] ^ s_te1[(s1 >> 16) & 0xff] ^ s_te2[(s2 >>  8) & 0xff] ^ s_te3[s3 & 0xff] ^ ks[ 4];
+  t1 = s_te0[s1 >> 24] ^ s_te1[(s2 >> 16) & 0xff] ^ s_te2[(s3 >>  8) & 0xff] ^ s_te3[s0 & 0xff] ^ ks[ 5];
+  t2 = s_te0[s2 >> 24] ^ s_te1[(s3 >> 16) & 0xff] ^ s_te2[(s0 >>  8) & 0xff] ^ s_te3[s1 & 0xff] ^ ks[ 6];
+  t3 = s_te0[s3 >> 24] ^ s_te1[(s0 >> 16) & 0xff] ^ s_te2[(s1 >>  8) & 0xff] ^ s_te3[s2 & 0xff] ^ ks[ 7];
+  s0 = s_te0[t0 >> 24] ^ s_te1[(t1 >> 16) & 0xff] ^ s_te2[(t2 >>  8) & 0xff] ^ s_te3[t3 & 0xff] ^ ks[ 8];
+  s1 = s_te0[t1 >> 24] ^ s_te1[(t2 >> 16) & 0xff] ^ s_te2[(t3 >>  8) & 0xff] ^ s_te3[t0 & 0xff] ^ ks[ 9];
+  s2 = s_te0[t2 >> 24] ^ s_te1[(t3 >> 16) & 0xff] ^ s_te2[(t0 >>  8) & 0xff] ^ s_te3[t1 & 0xff] ^ ks[10];
+  s3 = s_te0[t3 >> 24] ^ s_te1[(t0 >> 16) & 0xff] ^ s_te2[(t1 >>  8) & 0xff] ^ s_te3[t2 & 0xff] ^ ks[11];
+  t0 = s_te0[s0 >> 24] ^ s_te1[(s1 >> 16) & 0xff] ^ s_te2[(s2 >>  8) & 0xff] ^ s_te3[s3 & 0xff] ^ ks[12];
+  t1 = s_te0[s1 >> 24] ^ s_te1[(s2 >> 16) & 0xff] ^ s_te2[(s3 >>  8) & 0xff] ^ s_te3[s0 & 0xff] ^ ks[13];
+  t2 = s_te0[s2 >> 24] ^ s_te1[(s3 >> 16) & 0xff] ^ s_te2[(s0 >>  8) & 0xff] ^ s_te3[s1 & 0xff] ^ ks[14];
+  t3 = s_te0[s3 >> 24] ^ s_te1[(s0 >> 16) & 0xff] ^ s_te2[(s1 >>  8) & 0xff] ^ s_te3[s2 & 0xff] ^ ks[15];
+  s0 = s_te0[t0 >> 24] ^ s_te1[(t1 >> 16) & 0xff] ^ s_te2[(t2 >>  8) & 0xff] ^ s_te3[t3 & 0xff] ^ ks[16];
+  s1 = s_te0[t1 >> 24] ^ s_te1[(t2 >> 16) & 0xff] ^ s_te2[(t3 >>  8) & 0xff] ^ s_te3[t0 & 0xff] ^ ks[17];
+  s2 = s_te0[t2 >> 24] ^ s_te1[(t3 >> 16) & 0xff] ^ s_te2[(t0 >>  8) & 0xff] ^ s_te3[t1 & 0xff] ^ ks[18];
+  s3 = s_te0[t3 >> 24] ^ s_te1[(t0 >> 16) & 0xff] ^ s_te2[(t1 >>  8) & 0xff] ^ s_te3[t2 & 0xff] ^ ks[19];
+  t0 = s_te0[s0 >> 24] ^ s_te1[(s1 >> 16) & 0xff] ^ s_te2[(s2 >>  8) & 0xff] ^ s_te3[s3 & 0xff] ^ ks[20];
+  t1 = s_te0[s1 >> 24] ^ s_te1[(s2 >> 16) & 0xff] ^ s_te2[(s3 >>  8) & 0xff] ^ s_te3[s0 & 0xff] ^ ks[21];
+  t2 = s_te0[s2 >> 24] ^ s_te1[(s3 >> 16) & 0xff] ^ s_te2[(s0 >>  8) & 0xff] ^ s_te3[s1 & 0xff] ^ ks[22];
+  t3 = s_te0[s3 >> 24] ^ s_te1[(s0 >> 16) & 0xff] ^ s_te2[(s1 >>  8) & 0xff] ^ s_te3[s2 & 0xff] ^ ks[23];
+  s0 = s_te0[t0 >> 24] ^ s_te1[(t1 >> 16) & 0xff] ^ s_te2[(t2 >>  8) & 0xff] ^ s_te3[t3 & 0xff] ^ ks[24];
+  s1 = s_te0[t1 >> 24] ^ s_te1[(t2 >> 16) & 0xff] ^ s_te2[(t3 >>  8) & 0xff] ^ s_te3[t0 & 0xff] ^ ks[25];
+  s2 = s_te0[t2 >> 24] ^ s_te1[(t3 >> 16) & 0xff] ^ s_te2[(t0 >>  8) & 0xff] ^ s_te3[t1 & 0xff] ^ ks[26];
+  s3 = s_te0[t3 >> 24] ^ s_te1[(t0 >> 16) & 0xff] ^ s_te2[(t1 >>  8) & 0xff] ^ s_te3[t2 & 0xff] ^ ks[27];
+  t0 = s_te0[s0 >> 24] ^ s_te1[(s1 >> 16) & 0xff] ^ s_te2[(s2 >>  8) & 0xff] ^ s_te3[s3 & 0xff] ^ ks[28];
+  t1 = s_te0[s1 >> 24] ^ s_te1[(s2 >> 16) & 0xff] ^ s_te2[(s3 >>  8) & 0xff] ^ s_te3[s0 & 0xff] ^ ks[29];
+  t2 = s_te0[s2 >> 24] ^ s_te1[(s3 >> 16) & 0xff] ^ s_te2[(s0 >>  8) & 0xff] ^ s_te3[s1 & 0xff] ^ ks[30];
+  t3 = s_te0[s3 >> 24] ^ s_te1[(s0 >> 16) & 0xff] ^ s_te2[(s1 >>  8) & 0xff] ^ s_te3[s2 & 0xff] ^ ks[31];
+  s0 = s_te0[t0 >> 24] ^ s_te1[(t1 >> 16) & 0xff] ^ s_te2[(t2 >>  8) & 0xff] ^ s_te3[t3 & 0xff] ^ ks[32];
+  s1 = s_te0[t1 >> 24] ^ s_te1[(t2 >> 16) & 0xff] ^ s_te2[(t3 >>  8) & 0xff] ^ s_te3[t0 & 0xff] ^ ks[33];
+  s2 = s_te0[t2 >> 24] ^ s_te1[(t3 >> 16) & 0xff] ^ s_te2[(t0 >>  8) & 0xff] ^ s_te3[t1 & 0xff] ^ ks[34];
+  s3 = s_te0[t3 >> 24] ^ s_te1[(t0 >> 16) & 0xff] ^ s_te2[(t1 >>  8) & 0xff] ^ s_te3[t2 & 0xff] ^ ks[35];
+  t0 = s_te0[s0 >> 24] ^ s_te1[(s1 >> 16) & 0xff] ^ s_te2[(s2 >>  8) & 0xff] ^ s_te3[s3 & 0xff] ^ ks[36];
+  t1 = s_te0[s1 >> 24] ^ s_te1[(s2 >> 16) & 0xff] ^ s_te2[(s3 >>  8) & 0xff] ^ s_te3[s0 & 0xff] ^ ks[37];
+  t2 = s_te0[s2 >> 24] ^ s_te1[(s3 >> 16) & 0xff] ^ s_te2[(s0 >>  8) & 0xff] ^ s_te3[s1 & 0xff] ^ ks[38];
+  t3 = s_te0[s3 >> 24] ^ s_te1[(s0 >> 16) & 0xff] ^ s_te2[(s1 >>  8) & 0xff] ^ s_te3[s2 & 0xff] ^ ks[39];
+  s0 = s_te0[t0 >> 24] ^ s_te1[(t1 >> 16) & 0xff] ^ s_te2[(t2 >>  8) & 0xff] ^ s_te3[t3 & 0xff] ^ ks[40];
+  s1 = s_te0[t1 >> 24] ^ s_te1[(t2 >> 16) & 0xff] ^ s_te2[(t3 >>  8) & 0xff] ^ s_te3[t0 & 0xff] ^ ks[41];
+  s2 = s_te0[t2 >> 24] ^ s_te1[(t3 >> 16) & 0xff] ^ s_te2[(t0 >>  8) & 0xff] ^ s_te3[t1 & 0xff] ^ ks[42];
+  s3 = s_te0[t3 >> 24] ^ s_te1[(t0 >> 16) & 0xff] ^ s_te2[(t1 >>  8) & 0xff] ^ s_te3[t2 & 0xff] ^ ks[43];
+  t0 = s_te0[s0 >> 24] ^ s_te1[(s1 >> 16) & 0xff] ^ s_te2[(s2 >>  8) & 0xff] ^ s_te3[s3 & 0xff] ^ ks[44];
+  t1 = s_te0[s1 >> 24] ^ s_te1[(s2 >> 16) & 0xff] ^ s_te2[(s3 >>  8) & 0xff] ^ s_te3[s0 & 0xff] ^ ks[45];
+  t2 = s_te0[s2 >> 24] ^ s_te1[(s3 >> 16) & 0xff] ^ s_te2[(s0 >>  8) & 0xff] ^ s_te3[s1 & 0xff] ^ ks[46];
+  t3 = s_te0[s3 >> 24] ^ s_te1[(s0 >> 16) & 0xff] ^ s_te2[(s1 >>  8) & 0xff] ^ s_te3[s2 & 0xff] ^ ks[47];
+
+  out[0] = (s_te4[(t0 >> 24) & 0xff] & 0xff000000)
+         ^ (s_te4[(t1 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_te4[(t2 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_te4[(t3 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[48];
+
+  out[1] = (s_te4[(t1 >> 24) & 0xff] & 0xff000000)
+         ^ (s_te4[(t2 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_te4[(t3 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_te4[(t0 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[49];
+
+  out[2] = (s_te4[(t2 >> 24) & 0xff] & 0xff000000)
+         ^ (s_te4[(t3 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_te4[(t0 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_te4[(t1 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[50];
+
+  out[3] = (s_te4[(t3 >> 24) & 0xff] & 0xff000000)
+         ^ (s_te4[(t0 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_te4[(t1 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_te4[(t2 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[51];
+
+  out[0] = hc_swap32_S (out[0]);
+  out[1] = hc_swap32_S (out[1]);
+  out[2] = hc_swap32_S (out[2]);
+  out[3] = hc_swap32_S (out[3]);
+}
+
+DECLSPEC void aes192_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4)
+{
+  u32 in_s[4];
+
+  in_s[0] = hc_swap32_S (in[0]);
+  in_s[1] = hc_swap32_S (in[1]);
+  in_s[2] = hc_swap32_S (in[2]);
+  in_s[3] = hc_swap32_S (in[3]);
+
+  u32 s0 = in_s[0] ^ ks[0];
+  u32 s1 = in_s[1] ^ ks[1];
+  u32 s2 = in_s[2] ^ ks[2];
+  u32 s3 = in_s[3] ^ ks[3];
+
+  u32 t0;
+  u32 t1;
+  u32 t2;
+  u32 t3;
+
+  t0 = s_td0[s0 >> 24] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[ 4];
+  t1 = s_td0[s1 >> 24] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[ 5];
+  t2 = s_td0[s2 >> 24] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[ 6];
+  t3 = s_td0[s3 >> 24] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[ 7];
+  s0 = s_td0[t0 >> 24] ^ s_td1[(t3 >> 16) & 0xff] ^ s_td2[(t2 >>  8) & 0xff] ^ s_td3[t1 & 0xff] ^ ks[ 8];
+  s1 = s_td0[t1 >> 24] ^ s_td1[(t0 >> 16) & 0xff] ^ s_td2[(t3 >>  8) & 0xff] ^ s_td3[t2 & 0xff] ^ ks[ 9];
+  s2 = s_td0[t2 >> 24] ^ s_td1[(t1 >> 16) & 0xff] ^ s_td2[(t0 >>  8) & 0xff] ^ s_td3[t3 & 0xff] ^ ks[10];
+  s3 = s_td0[t3 >> 24] ^ s_td1[(t2 >> 16) & 0xff] ^ s_td2[(t1 >>  8) & 0xff] ^ s_td3[t0 & 0xff] ^ ks[11];
+  t0 = s_td0[s0 >> 24] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[12];
+  t1 = s_td0[s1 >> 24] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[13];
+  t2 = s_td0[s2 >> 24] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[14];
+  t3 = s_td0[s3 >> 24] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[15];
+  s0 = s_td0[t0 >> 24] ^ s_td1[(t3 >> 16) & 0xff] ^ s_td2[(t2 >>  8) & 0xff] ^ s_td3[t1 & 0xff] ^ ks[16];
+  s1 = s_td0[t1 >> 24] ^ s_td1[(t0 >> 16) & 0xff] ^ s_td2[(t3 >>  8) & 0xff] ^ s_td3[t2 & 0xff] ^ ks[17];
+  s2 = s_td0[t2 >> 24] ^ s_td1[(t1 >> 16) & 0xff] ^ s_td2[(t0 >>  8) & 0xff] ^ s_td3[t3 & 0xff] ^ ks[18];
+  s3 = s_td0[t3 >> 24] ^ s_td1[(t2 >> 16) & 0xff] ^ s_td2[(t1 >>  8) & 0xff] ^ s_td3[t0 & 0xff] ^ ks[19];
+  t0 = s_td0[s0 >> 24] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[20];
+  t1 = s_td0[s1 >> 24] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[21];
+  t2 = s_td0[s2 >> 24] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[22];
+  t3 = s_td0[s3 >> 24] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[23];
+  s0 = s_td0[t0 >> 24] ^ s_td1[(t3 >> 16) & 0xff] ^ s_td2[(t2 >>  8) & 0xff] ^ s_td3[t1 & 0xff] ^ ks[24];
+  s1 = s_td0[t1 >> 24] ^ s_td1[(t0 >> 16) & 0xff] ^ s_td2[(t3 >>  8) & 0xff] ^ s_td3[t2 & 0xff] ^ ks[25];
+  s2 = s_td0[t2 >> 24] ^ s_td1[(t1 >> 16) & 0xff] ^ s_td2[(t0 >>  8) & 0xff] ^ s_td3[t3 & 0xff] ^ ks[26];
+  s3 = s_td0[t3 >> 24] ^ s_td1[(t2 >> 16) & 0xff] ^ s_td2[(t1 >>  8) & 0xff] ^ s_td3[t0 & 0xff] ^ ks[27];
+  t0 = s_td0[s0 >> 24] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[28];
+  t1 = s_td0[s1 >> 24] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[29];
+  t2 = s_td0[s2 >> 24] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[30];
+  t3 = s_td0[s3 >> 24] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[31];
+  s0 = s_td0[t0 >> 24] ^ s_td1[(t3 >> 16) & 0xff] ^ s_td2[(t2 >>  8) & 0xff] ^ s_td3[t1 & 0xff] ^ ks[32];
+  s1 = s_td0[t1 >> 24] ^ s_td1[(t0 >> 16) & 0xff] ^ s_td2[(t3 >>  8) & 0xff] ^ s_td3[t2 & 0xff] ^ ks[33];
+  s2 = s_td0[t2 >> 24] ^ s_td1[(t1 >> 16) & 0xff] ^ s_td2[(t0 >>  8) & 0xff] ^ s_td3[t3 & 0xff] ^ ks[34];
+  s3 = s_td0[t3 >> 24] ^ s_td1[(t2 >> 16) & 0xff] ^ s_td2[(t1 >>  8) & 0xff] ^ s_td3[t0 & 0xff] ^ ks[35];
+  t0 = s_td0[s0 >> 24] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[36];
+  t1 = s_td0[s1 >> 24] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[37];
+  t2 = s_td0[s2 >> 24] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[38];
+  t3 = s_td0[s3 >> 24] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[39];
+  s0 = s_td0[t0 >> 24] ^ s_td1[(t3 >> 16) & 0xff] ^ s_td2[(t2 >>  8) & 0xff] ^ s_td3[t1 & 0xff] ^ ks[40];
+  s1 = s_td0[t1 >> 24] ^ s_td1[(t0 >> 16) & 0xff] ^ s_td2[(t3 >>  8) & 0xff] ^ s_td3[t2 & 0xff] ^ ks[41];
+  s2 = s_td0[t2 >> 24] ^ s_td1[(t1 >> 16) & 0xff] ^ s_td2[(t0 >>  8) & 0xff] ^ s_td3[t3 & 0xff] ^ ks[42];
+  s3 = s_td0[t3 >> 24] ^ s_td1[(t2 >> 16) & 0xff] ^ s_td2[(t1 >>  8) & 0xff] ^ s_td3[t0 & 0xff] ^ ks[43];
+  t0 = s_td0[s0 >> 24] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[44];
+  t1 = s_td0[s1 >> 24] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[45];
+  t2 = s_td0[s2 >> 24] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[46];
+  t3 = s_td0[s3 >> 24] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[47];
+
+  out[0] = (s_td4[(t0 >> 24) & 0xff] & 0xff000000)
+         ^ (s_td4[(t3 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_td4[(t2 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_td4[(t1 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[48];
+
+  out[1] = (s_td4[(t1 >> 24) & 0xff] & 0xff000000)
+         ^ (s_td4[(t0 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_td4[(t3 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_td4[(t2 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[49];
+
+  out[2] = (s_td4[(t2 >> 24) & 0xff] & 0xff000000)
+         ^ (s_td4[(t1 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_td4[(t0 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_td4[(t3 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[50];
+
+  out[3] = (s_td4[(t3 >> 24) & 0xff] & 0xff000000)
+         ^ (s_td4[(t2 >> 16) & 0xff] & 0x00ff0000)
+         ^ (s_td4[(t1 >>  8) & 0xff] & 0x0000ff00)
+         ^ (s_td4[(t0 >>  0) & 0xff] & 0x000000ff)
+         ^ ks[51];
+
+  out[0] = hc_swap32_S (out[0]);
+  out[1] = hc_swap32_S (out[1]);
+  out[2] = hc_swap32_S (out[2]);
+  out[3] = hc_swap32_S (out[3]);
+}
+
 // 256 bit key
 
 DECLSPEC void aes256_ExpandKey (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3)
@@ -1540,6 +1923,72 @@ DECLSPEC void AES128_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u
   u32 out_s[4];
 
   aes128_decrypt (ks, in_s, out_s, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  out[0] = hc_swap32_S (out_s[0]);
+  out[1] = hc_swap32_S (out_s[1]);
+  out[2] = hc_swap32_S (out_s[2]);
+  out[3] = hc_swap32_S (out_s[3]);
+}
+
+DECLSPEC void AES192_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3)
+{
+  u32 ukey_s[6];
+
+  ukey_s[0] = hc_swap32_S (ukey[0]);
+  ukey_s[1] = hc_swap32_S (ukey[1]);
+  ukey_s[2] = hc_swap32_S (ukey[2]);
+  ukey_s[3] = hc_swap32_S (ukey[3]);
+  ukey_s[4] = hc_swap32_S (ukey[4]);
+  ukey_s[5] = hc_swap32_S (ukey[5]);
+
+  aes192_set_encrypt_key (ks, ukey_s, s_te0, s_te1, s_te2, s_te3);
+}
+
+DECLSPEC void AES192_set_decrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3)
+{
+  u32 ukey_s[6];
+
+  ukey_s[0] = hc_swap32_S (ukey[0]);
+  ukey_s[1] = hc_swap32_S (ukey[1]);
+  ukey_s[2] = hc_swap32_S (ukey[2]);
+  ukey_s[3] = hc_swap32_S (ukey[3]);
+  ukey_s[4] = hc_swap32_S (ukey[4]);
+  ukey_s[5] = hc_swap32_S (ukey[5]);
+
+  aes192_set_decrypt_key (ks, ukey_s, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+}
+
+DECLSPEC void AES192_encrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 in_s[4];
+
+  in_s[0] = hc_swap32_S (in[0]);
+  in_s[1] = hc_swap32_S (in[1]);
+  in_s[2] = hc_swap32_S (in[2]);
+  in_s[3] = hc_swap32_S (in[3]);
+
+  u32 out_s[4];
+
+  aes192_encrypt (ks, in_s, out_s, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  out[0] = hc_swap32_S (out_s[0]);
+  out[1] = hc_swap32_S (out_s[1]);
+  out[2] = hc_swap32_S (out_s[2]);
+  out[3] = hc_swap32_S (out_s[3]);
+}
+
+DECLSPEC void AES192_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4)
+{
+  u32 in_s[4];
+
+  in_s[0] = hc_swap32_S (in[0]);
+  in_s[1] = hc_swap32_S (in[1]);
+  in_s[2] = hc_swap32_S (in[2]);
+  in_s[3] = hc_swap32_S (in[3]);
+
+  u32 out_s[4];
+
+  aes192_decrypt (ks, in_s, out_s, s_td0, s_td1, s_td2, s_td3, s_td4);
 
   out[0] = hc_swap32_S (out_s[0]);
   out[1] = hc_swap32_S (out_s[1]);

--- a/OpenCL/inc_cipher_aes.h
+++ b/OpenCL/inc_cipher_aes.h
@@ -12,6 +12,12 @@ DECLSPEC void aes128_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_
 DECLSPEC void aes128_set_decrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3);
 DECLSPEC void aes128_encrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4);
 DECLSPEC void aes128_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4);
+DECLSPEC void aes192_ExpandKey (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3);
+DECLSPEC void aes192_InvertKey (u32 *ks, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3);
+DECLSPEC void aes192_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3);
+DECLSPEC void aes192_set_decrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3);
+DECLSPEC void aes192_encrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4);
+DECLSPEC void aes192_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4);
 DECLSPEC void aes256_ExpandKey (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3);
 DECLSPEC void aes256_InvertKey (u32 *ks, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3);
 DECLSPEC void aes256_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3);
@@ -22,6 +28,10 @@ DECLSPEC void AES128_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_
 DECLSPEC void AES128_set_decrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3);
 DECLSPEC void AES128_encrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4);
 DECLSPEC void AES128_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4);
+DECLSPEC void AES192_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3);
+DECLSPEC void AES192_set_decrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3);
+DECLSPEC void AES192_encrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4);
+DECLSPEC void AES192_decrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4);
 DECLSPEC void AES256_set_encrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3);
 DECLSPEC void AES256_set_decrypt_key (u32 *ks, const u32 *ukey, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3);
 DECLSPEC void AES256_encrypt (const u32 *ks, const u32 *in, u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4);

--- a/OpenCL/m23001_a0-optimized.cl
+++ b/OpenCL/m23001_a0-optimized.cl
@@ -1,0 +1,695 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp_optimized.h"
+#include "inc_rp_optimized.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23001_m04 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_m08 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23001_m16 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23001_s04 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_s08 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23001_s16 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}

--- a/OpenCL/m23001_a0-pure.cl
+++ b/OpenCL/m23001_a0-pure.cl
@@ -1,0 +1,411 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp.h"
+#include "inc_rp.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23001_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_sxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23001_a1-optimized.cl
+++ b/OpenCL/m23001_a1-optimized.cl
@@ -1,0 +1,809 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23001_m04 (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_m08 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23001_m16 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23001_s04 (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_s08 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23001_s16 (KERN_ATTR_ESALT (securezip_t))
+{
+}

--- a/OpenCL/m23001_a1-pure.cl
+++ b/OpenCL/m23001_a1-pure.cl
@@ -1,0 +1,405 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23001_mxx (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_sxx (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23001_a3-optimized.cl
+++ b/OpenCL/m23001_a3-optimized.cl
@@ -1,0 +1,1279 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+DECLSPEC void m23001m (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a *s_te2, SHM_TYPE u32a *s_te3, SHM_TYPE u32a *s_te4, SHM_TYPE u32a *s_td0, SHM_TYPE u32a *s_td1, SHM_TYPE u32a *s_td2, SHM_TYPE u32a *s_td3, SHM_TYPE u32a *s_td4, u32 *w, const u32 pw_len, KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  /**
+   * base
+   */
+
+  const u32 c_16s = hc_rotl32_S ((w[13] ^ w[ 8] ^ w[ 2]        ), 1u);
+  const u32 c_17s = hc_rotl32_S ((w[14] ^ w[ 9] ^ w[ 3] ^ w[ 1]), 1u);
+  const u32 c_18s = hc_rotl32_S ((w[15] ^ w[10] ^ w[ 4] ^ w[ 2]), 1u);
+  const u32 c_19s = hc_rotl32_S ((c_16s ^ w[11] ^ w[ 5] ^ w[ 3]), 1u);
+  const u32 c_20s = hc_rotl32_S ((c_17s ^ w[12] ^ w[ 6] ^ w[ 4]), 1u);
+  const u32 c_21s = hc_rotl32_S ((c_18s ^ w[13] ^ w[ 7] ^ w[ 5]), 1u);
+  const u32 c_22s = hc_rotl32_S ((c_19s ^ w[14] ^ w[ 8] ^ w[ 6]), 1u);
+  const u32 c_23s = hc_rotl32_S ((c_20s ^ w[15] ^ w[ 9] ^ w[ 7]), 1u);
+  const u32 c_24s = hc_rotl32_S ((c_21s ^ c_16s ^ w[10] ^ w[ 8]), 1u);
+  const u32 c_25s = hc_rotl32_S ((c_22s ^ c_17s ^ w[11] ^ w[ 9]), 1u);
+  const u32 c_26s = hc_rotl32_S ((c_23s ^ c_18s ^ w[12] ^ w[10]), 1u);
+  const u32 c_27s = hc_rotl32_S ((c_24s ^ c_19s ^ w[13] ^ w[11]), 1u);
+  const u32 c_28s = hc_rotl32_S ((c_25s ^ c_20s ^ w[14] ^ w[12]), 1u);
+  const u32 c_29s = hc_rotl32_S ((c_26s ^ c_21s ^ w[15] ^ w[13]), 1u);
+  const u32 c_30s = hc_rotl32_S ((c_27s ^ c_22s ^ c_16s ^ w[14]), 1u);
+  const u32 c_31s = hc_rotl32_S ((c_28s ^ c_23s ^ c_17s ^ w[15]), 1u);
+  const u32 c_32s = hc_rotl32_S ((c_29s ^ c_24s ^ c_18s ^ c_16s), 1u);
+  const u32 c_33s = hc_rotl32_S ((c_30s ^ c_25s ^ c_19s ^ c_17s), 1u);
+  const u32 c_34s = hc_rotl32_S ((c_31s ^ c_26s ^ c_20s ^ c_18s), 1u);
+  const u32 c_35s = hc_rotl32_S ((c_32s ^ c_27s ^ c_21s ^ c_19s), 1u);
+  const u32 c_36s = hc_rotl32_S ((c_33s ^ c_28s ^ c_22s ^ c_20s), 1u);
+  const u32 c_37s = hc_rotl32_S ((c_34s ^ c_29s ^ c_23s ^ c_21s), 1u);
+  const u32 c_38s = hc_rotl32_S ((c_35s ^ c_30s ^ c_24s ^ c_22s), 1u);
+  const u32 c_39s = hc_rotl32_S ((c_36s ^ c_31s ^ c_25s ^ c_23s), 1u);
+  const u32 c_40s = hc_rotl32_S ((c_37s ^ c_32s ^ c_26s ^ c_24s), 1u);
+  const u32 c_41s = hc_rotl32_S ((c_38s ^ c_33s ^ c_27s ^ c_25s), 1u);
+  const u32 c_42s = hc_rotl32_S ((c_39s ^ c_34s ^ c_28s ^ c_26s), 1u);
+  const u32 c_43s = hc_rotl32_S ((c_40s ^ c_35s ^ c_29s ^ c_27s), 1u);
+  const u32 c_44s = hc_rotl32_S ((c_41s ^ c_36s ^ c_30s ^ c_28s), 1u);
+  const u32 c_45s = hc_rotl32_S ((c_42s ^ c_37s ^ c_31s ^ c_29s), 1u);
+  const u32 c_46s = hc_rotl32_S ((c_43s ^ c_38s ^ c_32s ^ c_30s), 1u);
+  const u32 c_47s = hc_rotl32_S ((c_44s ^ c_39s ^ c_33s ^ c_31s), 1u);
+  const u32 c_48s = hc_rotl32_S ((c_45s ^ c_40s ^ c_34s ^ c_32s), 1u);
+  const u32 c_49s = hc_rotl32_S ((c_46s ^ c_41s ^ c_35s ^ c_33s), 1u);
+  const u32 c_50s = hc_rotl32_S ((c_47s ^ c_42s ^ c_36s ^ c_34s), 1u);
+  const u32 c_51s = hc_rotl32_S ((c_48s ^ c_43s ^ c_37s ^ c_35s), 1u);
+  const u32 c_52s = hc_rotl32_S ((c_49s ^ c_44s ^ c_38s ^ c_36s), 1u);
+  const u32 c_53s = hc_rotl32_S ((c_50s ^ c_45s ^ c_39s ^ c_37s), 1u);
+  const u32 c_54s = hc_rotl32_S ((c_51s ^ c_46s ^ c_40s ^ c_38s), 1u);
+  const u32 c_55s = hc_rotl32_S ((c_52s ^ c_47s ^ c_41s ^ c_39s), 1u);
+  const u32 c_56s = hc_rotl32_S ((c_53s ^ c_48s ^ c_42s ^ c_40s), 1u);
+  const u32 c_57s = hc_rotl32_S ((c_54s ^ c_49s ^ c_43s ^ c_41s), 1u);
+  const u32 c_58s = hc_rotl32_S ((c_55s ^ c_50s ^ c_44s ^ c_42s), 1u);
+  const u32 c_59s = hc_rotl32_S ((c_56s ^ c_51s ^ c_45s ^ c_43s), 1u);
+  const u32 c_60s = hc_rotl32_S ((c_57s ^ c_52s ^ c_46s ^ c_44s), 1u);
+  const u32 c_61s = hc_rotl32_S ((c_58s ^ c_53s ^ c_47s ^ c_45s), 1u);
+  const u32 c_62s = hc_rotl32_S ((c_59s ^ c_54s ^ c_48s ^ c_46s), 1u);
+  const u32 c_63s = hc_rotl32_S ((c_60s ^ c_55s ^ c_49s ^ c_47s), 1u);
+  const u32 c_64s = hc_rotl32_S ((c_61s ^ c_56s ^ c_50s ^ c_48s), 1u);
+  const u32 c_65s = hc_rotl32_S ((c_62s ^ c_57s ^ c_51s ^ c_49s), 1u);
+  const u32 c_66s = hc_rotl32_S ((c_63s ^ c_58s ^ c_52s ^ c_50s), 1u);
+  const u32 c_67s = hc_rotl32_S ((c_64s ^ c_59s ^ c_53s ^ c_51s), 1u);
+  const u32 c_68s = hc_rotl32_S ((c_65s ^ c_60s ^ c_54s ^ c_52s), 1u);
+  const u32 c_69s = hc_rotl32_S ((c_66s ^ c_61s ^ c_55s ^ c_53s), 1u);
+  const u32 c_70s = hc_rotl32_S ((c_67s ^ c_62s ^ c_56s ^ c_54s), 1u);
+  const u32 c_71s = hc_rotl32_S ((c_68s ^ c_63s ^ c_57s ^ c_55s), 1u);
+  const u32 c_72s = hc_rotl32_S ((c_69s ^ c_64s ^ c_58s ^ c_56s), 1u);
+  const u32 c_73s = hc_rotl32_S ((c_70s ^ c_65s ^ c_59s ^ c_57s), 1u);
+  const u32 c_74s = hc_rotl32_S ((c_71s ^ c_66s ^ c_60s ^ c_58s), 1u);
+  const u32 c_75s = hc_rotl32_S ((c_72s ^ c_67s ^ c_61s ^ c_59s), 1u);
+
+  const u32 c_17sK = c_17s + SHA1C00;
+  const u32 c_18sK = c_18s + SHA1C00;
+  const u32 c_20sK = c_20s + SHA1C01;
+  const u32 c_21sK = c_21s + SHA1C01;
+  const u32 c_23sK = c_23s + SHA1C01;
+  const u32 c_26sK = c_26s + SHA1C01;
+  const u32 c_27sK = c_27s + SHA1C01;
+  const u32 c_29sK = c_29s + SHA1C01;
+  const u32 c_33sK = c_33s + SHA1C01;
+  const u32 c_39sK = c_39s + SHA1C01;
+  const u32 c_41sK = c_41s + SHA1C02;
+  const u32 c_45sK = c_45s + SHA1C02;
+  const u32 c_53sK = c_53s + SHA1C02;
+  const u32 c_65sK = c_65s + SHA1C03;
+  const u32 c_69sK = c_69s + SHA1C03;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x w0s01 = hc_rotl32 (w0, 1u);
+    const u32x w0s02 = hc_rotl32 (w0, 2u);
+    const u32x w0s03 = hc_rotl32 (w0, 3u);
+    const u32x w0s04 = hc_rotl32 (w0, 4u);
+    const u32x w0s05 = hc_rotl32 (w0, 5u);
+    const u32x w0s06 = hc_rotl32 (w0, 6u);
+    const u32x w0s07 = hc_rotl32 (w0, 7u);
+    const u32x w0s08 = hc_rotl32 (w0, 8u);
+    const u32x w0s09 = hc_rotl32 (w0, 9u);
+    const u32x w0s10 = hc_rotl32 (w0, 10u);
+    const u32x w0s11 = hc_rotl32 (w0, 11u);
+    const u32x w0s12 = hc_rotl32 (w0, 12u);
+    const u32x w0s13 = hc_rotl32 (w0, 13u);
+    const u32x w0s14 = hc_rotl32 (w0, 14u);
+    const u32x w0s15 = hc_rotl32 (w0, 15u);
+    const u32x w0s16 = hc_rotl32 (w0, 16u);
+    const u32x w0s17 = hc_rotl32 (w0, 17u);
+    const u32x w0s18 = hc_rotl32 (w0, 18u);
+    const u32x w0s19 = hc_rotl32 (w0, 19u);
+    const u32x w0s20 = hc_rotl32 (w0, 20u);
+
+    const u32x w0s04___w0s06 = w0s04 ^ w0s06;
+    const u32x w0s04___w0s08 = w0s04 ^ w0s08;
+    const u32x w0s08___w0s12 = w0s08 ^ w0s12;
+    const u32x w0s04___w0s06___w0s07 = w0s04___w0s06 ^ w0s07;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 1]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 2]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 3]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 4]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[ 5]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 6]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 7]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 8]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 9]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[10]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[11]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[12]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[13]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[14]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[15]);
+
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, (c_16s ^ w0s01));
+    SHA1_STEPX(SHA1_F0o, d, e, a, b, c, (c_17sK));
+    SHA1_STEPX(SHA1_F0o, c, d, e, a, b, (c_18sK));
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, (c_19s ^ w0s02));
+
+    #undef K
+    #define K SHA1C01
+
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_20sK));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_21sK));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_22s ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_23sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_24s ^ w0s02));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_25s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_26sK));
+    SHA1_STEPX(SHA1_F1 , d, e, a, b, c, (c_27sK));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_28s ^ w0s05));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_29sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_30s ^ w0s02 ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_31s ^ w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_32s ^ w0s02 ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_33sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_34s ^ w0s07));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_35s ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_36s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_37s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_38s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_39sK));
+
+    #undef K
+    #define K SHA1C02
+
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_40s ^ w0s04 ^ w0s09));
+    SHA1_STEPX(SHA1_F2o, e, a, b, c, d, (c_41sK));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_42s ^ w0s06 ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_43s ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_44s ^ w0s03 ^ w0s06 ^ w0s07));
+    SHA1_STEPX(SHA1_F2o, a, b, c, d, e, (c_45sK));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_46s ^ w0s04 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_47s ^ w0s04___w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_48s ^ w0s03 ^ w0s04___w0s08 ^ w0s05 ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_49s ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_50s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_51s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_52s ^ w0s04___w0s08 ^ w0s13));
+    SHA1_STEPX(SHA1_F2o, c, d, e, a, b, (c_53sK));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_54s ^ w0s07 ^ w0s10 ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_55s ^ w0s14));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_56s ^ w0s04___w0s06___w0s07 ^ w0s10 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_57s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_58s ^ w0s04___w0s08 ^ w0s15));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_59s ^ w0s08___w0s12));
+
+    #undef K
+    #define K SHA1C03
+
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_60s ^ w0s04 ^ w0s08___w0s12 ^ w0s07 ^ w0s14));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_61s ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_62s ^ w0s04___w0s06 ^ w0s08___w0s12));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_63s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_64s ^ w0s04___w0s06___w0s07 ^ w0s08___w0s12 ^ w0s17));
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_65sK));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_66s ^ w0s14 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_67s ^ w0s08 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_68s ^ w0s11 ^ w0s14 ^ w0s15));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_69sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_70s ^ w0s12 ^ w0s19));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_71s ^ w0s12 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_72s ^ w0s05 ^ w0s11 ^ w0s12 ^ w0s13 ^ w0s16 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_73s ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_74s ^ w0s08 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_75s ^ w0s06 ^ w0s12 ^ w0s14));
+
+    const u32x c_76s = hc_rotl32 ((c_73s ^ c_68s ^ c_62s ^ c_60s), 1u);
+    const u32x c_77s = hc_rotl32 ((c_74s ^ c_69s ^ c_63s ^ c_61s), 1u);
+    const u32x c_78s = hc_rotl32 ((c_75s ^ c_70s ^ c_64s ^ c_62s), 1u);
+    const u32x c_79s = hc_rotl32 ((c_76s ^ c_71s ^ c_65s ^ c_63s), 1u);
+
+    const u32x w0s21 = hc_rotl32 (w0, 21u);
+    const u32x w0s22 = hc_rotl32 (w0, 22U);
+
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_76s ^ w0s07 ^ w0s08___w0s12 ^ w0s16 ^ w0s21));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_77s));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_78s ^ w0s07 ^ w0s08 ^ w0s15 ^ w0s18 ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_79s ^ w0s08 ^ w0s22));
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+DECLSPEC void m23001s (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a *s_te2, SHM_TYPE u32a *s_te3, SHM_TYPE u32a *s_te4, SHM_TYPE u32a *s_td0, SHM_TYPE u32a *s_td1, SHM_TYPE u32a *s_td2, SHM_TYPE u32a *s_td3, SHM_TYPE u32a *s_td4, u32 *w, const u32 pw_len, KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  /**
+   * base
+   */
+
+  const u32 c_16s = hc_rotl32_S ((w[13] ^ w[ 8] ^ w[ 2]        ), 1u);
+  const u32 c_17s = hc_rotl32_S ((w[14] ^ w[ 9] ^ w[ 3] ^ w[ 1]), 1u);
+  const u32 c_18s = hc_rotl32_S ((w[15] ^ w[10] ^ w[ 4] ^ w[ 2]), 1u);
+  const u32 c_19s = hc_rotl32_S ((c_16s ^ w[11] ^ w[ 5] ^ w[ 3]), 1u);
+  const u32 c_20s = hc_rotl32_S ((c_17s ^ w[12] ^ w[ 6] ^ w[ 4]), 1u);
+  const u32 c_21s = hc_rotl32_S ((c_18s ^ w[13] ^ w[ 7] ^ w[ 5]), 1u);
+  const u32 c_22s = hc_rotl32_S ((c_19s ^ w[14] ^ w[ 8] ^ w[ 6]), 1u);
+  const u32 c_23s = hc_rotl32_S ((c_20s ^ w[15] ^ w[ 9] ^ w[ 7]), 1u);
+  const u32 c_24s = hc_rotl32_S ((c_21s ^ c_16s ^ w[10] ^ w[ 8]), 1u);
+  const u32 c_25s = hc_rotl32_S ((c_22s ^ c_17s ^ w[11] ^ w[ 9]), 1u);
+  const u32 c_26s = hc_rotl32_S ((c_23s ^ c_18s ^ w[12] ^ w[10]), 1u);
+  const u32 c_27s = hc_rotl32_S ((c_24s ^ c_19s ^ w[13] ^ w[11]), 1u);
+  const u32 c_28s = hc_rotl32_S ((c_25s ^ c_20s ^ w[14] ^ w[12]), 1u);
+  const u32 c_29s = hc_rotl32_S ((c_26s ^ c_21s ^ w[15] ^ w[13]), 1u);
+  const u32 c_30s = hc_rotl32_S ((c_27s ^ c_22s ^ c_16s ^ w[14]), 1u);
+  const u32 c_31s = hc_rotl32_S ((c_28s ^ c_23s ^ c_17s ^ w[15]), 1u);
+  const u32 c_32s = hc_rotl32_S ((c_29s ^ c_24s ^ c_18s ^ c_16s), 1u);
+  const u32 c_33s = hc_rotl32_S ((c_30s ^ c_25s ^ c_19s ^ c_17s), 1u);
+  const u32 c_34s = hc_rotl32_S ((c_31s ^ c_26s ^ c_20s ^ c_18s), 1u);
+  const u32 c_35s = hc_rotl32_S ((c_32s ^ c_27s ^ c_21s ^ c_19s), 1u);
+  const u32 c_36s = hc_rotl32_S ((c_33s ^ c_28s ^ c_22s ^ c_20s), 1u);
+  const u32 c_37s = hc_rotl32_S ((c_34s ^ c_29s ^ c_23s ^ c_21s), 1u);
+  const u32 c_38s = hc_rotl32_S ((c_35s ^ c_30s ^ c_24s ^ c_22s), 1u);
+  const u32 c_39s = hc_rotl32_S ((c_36s ^ c_31s ^ c_25s ^ c_23s), 1u);
+  const u32 c_40s = hc_rotl32_S ((c_37s ^ c_32s ^ c_26s ^ c_24s), 1u);
+  const u32 c_41s = hc_rotl32_S ((c_38s ^ c_33s ^ c_27s ^ c_25s), 1u);
+  const u32 c_42s = hc_rotl32_S ((c_39s ^ c_34s ^ c_28s ^ c_26s), 1u);
+  const u32 c_43s = hc_rotl32_S ((c_40s ^ c_35s ^ c_29s ^ c_27s), 1u);
+  const u32 c_44s = hc_rotl32_S ((c_41s ^ c_36s ^ c_30s ^ c_28s), 1u);
+  const u32 c_45s = hc_rotl32_S ((c_42s ^ c_37s ^ c_31s ^ c_29s), 1u);
+  const u32 c_46s = hc_rotl32_S ((c_43s ^ c_38s ^ c_32s ^ c_30s), 1u);
+  const u32 c_47s = hc_rotl32_S ((c_44s ^ c_39s ^ c_33s ^ c_31s), 1u);
+  const u32 c_48s = hc_rotl32_S ((c_45s ^ c_40s ^ c_34s ^ c_32s), 1u);
+  const u32 c_49s = hc_rotl32_S ((c_46s ^ c_41s ^ c_35s ^ c_33s), 1u);
+  const u32 c_50s = hc_rotl32_S ((c_47s ^ c_42s ^ c_36s ^ c_34s), 1u);
+  const u32 c_51s = hc_rotl32_S ((c_48s ^ c_43s ^ c_37s ^ c_35s), 1u);
+  const u32 c_52s = hc_rotl32_S ((c_49s ^ c_44s ^ c_38s ^ c_36s), 1u);
+  const u32 c_53s = hc_rotl32_S ((c_50s ^ c_45s ^ c_39s ^ c_37s), 1u);
+  const u32 c_54s = hc_rotl32_S ((c_51s ^ c_46s ^ c_40s ^ c_38s), 1u);
+  const u32 c_55s = hc_rotl32_S ((c_52s ^ c_47s ^ c_41s ^ c_39s), 1u);
+  const u32 c_56s = hc_rotl32_S ((c_53s ^ c_48s ^ c_42s ^ c_40s), 1u);
+  const u32 c_57s = hc_rotl32_S ((c_54s ^ c_49s ^ c_43s ^ c_41s), 1u);
+  const u32 c_58s = hc_rotl32_S ((c_55s ^ c_50s ^ c_44s ^ c_42s), 1u);
+  const u32 c_59s = hc_rotl32_S ((c_56s ^ c_51s ^ c_45s ^ c_43s), 1u);
+  const u32 c_60s = hc_rotl32_S ((c_57s ^ c_52s ^ c_46s ^ c_44s), 1u);
+  const u32 c_61s = hc_rotl32_S ((c_58s ^ c_53s ^ c_47s ^ c_45s), 1u);
+  const u32 c_62s = hc_rotl32_S ((c_59s ^ c_54s ^ c_48s ^ c_46s), 1u);
+  const u32 c_63s = hc_rotl32_S ((c_60s ^ c_55s ^ c_49s ^ c_47s), 1u);
+  const u32 c_64s = hc_rotl32_S ((c_61s ^ c_56s ^ c_50s ^ c_48s), 1u);
+  const u32 c_65s = hc_rotl32_S ((c_62s ^ c_57s ^ c_51s ^ c_49s), 1u);
+  const u32 c_66s = hc_rotl32_S ((c_63s ^ c_58s ^ c_52s ^ c_50s), 1u);
+  const u32 c_67s = hc_rotl32_S ((c_64s ^ c_59s ^ c_53s ^ c_51s), 1u);
+  const u32 c_68s = hc_rotl32_S ((c_65s ^ c_60s ^ c_54s ^ c_52s), 1u);
+  const u32 c_69s = hc_rotl32_S ((c_66s ^ c_61s ^ c_55s ^ c_53s), 1u);
+  const u32 c_70s = hc_rotl32_S ((c_67s ^ c_62s ^ c_56s ^ c_54s), 1u);
+  const u32 c_71s = hc_rotl32_S ((c_68s ^ c_63s ^ c_57s ^ c_55s), 1u);
+  const u32 c_72s = hc_rotl32_S ((c_69s ^ c_64s ^ c_58s ^ c_56s), 1u);
+  const u32 c_73s = hc_rotl32_S ((c_70s ^ c_65s ^ c_59s ^ c_57s), 1u);
+  const u32 c_74s = hc_rotl32_S ((c_71s ^ c_66s ^ c_60s ^ c_58s), 1u);
+  const u32 c_75s = hc_rotl32_S ((c_72s ^ c_67s ^ c_61s ^ c_59s), 1u);
+
+  const u32 c_17sK = c_17s + SHA1C00;
+  const u32 c_18sK = c_18s + SHA1C00;
+  const u32 c_20sK = c_20s + SHA1C01;
+  const u32 c_21sK = c_21s + SHA1C01;
+  const u32 c_23sK = c_23s + SHA1C01;
+  const u32 c_26sK = c_26s + SHA1C01;
+  const u32 c_27sK = c_27s + SHA1C01;
+  const u32 c_29sK = c_29s + SHA1C01;
+  const u32 c_33sK = c_33s + SHA1C01;
+  const u32 c_39sK = c_39s + SHA1C01;
+  const u32 c_41sK = c_41s + SHA1C02;
+  const u32 c_45sK = c_45s + SHA1C02;
+  const u32 c_53sK = c_53s + SHA1C02;
+  const u32 c_65sK = c_65s + SHA1C03;
+  const u32 c_69sK = c_69s + SHA1C03;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x w0s01 = hc_rotl32 (w0, 1u);
+    const u32x w0s02 = hc_rotl32 (w0, 2u);
+    const u32x w0s03 = hc_rotl32 (w0, 3u);
+    const u32x w0s04 = hc_rotl32 (w0, 4u);
+    const u32x w0s05 = hc_rotl32 (w0, 5u);
+    const u32x w0s06 = hc_rotl32 (w0, 6u);
+    const u32x w0s07 = hc_rotl32 (w0, 7u);
+    const u32x w0s08 = hc_rotl32 (w0, 8u);
+    const u32x w0s09 = hc_rotl32 (w0, 9u);
+    const u32x w0s10 = hc_rotl32 (w0, 10u);
+    const u32x w0s11 = hc_rotl32 (w0, 11u);
+    const u32x w0s12 = hc_rotl32 (w0, 12u);
+    const u32x w0s13 = hc_rotl32 (w0, 13u);
+    const u32x w0s14 = hc_rotl32 (w0, 14u);
+    const u32x w0s15 = hc_rotl32 (w0, 15u);
+    const u32x w0s16 = hc_rotl32 (w0, 16u);
+    const u32x w0s17 = hc_rotl32 (w0, 17u);
+    const u32x w0s18 = hc_rotl32 (w0, 18u);
+    const u32x w0s19 = hc_rotl32 (w0, 19u);
+    const u32x w0s20 = hc_rotl32 (w0, 20u);
+
+    const u32x w0s04___w0s06 = w0s04 ^ w0s06;
+    const u32x w0s04___w0s08 = w0s04 ^ w0s08;
+    const u32x w0s08___w0s12 = w0s08 ^ w0s12;
+    const u32x w0s04___w0s06___w0s07 = w0s04___w0s06 ^ w0s07;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 1]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 2]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 3]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 4]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[ 5]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 6]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 7]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 8]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 9]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[10]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[11]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[12]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[13]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[14]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[15]);
+
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, (c_16s ^ w0s01));
+    SHA1_STEPX(SHA1_F0o, d, e, a, b, c, (c_17sK));
+    SHA1_STEPX(SHA1_F0o, c, d, e, a, b, (c_18sK));
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, (c_19s ^ w0s02));
+
+    #undef K
+    #define K SHA1C01
+
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_20sK));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_21sK));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_22s ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_23sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_24s ^ w0s02));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_25s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_26sK));
+    SHA1_STEPX(SHA1_F1 , d, e, a, b, c, (c_27sK));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_28s ^ w0s05));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_29sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_30s ^ w0s02 ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_31s ^ w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_32s ^ w0s02 ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_33sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_34s ^ w0s07));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_35s ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_36s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_37s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_38s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_39sK));
+
+    #undef K
+    #define K SHA1C02
+
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_40s ^ w0s04 ^ w0s09));
+    SHA1_STEPX(SHA1_F2o, e, a, b, c, d, (c_41sK));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_42s ^ w0s06 ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_43s ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_44s ^ w0s03 ^ w0s06 ^ w0s07));
+    SHA1_STEPX(SHA1_F2o, a, b, c, d, e, (c_45sK));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_46s ^ w0s04 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_47s ^ w0s04___w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_48s ^ w0s03 ^ w0s04___w0s08 ^ w0s05 ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_49s ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_50s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_51s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_52s ^ w0s04___w0s08 ^ w0s13));
+    SHA1_STEPX(SHA1_F2o, c, d, e, a, b, (c_53sK));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_54s ^ w0s07 ^ w0s10 ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_55s ^ w0s14));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_56s ^ w0s04___w0s06___w0s07 ^ w0s10 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_57s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_58s ^ w0s04___w0s08 ^ w0s15));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_59s ^ w0s08___w0s12));
+
+    #undef K
+    #define K SHA1C03
+
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_60s ^ w0s04 ^ w0s08___w0s12 ^ w0s07 ^ w0s14));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_61s ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_62s ^ w0s04___w0s06 ^ w0s08___w0s12));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_63s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_64s ^ w0s04___w0s06___w0s07 ^ w0s08___w0s12 ^ w0s17));
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_65sK));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_66s ^ w0s14 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_67s ^ w0s08 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_68s ^ w0s11 ^ w0s14 ^ w0s15));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_69sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_70s ^ w0s12 ^ w0s19));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_71s ^ w0s12 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_72s ^ w0s05 ^ w0s11 ^ w0s12 ^ w0s13 ^ w0s16 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_73s ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_74s ^ w0s08 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_75s ^ w0s06 ^ w0s12 ^ w0s14));
+
+    const u32x c_76s = hc_rotl32 ((c_73s ^ c_68s ^ c_62s ^ c_60s), 1u);
+    const u32x c_77s = hc_rotl32 ((c_74s ^ c_69s ^ c_63s ^ c_61s), 1u);
+    const u32x c_78s = hc_rotl32 ((c_75s ^ c_70s ^ c_64s ^ c_62s), 1u);
+    const u32x c_79s = hc_rotl32 ((c_76s ^ c_71s ^ c_65s ^ c_63s), 1u);
+
+    const u32x w0s21 = hc_rotl32 (w0, 21u);
+    const u32x w0s22 = hc_rotl32 (w0, 22U);
+
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_76s ^ w0s07 ^ w0s08___w0s12 ^ w0s16 ^ w0s21));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_77s));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_78s ^ w0s07 ^ w0s08 ^ w0s15 ^ w0s18 ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_79s ^ w0s08 ^ w0s22));
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_m04 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23001m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23001_m08 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23001m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23001_m16 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23001m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23001_s04 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23001s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23001_s08 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23001s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23001_s16 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23001s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}

--- a/OpenCL/m23001_a3-pure.cl
+++ b/OpenCL/m23001_a3-pure.cl
@@ -1,0 +1,431 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23001_mxx (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx;
+
+    sha1_init_vector (&ctx);
+
+    sha1_update_vector (&ctx, w, pw_len);
+
+    sha1_final_vector (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23001_sxx (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx;
+
+    sha1_init_vector (&ctx);
+
+    sha1_update_vector (&ctx, w, pw_len);
+
+    sha1_final_vector (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[4];
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 44
+
+    u32 ks[KEYLEN];
+
+    AES128_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes128_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23002_a0-optimized.cl
+++ b/OpenCL/m23002_a0-optimized.cl
@@ -1,0 +1,801 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp_optimized.h"
+#include "inc_rp_optimized.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23002_m04 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_m08 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23002_m16 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23002_s04 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_s08 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23002_s16 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}

--- a/OpenCL/m23002_a0-pure.cl
+++ b/OpenCL/m23002_a0-pure.cl
@@ -1,0 +1,517 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp.h"
+#include "inc_rp.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23002_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_sxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23002_a1-optimized.cl
+++ b/OpenCL/m23002_a1-optimized.cl
@@ -1,0 +1,915 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23002_m04 (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_m08 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23002_m16 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23002_s04 (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_s08 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23002_s16 (KERN_ATTR_ESALT (securezip_t))
+{
+}

--- a/OpenCL/m23002_a1-pure.cl
+++ b/OpenCL/m23002_a1-pure.cl
@@ -1,0 +1,511 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23002_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_sxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23002_a3-optimized.cl
+++ b/OpenCL/m23002_a3-optimized.cl
@@ -1,0 +1,1385 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+DECLSPEC void m23002m (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a *s_te2, SHM_TYPE u32a *s_te3, SHM_TYPE u32a *s_te4, SHM_TYPE u32a *s_td0, SHM_TYPE u32a *s_td1, SHM_TYPE u32a *s_td2, SHM_TYPE u32a *s_td3, SHM_TYPE u32a *s_td4, u32 *w, const u32 pw_len, KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  /**
+   * base
+   */
+
+  const u32 c_16s = hc_rotl32_S ((w[13] ^ w[ 8] ^ w[ 2]        ), 1u);
+  const u32 c_17s = hc_rotl32_S ((w[14] ^ w[ 9] ^ w[ 3] ^ w[ 1]), 1u);
+  const u32 c_18s = hc_rotl32_S ((w[15] ^ w[10] ^ w[ 4] ^ w[ 2]), 1u);
+  const u32 c_19s = hc_rotl32_S ((c_16s ^ w[11] ^ w[ 5] ^ w[ 3]), 1u);
+  const u32 c_20s = hc_rotl32_S ((c_17s ^ w[12] ^ w[ 6] ^ w[ 4]), 1u);
+  const u32 c_21s = hc_rotl32_S ((c_18s ^ w[13] ^ w[ 7] ^ w[ 5]), 1u);
+  const u32 c_22s = hc_rotl32_S ((c_19s ^ w[14] ^ w[ 8] ^ w[ 6]), 1u);
+  const u32 c_23s = hc_rotl32_S ((c_20s ^ w[15] ^ w[ 9] ^ w[ 7]), 1u);
+  const u32 c_24s = hc_rotl32_S ((c_21s ^ c_16s ^ w[10] ^ w[ 8]), 1u);
+  const u32 c_25s = hc_rotl32_S ((c_22s ^ c_17s ^ w[11] ^ w[ 9]), 1u);
+  const u32 c_26s = hc_rotl32_S ((c_23s ^ c_18s ^ w[12] ^ w[10]), 1u);
+  const u32 c_27s = hc_rotl32_S ((c_24s ^ c_19s ^ w[13] ^ w[11]), 1u);
+  const u32 c_28s = hc_rotl32_S ((c_25s ^ c_20s ^ w[14] ^ w[12]), 1u);
+  const u32 c_29s = hc_rotl32_S ((c_26s ^ c_21s ^ w[15] ^ w[13]), 1u);
+  const u32 c_30s = hc_rotl32_S ((c_27s ^ c_22s ^ c_16s ^ w[14]), 1u);
+  const u32 c_31s = hc_rotl32_S ((c_28s ^ c_23s ^ c_17s ^ w[15]), 1u);
+  const u32 c_32s = hc_rotl32_S ((c_29s ^ c_24s ^ c_18s ^ c_16s), 1u);
+  const u32 c_33s = hc_rotl32_S ((c_30s ^ c_25s ^ c_19s ^ c_17s), 1u);
+  const u32 c_34s = hc_rotl32_S ((c_31s ^ c_26s ^ c_20s ^ c_18s), 1u);
+  const u32 c_35s = hc_rotl32_S ((c_32s ^ c_27s ^ c_21s ^ c_19s), 1u);
+  const u32 c_36s = hc_rotl32_S ((c_33s ^ c_28s ^ c_22s ^ c_20s), 1u);
+  const u32 c_37s = hc_rotl32_S ((c_34s ^ c_29s ^ c_23s ^ c_21s), 1u);
+  const u32 c_38s = hc_rotl32_S ((c_35s ^ c_30s ^ c_24s ^ c_22s), 1u);
+  const u32 c_39s = hc_rotl32_S ((c_36s ^ c_31s ^ c_25s ^ c_23s), 1u);
+  const u32 c_40s = hc_rotl32_S ((c_37s ^ c_32s ^ c_26s ^ c_24s), 1u);
+  const u32 c_41s = hc_rotl32_S ((c_38s ^ c_33s ^ c_27s ^ c_25s), 1u);
+  const u32 c_42s = hc_rotl32_S ((c_39s ^ c_34s ^ c_28s ^ c_26s), 1u);
+  const u32 c_43s = hc_rotl32_S ((c_40s ^ c_35s ^ c_29s ^ c_27s), 1u);
+  const u32 c_44s = hc_rotl32_S ((c_41s ^ c_36s ^ c_30s ^ c_28s), 1u);
+  const u32 c_45s = hc_rotl32_S ((c_42s ^ c_37s ^ c_31s ^ c_29s), 1u);
+  const u32 c_46s = hc_rotl32_S ((c_43s ^ c_38s ^ c_32s ^ c_30s), 1u);
+  const u32 c_47s = hc_rotl32_S ((c_44s ^ c_39s ^ c_33s ^ c_31s), 1u);
+  const u32 c_48s = hc_rotl32_S ((c_45s ^ c_40s ^ c_34s ^ c_32s), 1u);
+  const u32 c_49s = hc_rotl32_S ((c_46s ^ c_41s ^ c_35s ^ c_33s), 1u);
+  const u32 c_50s = hc_rotl32_S ((c_47s ^ c_42s ^ c_36s ^ c_34s), 1u);
+  const u32 c_51s = hc_rotl32_S ((c_48s ^ c_43s ^ c_37s ^ c_35s), 1u);
+  const u32 c_52s = hc_rotl32_S ((c_49s ^ c_44s ^ c_38s ^ c_36s), 1u);
+  const u32 c_53s = hc_rotl32_S ((c_50s ^ c_45s ^ c_39s ^ c_37s), 1u);
+  const u32 c_54s = hc_rotl32_S ((c_51s ^ c_46s ^ c_40s ^ c_38s), 1u);
+  const u32 c_55s = hc_rotl32_S ((c_52s ^ c_47s ^ c_41s ^ c_39s), 1u);
+  const u32 c_56s = hc_rotl32_S ((c_53s ^ c_48s ^ c_42s ^ c_40s), 1u);
+  const u32 c_57s = hc_rotl32_S ((c_54s ^ c_49s ^ c_43s ^ c_41s), 1u);
+  const u32 c_58s = hc_rotl32_S ((c_55s ^ c_50s ^ c_44s ^ c_42s), 1u);
+  const u32 c_59s = hc_rotl32_S ((c_56s ^ c_51s ^ c_45s ^ c_43s), 1u);
+  const u32 c_60s = hc_rotl32_S ((c_57s ^ c_52s ^ c_46s ^ c_44s), 1u);
+  const u32 c_61s = hc_rotl32_S ((c_58s ^ c_53s ^ c_47s ^ c_45s), 1u);
+  const u32 c_62s = hc_rotl32_S ((c_59s ^ c_54s ^ c_48s ^ c_46s), 1u);
+  const u32 c_63s = hc_rotl32_S ((c_60s ^ c_55s ^ c_49s ^ c_47s), 1u);
+  const u32 c_64s = hc_rotl32_S ((c_61s ^ c_56s ^ c_50s ^ c_48s), 1u);
+  const u32 c_65s = hc_rotl32_S ((c_62s ^ c_57s ^ c_51s ^ c_49s), 1u);
+  const u32 c_66s = hc_rotl32_S ((c_63s ^ c_58s ^ c_52s ^ c_50s), 1u);
+  const u32 c_67s = hc_rotl32_S ((c_64s ^ c_59s ^ c_53s ^ c_51s), 1u);
+  const u32 c_68s = hc_rotl32_S ((c_65s ^ c_60s ^ c_54s ^ c_52s), 1u);
+  const u32 c_69s = hc_rotl32_S ((c_66s ^ c_61s ^ c_55s ^ c_53s), 1u);
+  const u32 c_70s = hc_rotl32_S ((c_67s ^ c_62s ^ c_56s ^ c_54s), 1u);
+  const u32 c_71s = hc_rotl32_S ((c_68s ^ c_63s ^ c_57s ^ c_55s), 1u);
+  const u32 c_72s = hc_rotl32_S ((c_69s ^ c_64s ^ c_58s ^ c_56s), 1u);
+  const u32 c_73s = hc_rotl32_S ((c_70s ^ c_65s ^ c_59s ^ c_57s), 1u);
+  const u32 c_74s = hc_rotl32_S ((c_71s ^ c_66s ^ c_60s ^ c_58s), 1u);
+  const u32 c_75s = hc_rotl32_S ((c_72s ^ c_67s ^ c_61s ^ c_59s), 1u);
+
+  const u32 c_17sK = c_17s + SHA1C00;
+  const u32 c_18sK = c_18s + SHA1C00;
+  const u32 c_20sK = c_20s + SHA1C01;
+  const u32 c_21sK = c_21s + SHA1C01;
+  const u32 c_23sK = c_23s + SHA1C01;
+  const u32 c_26sK = c_26s + SHA1C01;
+  const u32 c_27sK = c_27s + SHA1C01;
+  const u32 c_29sK = c_29s + SHA1C01;
+  const u32 c_33sK = c_33s + SHA1C01;
+  const u32 c_39sK = c_39s + SHA1C01;
+  const u32 c_41sK = c_41s + SHA1C02;
+  const u32 c_45sK = c_45s + SHA1C02;
+  const u32 c_53sK = c_53s + SHA1C02;
+  const u32 c_65sK = c_65s + SHA1C03;
+  const u32 c_69sK = c_69s + SHA1C03;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x w0s01 = hc_rotl32 (w0, 1u);
+    const u32x w0s02 = hc_rotl32 (w0, 2u);
+    const u32x w0s03 = hc_rotl32 (w0, 3u);
+    const u32x w0s04 = hc_rotl32 (w0, 4u);
+    const u32x w0s05 = hc_rotl32 (w0, 5u);
+    const u32x w0s06 = hc_rotl32 (w0, 6u);
+    const u32x w0s07 = hc_rotl32 (w0, 7u);
+    const u32x w0s08 = hc_rotl32 (w0, 8u);
+    const u32x w0s09 = hc_rotl32 (w0, 9u);
+    const u32x w0s10 = hc_rotl32 (w0, 10u);
+    const u32x w0s11 = hc_rotl32 (w0, 11u);
+    const u32x w0s12 = hc_rotl32 (w0, 12u);
+    const u32x w0s13 = hc_rotl32 (w0, 13u);
+    const u32x w0s14 = hc_rotl32 (w0, 14u);
+    const u32x w0s15 = hc_rotl32 (w0, 15u);
+    const u32x w0s16 = hc_rotl32 (w0, 16u);
+    const u32x w0s17 = hc_rotl32 (w0, 17u);
+    const u32x w0s18 = hc_rotl32 (w0, 18u);
+    const u32x w0s19 = hc_rotl32 (w0, 19u);
+    const u32x w0s20 = hc_rotl32 (w0, 20u);
+
+    const u32x w0s04___w0s06 = w0s04 ^ w0s06;
+    const u32x w0s04___w0s08 = w0s04 ^ w0s08;
+    const u32x w0s08___w0s12 = w0s08 ^ w0s12;
+    const u32x w0s04___w0s06___w0s07 = w0s04___w0s06 ^ w0s07;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 1]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 2]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 3]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 4]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[ 5]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 6]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 7]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 8]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 9]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[10]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[11]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[12]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[13]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[14]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[15]);
+
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, (c_16s ^ w0s01));
+    SHA1_STEPX(SHA1_F0o, d, e, a, b, c, (c_17sK));
+    SHA1_STEPX(SHA1_F0o, c, d, e, a, b, (c_18sK));
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, (c_19s ^ w0s02));
+
+    #undef K
+    #define K SHA1C01
+
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_20sK));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_21sK));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_22s ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_23sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_24s ^ w0s02));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_25s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_26sK));
+    SHA1_STEPX(SHA1_F1 , d, e, a, b, c, (c_27sK));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_28s ^ w0s05));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_29sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_30s ^ w0s02 ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_31s ^ w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_32s ^ w0s02 ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_33sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_34s ^ w0s07));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_35s ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_36s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_37s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_38s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_39sK));
+
+    #undef K
+    #define K SHA1C02
+
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_40s ^ w0s04 ^ w0s09));
+    SHA1_STEPX(SHA1_F2o, e, a, b, c, d, (c_41sK));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_42s ^ w0s06 ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_43s ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_44s ^ w0s03 ^ w0s06 ^ w0s07));
+    SHA1_STEPX(SHA1_F2o, a, b, c, d, e, (c_45sK));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_46s ^ w0s04 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_47s ^ w0s04___w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_48s ^ w0s03 ^ w0s04___w0s08 ^ w0s05 ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_49s ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_50s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_51s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_52s ^ w0s04___w0s08 ^ w0s13));
+    SHA1_STEPX(SHA1_F2o, c, d, e, a, b, (c_53sK));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_54s ^ w0s07 ^ w0s10 ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_55s ^ w0s14));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_56s ^ w0s04___w0s06___w0s07 ^ w0s10 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_57s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_58s ^ w0s04___w0s08 ^ w0s15));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_59s ^ w0s08___w0s12));
+
+    #undef K
+    #define K SHA1C03
+
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_60s ^ w0s04 ^ w0s08___w0s12 ^ w0s07 ^ w0s14));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_61s ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_62s ^ w0s04___w0s06 ^ w0s08___w0s12));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_63s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_64s ^ w0s04___w0s06___w0s07 ^ w0s08___w0s12 ^ w0s17));
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_65sK));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_66s ^ w0s14 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_67s ^ w0s08 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_68s ^ w0s11 ^ w0s14 ^ w0s15));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_69sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_70s ^ w0s12 ^ w0s19));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_71s ^ w0s12 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_72s ^ w0s05 ^ w0s11 ^ w0s12 ^ w0s13 ^ w0s16 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_73s ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_74s ^ w0s08 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_75s ^ w0s06 ^ w0s12 ^ w0s14));
+
+    const u32x c_76s = hc_rotl32 ((c_73s ^ c_68s ^ c_62s ^ c_60s), 1u);
+    const u32x c_77s = hc_rotl32 ((c_74s ^ c_69s ^ c_63s ^ c_61s), 1u);
+    const u32x c_78s = hc_rotl32 ((c_75s ^ c_70s ^ c_64s ^ c_62s), 1u);
+    const u32x c_79s = hc_rotl32 ((c_76s ^ c_71s ^ c_65s ^ c_63s), 1u);
+
+    const u32x w0s21 = hc_rotl32 (w0, 21u);
+    const u32x w0s22 = hc_rotl32 (w0, 22U);
+
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_76s ^ w0s07 ^ w0s08___w0s12 ^ w0s16 ^ w0s21));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_77s));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_78s ^ w0s07 ^ w0s08 ^ w0s15 ^ w0s18 ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_79s ^ w0s08 ^ w0s22));
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+DECLSPEC void m23002s (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a *s_te2, SHM_TYPE u32a *s_te3, SHM_TYPE u32a *s_te4, SHM_TYPE u32a *s_td0, SHM_TYPE u32a *s_td1, SHM_TYPE u32a *s_td2, SHM_TYPE u32a *s_td3, SHM_TYPE u32a *s_td4, u32 *w, const u32 pw_len, KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  /**
+   * base
+   */
+
+  const u32 c_16s = hc_rotl32_S ((w[13] ^ w[ 8] ^ w[ 2]        ), 1u);
+  const u32 c_17s = hc_rotl32_S ((w[14] ^ w[ 9] ^ w[ 3] ^ w[ 1]), 1u);
+  const u32 c_18s = hc_rotl32_S ((w[15] ^ w[10] ^ w[ 4] ^ w[ 2]), 1u);
+  const u32 c_19s = hc_rotl32_S ((c_16s ^ w[11] ^ w[ 5] ^ w[ 3]), 1u);
+  const u32 c_20s = hc_rotl32_S ((c_17s ^ w[12] ^ w[ 6] ^ w[ 4]), 1u);
+  const u32 c_21s = hc_rotl32_S ((c_18s ^ w[13] ^ w[ 7] ^ w[ 5]), 1u);
+  const u32 c_22s = hc_rotl32_S ((c_19s ^ w[14] ^ w[ 8] ^ w[ 6]), 1u);
+  const u32 c_23s = hc_rotl32_S ((c_20s ^ w[15] ^ w[ 9] ^ w[ 7]), 1u);
+  const u32 c_24s = hc_rotl32_S ((c_21s ^ c_16s ^ w[10] ^ w[ 8]), 1u);
+  const u32 c_25s = hc_rotl32_S ((c_22s ^ c_17s ^ w[11] ^ w[ 9]), 1u);
+  const u32 c_26s = hc_rotl32_S ((c_23s ^ c_18s ^ w[12] ^ w[10]), 1u);
+  const u32 c_27s = hc_rotl32_S ((c_24s ^ c_19s ^ w[13] ^ w[11]), 1u);
+  const u32 c_28s = hc_rotl32_S ((c_25s ^ c_20s ^ w[14] ^ w[12]), 1u);
+  const u32 c_29s = hc_rotl32_S ((c_26s ^ c_21s ^ w[15] ^ w[13]), 1u);
+  const u32 c_30s = hc_rotl32_S ((c_27s ^ c_22s ^ c_16s ^ w[14]), 1u);
+  const u32 c_31s = hc_rotl32_S ((c_28s ^ c_23s ^ c_17s ^ w[15]), 1u);
+  const u32 c_32s = hc_rotl32_S ((c_29s ^ c_24s ^ c_18s ^ c_16s), 1u);
+  const u32 c_33s = hc_rotl32_S ((c_30s ^ c_25s ^ c_19s ^ c_17s), 1u);
+  const u32 c_34s = hc_rotl32_S ((c_31s ^ c_26s ^ c_20s ^ c_18s), 1u);
+  const u32 c_35s = hc_rotl32_S ((c_32s ^ c_27s ^ c_21s ^ c_19s), 1u);
+  const u32 c_36s = hc_rotl32_S ((c_33s ^ c_28s ^ c_22s ^ c_20s), 1u);
+  const u32 c_37s = hc_rotl32_S ((c_34s ^ c_29s ^ c_23s ^ c_21s), 1u);
+  const u32 c_38s = hc_rotl32_S ((c_35s ^ c_30s ^ c_24s ^ c_22s), 1u);
+  const u32 c_39s = hc_rotl32_S ((c_36s ^ c_31s ^ c_25s ^ c_23s), 1u);
+  const u32 c_40s = hc_rotl32_S ((c_37s ^ c_32s ^ c_26s ^ c_24s), 1u);
+  const u32 c_41s = hc_rotl32_S ((c_38s ^ c_33s ^ c_27s ^ c_25s), 1u);
+  const u32 c_42s = hc_rotl32_S ((c_39s ^ c_34s ^ c_28s ^ c_26s), 1u);
+  const u32 c_43s = hc_rotl32_S ((c_40s ^ c_35s ^ c_29s ^ c_27s), 1u);
+  const u32 c_44s = hc_rotl32_S ((c_41s ^ c_36s ^ c_30s ^ c_28s), 1u);
+  const u32 c_45s = hc_rotl32_S ((c_42s ^ c_37s ^ c_31s ^ c_29s), 1u);
+  const u32 c_46s = hc_rotl32_S ((c_43s ^ c_38s ^ c_32s ^ c_30s), 1u);
+  const u32 c_47s = hc_rotl32_S ((c_44s ^ c_39s ^ c_33s ^ c_31s), 1u);
+  const u32 c_48s = hc_rotl32_S ((c_45s ^ c_40s ^ c_34s ^ c_32s), 1u);
+  const u32 c_49s = hc_rotl32_S ((c_46s ^ c_41s ^ c_35s ^ c_33s), 1u);
+  const u32 c_50s = hc_rotl32_S ((c_47s ^ c_42s ^ c_36s ^ c_34s), 1u);
+  const u32 c_51s = hc_rotl32_S ((c_48s ^ c_43s ^ c_37s ^ c_35s), 1u);
+  const u32 c_52s = hc_rotl32_S ((c_49s ^ c_44s ^ c_38s ^ c_36s), 1u);
+  const u32 c_53s = hc_rotl32_S ((c_50s ^ c_45s ^ c_39s ^ c_37s), 1u);
+  const u32 c_54s = hc_rotl32_S ((c_51s ^ c_46s ^ c_40s ^ c_38s), 1u);
+  const u32 c_55s = hc_rotl32_S ((c_52s ^ c_47s ^ c_41s ^ c_39s), 1u);
+  const u32 c_56s = hc_rotl32_S ((c_53s ^ c_48s ^ c_42s ^ c_40s), 1u);
+  const u32 c_57s = hc_rotl32_S ((c_54s ^ c_49s ^ c_43s ^ c_41s), 1u);
+  const u32 c_58s = hc_rotl32_S ((c_55s ^ c_50s ^ c_44s ^ c_42s), 1u);
+  const u32 c_59s = hc_rotl32_S ((c_56s ^ c_51s ^ c_45s ^ c_43s), 1u);
+  const u32 c_60s = hc_rotl32_S ((c_57s ^ c_52s ^ c_46s ^ c_44s), 1u);
+  const u32 c_61s = hc_rotl32_S ((c_58s ^ c_53s ^ c_47s ^ c_45s), 1u);
+  const u32 c_62s = hc_rotl32_S ((c_59s ^ c_54s ^ c_48s ^ c_46s), 1u);
+  const u32 c_63s = hc_rotl32_S ((c_60s ^ c_55s ^ c_49s ^ c_47s), 1u);
+  const u32 c_64s = hc_rotl32_S ((c_61s ^ c_56s ^ c_50s ^ c_48s), 1u);
+  const u32 c_65s = hc_rotl32_S ((c_62s ^ c_57s ^ c_51s ^ c_49s), 1u);
+  const u32 c_66s = hc_rotl32_S ((c_63s ^ c_58s ^ c_52s ^ c_50s), 1u);
+  const u32 c_67s = hc_rotl32_S ((c_64s ^ c_59s ^ c_53s ^ c_51s), 1u);
+  const u32 c_68s = hc_rotl32_S ((c_65s ^ c_60s ^ c_54s ^ c_52s), 1u);
+  const u32 c_69s = hc_rotl32_S ((c_66s ^ c_61s ^ c_55s ^ c_53s), 1u);
+  const u32 c_70s = hc_rotl32_S ((c_67s ^ c_62s ^ c_56s ^ c_54s), 1u);
+  const u32 c_71s = hc_rotl32_S ((c_68s ^ c_63s ^ c_57s ^ c_55s), 1u);
+  const u32 c_72s = hc_rotl32_S ((c_69s ^ c_64s ^ c_58s ^ c_56s), 1u);
+  const u32 c_73s = hc_rotl32_S ((c_70s ^ c_65s ^ c_59s ^ c_57s), 1u);
+  const u32 c_74s = hc_rotl32_S ((c_71s ^ c_66s ^ c_60s ^ c_58s), 1u);
+  const u32 c_75s = hc_rotl32_S ((c_72s ^ c_67s ^ c_61s ^ c_59s), 1u);
+
+  const u32 c_17sK = c_17s + SHA1C00;
+  const u32 c_18sK = c_18s + SHA1C00;
+  const u32 c_20sK = c_20s + SHA1C01;
+  const u32 c_21sK = c_21s + SHA1C01;
+  const u32 c_23sK = c_23s + SHA1C01;
+  const u32 c_26sK = c_26s + SHA1C01;
+  const u32 c_27sK = c_27s + SHA1C01;
+  const u32 c_29sK = c_29s + SHA1C01;
+  const u32 c_33sK = c_33s + SHA1C01;
+  const u32 c_39sK = c_39s + SHA1C01;
+  const u32 c_41sK = c_41s + SHA1C02;
+  const u32 c_45sK = c_45s + SHA1C02;
+  const u32 c_53sK = c_53s + SHA1C02;
+  const u32 c_65sK = c_65s + SHA1C03;
+  const u32 c_69sK = c_69s + SHA1C03;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x w0s01 = hc_rotl32 (w0, 1u);
+    const u32x w0s02 = hc_rotl32 (w0, 2u);
+    const u32x w0s03 = hc_rotl32 (w0, 3u);
+    const u32x w0s04 = hc_rotl32 (w0, 4u);
+    const u32x w0s05 = hc_rotl32 (w0, 5u);
+    const u32x w0s06 = hc_rotl32 (w0, 6u);
+    const u32x w0s07 = hc_rotl32 (w0, 7u);
+    const u32x w0s08 = hc_rotl32 (w0, 8u);
+    const u32x w0s09 = hc_rotl32 (w0, 9u);
+    const u32x w0s10 = hc_rotl32 (w0, 10u);
+    const u32x w0s11 = hc_rotl32 (w0, 11u);
+    const u32x w0s12 = hc_rotl32 (w0, 12u);
+    const u32x w0s13 = hc_rotl32 (w0, 13u);
+    const u32x w0s14 = hc_rotl32 (w0, 14u);
+    const u32x w0s15 = hc_rotl32 (w0, 15u);
+    const u32x w0s16 = hc_rotl32 (w0, 16u);
+    const u32x w0s17 = hc_rotl32 (w0, 17u);
+    const u32x w0s18 = hc_rotl32 (w0, 18u);
+    const u32x w0s19 = hc_rotl32 (w0, 19u);
+    const u32x w0s20 = hc_rotl32 (w0, 20u);
+
+    const u32x w0s04___w0s06 = w0s04 ^ w0s06;
+    const u32x w0s04___w0s08 = w0s04 ^ w0s08;
+    const u32x w0s08___w0s12 = w0s08 ^ w0s12;
+    const u32x w0s04___w0s06___w0s07 = w0s04___w0s06 ^ w0s07;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 1]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 2]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 3]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 4]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[ 5]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 6]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 7]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 8]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 9]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[10]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[11]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[12]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[13]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[14]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[15]);
+
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, (c_16s ^ w0s01));
+    SHA1_STEPX(SHA1_F0o, d, e, a, b, c, (c_17sK));
+    SHA1_STEPX(SHA1_F0o, c, d, e, a, b, (c_18sK));
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, (c_19s ^ w0s02));
+
+    #undef K
+    #define K SHA1C01
+
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_20sK));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_21sK));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_22s ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_23sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_24s ^ w0s02));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_25s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_26sK));
+    SHA1_STEPX(SHA1_F1 , d, e, a, b, c, (c_27sK));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_28s ^ w0s05));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_29sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_30s ^ w0s02 ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_31s ^ w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_32s ^ w0s02 ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_33sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_34s ^ w0s07));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_35s ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_36s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_37s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_38s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_39sK));
+
+    #undef K
+    #define K SHA1C02
+
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_40s ^ w0s04 ^ w0s09));
+    SHA1_STEPX(SHA1_F2o, e, a, b, c, d, (c_41sK));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_42s ^ w0s06 ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_43s ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_44s ^ w0s03 ^ w0s06 ^ w0s07));
+    SHA1_STEPX(SHA1_F2o, a, b, c, d, e, (c_45sK));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_46s ^ w0s04 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_47s ^ w0s04___w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_48s ^ w0s03 ^ w0s04___w0s08 ^ w0s05 ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_49s ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_50s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_51s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_52s ^ w0s04___w0s08 ^ w0s13));
+    SHA1_STEPX(SHA1_F2o, c, d, e, a, b, (c_53sK));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_54s ^ w0s07 ^ w0s10 ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_55s ^ w0s14));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_56s ^ w0s04___w0s06___w0s07 ^ w0s10 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_57s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_58s ^ w0s04___w0s08 ^ w0s15));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_59s ^ w0s08___w0s12));
+
+    #undef K
+    #define K SHA1C03
+
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_60s ^ w0s04 ^ w0s08___w0s12 ^ w0s07 ^ w0s14));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_61s ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_62s ^ w0s04___w0s06 ^ w0s08___w0s12));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_63s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_64s ^ w0s04___w0s06___w0s07 ^ w0s08___w0s12 ^ w0s17));
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_65sK));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_66s ^ w0s14 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_67s ^ w0s08 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_68s ^ w0s11 ^ w0s14 ^ w0s15));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_69sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_70s ^ w0s12 ^ w0s19));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_71s ^ w0s12 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_72s ^ w0s05 ^ w0s11 ^ w0s12 ^ w0s13 ^ w0s16 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_73s ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_74s ^ w0s08 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_75s ^ w0s06 ^ w0s12 ^ w0s14));
+
+    const u32x c_76s = hc_rotl32 ((c_73s ^ c_68s ^ c_62s ^ c_60s), 1u);
+    const u32x c_77s = hc_rotl32 ((c_74s ^ c_69s ^ c_63s ^ c_61s), 1u);
+    const u32x c_78s = hc_rotl32 ((c_75s ^ c_70s ^ c_64s ^ c_62s), 1u);
+    const u32x c_79s = hc_rotl32 ((c_76s ^ c_71s ^ c_65s ^ c_63s), 1u);
+
+    const u32x w0s21 = hc_rotl32 (w0, 21u);
+    const u32x w0s22 = hc_rotl32 (w0, 22U);
+
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_76s ^ w0s07 ^ w0s08___w0s12 ^ w0s16 ^ w0s21));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_77s));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_78s ^ w0s07 ^ w0s08 ^ w0s15 ^ w0s18 ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_79s ^ w0s08 ^ w0s22));
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_m04 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23002m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23002_m08 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23002m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23002_m16 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23002m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23002_s04 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23002s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23002_s08 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23002s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23002_s16 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23002s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}

--- a/OpenCL/m23002_a3-pure.cl
+++ b/OpenCL/m23002_a3-pure.cl
@@ -1,0 +1,537 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23002_mxx (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx;
+
+    sha1_init_vector (&ctx);
+
+    sha1_update_vector (&ctx, w, pw_len);
+
+    sha1_final_vector (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23002_sxx (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx;
+
+    sha1_init_vector (&ctx);
+
+    sha1_update_vector (&ctx, w, pw_len);
+
+    sha1_final_vector (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[6]; // 5 + 1 = 6 (20 bytes + 4 bytes = 24 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 52
+
+    u32 ks[KEYLEN];
+
+    AES192_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes192_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23003_a0-optimized.cl
+++ b/OpenCL/m23003_a0-optimized.cl
@@ -1,0 +1,805 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp_optimized.h"
+#include "inc_rp_optimized.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23003_m04 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_m08 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23003_m16 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23003_s04 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_s08 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23003_s16 (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+}

--- a/OpenCL/m23003_a0-pure.cl
+++ b/OpenCL/m23003_a0-pure.cl
@@ -1,0 +1,521 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp.h"
+#include "inc_rp.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23003_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_sxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23003_a1-optimized.cl
+++ b/OpenCL/m23003_a1-optimized.cl
@@ -1,0 +1,919 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23003_m04 (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_m08 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23003_m16 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23003_s04 (KERN_ATTR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_s08 (KERN_ATTR_ESALT (securezip_t))
+{
+}
+
+KERNEL_FQ void m23003_s16 (KERN_ATTR_ESALT (securezip_t))
+{
+}

--- a/OpenCL/m23003_a1-pure.cl
+++ b/OpenCL/m23003_a1-pure.cl
@@ -1,0 +1,515 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23003_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_sxx (KERN_ATTR_RULES_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m23003_a3-optimized.cl
+++ b/OpenCL/m23003_a3-optimized.cl
@@ -1,0 +1,1389 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+DECLSPEC void m23003m (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a *s_te2, SHM_TYPE u32a *s_te3, SHM_TYPE u32a *s_te4, SHM_TYPE u32a *s_td0, SHM_TYPE u32a *s_td1, SHM_TYPE u32a *s_td2, SHM_TYPE u32a *s_td3, SHM_TYPE u32a *s_td4, u32 *w, const u32 pw_len, KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  /**
+   * base
+   */
+
+  const u32 c_16s = hc_rotl32_S ((w[13] ^ w[ 8] ^ w[ 2]        ), 1u);
+  const u32 c_17s = hc_rotl32_S ((w[14] ^ w[ 9] ^ w[ 3] ^ w[ 1]), 1u);
+  const u32 c_18s = hc_rotl32_S ((w[15] ^ w[10] ^ w[ 4] ^ w[ 2]), 1u);
+  const u32 c_19s = hc_rotl32_S ((c_16s ^ w[11] ^ w[ 5] ^ w[ 3]), 1u);
+  const u32 c_20s = hc_rotl32_S ((c_17s ^ w[12] ^ w[ 6] ^ w[ 4]), 1u);
+  const u32 c_21s = hc_rotl32_S ((c_18s ^ w[13] ^ w[ 7] ^ w[ 5]), 1u);
+  const u32 c_22s = hc_rotl32_S ((c_19s ^ w[14] ^ w[ 8] ^ w[ 6]), 1u);
+  const u32 c_23s = hc_rotl32_S ((c_20s ^ w[15] ^ w[ 9] ^ w[ 7]), 1u);
+  const u32 c_24s = hc_rotl32_S ((c_21s ^ c_16s ^ w[10] ^ w[ 8]), 1u);
+  const u32 c_25s = hc_rotl32_S ((c_22s ^ c_17s ^ w[11] ^ w[ 9]), 1u);
+  const u32 c_26s = hc_rotl32_S ((c_23s ^ c_18s ^ w[12] ^ w[10]), 1u);
+  const u32 c_27s = hc_rotl32_S ((c_24s ^ c_19s ^ w[13] ^ w[11]), 1u);
+  const u32 c_28s = hc_rotl32_S ((c_25s ^ c_20s ^ w[14] ^ w[12]), 1u);
+  const u32 c_29s = hc_rotl32_S ((c_26s ^ c_21s ^ w[15] ^ w[13]), 1u);
+  const u32 c_30s = hc_rotl32_S ((c_27s ^ c_22s ^ c_16s ^ w[14]), 1u);
+  const u32 c_31s = hc_rotl32_S ((c_28s ^ c_23s ^ c_17s ^ w[15]), 1u);
+  const u32 c_32s = hc_rotl32_S ((c_29s ^ c_24s ^ c_18s ^ c_16s), 1u);
+  const u32 c_33s = hc_rotl32_S ((c_30s ^ c_25s ^ c_19s ^ c_17s), 1u);
+  const u32 c_34s = hc_rotl32_S ((c_31s ^ c_26s ^ c_20s ^ c_18s), 1u);
+  const u32 c_35s = hc_rotl32_S ((c_32s ^ c_27s ^ c_21s ^ c_19s), 1u);
+  const u32 c_36s = hc_rotl32_S ((c_33s ^ c_28s ^ c_22s ^ c_20s), 1u);
+  const u32 c_37s = hc_rotl32_S ((c_34s ^ c_29s ^ c_23s ^ c_21s), 1u);
+  const u32 c_38s = hc_rotl32_S ((c_35s ^ c_30s ^ c_24s ^ c_22s), 1u);
+  const u32 c_39s = hc_rotl32_S ((c_36s ^ c_31s ^ c_25s ^ c_23s), 1u);
+  const u32 c_40s = hc_rotl32_S ((c_37s ^ c_32s ^ c_26s ^ c_24s), 1u);
+  const u32 c_41s = hc_rotl32_S ((c_38s ^ c_33s ^ c_27s ^ c_25s), 1u);
+  const u32 c_42s = hc_rotl32_S ((c_39s ^ c_34s ^ c_28s ^ c_26s), 1u);
+  const u32 c_43s = hc_rotl32_S ((c_40s ^ c_35s ^ c_29s ^ c_27s), 1u);
+  const u32 c_44s = hc_rotl32_S ((c_41s ^ c_36s ^ c_30s ^ c_28s), 1u);
+  const u32 c_45s = hc_rotl32_S ((c_42s ^ c_37s ^ c_31s ^ c_29s), 1u);
+  const u32 c_46s = hc_rotl32_S ((c_43s ^ c_38s ^ c_32s ^ c_30s), 1u);
+  const u32 c_47s = hc_rotl32_S ((c_44s ^ c_39s ^ c_33s ^ c_31s), 1u);
+  const u32 c_48s = hc_rotl32_S ((c_45s ^ c_40s ^ c_34s ^ c_32s), 1u);
+  const u32 c_49s = hc_rotl32_S ((c_46s ^ c_41s ^ c_35s ^ c_33s), 1u);
+  const u32 c_50s = hc_rotl32_S ((c_47s ^ c_42s ^ c_36s ^ c_34s), 1u);
+  const u32 c_51s = hc_rotl32_S ((c_48s ^ c_43s ^ c_37s ^ c_35s), 1u);
+  const u32 c_52s = hc_rotl32_S ((c_49s ^ c_44s ^ c_38s ^ c_36s), 1u);
+  const u32 c_53s = hc_rotl32_S ((c_50s ^ c_45s ^ c_39s ^ c_37s), 1u);
+  const u32 c_54s = hc_rotl32_S ((c_51s ^ c_46s ^ c_40s ^ c_38s), 1u);
+  const u32 c_55s = hc_rotl32_S ((c_52s ^ c_47s ^ c_41s ^ c_39s), 1u);
+  const u32 c_56s = hc_rotl32_S ((c_53s ^ c_48s ^ c_42s ^ c_40s), 1u);
+  const u32 c_57s = hc_rotl32_S ((c_54s ^ c_49s ^ c_43s ^ c_41s), 1u);
+  const u32 c_58s = hc_rotl32_S ((c_55s ^ c_50s ^ c_44s ^ c_42s), 1u);
+  const u32 c_59s = hc_rotl32_S ((c_56s ^ c_51s ^ c_45s ^ c_43s), 1u);
+  const u32 c_60s = hc_rotl32_S ((c_57s ^ c_52s ^ c_46s ^ c_44s), 1u);
+  const u32 c_61s = hc_rotl32_S ((c_58s ^ c_53s ^ c_47s ^ c_45s), 1u);
+  const u32 c_62s = hc_rotl32_S ((c_59s ^ c_54s ^ c_48s ^ c_46s), 1u);
+  const u32 c_63s = hc_rotl32_S ((c_60s ^ c_55s ^ c_49s ^ c_47s), 1u);
+  const u32 c_64s = hc_rotl32_S ((c_61s ^ c_56s ^ c_50s ^ c_48s), 1u);
+  const u32 c_65s = hc_rotl32_S ((c_62s ^ c_57s ^ c_51s ^ c_49s), 1u);
+  const u32 c_66s = hc_rotl32_S ((c_63s ^ c_58s ^ c_52s ^ c_50s), 1u);
+  const u32 c_67s = hc_rotl32_S ((c_64s ^ c_59s ^ c_53s ^ c_51s), 1u);
+  const u32 c_68s = hc_rotl32_S ((c_65s ^ c_60s ^ c_54s ^ c_52s), 1u);
+  const u32 c_69s = hc_rotl32_S ((c_66s ^ c_61s ^ c_55s ^ c_53s), 1u);
+  const u32 c_70s = hc_rotl32_S ((c_67s ^ c_62s ^ c_56s ^ c_54s), 1u);
+  const u32 c_71s = hc_rotl32_S ((c_68s ^ c_63s ^ c_57s ^ c_55s), 1u);
+  const u32 c_72s = hc_rotl32_S ((c_69s ^ c_64s ^ c_58s ^ c_56s), 1u);
+  const u32 c_73s = hc_rotl32_S ((c_70s ^ c_65s ^ c_59s ^ c_57s), 1u);
+  const u32 c_74s = hc_rotl32_S ((c_71s ^ c_66s ^ c_60s ^ c_58s), 1u);
+  const u32 c_75s = hc_rotl32_S ((c_72s ^ c_67s ^ c_61s ^ c_59s), 1u);
+
+  const u32 c_17sK = c_17s + SHA1C00;
+  const u32 c_18sK = c_18s + SHA1C00;
+  const u32 c_20sK = c_20s + SHA1C01;
+  const u32 c_21sK = c_21s + SHA1C01;
+  const u32 c_23sK = c_23s + SHA1C01;
+  const u32 c_26sK = c_26s + SHA1C01;
+  const u32 c_27sK = c_27s + SHA1C01;
+  const u32 c_29sK = c_29s + SHA1C01;
+  const u32 c_33sK = c_33s + SHA1C01;
+  const u32 c_39sK = c_39s + SHA1C01;
+  const u32 c_41sK = c_41s + SHA1C02;
+  const u32 c_45sK = c_45s + SHA1C02;
+  const u32 c_53sK = c_53s + SHA1C02;
+  const u32 c_65sK = c_65s + SHA1C03;
+  const u32 c_69sK = c_69s + SHA1C03;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x w0s01 = hc_rotl32 (w0, 1u);
+    const u32x w0s02 = hc_rotl32 (w0, 2u);
+    const u32x w0s03 = hc_rotl32 (w0, 3u);
+    const u32x w0s04 = hc_rotl32 (w0, 4u);
+    const u32x w0s05 = hc_rotl32 (w0, 5u);
+    const u32x w0s06 = hc_rotl32 (w0, 6u);
+    const u32x w0s07 = hc_rotl32 (w0, 7u);
+    const u32x w0s08 = hc_rotl32 (w0, 8u);
+    const u32x w0s09 = hc_rotl32 (w0, 9u);
+    const u32x w0s10 = hc_rotl32 (w0, 10u);
+    const u32x w0s11 = hc_rotl32 (w0, 11u);
+    const u32x w0s12 = hc_rotl32 (w0, 12u);
+    const u32x w0s13 = hc_rotl32 (w0, 13u);
+    const u32x w0s14 = hc_rotl32 (w0, 14u);
+    const u32x w0s15 = hc_rotl32 (w0, 15u);
+    const u32x w0s16 = hc_rotl32 (w0, 16u);
+    const u32x w0s17 = hc_rotl32 (w0, 17u);
+    const u32x w0s18 = hc_rotl32 (w0, 18u);
+    const u32x w0s19 = hc_rotl32 (w0, 19u);
+    const u32x w0s20 = hc_rotl32 (w0, 20u);
+
+    const u32x w0s04___w0s06 = w0s04 ^ w0s06;
+    const u32x w0s04___w0s08 = w0s04 ^ w0s08;
+    const u32x w0s08___w0s12 = w0s08 ^ w0s12;
+    const u32x w0s04___w0s06___w0s07 = w0s04___w0s06 ^ w0s07;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 1]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 2]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 3]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 4]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[ 5]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 6]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 7]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 8]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 9]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[10]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[11]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[12]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[13]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[14]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[15]);
+
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, (c_16s ^ w0s01));
+    SHA1_STEPX(SHA1_F0o, d, e, a, b, c, (c_17sK));
+    SHA1_STEPX(SHA1_F0o, c, d, e, a, b, (c_18sK));
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, (c_19s ^ w0s02));
+
+    #undef K
+    #define K SHA1C01
+
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_20sK));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_21sK));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_22s ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_23sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_24s ^ w0s02));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_25s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_26sK));
+    SHA1_STEPX(SHA1_F1 , d, e, a, b, c, (c_27sK));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_28s ^ w0s05));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_29sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_30s ^ w0s02 ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_31s ^ w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_32s ^ w0s02 ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_33sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_34s ^ w0s07));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_35s ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_36s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_37s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_38s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_39sK));
+
+    #undef K
+    #define K SHA1C02
+
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_40s ^ w0s04 ^ w0s09));
+    SHA1_STEPX(SHA1_F2o, e, a, b, c, d, (c_41sK));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_42s ^ w0s06 ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_43s ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_44s ^ w0s03 ^ w0s06 ^ w0s07));
+    SHA1_STEPX(SHA1_F2o, a, b, c, d, e, (c_45sK));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_46s ^ w0s04 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_47s ^ w0s04___w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_48s ^ w0s03 ^ w0s04___w0s08 ^ w0s05 ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_49s ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_50s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_51s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_52s ^ w0s04___w0s08 ^ w0s13));
+    SHA1_STEPX(SHA1_F2o, c, d, e, a, b, (c_53sK));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_54s ^ w0s07 ^ w0s10 ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_55s ^ w0s14));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_56s ^ w0s04___w0s06___w0s07 ^ w0s10 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_57s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_58s ^ w0s04___w0s08 ^ w0s15));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_59s ^ w0s08___w0s12));
+
+    #undef K
+    #define K SHA1C03
+
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_60s ^ w0s04 ^ w0s08___w0s12 ^ w0s07 ^ w0s14));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_61s ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_62s ^ w0s04___w0s06 ^ w0s08___w0s12));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_63s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_64s ^ w0s04___w0s06___w0s07 ^ w0s08___w0s12 ^ w0s17));
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_65sK));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_66s ^ w0s14 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_67s ^ w0s08 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_68s ^ w0s11 ^ w0s14 ^ w0s15));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_69sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_70s ^ w0s12 ^ w0s19));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_71s ^ w0s12 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_72s ^ w0s05 ^ w0s11 ^ w0s12 ^ w0s13 ^ w0s16 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_73s ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_74s ^ w0s08 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_75s ^ w0s06 ^ w0s12 ^ w0s14));
+
+    const u32x c_76s = hc_rotl32 ((c_73s ^ c_68s ^ c_62s ^ c_60s), 1u);
+    const u32x c_77s = hc_rotl32 ((c_74s ^ c_69s ^ c_63s ^ c_61s), 1u);
+    const u32x c_78s = hc_rotl32 ((c_75s ^ c_70s ^ c_64s ^ c_62s), 1u);
+    const u32x c_79s = hc_rotl32 ((c_76s ^ c_71s ^ c_65s ^ c_63s), 1u);
+
+    const u32x w0s21 = hc_rotl32 (w0, 21u);
+    const u32x w0s22 = hc_rotl32 (w0, 22U);
+
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_76s ^ w0s07 ^ w0s08___w0s12 ^ w0s16 ^ w0s21));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_77s));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_78s ^ w0s07 ^ w0s08 ^ w0s15 ^ w0s18 ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_79s ^ w0s08 ^ w0s22));
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+DECLSPEC void m23003s (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a *s_te2, SHM_TYPE u32a *s_te3, SHM_TYPE u32a *s_te4, SHM_TYPE u32a *s_td0, SHM_TYPE u32a *s_td1, SHM_TYPE u32a *s_td2, SHM_TYPE u32a *s_td3, SHM_TYPE u32a *s_td4, u32 *w, const u32 pw_len, KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  /**
+   * base
+   */
+
+  const u32 c_16s = hc_rotl32_S ((w[13] ^ w[ 8] ^ w[ 2]        ), 1u);
+  const u32 c_17s = hc_rotl32_S ((w[14] ^ w[ 9] ^ w[ 3] ^ w[ 1]), 1u);
+  const u32 c_18s = hc_rotl32_S ((w[15] ^ w[10] ^ w[ 4] ^ w[ 2]), 1u);
+  const u32 c_19s = hc_rotl32_S ((c_16s ^ w[11] ^ w[ 5] ^ w[ 3]), 1u);
+  const u32 c_20s = hc_rotl32_S ((c_17s ^ w[12] ^ w[ 6] ^ w[ 4]), 1u);
+  const u32 c_21s = hc_rotl32_S ((c_18s ^ w[13] ^ w[ 7] ^ w[ 5]), 1u);
+  const u32 c_22s = hc_rotl32_S ((c_19s ^ w[14] ^ w[ 8] ^ w[ 6]), 1u);
+  const u32 c_23s = hc_rotl32_S ((c_20s ^ w[15] ^ w[ 9] ^ w[ 7]), 1u);
+  const u32 c_24s = hc_rotl32_S ((c_21s ^ c_16s ^ w[10] ^ w[ 8]), 1u);
+  const u32 c_25s = hc_rotl32_S ((c_22s ^ c_17s ^ w[11] ^ w[ 9]), 1u);
+  const u32 c_26s = hc_rotl32_S ((c_23s ^ c_18s ^ w[12] ^ w[10]), 1u);
+  const u32 c_27s = hc_rotl32_S ((c_24s ^ c_19s ^ w[13] ^ w[11]), 1u);
+  const u32 c_28s = hc_rotl32_S ((c_25s ^ c_20s ^ w[14] ^ w[12]), 1u);
+  const u32 c_29s = hc_rotl32_S ((c_26s ^ c_21s ^ w[15] ^ w[13]), 1u);
+  const u32 c_30s = hc_rotl32_S ((c_27s ^ c_22s ^ c_16s ^ w[14]), 1u);
+  const u32 c_31s = hc_rotl32_S ((c_28s ^ c_23s ^ c_17s ^ w[15]), 1u);
+  const u32 c_32s = hc_rotl32_S ((c_29s ^ c_24s ^ c_18s ^ c_16s), 1u);
+  const u32 c_33s = hc_rotl32_S ((c_30s ^ c_25s ^ c_19s ^ c_17s), 1u);
+  const u32 c_34s = hc_rotl32_S ((c_31s ^ c_26s ^ c_20s ^ c_18s), 1u);
+  const u32 c_35s = hc_rotl32_S ((c_32s ^ c_27s ^ c_21s ^ c_19s), 1u);
+  const u32 c_36s = hc_rotl32_S ((c_33s ^ c_28s ^ c_22s ^ c_20s), 1u);
+  const u32 c_37s = hc_rotl32_S ((c_34s ^ c_29s ^ c_23s ^ c_21s), 1u);
+  const u32 c_38s = hc_rotl32_S ((c_35s ^ c_30s ^ c_24s ^ c_22s), 1u);
+  const u32 c_39s = hc_rotl32_S ((c_36s ^ c_31s ^ c_25s ^ c_23s), 1u);
+  const u32 c_40s = hc_rotl32_S ((c_37s ^ c_32s ^ c_26s ^ c_24s), 1u);
+  const u32 c_41s = hc_rotl32_S ((c_38s ^ c_33s ^ c_27s ^ c_25s), 1u);
+  const u32 c_42s = hc_rotl32_S ((c_39s ^ c_34s ^ c_28s ^ c_26s), 1u);
+  const u32 c_43s = hc_rotl32_S ((c_40s ^ c_35s ^ c_29s ^ c_27s), 1u);
+  const u32 c_44s = hc_rotl32_S ((c_41s ^ c_36s ^ c_30s ^ c_28s), 1u);
+  const u32 c_45s = hc_rotl32_S ((c_42s ^ c_37s ^ c_31s ^ c_29s), 1u);
+  const u32 c_46s = hc_rotl32_S ((c_43s ^ c_38s ^ c_32s ^ c_30s), 1u);
+  const u32 c_47s = hc_rotl32_S ((c_44s ^ c_39s ^ c_33s ^ c_31s), 1u);
+  const u32 c_48s = hc_rotl32_S ((c_45s ^ c_40s ^ c_34s ^ c_32s), 1u);
+  const u32 c_49s = hc_rotl32_S ((c_46s ^ c_41s ^ c_35s ^ c_33s), 1u);
+  const u32 c_50s = hc_rotl32_S ((c_47s ^ c_42s ^ c_36s ^ c_34s), 1u);
+  const u32 c_51s = hc_rotl32_S ((c_48s ^ c_43s ^ c_37s ^ c_35s), 1u);
+  const u32 c_52s = hc_rotl32_S ((c_49s ^ c_44s ^ c_38s ^ c_36s), 1u);
+  const u32 c_53s = hc_rotl32_S ((c_50s ^ c_45s ^ c_39s ^ c_37s), 1u);
+  const u32 c_54s = hc_rotl32_S ((c_51s ^ c_46s ^ c_40s ^ c_38s), 1u);
+  const u32 c_55s = hc_rotl32_S ((c_52s ^ c_47s ^ c_41s ^ c_39s), 1u);
+  const u32 c_56s = hc_rotl32_S ((c_53s ^ c_48s ^ c_42s ^ c_40s), 1u);
+  const u32 c_57s = hc_rotl32_S ((c_54s ^ c_49s ^ c_43s ^ c_41s), 1u);
+  const u32 c_58s = hc_rotl32_S ((c_55s ^ c_50s ^ c_44s ^ c_42s), 1u);
+  const u32 c_59s = hc_rotl32_S ((c_56s ^ c_51s ^ c_45s ^ c_43s), 1u);
+  const u32 c_60s = hc_rotl32_S ((c_57s ^ c_52s ^ c_46s ^ c_44s), 1u);
+  const u32 c_61s = hc_rotl32_S ((c_58s ^ c_53s ^ c_47s ^ c_45s), 1u);
+  const u32 c_62s = hc_rotl32_S ((c_59s ^ c_54s ^ c_48s ^ c_46s), 1u);
+  const u32 c_63s = hc_rotl32_S ((c_60s ^ c_55s ^ c_49s ^ c_47s), 1u);
+  const u32 c_64s = hc_rotl32_S ((c_61s ^ c_56s ^ c_50s ^ c_48s), 1u);
+  const u32 c_65s = hc_rotl32_S ((c_62s ^ c_57s ^ c_51s ^ c_49s), 1u);
+  const u32 c_66s = hc_rotl32_S ((c_63s ^ c_58s ^ c_52s ^ c_50s), 1u);
+  const u32 c_67s = hc_rotl32_S ((c_64s ^ c_59s ^ c_53s ^ c_51s), 1u);
+  const u32 c_68s = hc_rotl32_S ((c_65s ^ c_60s ^ c_54s ^ c_52s), 1u);
+  const u32 c_69s = hc_rotl32_S ((c_66s ^ c_61s ^ c_55s ^ c_53s), 1u);
+  const u32 c_70s = hc_rotl32_S ((c_67s ^ c_62s ^ c_56s ^ c_54s), 1u);
+  const u32 c_71s = hc_rotl32_S ((c_68s ^ c_63s ^ c_57s ^ c_55s), 1u);
+  const u32 c_72s = hc_rotl32_S ((c_69s ^ c_64s ^ c_58s ^ c_56s), 1u);
+  const u32 c_73s = hc_rotl32_S ((c_70s ^ c_65s ^ c_59s ^ c_57s), 1u);
+  const u32 c_74s = hc_rotl32_S ((c_71s ^ c_66s ^ c_60s ^ c_58s), 1u);
+  const u32 c_75s = hc_rotl32_S ((c_72s ^ c_67s ^ c_61s ^ c_59s), 1u);
+
+  const u32 c_17sK = c_17s + SHA1C00;
+  const u32 c_18sK = c_18s + SHA1C00;
+  const u32 c_20sK = c_20s + SHA1C01;
+  const u32 c_21sK = c_21s + SHA1C01;
+  const u32 c_23sK = c_23s + SHA1C01;
+  const u32 c_26sK = c_26s + SHA1C01;
+  const u32 c_27sK = c_27s + SHA1C01;
+  const u32 c_29sK = c_29s + SHA1C01;
+  const u32 c_33sK = c_33s + SHA1C01;
+  const u32 c_39sK = c_39s + SHA1C01;
+  const u32 c_41sK = c_41s + SHA1C02;
+  const u32 c_45sK = c_45s + SHA1C02;
+  const u32 c_53sK = c_53s + SHA1C02;
+  const u32 c_65sK = c_65s + SHA1C03;
+  const u32 c_69sK = c_69s + SHA1C03;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    const u32x w0s01 = hc_rotl32 (w0, 1u);
+    const u32x w0s02 = hc_rotl32 (w0, 2u);
+    const u32x w0s03 = hc_rotl32 (w0, 3u);
+    const u32x w0s04 = hc_rotl32 (w0, 4u);
+    const u32x w0s05 = hc_rotl32 (w0, 5u);
+    const u32x w0s06 = hc_rotl32 (w0, 6u);
+    const u32x w0s07 = hc_rotl32 (w0, 7u);
+    const u32x w0s08 = hc_rotl32 (w0, 8u);
+    const u32x w0s09 = hc_rotl32 (w0, 9u);
+    const u32x w0s10 = hc_rotl32 (w0, 10u);
+    const u32x w0s11 = hc_rotl32 (w0, 11u);
+    const u32x w0s12 = hc_rotl32 (w0, 12u);
+    const u32x w0s13 = hc_rotl32 (w0, 13u);
+    const u32x w0s14 = hc_rotl32 (w0, 14u);
+    const u32x w0s15 = hc_rotl32 (w0, 15u);
+    const u32x w0s16 = hc_rotl32 (w0, 16u);
+    const u32x w0s17 = hc_rotl32 (w0, 17u);
+    const u32x w0s18 = hc_rotl32 (w0, 18u);
+    const u32x w0s19 = hc_rotl32 (w0, 19u);
+    const u32x w0s20 = hc_rotl32 (w0, 20u);
+
+    const u32x w0s04___w0s06 = w0s04 ^ w0s06;
+    const u32x w0s04___w0s08 = w0s04 ^ w0s08;
+    const u32x w0s08___w0s12 = w0s08 ^ w0s12;
+    const u32x w0s04___w0s06___w0s07 = w0s04___w0s06 ^ w0s07;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 1]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 2]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 3]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 4]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[ 5]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[ 6]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[ 7]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[ 8]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[ 9]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[10]);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w[11]);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w[12]);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w[13]);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w[14]);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w[15]);
+
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, (c_16s ^ w0s01));
+    SHA1_STEPX(SHA1_F0o, d, e, a, b, c, (c_17sK));
+    SHA1_STEPX(SHA1_F0o, c, d, e, a, b, (c_18sK));
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, (c_19s ^ w0s02));
+
+    #undef K
+    #define K SHA1C01
+
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_20sK));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_21sK));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_22s ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_23sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_24s ^ w0s02));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_25s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , e, a, b, c, d, (c_26sK));
+    SHA1_STEPX(SHA1_F1 , d, e, a, b, c, (c_27sK));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_28s ^ w0s05));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_29sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_30s ^ w0s02 ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_31s ^ w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_32s ^ w0s02 ^ w0s03));
+    SHA1_STEPX(SHA1_F1 , c, d, e, a, b, (c_33sK));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_34s ^ w0s07));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_35s ^ w0s04));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_36s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_37s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_38s ^ w0s04));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_39sK));
+
+    #undef K
+    #define K SHA1C02
+
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_40s ^ w0s04 ^ w0s09));
+    SHA1_STEPX(SHA1_F2o, e, a, b, c, d, (c_41sK));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_42s ^ w0s06 ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_43s ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_44s ^ w0s03 ^ w0s06 ^ w0s07));
+    SHA1_STEPX(SHA1_F2o, a, b, c, d, e, (c_45sK));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_46s ^ w0s04 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_47s ^ w0s04___w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_48s ^ w0s03 ^ w0s04___w0s08 ^ w0s05 ^ w0s10));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_49s ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_50s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_51s ^ w0s04___w0s06));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_52s ^ w0s04___w0s08 ^ w0s13));
+    SHA1_STEPX(SHA1_F2o, c, d, e, a, b, (c_53sK));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_54s ^ w0s07 ^ w0s10 ^ w0s12));
+    SHA1_STEP (SHA1_F2o, a, b, c, d, e, (c_55s ^ w0s14));
+    SHA1_STEP (SHA1_F2o, e, a, b, c, d, (c_56s ^ w0s04___w0s06___w0s07 ^ w0s10 ^ w0s11));
+    SHA1_STEP (SHA1_F2o, d, e, a, b, c, (c_57s ^ w0s08));
+    SHA1_STEP (SHA1_F2o, c, d, e, a, b, (c_58s ^ w0s04___w0s08 ^ w0s15));
+    SHA1_STEP (SHA1_F2o, b, c, d, e, a, (c_59s ^ w0s08___w0s12));
+
+    #undef K
+    #define K SHA1C03
+
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_60s ^ w0s04 ^ w0s08___w0s12 ^ w0s07 ^ w0s14));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_61s ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_62s ^ w0s04___w0s06 ^ w0s08___w0s12));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_63s ^ w0s08));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_64s ^ w0s04___w0s06___w0s07 ^ w0s08___w0s12 ^ w0s17));
+    SHA1_STEPX(SHA1_F1 , a, b, c, d, e, (c_65sK));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_66s ^ w0s14 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_67s ^ w0s08 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_68s ^ w0s11 ^ w0s14 ^ w0s15));
+    SHA1_STEPX(SHA1_F1 , b, c, d, e, a, (c_69sK));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_70s ^ w0s12 ^ w0s19));
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_71s ^ w0s12 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_72s ^ w0s05 ^ w0s11 ^ w0s12 ^ w0s13 ^ w0s16 ^ w0s18));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_73s ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_74s ^ w0s08 ^ w0s16));
+    SHA1_STEP (SHA1_F1 , a, b, c, d, e, (c_75s ^ w0s06 ^ w0s12 ^ w0s14));
+
+    const u32x c_76s = hc_rotl32 ((c_73s ^ c_68s ^ c_62s ^ c_60s), 1u);
+    const u32x c_77s = hc_rotl32 ((c_74s ^ c_69s ^ c_63s ^ c_61s), 1u);
+    const u32x c_78s = hc_rotl32 ((c_75s ^ c_70s ^ c_64s ^ c_62s), 1u);
+    const u32x c_79s = hc_rotl32 ((c_76s ^ c_71s ^ c_65s ^ c_63s), 1u);
+
+    const u32x w0s21 = hc_rotl32 (w0, 21u);
+    const u32x w0s22 = hc_rotl32 (w0, 22U);
+
+    SHA1_STEP (SHA1_F1 , e, a, b, c, d, (c_76s ^ w0s07 ^ w0s08___w0s12 ^ w0s16 ^ w0s21));
+    SHA1_STEP (SHA1_F1 , d, e, a, b, c, (c_77s));
+    SHA1_STEP (SHA1_F1 , c, d, e, a, b, (c_78s ^ w0s07 ^ w0s08 ^ w0s15 ^ w0s18 ^ w0s20));
+    SHA1_STEP (SHA1_F1 , b, c, d, e, a, (c_79s ^ w0s08 ^ w0s22));
+
+    a += SHA1M_A;
+    b += SHA1M_B;
+    c += SHA1M_C;
+    d += SHA1M_D;
+    e += SHA1M_E;
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ a;
+    t0[1] = 0x36363636 ^ b;
+    t0[2] = 0x36363636 ^ c;
+    t0[3] = 0x36363636 ^ d;
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ e;
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ a;
+    t0[1] = 0x5c5c5c5c ^ b;
+    t0[2] = 0x5c5c5c5c ^ c;
+    t0[3] = 0x5c5c5c5c ^ d;
+
+    t1[0] = 0x5c5c5c5c ^ e;
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_m04 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23003m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23003_m08 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23003m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23003_m16 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23003m (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23003_s04 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23003s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23003_s08 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23003s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}
+
+KERNEL_FQ void m23003_s16 (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  u32 w[16];
+
+  w[ 0] = pws[gid].i[ 0];
+  w[ 1] = pws[gid].i[ 1];
+  w[ 2] = pws[gid].i[ 2];
+  w[ 3] = pws[gid].i[ 3];
+  w[ 4] = pws[gid].i[ 4];
+  w[ 5] = pws[gid].i[ 5];
+  w[ 6] = pws[gid].i[ 6];
+  w[ 7] = pws[gid].i[ 7];
+  w[ 8] = pws[gid].i[ 8];
+  w[ 9] = pws[gid].i[ 9];
+  w[10] = pws[gid].i[10];
+  w[11] = pws[gid].i[11];
+  w[12] = pws[gid].i[12];
+  w[13] = pws[gid].i[13];
+  w[14] = pws[gid].i[14];
+  w[15] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m23003s (s_te0, s_te1, s_te2, s_te3, s_te4, s_td0, s_td1, s_td2, s_td3, s_td4, w, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, salt_pos, loop_pos, loop_cnt, il_cnt, digests_cnt, digests_offset, combs_mode, gid_max);
+}

--- a/OpenCL/m23003_a3-pure.cl
+++ b/OpenCL/m23003_a3-pure.cl
@@ -1,0 +1,541 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+KERNEL_FQ void m23003_mxx (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx;
+
+    sha1_init_vector (&ctx);
+
+    sha1_update_vector (&ctx, w, pw_len);
+
+    sha1_final_vector (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ void m23003_sxx (KERN_ATTR_VECTOR_ESALT (securezip_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx;
+
+    sha1_init_vector (&ctx);
+
+    sha1_update_vector (&ctx, w, pw_len);
+
+    sha1_final_vector (&ctx);
+
+    u32 t0[4];
+
+    t0[0] = 0x36363636 ^ ctx.h[0];
+    t0[1] = 0x36363636 ^ ctx.h[1];
+    t0[2] = 0x36363636 ^ ctx.h[2];
+    t0[3] = 0x36363636 ^ ctx.h[3];
+
+    u32 t1[4];
+
+    t1[0] = 0x36363636 ^ ctx.h[4];
+    t1[1] = 0x36363636;
+    t1[2] = 0x36363636;
+    t1[3] = 0x36363636;
+
+    u32 t2[4];
+
+    t2[0] = 0x36363636;
+    t2[1] = 0x36363636;
+    t2[2] = 0x36363636;
+    t2[3] = 0x36363636;
+
+    u32 t3[4];
+
+    t3[0] = 0x36363636;
+    t3[1] = 0x36363636;
+    t3[2] = 0x36363636;
+    t3[3] = 0x36363636;
+
+    u32 digest[5];
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    u32 key[8]; // 5 + 3 = 8 (20 bytes + 12 bytes = 32 bytes for the key)
+
+    key[0] = digest[0];
+    key[1] = digest[1];
+    key[2] = digest[2];
+    key[3] = digest[3];
+    key[4] = digest[4];
+
+    t0[0] = 0x5c5c5c5c ^ ctx.h[0];
+    t0[1] = 0x5c5c5c5c ^ ctx.h[1];
+    t0[2] = 0x5c5c5c5c ^ ctx.h[2];
+    t0[3] = 0x5c5c5c5c ^ ctx.h[3];
+
+    t1[0] = 0x5c5c5c5c ^ ctx.h[4];
+    t1[1] = 0x5c5c5c5c;
+    t1[2] = 0x5c5c5c5c;
+    t1[3] = 0x5c5c5c5c;
+
+    t2[0] = 0x5c5c5c5c;
+    t2[1] = 0x5c5c5c5c;
+    t2[2] = 0x5c5c5c5c;
+    t2[3] = 0x5c5c5c5c;
+
+    t3[0] = 0x5c5c5c5c;
+    t3[1] = 0x5c5c5c5c;
+    t3[2] = 0x5c5c5c5c;
+    t3[3] = 0x5c5c5c5c;
+
+    digest[0] = SHA1M_A;
+    digest[1] = SHA1M_B;
+    digest[2] = SHA1M_C;
+    digest[3] = SHA1M_D;
+    digest[4] = SHA1M_E;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    t0[0] = 0x80000000;
+    t0[1] = 0;
+    t0[2] = 0;
+    t0[3] = 0;
+
+    t1[0] = 0;
+    t1[1] = 0;
+    t1[2] = 0;
+    t1[3] = 0;
+
+    t2[0] = 0;
+    t2[1] = 0;
+    t2[2] = 0;
+    t2[3] = 0;
+
+    t3[0] = 0;
+    t3[1] = 0;
+    t3[2] = 0;
+    t3[3] = 64 * 8;
+
+    sha1_transform (t0, t1, t2, t3, digest);
+
+    key[5] = digest[0];
+    key[6] = digest[1];
+    key[7] = digest[2];
+
+    u32 iv[4];
+
+    iv[0] = esalt_bufs[digests_offset].data[28];
+    iv[1] = esalt_bufs[digests_offset].data[29];
+    iv[2] = esalt_bufs[digests_offset].data[30];
+    iv[3] = esalt_bufs[digests_offset].data[31];
+
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[32];
+    data[1] = esalt_bufs[digests_offset].data[33];
+    data[2] = esalt_bufs[digests_offset].data[34];
+    data[3] = esalt_bufs[digests_offset].data[35];
+
+    #define KEYLEN 60
+
+    u32 ks[KEYLEN];
+
+    AES256_set_decrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    out[0] ^= iv[0];
+    out[1] ^= iv[1];
+    out[2] ^= iv[2];
+    out[3] ^= iv[3];
+
+    if ((out[0] == 0x10101010) &&
+        (out[1] == 0x10101010) &&
+        (out[2] == 0x10101010) &&
+        (out[3] == 0x10101010))
+    {
+      if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -64,6 +64,9 @@
 - Added hash-mode: sha256($salt.$pass.$salt)
 - Added hash-mode: sha256(sha256_bin($pass))
 - Added hash-mode: sha256(sha256($pass).$salt)
+- Added hash-mode: SecureZIP AES-128
+- Added hash-mode: SecureZIP AES-192
+- Added hash-mode: SecureZIP AES-256
 - Added hash-mode: SolarWinds Orion
 - Added hash-mode: Telegram Desktop App Passcode (PBKDF2-HMAC-SHA1)
 - Added hash-mode: Telegram Mobile App Passcode (SHA256)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -297,6 +297,9 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - PKZIP (Uncompressed)
 - PKZIP Master Key
 - PKZIP Master Key (6 byte optimization)
+- SecureZIP AES-128
+- SecureZIP AES-192
+- SecureZIP AES-256
 - iTunes backup < 10.0
 - iTunes backup >= 10.0
 - WinZip

--- a/src/modules/module_23001.c
+++ b/src/modules/module_23001.c
@@ -1,0 +1,338 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_ARCHIVE;
+static const char *HASH_NAME      = "SecureZIP AES-128";
+static const u64   KERN_TYPE      = 23001;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_NOT_SALTED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS15;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$zip3$*0*1*128*0*b4630625c92b6e7848f6fd86*df2f62611b3d02d2c7e05a48dad57c7d93b0bac1362261ab533807afb69db856676aa6e350320130b5cbf27c55a48c0f75739654ac312f1cf5c37149557fc88a92c7e3dde8d23edd2b839036e88092a708b7e818bf1b6de92f0efb5cce184cceb11db6b3ca0527d0bdf1f1137ee6660d9890928cd80542ac1f439515519147c14d965b5ba107c6227f971e3e115170bf*0*0*0*file.txt";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+static const char *SIGNATURE_SECUREZIP = "$zip3$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (securezip_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  securezip_t *securezip = (securezip_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt   = 11;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_SECUREZIP;
+
+  token.len_min[0]  = 6;
+  token.len_max[0]  = 6;
+  token.sep[0]      = '*';
+  token.attr[0]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.len_min[1]  = 1;
+  token.len_max[1]  = 1;
+  token.sep[1]      = '*';
+  token.attr[1]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[2]  = 1;
+  token.len_max[2]  = 1;
+  token.sep[2]      = '*';
+  token.attr[2]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[3]  = 3;
+  token.len_max[3]  = 3;
+  token.sep[3]      = '*';
+  token.attr[3]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[4]  = 1;
+  token.len_max[4]  = 1;
+  token.sep[4]      = '*';
+  token.attr[4]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[5]  = 0;
+  token.len_max[5]  = 32;
+  token.sep[5]      = '*';
+  token.attr[5]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[6]  = 288;
+  token.len_max[6]  = 288;
+  token.sep[6]      = '*';
+  token.attr[6]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[7]  = 1;
+  token.len_max[7]  = 1;
+  token.sep[7]      = '*';
+  token.attr[7]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[8]  = 1;
+  token.len_max[8]  = 1;
+  token.sep[8]      = '*';
+  token.attr[8]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[9]  = 1;
+  token.len_max[9]  = 1;
+  token.sep[9]      = '*';
+  token.attr[9]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[10] = 0;
+  token.len_max[10] = 64;
+  token.sep[10]     = '*';
+  token.attr[10]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *version_pos = token.buf[ 1];
+  const u8 *type_pos    = token.buf[ 2];
+  const u8 *bit_len_pos = token.buf[ 3];
+  const u8 *unused1_pos = token.buf[ 4];
+  const u8 *iv_pos      = token.buf[ 5];
+  const u8 *data_pos    = token.buf[ 6];
+  const u8 *unused2_pos = token.buf[ 7];
+  const u8 *unused3_pos = token.buf[ 8];
+  const u8 *unused4_pos = token.buf[ 9];
+  const u8 *file_pos    = token.buf[10];
+
+  if (version_pos[0] != '0') return (PARSER_HASH_ENCODING); // version 0
+  if (type_pos[0]    != '1') return (PARSER_HASH_ENCODING); // AES
+
+  const u32 bit_len = hc_strtoul ((const char *) bit_len_pos, NULL, 10);
+
+  if (bit_len != 128) return (PARSER_HASH_ENCODING);
+
+  if (unused1_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused2_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused3_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused4_pos[0] != '0') return (PARSER_HASH_ENCODING);
+
+  // IV:
+
+  u8 *iv = (u8 *) securezip->iv;
+
+  memset (iv, 0, 16);
+
+  for (int i = 0, j = 0; i < token.len[5]; i += 2, j += 1)
+  {
+    iv[j] = hex_to_u8 (iv_pos + i);
+  }
+
+  securezip->iv_len = (u32) (token.len[5] / 2);
+
+  // data:
+
+  u32 *data = securezip->data;
+
+  for (int i = 0, j = 0; i < token.len[6]; i += 8, j += 1)
+  {
+    data[j] = hex_to_u32 (data_pos + i);
+  }
+
+  // file:
+
+  u8 *file = (u8 *) securezip->file;
+
+  memset (file, 0, 64);
+
+  for (int i = 0; i < token.len[10]; i++)
+  {
+    file[i] = file_pos[i]; // or just memcpy ()
+  }
+
+  file[63] = 0;
+
+  // fake salt:
+
+  salt->salt_buf[0] = iv[0];
+  salt->salt_buf[1] = iv[1];
+  salt->salt_buf[2] = iv[2];
+  salt->salt_buf[3] = iv[3];
+
+  salt->salt_len  = 16;
+
+  // fake digest:
+
+  digest[0] = data[0];
+  digest[1] = data[1];
+  digest[2] = data[2];
+  digest[3] = data[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const securezip_t *securezip = (const securezip_t *) esalt_buf;
+
+  // IV:
+
+  const u8 *iv_ptr = (const u8 *) securezip->iv;
+
+  char iv[33] = { 0 };
+
+  for (u32 i = 0, j = 0; i < securezip->iv_len; i += 1, j += 2)
+  {
+    snprintf (iv + j, 33 - j, "%02x", iv_ptr[i]);
+  }
+
+  // data:
+
+  char data[289] = { 0 };
+
+  for (u32 i = 0, j = 0; i < 36; i += 1, j += 8)
+  {
+    snprintf (data + j, 289 - j, "%08x", byte_swap_32 (securezip->data[i]));
+  }
+
+  // file:
+
+  const u8 *file_ptr = (const u8 *) securezip->file;
+
+  u8 file[65] = { 0 };
+
+  memcpy (file, file_ptr, 64);
+
+  int out_len = snprintf (line_buf, line_size, "%s*0*1*128*0*%s*%s*0*0*0*%s",
+    SIGNATURE_SECUREZIP,
+    iv,
+    data,
+    file
+  );
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_23001.c
+++ b/src/modules/module_23001.c
@@ -172,34 +172,19 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 *iv = (u8 *) securezip->iv;
 
-  memset (iv, 0, 16);
-
-  for (int i = 0, j = 0; i < token.len[5]; i += 2, j += 1)
-  {
-    iv[j] = hex_to_u8 (iv_pos + i);
-  }
-
-  securezip->iv_len = (u32) (token.len[5] / 2);
+  securezip->iv_len = hex_decode (iv_pos, token.len[5], iv);
 
   // data:
 
   u32 *data = securezip->data;
 
-  for (int i = 0, j = 0; i < token.len[6]; i += 8, j += 1)
-  {
-    data[j] = hex_to_u32 (data_pos + i);
-  }
+  hex_decode (data_pos, token.len[6], (u8 *) data);
 
   // file:
 
   u8 *file = (u8 *) securezip->file;
 
-  memset (file, 0, 64);
-
-  for (int i = 0; i < token.len[10]; i++)
-  {
-    file[i] = file_pos[i]; // or just memcpy ()
-  }
+  memcpy (file, file_pos, token.len[10]);
 
   file[63] = 0;
 
@@ -228,23 +213,15 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // IV:
 
-  const u8 *iv_ptr = (const u8 *) securezip->iv;
+  u8 iv[33] = { 0 };
 
-  char iv[33] = { 0 };
-
-  for (u32 i = 0, j = 0; i < securezip->iv_len; i += 1, j += 2)
-  {
-    snprintf (iv + j, 33 - j, "%02x", iv_ptr[i]);
-  }
+  hex_encode ((u8 *) securezip->iv, securezip->iv_len, iv);
 
   // data:
 
-  char data[289] = { 0 };
+  u8 data[289] = { 0 };
 
-  for (u32 i = 0, j = 0; i < 36; i += 1, j += 8)
-  {
-    snprintf (data + j, 289 - j, "%08x", byte_swap_32 (securezip->data[i]));
-  }
+  hex_encode ((u8 *) securezip->data, 144, data);
 
   // file:
 

--- a/src/modules/module_23002.c
+++ b/src/modules/module_23002.c
@@ -1,0 +1,338 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_ARCHIVE;
+static const char *HASH_NAME      = "SecureZIP AES-192";
+static const u64   KERN_TYPE      = 23002;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_NOT_SALTED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS15;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$zip3$*0*1*192*0*53ff2de8c280778e1e0ab997*603eb37dbab9ea109e2c405e37d8cae1ec89e1e0d0b9ce5bf55d1b571c343b6a3df35fe381c30249cb0738a9b956ba8e52dfc5552894296300446a771032776c811ff8a71d9bb3c4d6c37016c027e41fea2d157d5b0ce17804b1d7c1606b7c1121d37851bd705e001f2cd755bbf305966d129a17c1d48ff8e87cfa41f479090cd456527db7d1d43f9020ad8e73f851a5*0*0*0*file.txt";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+static const char *SIGNATURE_SECUREZIP = "$zip3$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (securezip_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  securezip_t *securezip = (securezip_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt   = 11;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_SECUREZIP;
+
+  token.len_min[0]  = 6;
+  token.len_max[0]  = 6;
+  token.sep[0]      = '*';
+  token.attr[0]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.len_min[1]  = 1;
+  token.len_max[1]  = 1;
+  token.sep[1]      = '*';
+  token.attr[1]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[2]  = 1;
+  token.len_max[2]  = 1;
+  token.sep[2]      = '*';
+  token.attr[2]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[3]  = 3;
+  token.len_max[3]  = 3;
+  token.sep[3]      = '*';
+  token.attr[3]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[4]  = 1;
+  token.len_max[4]  = 1;
+  token.sep[4]      = '*';
+  token.attr[4]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[5]  = 0;
+  token.len_max[5]  = 32;
+  token.sep[5]      = '*';
+  token.attr[5]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[6]  = 288;
+  token.len_max[6]  = 288;
+  token.sep[6]      = '*';
+  token.attr[6]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[7]  = 1;
+  token.len_max[7]  = 1;
+  token.sep[7]      = '*';
+  token.attr[7]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[8]  = 1;
+  token.len_max[8]  = 1;
+  token.sep[8]      = '*';
+  token.attr[8]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[9]  = 1;
+  token.len_max[9]  = 1;
+  token.sep[9]      = '*';
+  token.attr[9]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[10] = 0;
+  token.len_max[10] = 64;
+  token.sep[10]     = '*';
+  token.attr[10]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *version_pos = token.buf[ 1];
+  const u8 *type_pos    = token.buf[ 2];
+  const u8 *bit_len_pos = token.buf[ 3];
+  const u8 *unused1_pos = token.buf[ 4];
+  const u8 *iv_pos      = token.buf[ 5];
+  const u8 *data_pos    = token.buf[ 6];
+  const u8 *unused2_pos = token.buf[ 7];
+  const u8 *unused3_pos = token.buf[ 8];
+  const u8 *unused4_pos = token.buf[ 9];
+  const u8 *file_pos    = token.buf[10];
+
+  if (version_pos[0] != '0') return (PARSER_HASH_ENCODING); // version 0
+  if (type_pos[0]    != '1') return (PARSER_HASH_ENCODING); // AES
+
+  const u32 bit_len = hc_strtoul ((const char *) bit_len_pos, NULL, 10);
+
+  if (bit_len != 192) return (PARSER_HASH_ENCODING);
+
+  if (unused1_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused2_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused3_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused4_pos[0] != '0') return (PARSER_HASH_ENCODING);
+
+  // IV:
+
+  u8 *iv = (u8 *) securezip->iv;
+
+  memset (iv, 0, 16);
+
+  for (int i = 0, j = 0; i < token.len[5]; i += 2, j += 1)
+  {
+    iv[j] = hex_to_u8 (iv_pos + i);
+  }
+
+  securezip->iv_len = (u32) (token.len[5] / 2);
+
+  // data:
+
+  u32 *data = securezip->data;
+
+  for (int i = 0, j = 0; i < token.len[6]; i += 8, j += 1)
+  {
+    data[j] = hex_to_u32 (data_pos + i);
+  }
+
+  // file:
+
+  u8 *file = (u8 *) securezip->file;
+
+  memset (file, 0, 64);
+
+  for (int i = 0; i < token.len[10]; i++)
+  {
+    file[i] = file_pos[i]; // or just memcpy ()
+  }
+
+  file[63] = 0;
+
+  // fake salt:
+
+  salt->salt_buf[0] = iv[0];
+  salt->salt_buf[1] = iv[1];
+  salt->salt_buf[2] = iv[2];
+  salt->salt_buf[3] = iv[3];
+
+  salt->salt_len  = 16;
+
+  // fake digest:
+
+  digest[0] = data[0];
+  digest[1] = data[1];
+  digest[2] = data[2];
+  digest[3] = data[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const securezip_t *securezip = (const securezip_t *) esalt_buf;
+
+  // IV:
+
+  const u8 *iv_ptr = (const u8 *) securezip->iv;
+
+  char iv[33] = { 0 };
+
+  for (u32 i = 0, j = 0; i < securezip->iv_len; i += 1, j += 2)
+  {
+    snprintf (iv + j, 33 - j, "%02x", iv_ptr[i]);
+  }
+
+  // data:
+
+  char data[289] = { 0 };
+
+  for (u32 i = 0, j = 0; i < 36; i += 1, j += 8)
+  {
+    snprintf (data + j, 289 - j, "%08x", byte_swap_32 (securezip->data[i]));
+  }
+
+  // file:
+
+  const u8 *file_ptr = (const u8 *) securezip->file;
+
+  u8 file[65] = { 0 };
+
+  memcpy (file, file_ptr, 64);
+
+  int out_len = snprintf (line_buf, line_size, "%s*0*1*192*0*%s*%s*0*0*0*%s",
+    SIGNATURE_SECUREZIP,
+    iv,
+    data,
+    file
+  );
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_23002.c
+++ b/src/modules/module_23002.c
@@ -172,34 +172,19 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 *iv = (u8 *) securezip->iv;
 
-  memset (iv, 0, 16);
-
-  for (int i = 0, j = 0; i < token.len[5]; i += 2, j += 1)
-  {
-    iv[j] = hex_to_u8 (iv_pos + i);
-  }
-
-  securezip->iv_len = (u32) (token.len[5] / 2);
+  securezip->iv_len = hex_decode (iv_pos, token.len[5], iv);
 
   // data:
 
   u32 *data = securezip->data;
 
-  for (int i = 0, j = 0; i < token.len[6]; i += 8, j += 1)
-  {
-    data[j] = hex_to_u32 (data_pos + i);
-  }
+  hex_decode (data_pos, token.len[6], (u8 *) data);
 
   // file:
 
   u8 *file = (u8 *) securezip->file;
 
-  memset (file, 0, 64);
-
-  for (int i = 0; i < token.len[10]; i++)
-  {
-    file[i] = file_pos[i]; // or just memcpy ()
-  }
+  memcpy (file, file_pos, token.len[10]);
 
   file[63] = 0;
 
@@ -228,23 +213,15 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // IV:
 
-  const u8 *iv_ptr = (const u8 *) securezip->iv;
+  u8 iv[33] = { 0 };
 
-  char iv[33] = { 0 };
-
-  for (u32 i = 0, j = 0; i < securezip->iv_len; i += 1, j += 2)
-  {
-    snprintf (iv + j, 33 - j, "%02x", iv_ptr[i]);
-  }
+  hex_encode ((u8 *) securezip->iv, securezip->iv_len, iv);
 
   // data:
 
-  char data[289] = { 0 };
+  u8 data[289] = { 0 };
 
-  for (u32 i = 0, j = 0; i < 36; i += 1, j += 8)
-  {
-    snprintf (data + j, 289 - j, "%08x", byte_swap_32 (securezip->data[i]));
-  }
+  hex_encode ((u8 *) securezip->data, 144, data);
 
   // file:
 

--- a/src/modules/module_23003.c
+++ b/src/modules/module_23003.c
@@ -1,0 +1,338 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_ARCHIVE;
+static const char *HASH_NAME      = "SecureZIP AES-256";
+static const u64   KERN_TYPE      = 23003;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_NOT_SALTED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS15;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$zip3$*0*1*256*0*39bff47df6152a0214d7a967*65ff418ffb3b1198cccdef0327c03750f328d6dd5287e00e4c467f33b92a6ef40a74bb11b5afad61a6c3c9b279d8bd7961e96af7b470c36fc186fd3cfe059107021c9dea0cf206692f727eeca71f18f5b0b6ee1f702b648bba01aa21c7b7f3f0f7d547838aad46868155a04214f22feef7b31d7a15e1abe6dba5e569c62ee640783bb4a54054c2c69e93ece9f1a2af9d*0*0*0*file.txt";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct securezip
+{
+  u32 data[36];
+  u32 file[16];
+  u32 iv[4];
+  u32 iv_len;
+
+} securezip_t;
+
+static const char *SIGNATURE_SECUREZIP = "$zip3$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (securezip_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  securezip_t *securezip = (securezip_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt   = 11;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_SECUREZIP;
+
+  token.len_min[0]  = 6;
+  token.len_max[0]  = 6;
+  token.sep[0]      = '*';
+  token.attr[0]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.len_min[1]  = 1;
+  token.len_max[1]  = 1;
+  token.sep[1]      = '*';
+  token.attr[1]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[2]  = 1;
+  token.len_max[2]  = 1;
+  token.sep[2]      = '*';
+  token.attr[2]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[3]  = 3;
+  token.len_max[3]  = 3;
+  token.sep[3]      = '*';
+  token.attr[3]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[4]  = 1;
+  token.len_max[4]  = 1;
+  token.sep[4]      = '*';
+  token.attr[4]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[5]  = 0;
+  token.len_max[5]  = 32;
+  token.sep[5]      = '*';
+  token.attr[5]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[6]  = 288;
+  token.len_max[6]  = 288;
+  token.sep[6]      = '*';
+  token.attr[6]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[7]  = 1;
+  token.len_max[7]  = 1;
+  token.sep[7]      = '*';
+  token.attr[7]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[8]  = 1;
+  token.len_max[8]  = 1;
+  token.sep[8]      = '*';
+  token.attr[8]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[9]  = 1;
+  token.len_max[9]  = 1;
+  token.sep[9]      = '*';
+  token.attr[9]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[10] = 0;
+  token.len_max[10] = 64;
+  token.sep[10]     = '*';
+  token.attr[10]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *version_pos = token.buf[ 1];
+  const u8 *type_pos    = token.buf[ 2];
+  const u8 *bit_len_pos = token.buf[ 3];
+  const u8 *unused1_pos = token.buf[ 4];
+  const u8 *iv_pos      = token.buf[ 5];
+  const u8 *data_pos    = token.buf[ 6];
+  const u8 *unused2_pos = token.buf[ 7];
+  const u8 *unused3_pos = token.buf[ 8];
+  const u8 *unused4_pos = token.buf[ 9];
+  const u8 *file_pos    = token.buf[10];
+
+  if (version_pos[0] != '0') return (PARSER_HASH_ENCODING); // version 0
+  if (type_pos[0]    != '1') return (PARSER_HASH_ENCODING); // AES
+
+  const u32 bit_len = hc_strtoul ((const char *) bit_len_pos, NULL, 10);
+
+  if (bit_len != 256) return (PARSER_HASH_ENCODING);
+
+  if (unused1_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused2_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused3_pos[0] != '0') return (PARSER_HASH_ENCODING);
+  if (unused4_pos[0] != '0') return (PARSER_HASH_ENCODING);
+
+  // IV:
+
+  u8 *iv = (u8 *) securezip->iv;
+
+  memset (iv, 0, 16);
+
+  for (int i = 0, j = 0; i < token.len[5]; i += 2, j += 1)
+  {
+    iv[j] = hex_to_u8 (iv_pos + i);
+  }
+
+  securezip->iv_len = (u32) (token.len[5] / 2);
+
+  // data:
+
+  u32 *data = securezip->data;
+
+  for (int i = 0, j = 0; i < token.len[6]; i += 8, j += 1)
+  {
+    data[j] = hex_to_u32 (data_pos + i);
+  }
+
+  // file:
+
+  u8 *file = (u8 *) securezip->file;
+
+  memset (file, 0, 64);
+
+  for (int i = 0; i < token.len[10]; i++)
+  {
+    file[i] = file_pos[i]; // or just memcpy ()
+  }
+
+  file[63] = 0;
+
+  // fake salt:
+
+  salt->salt_buf[0] = iv[0];
+  salt->salt_buf[1] = iv[1];
+  salt->salt_buf[2] = iv[2];
+  salt->salt_buf[3] = iv[3];
+
+  salt->salt_len  = 16;
+
+  // fake digest:
+
+  digest[0] = data[0];
+  digest[1] = data[1];
+  digest[2] = data[2];
+  digest[3] = data[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const securezip_t *securezip = (const securezip_t *) esalt_buf;
+
+  // IV:
+
+  const u8 *iv_ptr = (const u8 *) securezip->iv;
+
+  char iv[33] = { 0 };
+
+  for (u32 i = 0, j = 0; i < securezip->iv_len; i += 1, j += 2)
+  {
+    snprintf (iv + j, 33 - j, "%02x", iv_ptr[i]);
+  }
+
+  // data:
+
+  char data[289] = { 0 };
+
+  for (u32 i = 0, j = 0; i < 36; i += 1, j += 8)
+  {
+    snprintf (data + j, 289 - j, "%08x", byte_swap_32 (securezip->data[i]));
+  }
+
+  // file:
+
+  const u8 *file_ptr = (const u8 *) securezip->file;
+
+  u8 file[65] = { 0 };
+
+  memcpy (file, file_ptr, 64);
+
+  int out_len = snprintf (line_buf, line_size, "%s*0*1*256*0*%s*%s*0*0*0*%s",
+    SIGNATURE_SECUREZIP,
+    iv,
+    data,
+    file
+  );
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_23003.c
+++ b/src/modules/module_23003.c
@@ -172,34 +172,19 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 *iv = (u8 *) securezip->iv;
 
-  memset (iv, 0, 16);
-
-  for (int i = 0, j = 0; i < token.len[5]; i += 2, j += 1)
-  {
-    iv[j] = hex_to_u8 (iv_pos + i);
-  }
-
-  securezip->iv_len = (u32) (token.len[5] / 2);
+  securezip->iv_len = hex_decode (iv_pos, token.len[5], iv);
 
   // data:
 
   u32 *data = securezip->data;
 
-  for (int i = 0, j = 0; i < token.len[6]; i += 8, j += 1)
-  {
-    data[j] = hex_to_u32 (data_pos + i);
-  }
+  hex_decode (data_pos, token.len[6], (u8 *) data);
 
   // file:
 
   u8 *file = (u8 *) securezip->file;
 
-  memset (file, 0, 64);
-
-  for (int i = 0; i < token.len[10]; i++)
-  {
-    file[i] = file_pos[i]; // or just memcpy ()
-  }
+  memcpy (file, file_pos, token.len[10]);
 
   file[63] = 0;
 
@@ -228,23 +213,15 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // IV:
 
-  const u8 *iv_ptr = (const u8 *) securezip->iv;
+  u8 iv[33] = { 0 };
 
-  char iv[33] = { 0 };
-
-  for (u32 i = 0, j = 0; i < securezip->iv_len; i += 1, j += 2)
-  {
-    snprintf (iv + j, 33 - j, "%02x", iv_ptr[i]);
-  }
+  hex_encode ((u8 *) securezip->iv, securezip->iv_len, iv);
 
   // data:
 
-  char data[289] = { 0 };
+  u8 data[289] = { 0 };
 
-  for (u32 i = 0, j = 0; i < 36; i += 1, j += 8)
-  {
-    snprintf (data + j, 289 - j, "%08x", byte_swap_32 (securezip->data[i]));
-  }
+  hex_encode ((u8 *) securezip->data, 144, data);
 
   // file:
 

--- a/tools/test_modules/m23001.pm
+++ b/tools/test_modules/m23001.pm
@@ -1,0 +1,193 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha1);
+use Crypt::CBC;
+
+sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word    = shift;
+  my $salt    = shift; # unused since unsalted algo
+  my $iv      = shift;
+  my $data    = shift;
+  my $file    = shift;
+
+  my $bit_len = 128;
+  my $key_len = $bit_len / 8;
+
+  my $is_decrypt = defined ($data);
+
+  my $padding = "none"; # for decryption we need this to "keep" the padding bytes
+
+  if ($is_decrypt == 0)
+  {
+    $padding = "standard";
+
+    # generate some additional random hash data:
+
+    my $iv_len = random_number (1, 16);
+
+    $iv = random_bytes ($iv_len);
+
+    $data = random_bytes (128);
+
+    $file = random_lowercase_string (random_number (1, 16));
+
+    $file .= ".txt";
+  }
+
+  my $iv_mod = $iv;
+
+  $iv_mod .= "\x00" x (16 - length ($iv_mod));
+
+
+  # start of main algo:
+
+  my $digest = sha1 ($word);
+
+  my $buf = "";
+
+  for (my $i = 0; $i < 20; $i++)
+  {
+    $buf .= chr (ord (substr ($digest, $i, 1)) ^ ord ("\x36")); # or  just ^ 0x36
+  }
+
+  $buf .= "\x36" x 44;
+
+  my $key = sha1 ($buf);
+
+
+  $buf = "";
+
+  for (my $i = 0; $i < 20; $i++)
+  {
+    $buf .= chr (ord (substr ($digest, $i, 1)) ^ ord ("\x5c")); # or  just ^ 0x36
+  }
+
+  $buf .= "\x5c" x 44;
+
+  # final key:
+
+  $key = $key . sha1 ($buf);
+
+  $key = substr ($key, 0, $key_len);
+
+  my $aes = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    key         => $key,
+    iv          => $iv_mod,
+    keysize     => $key_len,
+    literal_key => 1,
+    header      => "none",
+    padding     => $padding,
+  });
+
+  if ($is_decrypt == 0)
+  {
+    $data = $aes->encrypt ($data);
+  }
+  else
+  {
+    my $data_decrypted = $aes->decrypt ($data);
+
+    # the password is wrong if the decrypted data does not have the expected padding bytes:
+
+    if (substr ($data_decrypted, -16) ne "\x10" x 16)
+    {
+      $data = "fake"; # fake data
+    }
+  }
+
+  my $iv_padded = $iv;
+
+  if (length ($iv_padded) < 12)
+  {
+    $iv_padded .= "\x00" x (12 - length ($iv_padded));
+  }
+
+  my $hash = sprintf ("\$zip3\$*0*1*%i*0*%s*%s*0*0*0*%s", $bit_len, unpack ("H*", $iv_padded), unpack ("H*", $data), $file);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  return unless (substr ($line, 0, 11) eq "\$zip3\$*0*1*");
+
+  my $idx1 = index ($line, ":");
+
+  return unless ($idx1 >= 11);
+
+  my $hash = substr ($line, 0, $idx1);
+  my $word = substr ($line, $idx1 + 1);
+
+  # bit_len:
+
+  $idx1 = index ($hash, "*", 11);
+
+  return unless ($idx1 > 0);
+
+  my $bit_len = substr ($hash, 11, $idx1 - 11);
+
+  $bit_len = int ($bit_len);
+
+  return unless ($bit_len == 128);
+
+  # unused:
+
+  return unless (substr ($hash, $idx1 + 1, 2) eq "0*");
+
+  # iv:
+
+  my $idx2 = index ($hash, "*", $idx1 + 3);
+
+  return unless ($idx2 > 0);
+
+  my $iv = substr ($hash, $idx1 + 3, $idx2 - $idx1 - 3);
+
+  return unless ($iv =~ m/^[0-9a-fA-F]+$/);
+  return unless ((length ($iv) % 2) == 0);
+
+  # data:
+
+  $idx1 = index ($hash, "*", $idx2 + 1);
+
+  return unless ($idx1 > 0);
+
+  my $data = substr ($hash, $idx2 + 1, $idx1 - $idx2 - 1);
+
+  return unless ($data =~ m/^[0-9a-fA-F]+$/);
+  return unless ((length ($data) % 2) == 0);
+
+  # unused:
+
+  return unless (substr ($hash, $idx1 + 1, 6) eq "0*0*0*");
+
+  # file:
+
+  my $file = substr ($hash, $idx1 + 7);
+
+  # convert to hex:
+
+  $iv   = pack ("H*", $iv);
+  $data = pack ("H*", $data);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, "", $iv, $data, $file);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m23002.pm
+++ b/tools/test_modules/m23002.pm
@@ -1,0 +1,193 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha1);
+use Crypt::CBC;
+
+sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word    = shift;
+  my $salt    = shift; # unused since unsalted algo
+  my $iv      = shift;
+  my $data    = shift;
+  my $file    = shift;
+
+  my $bit_len = 192;
+  my $key_len = $bit_len / 8;
+
+  my $is_decrypt = defined ($data);
+
+  my $padding = "none"; # for decryption we need this to "keep" the padding bytes
+
+  if ($is_decrypt == 0)
+  {
+    $padding = "standard";
+
+    # generate some additional random hash data:
+
+    my $iv_len = random_number (1, 16);
+
+    $iv = random_bytes ($iv_len);
+
+    $data = random_bytes (128);
+
+    $file = random_lowercase_string (random_number (1, 16));
+
+    $file .= ".txt";
+  }
+
+  my $iv_mod = $iv;
+
+  $iv_mod .= "\x00" x (16 - length ($iv_mod));
+
+
+  # start of main algo:
+
+  my $digest = sha1 ($word);
+
+  my $buf = "";
+
+  for (my $i = 0; $i < 20; $i++)
+  {
+    $buf .= chr (ord (substr ($digest, $i, 1)) ^ ord ("\x36")); # or  just ^ 0x36
+  }
+
+  $buf .= "\x36" x 44;
+
+  my $key = sha1 ($buf);
+
+
+  $buf = "";
+
+  for (my $i = 0; $i < 20; $i++)
+  {
+    $buf .= chr (ord (substr ($digest, $i, 1)) ^ ord ("\x5c")); # or  just ^ 0x36
+  }
+
+  $buf .= "\x5c" x 44;
+
+  # final key:
+
+  $key = $key . sha1 ($buf);
+
+  $key = substr ($key, 0, $key_len);
+
+  my $aes = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    key         => $key,
+    iv          => $iv_mod,
+    keysize     => $key_len,
+    literal_key => 1,
+    header      => "none",
+    padding     => $padding,
+  });
+
+  if ($is_decrypt == 0)
+  {
+    $data = $aes->encrypt ($data);
+  }
+  else
+  {
+    my $data_decrypted = $aes->decrypt ($data);
+
+    # the password is wrong if the decrypted data does not have the expected padding bytes:
+
+    if (substr ($data_decrypted, -16) ne "\x10" x 16)
+    {
+      $data = "fake"; # fake data
+    }
+  }
+
+  my $iv_padded = $iv;
+
+  if (length ($iv_padded) < 12)
+  {
+    $iv_padded .= "\x00" x (12 - length ($iv_padded));
+  }
+
+  my $hash = sprintf ("\$zip3\$*0*1*%i*0*%s*%s*0*0*0*%s", $bit_len, unpack ("H*", $iv_padded), unpack ("H*", $data), $file);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  return unless (substr ($line, 0, 11) eq "\$zip3\$*0*1*");
+
+  my $idx1 = index ($line, ":");
+
+  return unless ($idx1 >= 11);
+
+  my $hash = substr ($line, 0, $idx1);
+  my $word = substr ($line, $idx1 + 1);
+
+  # bit_len:
+
+  $idx1 = index ($hash, "*", 11);
+
+  return unless ($idx1 > 0);
+
+  my $bit_len = substr ($hash, 11, $idx1 - 11);
+
+  $bit_len = int ($bit_len);
+
+  return unless ($bit_len == 192);
+
+  # unused:
+
+  return unless (substr ($hash, $idx1 + 1, 2) eq "0*");
+
+  # iv:
+
+  my $idx2 = index ($hash, "*", $idx1 + 3);
+
+  return unless ($idx2 > 0);
+
+  my $iv = substr ($hash, $idx1 + 3, $idx2 - $idx1 - 3);
+
+  return unless ($iv =~ m/^[0-9a-fA-F]+$/);
+  return unless ((length ($iv) % 2) == 0);
+
+  # data:
+
+  $idx1 = index ($hash, "*", $idx2 + 1);
+
+  return unless ($idx1 > 0);
+
+  my $data = substr ($hash, $idx2 + 1, $idx1 - $idx2 - 1);
+
+  return unless ($data =~ m/^[0-9a-fA-F]+$/);
+  return unless ((length ($data) % 2) == 0);
+
+  # unused:
+
+  return unless (substr ($hash, $idx1 + 1, 6) eq "0*0*0*");
+
+  # file:
+
+  my $file = substr ($hash, $idx1 + 7);
+
+  # convert to hex:
+
+  $iv   = pack ("H*", $iv);
+  $data = pack ("H*", $data);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, "", $iv, $data, $file);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m23003.pm
+++ b/tools/test_modules/m23003.pm
@@ -1,0 +1,193 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha1);
+use Crypt::CBC;
+
+sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word    = shift;
+  my $salt    = shift; # unused since unsalted algo
+  my $iv      = shift;
+  my $data    = shift;
+  my $file    = shift;
+
+  my $bit_len = 256;
+  my $key_len = $bit_len / 8;
+
+  my $is_decrypt = defined ($data);
+
+  my $padding = "none"; # for decryption we need this to "keep" the padding bytes
+
+  if ($is_decrypt == 0)
+  {
+    $padding = "standard";
+
+    # generate some additional random hash data:
+
+    my $iv_len = random_number (1, 16);
+
+    $iv = random_bytes ($iv_len);
+
+    $data = random_bytes (128);
+
+    $file = random_lowercase_string (random_number (1, 16));
+
+    $file .= ".txt";
+  }
+
+  my $iv_mod = $iv;
+
+  $iv_mod .= "\x00" x (16 - length ($iv_mod));
+
+
+  # start of main algo:
+
+  my $digest = sha1 ($word);
+
+  my $buf = "";
+
+  for (my $i = 0; $i < 20; $i++)
+  {
+    $buf .= chr (ord (substr ($digest, $i, 1)) ^ ord ("\x36")); # or  just ^ 0x36
+  }
+
+  $buf .= "\x36" x 44;
+
+  my $key = sha1 ($buf);
+
+
+  $buf = "";
+
+  for (my $i = 0; $i < 20; $i++)
+  {
+    $buf .= chr (ord (substr ($digest, $i, 1)) ^ ord ("\x5c")); # or  just ^ 0x36
+  }
+
+  $buf .= "\x5c" x 44;
+
+  # final key:
+
+  $key = $key . sha1 ($buf);
+
+  $key = substr ($key, 0, $key_len);
+
+  my $aes = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    key         => $key,
+    iv          => $iv_mod,
+    keysize     => $key_len,
+    literal_key => 1,
+    header      => "none",
+    padding     => $padding,
+  });
+
+  if ($is_decrypt == 0)
+  {
+    $data = $aes->encrypt ($data);
+  }
+  else
+  {
+    my $data_decrypted = $aes->decrypt ($data);
+
+    # the password is wrong if the decrypted data does not have the expected padding bytes:
+
+    if (substr ($data_decrypted, -16) ne "\x10" x 16)
+    {
+      $data = "fake"; # fake data
+    }
+  }
+
+  my $iv_padded = $iv;
+
+  if (length ($iv_padded) < 12)
+  {
+    $iv_padded .= "\x00" x (12 - length ($iv_padded));
+  }
+
+  my $hash = sprintf ("\$zip3\$*0*1*%i*0*%s*%s*0*0*0*%s", $bit_len, unpack ("H*", $iv_padded), unpack ("H*", $data), $file);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  return unless (substr ($line, 0, 11) eq "\$zip3\$*0*1*");
+
+  my $idx1 = index ($line, ":");
+
+  return unless ($idx1 >= 11);
+
+  my $hash = substr ($line, 0, $idx1);
+  my $word = substr ($line, $idx1 + 1);
+
+  # bit_len:
+
+  $idx1 = index ($hash, "*", 11);
+
+  return unless ($idx1 > 0);
+
+  my $bit_len = substr ($hash, 11, $idx1 - 11);
+
+  $bit_len = int ($bit_len);
+
+  return unless ($bit_len == 256);
+
+  # unused:
+
+  return unless (substr ($hash, $idx1 + 1, 2) eq "0*");
+
+  # iv:
+
+  my $idx2 = index ($hash, "*", $idx1 + 3);
+
+  return unless ($idx2 > 0);
+
+  my $iv = substr ($hash, $idx1 + 3, $idx2 - $idx1 - 3);
+
+  return unless ($iv =~ m/^[0-9a-fA-F]+$/);
+  return unless ((length ($iv) % 2) == 0);
+
+  # data:
+
+  $idx1 = index ($hash, "*", $idx2 + 1);
+
+  return unless ($idx1 > 0);
+
+  my $data = substr ($hash, $idx2 + 1, $idx1 - $idx2 - 1);
+
+  return unless ($data =~ m/^[0-9a-fA-F]+$/);
+  return unless ((length ($data) % 2) == 0);
+
+  # unused:
+
+  return unless (substr ($hash, $idx1 + 1, 6) eq "0*0*0*");
+
+  # file:
+
+  my $file = substr ($hash, $idx1 + 7);
+
+  # convert to hex:
+
+  $iv   = pack ("H*", $iv);
+  $data = pack ("H*", $data);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, "", $iv, $data, $file);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This PR adds AES-192 on GPU and implements issue #2410 = SecureZIP.

There are 3 variants: 128-bit AES, 192-bit AES, 256-bit AES. For performance reasons, I've splitted all of these variants into separate hash types (because if you need less bits, you also need to perform less SHA1 transforms and different decryption algo, see algo description in #2410 ).

Implementing this took again a lot of time (18 different/separate highly-optimized OpenCL kernels for 3 variants * pure/optimized * a0/a1/a3 = 3 * 2 * 3 = 18 kernel files).

As always, tests have also been added to this commit to check if everything is working correctly.

Hope this work is helpful to at least a couple of hashcat users, feedback is much appreciated. Thank you very much