### PR TITLE
fixes #2430: documentation of rules z/Z was incorrect

### DIFF
--- a/docs/rules.txt
+++ b/docs/rules.txt
@@ -23,8 +23,8 @@
 #define RULE_OP_MANGLE_TRUNCATE_AT      '\''// cut the word at pos N
 #define RULE_OP_MANGLE_REPLACE          's' // replace all chars X with char Y
 #define RULE_OP_MANGLE_PURGECHAR        '@' // purge all instances of char X
-#define RULE_OP_MANGLE_DUPECHAR_FIRST   'z' // prepend first char of word to itself. ex: hello -> hhello
-#define RULE_OP_MANGLE_DUPECHAR_LAST    'Z' // append last char of word to itself.   ex: hello -> helloo
+#define RULE_OP_MANGLE_DUPECHAR_FIRST   'z' // prepend first char of word to itself N times. ex: hello -> hhhello
+#define RULE_OP_MANGLE_DUPECHAR_LAST    'Z' // append last char of word to itself N times.   ex: hello -> hellooo
 #define RULE_OP_MANGLE_DUPECHAR_ALL     'q' // duplicate all chars. ex: hello -> hheelllloo
 #define RULE_OP_MANGLE_SWITCH_FIRST     'k' // switches the first 2 chars. ex: hello -> ehllo
 #define RULE_OP_MANGLE_SWITCH_LAST      'K' // switches the last 2 chars.  ex: hello -> helol
@@ -33,10 +33,10 @@
 #define RULE_OP_MANGLE_CHR_SHIFTR       'R' // bitwise shift right char at pos N. ex: hello` -> hello0
 #define RULE_OP_MANGLE_CHR_INCR         '+' // bytewise increase at pos N. ex: hello0 -> hello1
 #define RULE_OP_MANGLE_CHR_DECR         '-' // bytewise decreate at pos N. ex: hello1 -> hello0
-#define RULE_OP_MANGLE_REPLACE_NP1      '.' // replaces character @ n with value at @ n plus 1
-#define RULE_OP_MANGLE_REPLACE_NM1      ',' // replaces character @ n with value at @ n minus 1
-#define RULE_OP_MANGLE_DUPEBLOCK_FIRST  'y' // duplicates first n characters
-#define RULE_OP_MANGLE_DUPEBLOCK_LAST   'Y' // duplicates last n characters
+#define RULE_OP_MANGLE_REPLACE_NP1      '.' // replaces char @ n with value at @ n plus 1
+#define RULE_OP_MANGLE_REPLACE_NM1      ',' // replaces char @ n with value at @ n minus 1
+#define RULE_OP_MANGLE_DUPEBLOCK_FIRST  'y' // duplicates first N chars
+#define RULE_OP_MANGLE_DUPEBLOCK_LAST   'Y' // duplicates last N chars
 #define RULE_OP_MANGLE_TITLE            'E' // lowercase everything then upper case the first letter and every letter after a space
 #define RULE_OP_MANGLE_TITLE_SEP        'e' // lowercase everything then upper case the first letter and every letter after char X
 
@@ -57,4 +57,4 @@
 #define RULE_OP_REJECT_EQUAL_AT         '=' // reject plains that do not contain char X at pos N
 #define RULE_OP_REJECT_CONTAINS         '%' // reject plains that contain char X less than N times
 #define RULE_OP_REJECT_MEMORY           'Q' // reject plains that match the plain saved (see M), i.e. if unchanged
-#define RULE_LAST_REJECTED_SAVED_POS    'p' // pos of the character last found with '/' or '%'
+#define RULE_LAST_REJECTED_SAVED_POS    'p' // pos of the char last found with '/' or '%'


### PR DESCRIPTION
This fixes the description of the z and Z rule. The problem was reported in #2430 (thank you @Lense).

I've also replaced the "character"/"characters" string with just "char"/"chars" to make it more consistent and concise.

The problem here was that the explanation of the rule z (and Z) didn't mention that the rule appends (or prepends, accordingly) the character N times (not just once).

This should be fixed now.

Thank you