### PR TITLE
docs: add ROCm to supported runtimes list

### DIFF
--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -347,6 +347,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - Intel
 - NVidia
 - POCL
+- ROCm
 
 ##
 ## Supported OpenCL device types


### PR DESCRIPTION
For some reason ROCm was missing in the list of supported OpenCL runtimes. ROCm was already supported for a long time. we probably just forgot to add it.

BTW: we probably would later on also need to add "CUDA" somewhere, but in that case the section name `Supported OpenCL runtimes` wouldn't be really the best name. Maybe we need to (when it's the time for release etc) change it to a more general name ("backends") or use "OpenCL/CUDA"  ?

Thank you very much