### PR TITLE
Added option --verify-hashlist-only

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -768,9 +768,10 @@ typedef enum user_options_map
   IDX_VERACRYPT_KEYFILES        = 0xff49,
   IDX_VERACRYPT_PIM_START       = 0xff4a,
   IDX_VERACRYPT_PIM_STOP        = 0xff4b,
+  IDX_VERIFY_HASHLIST_ONLY      = 0xff4c,
   IDX_VERSION_LOWER             = 'v',
   IDX_VERSION                   = 'V',
-  IDX_WORDLIST_AUTOHEX_DISABLE  = 0xff4c,
+  IDX_WORDLIST_AUTOHEX_DISABLE  = 0xff4d,
   IDX_WORKLOAD_PROFILE          = 'w',
 
 } user_options_map_t;
@@ -1967,6 +1968,7 @@ typedef struct user_options
   bool         username;
   bool         veracrypt_pim_start_chgd;
   bool         veracrypt_pim_stop_chgd;
+  bool         verify_hashlist_only;
   bool         version;
   bool         wordlist_autohex_disable;
   #ifdef WITH_BRAIN

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -467,6 +467,8 @@ static int outer_loop (hashcat_ctx_t *hashcat_ctx)
 
   if (hashes_init_stage1 (hashcat_ctx) == -1) return -1;
 
+  if (user_options->verify_hashlist_only == true) return 0;
+
   if ((user_options->keyspace == false) && (user_options->stdout_flag == false))
   {
     if (hashes->hashes_cnt == 0)
@@ -1103,6 +1105,8 @@ int hashcat_session_init (hashcat_ctx_t *hashcat_ctx, const char *install_folder
 
   if (user_options_check_files (hashcat_ctx) == -1) return -1;
 
+  if (user_options->verify_hashlist_only == true) return 0;
+
   /**
    * Init backend library loader
    */
@@ -1215,6 +1219,8 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
   logfile_top_msg ("STOP");
 
   // free memory
+
+  if (user_options->verify_hashlist_only == true) return rc_final;
 
   if (rc_final == 0)
   {

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -123,6 +123,7 @@ static const struct option long_options[] =
   {"veracrypt-keyfiles",        required_argument, NULL, IDX_VERACRYPT_KEYFILES},
   {"veracrypt-pim-start",       required_argument, NULL, IDX_VERACRYPT_PIM_START},
   {"veracrypt-pim-stop",        required_argument, NULL, IDX_VERACRYPT_PIM_STOP},
+  {"verify-hashlist-only",      no_argument,       NULL, IDX_VERIFY_HASHLIST_ONLY},
   {"version",                   no_argument,       NULL, IDX_VERSION},
   {"wordlist-autohex-disable",  no_argument,       NULL, IDX_WORDLIST_AUTOHEX_DISABLE},
   {"workload-profile",          required_argument, NULL, IDX_WORKLOAD_PROFILE},
@@ -464,6 +465,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
                                           user_options->veracrypt_pim_start_chgd  = true;                            break;
       case IDX_VERACRYPT_PIM_STOP:        user_options->veracrypt_pim_stop        = hc_strtoul (optarg, NULL, 10);
                                           user_options->veracrypt_pim_stop_chgd   = true;                            break;
+      case IDX_VERIFY_HASHLIST_ONLY:      user_options->verify_hashlist_only      = true;                            break;
       case IDX_SEGMENT_SIZE:              user_options->segment_size              = hc_strtoul (optarg, NULL, 10);
                                           user_options->segment_size_chgd         = true;                            break;
       case IDX_SCRYPT_TMTO:               user_options->scrypt_tmto               = hc_strtoul (optarg, NULL, 10);   break;


### PR DESCRIPTION
This option allows to use hashcat as a "hash format validator" tool. 
Hashcat can verify hash format without need for opencl drivers, but currently it cannot do it on devices without opencl drivers and fails with an error.

This patch introduces new option to run only "hashlist parser" - this means that we don't need opencl at all.

PS: I am not very familiar with codebase and I just spend some time looking at the codebase to produce minimal code to implement this feature..
