### PR TITLE
tests: add php to requirements

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -66,6 +66,15 @@ pip2 uninstall -y pycryptodome
 
 ERRORS=$((ERRORS+$?))
 
+php --version > /dev/null 2> /dev/null
+
+if [ "$?" -ne 0 ]
+then
+  echo '[ ERROR ] php must be installed for some unit tests'
+
+  ERRORS=$((ERRORS+1))
+fi
+
 echo
 if [ $ERRORS -eq 0 ]; then
   echo '[  OK  ] All commands were successful'


### PR DESCRIPTION
I've tried to test latest hashcat, including running the test framework, on a new ubuntu installation. It worked quite well, but I saw that php (php command line tool, php-cli) was not installed out-of-the-box with the ubuntu installation and therefore some tests failed.

I would therefore recommend adding this additional check to the `tools/install_modules.sh` file.
This should of course work on any *nix system that has bash installed, i.e. exactly what we target with the install_modules.sh shell script. It will show an error message if PHP was not installed (of course ideally we would only need to have perl or only perl-and-python, but there are some rare/strange algorithms that need some php code to generate the hashes). I think it's okay to add the php reqiurement like in the patch below.
Thank you very much