### PR TITLE
tests: update perl module requirements

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -23,6 +23,7 @@ cpan install Authen::Passphrase::LANManager \
              Crypt::ECB                     \
              Crypt::Eksblowfish::Bcrypt     \
              Crypt::GCrypt                  \
+             Crypt::Mode::CBC               \
              Crypt::Mode::ECB               \
              Crypt::MySQL                   \
              Crypt::OpenSSH::ChachaPoly     \
@@ -50,11 +51,13 @@ cpan install Authen::Passphrase::LANManager \
              Digest::SHA1                   \
              Digest::SHA3                   \
              Digest::SipHash                \
+             Encode                         \
              JSON                           \
              MIME::Base32                   \
              MIME::Base64                   \
              Net::DNS::RR::NSEC3            \
              Net::DNS::SEC                  \
+             POSIX                          \
              Text::Iconv                    \
              ;
 


### PR DESCRIPTION
I've just done a little analysis if we have all the perl modules listed in tools/test_modules/
```
grep -h '^use ' tools/test_modules/ -r | sort -u
```

also listed in `tools/install_modules.sh`  and I've found out that (fortunatlely only) a few are missing. I would suggest adding these few modules also to `tools/install_modules.sh` for completeness. Thanks