### PR TITLE
rule engine: add zero-length check for rule 'z'

### DIFF
--- a/OpenCL/inc_rp.cl
+++ b/OpenCL/inc_rp.cl
@@ -518,6 +518,7 @@ DECLSPEC int mangle_dupechar_first (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const
 {
   const int out_len = len + p0;
 
+  if (len     ==                0) return (len);
   if (out_len >= RP_PASSWORD_SIZE) return (len);
 
   const u8 c = buf[0];


### PR DESCRIPTION
The 'z' rule (z5 for instance) didn't check for zero length password and therefore it could generate wrong output (and possible "buffer overflow", altrough our buffers are always of fized size and therefore long enough, but it exceeded the expected length).

To reproduce this problem you could use:
```
$ cat my.rule 
z5
$ echo | ./hashcat --stdout -r my.rule | xxd -p
```

This would (without the fix) generate a 5-byte long NUL-byte password, even through it should be zero-length.

Note that the optimized rule engine (OpenCL/inc_rp_optimized.cl) and the host code (CPU) rule enine (src/rp_cpu.c) are not affected by this bug.

This was a bug only affecting the on-GPU pure rule engine.

Thank you very much