### PR TITLE
fixes #2162: add -liconv to FreeBSD's Makefile LFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -260,6 +260,7 @@ CFLAGS_NATIVE           := $(CFLAGS)
 LFLAGS_NATIVE           := $(LFLAGS)
 LFLAGS_NATIVE           += -lpthread
 LFLAGS_NATIVE           += -lm
+LFLAGS_NATIVE           += -liconv
 endif
 endif # FreeBSD
 


### PR DESCRIPTION
This commit should allow the compilation of hashcat for FreeBSD operating system. The liconv support seems to be not natively enable on FreeBSD and therefore similar to the macOS and cygwin makefile target, we need to pass the LFLAGS manually for iconv support.

Thanks