### PR TITLE
fix some further kernel declarations

### DIFF
--- a/OpenCL/m02000_a0-pure.cl
+++ b/OpenCL/m02000_a0-pure.cl
@@ -10,10 +10,10 @@
 #include "inc_common.cl"
 #endif
 
-KERNEL_FQ void m02000_mxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m02000_mxx (KERN_ATTR_RULES ())
 {
 }
 
-KERNEL_FQ void m02000_sxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m02000_sxx (KERN_ATTR_RULES ())
 {
 }

--- a/OpenCL/m18500_a1-pure.cl
+++ b/OpenCL/m18500_a1-pure.cl
@@ -29,7 +29,7 @@
 #define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
 #endif
 
-KERNEL_FQ void m18500_mxx (KERN_ATTR_RULES ())
+KERNEL_FQ void m18500_mxx (KERN_ATTR_BASIC ())
 {
   /**
    * modifier
@@ -144,7 +144,7 @@ KERNEL_FQ void m18500_mxx (KERN_ATTR_RULES ())
   }
 }
 
-KERNEL_FQ void m18500_sxx (KERN_ATTR_RULES ())
+KERNEL_FQ void m18500_sxx (KERN_ATTR_BASIC ())
 {
   /**
    * modifier

--- a/OpenCL/m23002_a1-pure.cl
+++ b/OpenCL/m23002_a1-pure.cl
@@ -24,7 +24,7 @@ typedef struct securezip
 
 } securezip_t;
 
-KERNEL_FQ void m23002_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
+KERNEL_FQ void m23002_mxx (KERN_ATTR_ESALT (securezip_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
@@ -267,7 +267,7 @@ KERNEL_FQ void m23002_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
   }
 }
 
-KERNEL_FQ void m23002_sxx (KERN_ATTR_RULES_ESALT (securezip_t))
+KERNEL_FQ void m23002_sxx (KERN_ATTR_ESALT (securezip_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);

--- a/OpenCL/m23003_a1-pure.cl
+++ b/OpenCL/m23003_a1-pure.cl
@@ -24,7 +24,7 @@ typedef struct securezip
 
 } securezip_t;
 
-KERNEL_FQ void m23003_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
+KERNEL_FQ void m23003_mxx (KERN_ATTR_ESALT (securezip_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
@@ -269,7 +269,7 @@ KERNEL_FQ void m23003_mxx (KERN_ATTR_RULES_ESALT (securezip_t))
   }
 }
 
-KERNEL_FQ void m23003_sxx (KERN_ATTR_RULES_ESALT (securezip_t))
+KERNEL_FQ void m23003_sxx (KERN_ATTR_ESALT (securezip_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);


### PR DESCRIPTION
Similar to our most recent commit https://github.com/hashcat/hashcat/commit/78d72bbcfe27553b45d1bd9256319fc1a9802ecf , there were some further small problems with kernel function parameters.
Hopefully now everything is fixed... btw: we found these with some grep commands like this:
```
grep -l KERN_ATTR_RULES OpenCL/*a[13]*
``` 

or (opposite):
```
grep -L KERN_ATTR_RULES OpenCL/*a0*
```

thank you very much