### PR TITLE
fixes #2424: only print EOL in case of non-binary hash file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -390,8 +390,7 @@ static void main_potfile_hash_left (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAY
 
   if (outfile_ctx->fp.pfp != NULL) return; // cracked hash was not written to an outfile
 
-  fwrite (buf, len,          1, stdout);
-  fwrite (EOL, strlen (EOL), 1, stdout);
+  fwrite (buf, len, 1, stdout);
 }
 
 static void main_potfile_num_cracked (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const void *buf, MAYBE_UNUSED const size_t len)

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -1083,7 +1083,43 @@ int potfile_handle_left (hashcat_ctx_t *hashcat_ctx)
 
   for (u32 final_pos = 0; final_pos < final_cnt; final_pos++)
   {
-    EVENT_DATA (EVENT_POTFILE_HASH_LEFT, final_buf[final_pos].hash_buf, final_buf[final_pos].hash_len);
+    u8 *event_data = NULL;
+
+    int event_len = 0;
+
+    // add EOL after hash, but only if NOT binary:
+
+    if ((hashconfig->opts_type & OPTS_TYPE_BINARY_HASHFILE) == 0)
+    {
+      u8 *eol_chars = (u8 *) EOL;
+
+      int eol_len = (int) strlen (EOL);
+
+      event_len = final_buf[final_pos].hash_len + eol_len;
+
+      event_data = (u8 *) hcmalloc (event_len);
+
+      memcpy (event_data, final_buf[final_pos].hash_buf, final_buf[final_pos].hash_len);
+
+      // only difference (add EOL to the buffer):
+
+      for (int i = 0, j = event_len - eol_len; i < eol_len; i++, j++)
+      {
+        event_data[j] = eol_chars[i];
+      }
+    }
+    else
+    {
+      event_len = final_buf[final_pos].hash_len;
+
+      event_data = (u8 *) hcmalloc (event_len);
+
+      memcpy (event_data, final_buf[final_pos].hash_buf, final_buf[final_pos].hash_len);
+    }
+
+    EVENT_DATA (EVENT_POTFILE_HASH_LEFT, event_data, event_len);
+
+    hcfree (event_data);
 
     hcfree (final_buf[final_pos].hash_buf);
   }


### PR DESCRIPTION
As reported in #2424 , we had the problem that with binary hash files the output was EOL-separated. This is normally not what we would expect, since for instance hccapx files are just concatenated together without any separator character (no \n or \r\n).

Thanks