### PR TITLE
Re-implement alias check

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -6625,8 +6625,8 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
   // find duplicate devices
 
-  //if ((cuda_devices_cnt > 0) && (opencl_devices_cnt > 0))
-  //{
+  if ((cuda_devices_cnt > 0) && (opencl_devices_cnt > 0))
+  {
     // using force here enables both devices, which is the worst possible outcome
     // many users force by default, so this is not a good idea
 
@@ -6634,7 +6634,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
     //{
     backend_ctx_find_alias_devices (hashcat_ctx);
     //{
-  //}
+  }
 
   if (backend_ctx->backend_devices_active == 0)
   {


### PR DESCRIPTION
This is a repeat of
https://github.com/hashcat/hashcat/commit/57a149276c5a20d5af1b2364628b3a305772ab3d
which was undone in this commit
https://github.com/singe/hashcat/commit/34f71aaea3550d146b4a3f2a7b55e140e9bd3da5#diff-7af547b52769371de74af0bfca268a62R6599

The original issue was #2083 and discussion of a fix was #2086.

The problem is with Apple devices with an Intel and AMD GPU and using both
simultaneously and the alias check.