### PR TITLE
remove extra spaces in -m 20900

### DIFF
--- a/OpenCL/m20900_a0-optimized.cl
+++ b/OpenCL/m20900_a0-optimized.cl
@@ -421,7 +421,7 @@ KERNEL_FQ void m20900_m04 (KERN_ATTR_RULES ())
 
     _w2[0] = 0;
     _w2[1] = 0;
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -593,7 +593,7 @@ KERNEL_FQ void m20900_m04 (KERN_ATTR_RULES ())
     _w2[1] = uint_to_hex_lower8 ((e0 >>  8) & 255) <<  0
            | uint_to_hex_lower8 ((e0 >>  0) & 255) << 16;
 
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -1143,7 +1143,7 @@ KERNEL_FQ void m20900_s04 (KERN_ATTR_RULES ())
 
     _w2[0] = 0;
     _w2[1] = 0;
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -1315,7 +1315,7 @@ KERNEL_FQ void m20900_s04 (KERN_ATTR_RULES ())
     _w2[1] = uint_to_hex_lower8 ((e0 >>  8) & 255) <<  0
            | uint_to_hex_lower8 ((e0 >>  0) & 255) << 16;
 
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;

--- a/OpenCL/m20900_a1-optimized.cl
+++ b/OpenCL/m20900_a1-optimized.cl
@@ -477,7 +477,7 @@ KERNEL_FQ void m20900_m04 (KERN_ATTR_BASIC ())
 
     _w2[0] = 0;
     _w2[1] = 0;
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -649,7 +649,7 @@ KERNEL_FQ void m20900_m04 (KERN_ATTR_BASIC ())
     _w2[1] = uint_to_hex_lower8 ((e0 >>  8) & 255) <<  0
            | uint_to_hex_lower8 ((e0 >>  0) & 255) << 16;
 
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -1257,7 +1257,7 @@ KERNEL_FQ void m20900_s04 (KERN_ATTR_BASIC ())
 
     _w2[0] = 0;
     _w2[1] = 0;
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -1429,7 +1429,7 @@ KERNEL_FQ void m20900_s04 (KERN_ATTR_BASIC ())
     _w2[1] = uint_to_hex_lower8 ((e0 >>  8) & 255) <<  0
            | uint_to_hex_lower8 ((e0 >>  0) & 255) << 16;
 
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;

--- a/OpenCL/m20900_a3-optimized.cl
+++ b/OpenCL/m20900_a3-optimized.cl
@@ -378,7 +378,7 @@ DECLSPEC void m20900m (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
 
     _w2[0] = 0;
     _w2[1] = 0;
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -550,7 +550,7 @@ DECLSPEC void m20900m (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
     _w2[1] = uint_to_hex_lower8 ((e0 >>  8) & 255) <<  0
            | uint_to_hex_lower8 ((e0 >>  0) & 255) << 16;
 
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -1051,7 +1051,7 @@ DECLSPEC void m20900s (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
 
     _w2[0] = 0;
     _w2[1] = 0;
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;
@@ -1223,7 +1223,7 @@ DECLSPEC void m20900s (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
     _w2[1] = uint_to_hex_lower8 ((e0 >>  8) & 255) <<  0
            | uint_to_hex_lower8 ((e0 >>  0) & 255) << 16;
 
-    _w2[2] = 0; 
+    _w2[2] = 0;
     _w2[3] = 0;
     _w3[0] = 0;
     _w3[1] = 0;


### PR DESCRIPTION
The -m 20900 = `md5(sha1($pass).md5($pass).sha1($pass))` incorrectly had some extra whitespaces within the kernel.
I suggest removing it

Thanks