### PR TITLE
Makefile: update clean/distclean targets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -374,7 +374,10 @@ distclean: clean
 	$(RM) -f *.restore
 	$(RM) -f *.potfile
 	$(RM) -f *.out
-	$(RM) -rf test_[0-9]*/
+	$(RM) -f hashcat.dictstat2
+	$(RM) -f brain.*
+	$(RM) -rf test_[0-9]*
+	$(RM) -rf tools/luks_tests
 
 ##
 ## Targets: Linux install

--- a/src/Makefile
+++ b/src/Makefile
@@ -354,24 +354,27 @@ default: $(HASHCAT_FRONTEND) modules
 clean:
 	$(RM) -f $(HASHCAT_FRONTEND)
 	$(RM) -f $(HASHCAT_LIBRARY)
-	$(RM) -rf modules/*.dSYM
+	$(RM) -f modules/*.dSYM
 	$(RM) -f modules/*.dll
 	$(RM) -f modules/*.so
 	$(RM) -f obj/*/*/*.o
 	$(RM) -f obj/*.o
 	$(RM) -f obj/*.a
+	$(RM) -f *.dSYM
+	$(RM) -f *.dylib
 	$(RM) -f *.bin *.exe
 	$(RM) -f *.pid
-	$(RM) -f *.restore
 	$(RM) -f *.log
 	$(RM) -f core
 	$(RM) -rf *.induct
 	$(RM) -rf *.outfiles
-	$(RM) -rf *.dSYM
 	$(RM) -rf kernels
 
 distclean: clean
-	$(RM) -f *.restore *.pot *.out *.log
+	$(RM) -f *.restore
+	$(RM) -f *.potfile
+	$(RM) -f *.out
+	$(RM) -rf test_[0-9]*/
 
 ##
 ## Targets: Linux install


### PR DESCRIPTION
With this commit I suggest some minor changes to the `src/Makefile` which make the clean vs distclean target in the Makefile more meaningful.

In my opinion it makes sense to keep the .restore file and .potfile while debugging / testing, but if an user chooses to `make distclean` it can/should be deleted.

Repetitions between `distclean` and `clean` do not make sense, because `clean` is a dependency of `distclean` (and therefore it's redundant and therefore I removed instances of repetition between clean and distclean).

This change also added the test files `test_${unix_timestamp}` to the `distclean` target, because they can get annoying sometimes and I think it makes sense to delete these folders with `distclean`.

What do you think ? It seems good to me.

Thanks 