### PR TITLE
fix pw_max w/ -O for -m 10600

### DIFF
--- a/src/modules/module_10600.c
+++ b/src/modules/module_10600.c
@@ -81,7 +81,11 @@ u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED
 
 u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
-  const u32 pw_max = 127; // https://www.pdflib.com/knowledge-base/pdf-password-security/encryption/
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  // https://www.pdflib.com/knowledge-base/pdf-password-security/encryption/
+
+  const u32 pw_max = (optimized_kernel == false) ? 127 : hashconfig->pw_max;
 
   return pw_max;
 }


### PR DESCRIPTION
This is just a follow-up for our recent changes for pw_max in -O (optimized mode): https://github.com/hashcat/hashcat/commit/5d04e97adc45af254cb6340387aa3ae147d43e92

The -m 10600 =  `PDF 1.7 Level 3 (Acrobat 9)` was missing in the commit above and therefore the maximum password length for optimized mode was set to a wrong value. This should fix it (docs/changes.txt was already updated, no further changes needed there).

Thx