### PR TITLE
fixes #2465: --stdout should return status code 0

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -12,6 +12,7 @@
 ##
 
 - Fixed maximum password length in modules of hash-modes 600, 7800, 7801 and 9900
+- Fixed non-zero status code when using --stdout
 - Fixed uninitialized value in bitsliced DES kernel (BF mode only) leading to false negatives
 
 ##

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -1214,7 +1214,7 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
 
   logfile_top_msg ("STOP");
 
-  // free memory
+  // set final status code
 
   if (rc_final == 0)
   {
@@ -1225,6 +1225,16 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
     if (status_ctx->devices_status == STATUS_EXHAUSTED)           rc_final =  1;
     if (status_ctx->devices_status == STATUS_CRACKED)             rc_final =  0;
     if (status_ctx->devices_status == STATUS_ERROR)               rc_final = -1;
+  }
+
+  // special case for --stdout
+
+  if (user_options->stdout_flag == true)
+  {
+    if (status_ctx->devices_status == STATUS_EXHAUSTED)
+    {
+      rc_final = 0;
+    }
   }
 
   // done


### PR DESCRIPTION
As reported in #2465 , a --stdout run did incorrectly end with a status code of EXHAUSTED (1). This doesn't make much sense and it should just exit with exit code (status code) 0.

This special handling of --stdout should fix this issue.

Thanks