### PR TITLE
fixes #2460: better alias detection esp. for macOS

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -11,6 +11,7 @@
 ## Bugs
 ##
 
+- Fixed alias detection with additional processor core count check
 - Fixed maximum password length in modules of hash-modes 600, 7800, 7801 and 9900
 - Fixed uninitialized value in bitsliced DES kernel (BF mode only) leading to false negatives
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -47,6 +47,10 @@ static bool is_same_device (const hc_device_param_t *src, const hc_device_param_
 
   if (src->opencl_device_type != dst->opencl_device_type) return false;
 
+  // macOS still can't distinguish the devices by PCIe bus:
+
+  if (src->device_processors != dst->device_processors) return false;
+
   return true;
 }
 


### PR DESCRIPTION
We've discussed this problem that affects most importantly macOS devices already here: #2460 , #2466 and https://hashcat.net/forum/thread-9321-post-49267.html#pid49267

The problem is that macOS hardware doesn't really have different IDs / PCIe Bus IDs etc that we can use to distinguish the devices. This leads to a problem where hashcat detects the devices as aliases (same device, but different platform or OpenCL runtime/driver).

I think this additional check should be enough to get rid of all/most of the remaining wrongly detected aliases.

Thanks