### PR TITLE
minor: add "use warnings;" to every perl script

### DIFF
--- a/tools/test_modules/m05500.pm
+++ b/tools/test_modules/m05500.pm
@@ -6,6 +6,7 @@
 ##
 
 use strict;
+use warnings;
 
 use Authen::Passphrase::NTHash;
 use Digest::HMAC qw (hmac hmac_hex);

--- a/tools/test_modules/m05600.pm
+++ b/tools/test_modules/m05600.pm
@@ -6,6 +6,7 @@
 ##
 
 use strict;
+use warnings;
 
 use Authen::Passphrase::NTHash;
 use Digest::HMAC qw (hmac hmac_hex);

--- a/tools/test_modules/m05700.pm
+++ b/tools/test_modules/m05700.pm
@@ -6,6 +6,7 @@
 ##
 
 use strict;
+use warnings;
 
 use Digest::SHA  qw (sha256);
 use MIME::Base64 qw (encode_base64);

--- a/tools/test_modules/m05800.pm
+++ b/tools/test_modules/m05800.pm
@@ -6,6 +6,7 @@
 ##
 
 use strict;
+use warnings;
 
 use Digest::SHA  qw (sha1);
 


### PR DESCRIPTION
This is a minor change, I think it makes sense to have:
```
use strict;
use warnings;
```
in each and every perl script/module.
Only in a few files it was missing and this commit adds the missing module includes.
Thanks