### PR TITLE
tests: improve install_modules.sh python dependencies

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -63,9 +63,13 @@ cpan install Authen::Passphrase::LANManager \
 
 ERRORS=$((ERRORS+$?))
 
-pip2 install pygost pycryptoplus
+pip2 install pygost
 
+# pip2 uninstall -y pycryptoplus pycrypto pycryptodome
+
+pip2 install pycryptoplus
 pip2 uninstall -y pycryptodome
+pip2 install pycrypto
 
 ERRORS=$((ERRORS+$?))
 


### PR DESCRIPTION
I've tested the `tools/install_modules.sh` script on a new system and had some problems with running the test.pl tests because of the python dependencies (pycryptoplus vs pycryptodome).

Finally, it worked with the following change (first add `pycryptoplus`, then uninstall `pycryptodome`, but also install `pycrypto`).

It's unfortunate that there is no simpler way to use AES XTS with perl or a different python module (cryptography.io doesn't seem to support the serpent/twofish AES XTS encryption/decryption :( ).

I think this change should be good enough for any hashcat tester to easily install the modules and run the test.sh or verify tests.
Thx