### PR TITLE
tests: remove verify code for -m 16800 = WPA-PMKID-PBKDF2

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -30,6 +30,7 @@
 ##
 
 - Backend: Changed the maximum number of compute devices from 64 to 128
+- Tests: Improved tests for hash-mode 16800 (WPA-PMKID-PBKDF2)
 
 * changes v5.1.0 -> v6.0.0
 

--- a/tools/test_modules/m16800.pm
+++ b/tools/test_modules/m16800.pm
@@ -62,24 +62,9 @@ sub module_generate_hash
 
 sub module_verify_hash
 {
-  my $line = shift;
+  print "ERROR: verify currently not supported for WPA-PMKID-PBKDF2 (because of hashcat's output format)\n";
 
-  my ($hash, $word) = split (':', $line);
-
-  return unless defined $hash;
-  return unless defined $word;
-
-  my @data = split (/\:/, $hash);
-
-  return unless scalar @data == 4;
-
-  my (undef, $macap, $macsta, $essid) = @data;
-
-  my $word_packed = pack_if_HEX_notation ($word);
-
-  my $new_hash = module_generate_hash ($word_packed, undef, $macap, $macsta, $essid);
-
-  return ($new_hash, $word);
+  exit (1);
 }
 
 1;


### PR DESCRIPTION
I've tested the verifcation code for -m 16800 = `WPA-PMKID-PBKDF2` and with it's current implementation it doesn't work at all.

First problem are the `split (":", ...);` function calls. They do **not** work if we have already splitted the whole line because of "hash:plain", while "hash" itself contains colons (":"). So this code is wrong and the hashes can't load.

but there is a more serious problem: the current output of hashcat doesn't allow us to use "hash:pass" within the cracked list and "hash" within the hash list, because the output format for -m 16800 isn't really "hash:pass".

I guess we would need to change the output format before we allow the verification of `WPA-PMKID-PBKDF2` hashes (all hash verification functions normally compare "hash:pass" against the "hash" and check if starting from the pass we are able to generate the same "hash").

For now, I would just recommend not having this code while we might check if it makes sense to change the `WPA-PMKID-PBKDF2` output format.

Thx