### PR TITLE
tests: fixed -m 13600 = WinZip verification

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -30,6 +30,7 @@
 ##
 
 - Backend: Changed the maximum number of compute devices from 64 to 128
+- Tests: Improved tests for hash-mode 13600 (WinZip)
 
 * changes v5.1.0 -> v6.0.0
 

--- a/tools/test_modules/m13600.pm
+++ b/tools/test_modules/m13600.pm
@@ -94,7 +94,7 @@ sub module_generate_hash
 
   my $auth = hmac_hex ($data, $key_bin, \&sha1, 64);
 
-  my $hash = sprintf ('$zip2$*%u*%u*%u*%s*%s*%x*%s*%s*$/zip2$', $type, $mode, $magic, $salt, $verify_bytes, $compress_length, $data, substr ($auth, 0, 20));
+  my $hash = sprintf ('$zip2$*%u*%u*%u*%s*%s*%s*%s*%s*$/zip2$', $type, $mode, $magic, $salt, $verify_bytes, $compress_length, unpack ("H*", $data), substr ($auth, 0, 20));
 
   return $hash;
 }
@@ -135,6 +135,8 @@ sub module_verify_hash
 
   return unless defined $salt;
   return unless defined $word;
+
+  $param6 = pack ("H*", $param6);
 
   $word = pack_if_HEX_notation ($word);
 


### PR DESCRIPTION
While testing some verification functions of the hashcat unit test, I've noticed this problem with -m 13600 = `WinZIp`.

Whenever the `$data` was not of zero-length (empty string), the verification code did **fail**. Debugging this problem showed that the $data needs to be converted to binary first.

There was another small problem with the `%x` vs `%s` format string: only `%s` is correct, because the PBKDF2_hex () function already provides hexadecimal output (and therefore we need to use `%s`).

With this change, the "verify" feature for WinZip hashes should work flawlessly.

Thank