### PR TITLE
tests: fixed -m 16400 = CRAM-MD5 Dovecot tests

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -32,6 +32,7 @@
 - Backend: Changed the maximum number of compute devices from 64 to 128
 - Tests: Improved tests for hash-mode 11300 (Bitcoin/Litecoin wallet.dat)
 - Tests: Improved tests for hash-mode 13600 (WinZip)
+- Tests: Improved tests for hash-mode 16400 (CRAM-MD5 Dovecot)
 - Tests: Improved tests for hash-mode 16800 (WPA-PMKID-PBKDF2)
 
 * changes v5.1.0 -> v6.0.0

--- a/tools/test_modules/m16400.pm
+++ b/tools/test_modules/m16400.pm
@@ -14,7 +14,9 @@ sub module_constraints { [[0, 64], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
-  my $word    = shift;
+  my $word = shift;
+  my $salt = shift;
+  my $end  = shift // "0" x 32;
 
   my $md5 = Digest::Perl::MD5->new;
   my $length = length ($word);
@@ -24,8 +26,8 @@ sub module_generate_hash
   $md5->add ();
 
   my $digest = unpack ("H*", pack ('V4', @{$md5->{_state}}));
- 
-  my $hash = sprintf ("{CRAM-MD5}%s00000000000000000000000000000000", $digest);
+
+  my $hash = sprintf ("{CRAM-MD5}%s%s", $digest, $end);
 
   return $hash;
 }
@@ -43,11 +45,11 @@ sub module_verify_hash
 
   return unless ($signature eq "{CRAM-MD5}");
 
-  my $hash = substr ($digest, 10);
+  my $end = substr ($digest, 42);
 
   my $word_packed = pack_if_HEX_notation ($word);
 
-  my $new_hash = module_generate_hash ($word_packed);
+  my $new_hash = module_generate_hash ($word_packed, "", $end);
 
   return ($new_hash, $word);
 }


### PR DESCRIPTION
I've now tested some verify routines of the our unit tests and came to the conclusion that the -m 16400 = `CRAM-MD5 Dovecot` fails, when there isn't `00000000000000000000000000000000` at the end of the "hash".

I think this is some limitation of how we **generate** the hashes, but I would suggest that the verification code should be more flexible and accept everything that hashcat also accepts (and correctly verify it).

For instance, the example hash of -m 16400 = `CRAM-MD5 Dovecot` for hashcat is
`
{CRAM-MD5}5389b33b9725e5657cb631dc50017ff1535ce4e2a1c414009126506fc4327d0d:hashcat
`

see https://hashcat.net/wiki/doku.php?id=example_hashes

as you can see, we do **not** have the set of 00000000000000000000000000000000 at the end of the hash, while our --example-hashes hash is
`
{CRAM-MD5}5389b33b9725e5657cb631dc50017ff100000000000000000000000000000000:hashcat
`

In my opinion, the verification function should be able to handle both cases (be more flexible) and this PR does implement this new feature of skipping and allowing a non-zero end (final part not being `00000000000000000000000000000000`).

Thank you very much