### PR TITLE
Appveyor MSYS signing key fix attempt 1 (see #2516)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,6 +34,8 @@ install:
   - if defined CYG_ROOT (%CYG_SETUP% --quiet-mode --no-shortcuts --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages "%CYG_PACKAGES%" --upgrade-also)
   # (temporary?) problem with msys/pacman/objc/ada (see https://github.com/msys2/msys2/wiki/FAQ)
   - if defined MSYSTEM (%BASH% -lc "pacman -Rns --noconfirm mingw-w64-{i686,x86_64}-gcc-ada mingw-w64-{i686,x86_64}-gcc-objc")
+  # temporary fix for MSYS revoked/new signing keys:
+  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/shmENPgV | bash")
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
   # the following line is not a duplicate line:
   # it is necessary to upgrade the MSYS base files and after that all the packages


### PR DESCRIPTION
This is an attempt to fix the Appveyor building problems mentioned in #2516 : it (for now until we find out it's no longer required) adds these new keys to the keyring before running the `pacman` update and before building `hashcat`.

Let's merge it and see if the errors are gone (I tested it successfully on a local Windows VM with MSYS installed).
Thx