### PR TITLE
Appveyor MSYS2 signing key fix attempt 2 (#2516)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
   # (temporary?) problem with msys/pacman/objc/ada (see https://github.com/msys2/msys2/wiki/FAQ)
   - if defined MSYSTEM (%BASH% -lc "pacman -Rns --noconfirm mingw-w64-{i686,x86_64}-gcc-ada mingw-w64-{i686,x86_64}-gcc-objc")
   # temporary fix for MSYS revoked/new signing keys:
-  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/shmENPgV | bash")
+  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/wVgqQVN3 | bash")
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
   # the following line is not a duplicate line:
   # it is necessary to upgrade the MSYS base files and after that all the packages
@@ -43,7 +43,7 @@ install:
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
 
 build_script:
-  - if defined BASH (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && git submodule update --init && make")
+  - if defined BASH (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && make")
 
 test_script:
   # some file globbing tests
@@ -66,3 +66,4 @@ only_commits:
     - include/*
     - OpenCL/inc_*
     - Makefile
+    - .appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
   # (temporary?) problem with msys/pacman/objc/ada (see https://github.com/msys2/msys2/wiki/FAQ)
   - if defined MSYSTEM (%BASH% -lc "pacman -Rns --noconfirm mingw-w64-{i686,x86_64}-gcc-ada mingw-w64-{i686,x86_64}-gcc-objc")
   # temporary fix for MSYS revoked/new signing keys:
-  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/wVgqQVN3 | bash")
+  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/DRqNq5D3 | bash")
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
   # the following line is not a duplicate line:
   # it is necessary to upgrade the MSYS base files and after that all the packages


### PR DESCRIPTION
This is a follow-up fix for https://github.com/hashcat/hashcat/pull/2519 , it seems the actual signing key problem is now fixed, but there is some further MSYS2 specific problem with bash/pacman.

Hopefully this fix will finally fix each and every Appveyor problem we currently have. Thx