### PR TITLE
fixes #2516: MSYS2/Appveyor building problem fixed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
   # (temporary?) problem with msys/pacman/objc/ada (see https://github.com/msys2/msys2/wiki/FAQ)
   - if defined MSYSTEM (%BASH% -lc "pacman -Rns --noconfirm mingw-w64-{i686,x86_64}-gcc-ada mingw-w64-{i686,x86_64}-gcc-objc")
   # temporary fix for MSYS revoked/new signing keys:
-  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/shmENPgV | bash")
+  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/e0y4Ky9U | bash")
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
   # the following line is not a duplicate line:
   # it is necessary to upgrade the MSYS base files and after that all the packages
@@ -43,7 +43,7 @@ install:
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
 
 build_script:
-  - if defined BASH (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && git submodule update --init && make")
+  - if defined BASH (%BASH% -lc "cd $(cygpath ${APPVEYOR_BUILD_FOLDER}) && make")
 
 test_script:
   # some file globbing tests
@@ -66,3 +66,4 @@ only_commits:
     - include/*
     - OpenCL/inc_*
     - Makefile
+    - .appveyor.yml


### PR DESCRIPTION
After a few attempts, this commit should finally fix the problem reported in #2516 : due to a signing key change (1 revoked, 2 new keys) of the MSYS maintainers/devs, our `Appveyor` tests failed.

This fix should now trigger a re-build whenever `.appveyor.yml` was changed and should contain a temporary fix for the missing `MSYS2` dev keys (manual update of the `keyring`).

This is of course a temporary solution and we should consider removing this temporary fix as soon as possible.

Thx