### PR TITLE
add OPTS_TYPE_SUGGEST_KG to -m 23100 = Apple Keychain

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -23,6 +23,7 @@
 ## Improvements
 ##
 
+- Apple Keychain: Notify the user about the risk of collisions / false positives
 - Startup time: Improved the startup time by avoiding some time intensive operations for skipped devices
 
 ##

--- a/src/modules/module_23100.c
+++ b/src/modules/module_23100.c
@@ -21,7 +21,8 @@ static const char *HASH_NAME      = "Apple Keychain";
 static const u64   KERN_TYPE      = 23100;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
-static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_SUGGEST_KG;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$keychain$*74cd1efd49e54a8fdc8750288801e09fa26a33b1*66001ad4e0498dc7*5a084b7314971b728cb551ac40b2e50b7b5bd8b8496b902efe7af07538863a45394ead8399ec581681f7416003c49cc7";


### PR DESCRIPTION
As already mentioned over https://github.com/hashcat/hashcat/pull/2472 , the Apple Keychain verification is at risk of collisions.

I just noticed that we forgot to add `OPTS_TYPE_SUGGEST_KG` to the module. We should definitely notify the user about this risk.

Thx