### PR TITLE
fixes #2518: call clear_prompt () more often to avoid misaligned prompt

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -18,6 +18,7 @@
 - Fixed internal access on module option attribute OPTS_TYPE_SUGGEST_KG with the result that it was unused
 - Fixed race condition resulting in out of memory error on startup if multiple hashcat instances are started at the same time
 - Fixed unexpected non-unique salts in multi-hash cracking in Bitcoin/Litecoin wallet.dat module which lead to false negatives
+- Fixed rare case of misalignment of the status prompt when other user warnings are shown within the hashcat output
 
 ##
 ## Improvements

--- a/src/backend.c
+++ b/src/backend.c
@@ -23,6 +23,7 @@
 #include "event.h"
 #include "dynloader.h"
 #include "backend.h"
+#include "terminal.h"
 
 #if defined (__linux__)
 static const char *dri_card0_path = "/dev/dri/card0";
@@ -6890,6 +6891,8 @@ void backend_ctx_devices_update_power (hashcat_ctx_t *hashcat_ctx)
     {
       if (user_options->quiet == false)
       {
+        clear_prompt (hashcat_ctx);
+
         event_log_advice (hashcat_ctx, "The wordlist or mask that you are using is too small.");
         event_log_advice (hashcat_ctx, "This means that hashcat cannot use the full parallel power of your device(s).");
         event_log_advice (hashcat_ctx, "Unless you supply more work, your cracking speed will drop.");

--- a/src/main.c
+++ b/src/main.c
@@ -239,6 +239,8 @@ static void main_cracker_starting (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYB
     {
       event_log_info_nn (hashcat_ctx, NULL);
 
+      clear_prompt (hashcat_ctx);
+
       send_prompt (hashcat_ctx);
     }
   }


### PR DESCRIPTION
As mentioned in #2518 and very intensively tested / debugged by @roycewilliams (thank you very much), we have/had a minor cosmetic problem when some warning messages interfered and popped up almost simultanously with the status prompt.

This problem also occurred more often when using `--increment` with increasing mask length and/or by using the `.hcmask` feature (several mask running quickly one after the other). When doing so the prompt wasn't really cleared/gone after one length/mask was finished and therefore the interference happened (rarely, but still annoying).

This fix of course is not meant to be 100% guaranteed to be complete, because in theory we could have many more warnings/infos popping up... but it's definitely addressing very many (hopefully almost all) of the cases where simultanous updates to the user interface (i.e. output in the shell) could happen.

Thanks again to royce for testing

:+1: 