### PR TITLE
unit tests: fix packaging (-p) of tests

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -32,6 +32,7 @@
 
 - Hash-Mode 13200 (AxCrypt): Changed the name to AxCrypt 1 to avoid confusion
 - Hash-Mode 13300 (AxCrypt in-memory SHA1): Changed the name to AxCrypt 1 in-memory SHA1
+- Unit tests: Fixed the packaging of test (-p) feature
 
 * changes v6.1.0 -> v6.1.1
 

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -3346,6 +3346,6 @@ if [ "${PACKAGE}" -eq 1 ]; then
     -e "s/^\(ATTACK\)=0/\1=${ATTACK}/" \
     "${OUTD}/test.sh"
 
-  "${PACKAGE_CMD}" "${OUTD}/${OUTD}.7z" "${OUTD}/" >/dev/null 2>/dev/null
+  ${PACKAGE_CMD} "${OUTD}/${OUTD}.7z" "${OUTD}/" >/dev/null 2>/dev/null
 
 fi


### PR DESCRIPTION
I just noticed that the packaging of unit tests (`test.sh -p`) didn't work anymore.

I got an error similar to
command "7z a" not found

We need to get rid of the quoting here (").

Thx