### PR TITLE
minor: update list of perl modules for unit tests

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -18,6 +18,7 @@ cpan install Authen::Passphrase::LANManager \
              Convert::EBCDIC                \
              Crypt::CBC                     \
              Crypt::DES                     \
+             Crypt::DES_EDE3                \
              Crypt::Digest::RIPEMD160       \
              Crypt::Digest::Whirlpool       \
              Crypt::ECB                     \

--- a/tools/test_modules/m22911.pm
+++ b/tools/test_modules/m22911.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use Crypt::CBC;
+use Crypt::DES_EDE3;
 use Digest::MD5 qw (md5);
 
 sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }


### PR DESCRIPTION
This is a minor new problem with our unit tests. When -m 22911 was added, we forgot to add `Crypt::DES_EDE3` to the list of required perl modules.

Since this is a very new problem, no entries to `docs/changes.txt` are needed.

Thx