### PR TITLE
tests: added Python 3 support and make it default

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -32,6 +32,7 @@
 
 - Hash-Mode 13200 (AxCrypt): Changed the name to AxCrypt 1 to avoid confusion
 - Hash-Mode 13300 (AxCrypt in-memory SHA1): Changed the name to AxCrypt 1 in-memory SHA1
+- Unit tests: Added Python 3 support for all of the Python code in our test framework
 
 * changes v6.1.0 -> v6.1.1
 

--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -63,13 +63,13 @@ cpan install Authen::Passphrase::LANManager \
 
 ERRORS=$((ERRORS+$?))
 
-pip2 install pygost
+pip install pygost
 
-# pip2 uninstall -y pycryptoplus pycrypto pycryptodome
+# pip uninstall -y pycryptoplus pycrypto pycryptodome
 
-pip2 install pycryptoplus
-pip2 uninstall -y pycryptodome
-pip2 install pycrypto
+pip install pycryptoplus
+pip uninstall -y pycryptodome
+pip install pycrypto
 
 ERRORS=$((ERRORS+$?))
 

--- a/tools/test_modules/m11700.pm
+++ b/tools/test_modules/m11700.pm
@@ -16,18 +16,17 @@ sub module_generate_hash
 
   # PyGOST outputs digests in little-endian order, while the kernels
   # expect them in big-endian; hence the digest[::-1] mirroring.
-  # Using sys.stdout.write instead of print to disable \n character.
   my $python_code = <<"END_CODE";
 
 import binascii
 import sys
 from pygost import gost34112012256
 digest = gost34112012256.new (b"$word").digest ()
-sys.stdout.write (binascii.hexlify (digest[::-1]))
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $hash = `python2 -c '$python_code'`;
+  my $hash = `python -c '$python_code'`;
 
   return $hash;
 }

--- a/tools/test_modules/m11750.pm
+++ b/tools/test_modules/m11750.pm
@@ -23,11 +23,11 @@ from pygost import gost34112012256
 key    = b"$word"
 msg    = b"$salt"
 digest = hmac.new (key, msg, gost34112012256).digest ()
-sys.stdout.write (binascii.hexlify (digest[::-1]))
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python2 -c '$python_code'`;
+  my $digest = `python -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m11760.pm
+++ b/tools/test_modules/m11760.pm
@@ -23,11 +23,11 @@ from pygost import gost34112012256
 key    = b"$salt"
 msg    = b"$word"
 digest = hmac.new (key, msg, gost34112012256).digest ()
-sys.stdout.write (binascii.hexlify (digest[::-1]))
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python2 -c '$python_code'`;
+  my $digest = `python -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m11800.pm
+++ b/tools/test_modules/m11800.pm
@@ -20,11 +20,11 @@ import binascii
 import sys
 from pygost import gost34112012512
 digest = gost34112012512.new (b"$word").digest ()
-sys.stdout.write (binascii.hexlify (digest[::-1]))
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $hash = `python2 -c '$python_code'`;
+  my $hash = `python -c '$python_code'`;
 
   return $hash;
 }

--- a/tools/test_modules/m11850.pm
+++ b/tools/test_modules/m11850.pm
@@ -24,11 +24,11 @@ from pygost import gost34112012512
 key    = b"$word"
 msg    = b"$salt"
 digest = hmac.new (key, msg, gost34112012512).digest ()
-sys.stdout.write (binascii.hexlify (digest[::-1]))
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python2 -c '$python_code'`;
+  my $digest = `python -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m11860.pm
+++ b/tools/test_modules/m11860.pm
@@ -24,11 +24,11 @@ from pygost import gost34112012512
 key    = b"$salt"
 msg    = b"$word"
 digest = hmac.new (key, msg, gost34112012512).digest ()
-sys.stdout.write (binascii.hexlify (digest[::-1]))
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python2 -c '$python_code'`;
+  my $digest = `python -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m20011.pm
+++ b/tools/test_modules/m20011.pm
@@ -34,11 +34,11 @@ key = (key1, key2)
 
 cipher = AES.new (key, AES.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -48,7 +48,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -77,11 +77,11 @@ key = (key1, key2)
 
 cipher = AES.new (key, AES.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -91,7 +91,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -122,11 +122,11 @@ key = (key1, key2)
 
 cipher = python_Twofish.new (key, python_Twofish.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -136,7 +136,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -165,11 +165,11 @@ key = (key1, key2)
 
 cipher = python_Twofish.new (key, python_Twofish.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -179,7 +179,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -210,11 +210,11 @@ key = (key1, key2)
 
 cipher = python_Serpent.new (key, python_Serpent.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -224,7 +224,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -253,11 +253,11 @@ key = (key1, key2)
 
 cipher = python_Serpent.new (key, python_Serpent.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -267,7 +267,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 

--- a/tools/test_modules/m20012.pm
+++ b/tools/test_modules/m20012.pm
@@ -34,11 +34,11 @@ key = (key1, key2)
 
 cipher = AES.new (key, AES.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -48,7 +48,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -77,11 +77,11 @@ key = (key1, key2)
 
 cipher = AES.new (key, AES.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -91,7 +91,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -122,11 +122,11 @@ key = (key1, key2)
 
 cipher = python_Twofish.new (key, python_Twofish.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -136,7 +136,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -165,11 +165,11 @@ key = (key1, key2)
 
 cipher = python_Twofish.new (key, python_Twofish.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -179,7 +179,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -210,11 +210,11 @@ key = (key1, key2)
 
 cipher = python_Serpent.new (key, python_Serpent.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -224,7 +224,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -253,11 +253,11 @@ key = (key1, key2)
 
 cipher = python_Serpent.new (key, python_Serpent.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -267,7 +267,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 

--- a/tools/test_modules/m20013.pm
+++ b/tools/test_modules/m20013.pm
@@ -34,11 +34,11 @@ key = (key1, key2)
 
 cipher = AES.new (key, AES.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -48,7 +48,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -77,11 +77,11 @@ key = (key1, key2)
 
 cipher = AES.new (key, AES.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -91,7 +91,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -122,11 +122,11 @@ key = (key1, key2)
 
 cipher = python_Twofish.new (key, python_Twofish.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -136,7 +136,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -165,11 +165,11 @@ key = (key1, key2)
 
 cipher = python_Twofish.new (key, python_Twofish.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -179,7 +179,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -210,11 +210,11 @@ key = (key1, key2)
 
 cipher = python_Serpent.new (key, python_Serpent.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 encrypted = cipher.encrypt (base64.b64decode (data), sequence)
 
-print encrypted.encode ("hex")
+print (encrypted.hex ())
 
 END_CODE
 
@@ -224,7 +224,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -253,11 +253,11 @@ key = (key1, key2)
 
 cipher = python_Serpent.new (key, python_Serpent.MODE_XTS)
 
-sequence = "01".decode ("hex")
+sequence = b"\x01"
 
 decrypted = cipher.decrypt (base64.b64decode (data), sequence)
 
-print decrypted.encode ("hex")
+print (decrypted.hex ())
 
 END_CODE
 
@@ -267,7 +267,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python2 -c '$python_code'`;
+  my $output_buf = `python -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 


### PR DESCRIPTION
This got to my attention very recently in a personal note to me: several modern/new operating system do **NOT** support python 2 anymore and it's quite cumbersome to install pip2/python2 for these systems. Even Ubuntu versions dropped support for python 2 (by default) and of course python itself also recommends users to stop using `Python 2` and use `Python 3` instead.

I think this is a good way to avoid problems with installations and updates with updated python modules in the future etc. We should also stay up to date here and at the end: there aren't that many users that run the whole tests regularly... so keeping support for Python 2 isn't really that important (we can just tell the dev/user that `Python 3` is required for the test framework).

We also only use very few python code sections in our (otherwise mainly) perl scripts / modules.

I think this change should work without any problems and it makes it easier for new devs to run the tests (because python 3 is often pre-installed, but python 2 needs to by manually installed and sometimes is quite difficult to get working with modern OS, because not supported anymore).

Thx