### PR TITLE
Appveyor: test if it started to work without our workaround

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,8 +34,6 @@ install:
   - if defined CYG_ROOT (%CYG_SETUP% --quiet-mode --no-shortcuts --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages "%CYG_PACKAGES%" --upgrade-also)
   # (temporary?) problem with msys/pacman/objc/ada (see https://github.com/msys2/msys2/wiki/FAQ)
   - if defined MSYSTEM (%BASH% -lc "pacman -Rns --noconfirm mingw-w64-{i686,x86_64}-gcc-ada mingw-w64-{i686,x86_64}-gcc-objc")
-  # temporary fix for MSYS revoked/new signing keys:
-  - if defined MSYSTEM (%BASH% -lc "curl https://pastebin.com/raw/e0y4Ky9U | bash")
   - if defined MSYSTEM (%BASH% -lc "pacman -Suuy --noconfirm")
   # the following line is not a duplicate line:
   # it is necessary to upgrade the MSYS base files and after that all the packages


### PR DESCRIPTION
This is just a test to see if we still need the signing key workaround added by https://github.com/hashcat/hashcat/pull/2521 . Let's see if Appveyor succeeds or fails. fingers crossed