### PR TITLE
No need for this (object) reference in -m 23800

### DIFF
--- a/deps/unrar/hc_decompress_rar.cpp
+++ b/deps/unrar/hc_decompress_rar.cpp
@@ -27,7 +27,7 @@ extern "C" unsigned int hc_decompress_rar (unsigned char *Win, unsigned char *In
   DataIO.SetUnpackFromMemory ((byte *) Input,  PackSize);
   DataIO.SetUnpackToMemory   ((byte *) NULL, UnpackSize);
 
-  Unpack *Unp = new Unpack (&DataIO);
+  Unpack Unp = Unpack (&DataIO);
 
   // not needed in our tests (no false positives):
   // memset (Win, 0, UnpackSize);
@@ -37,19 +37,17 @@ extern "C" unsigned int hc_decompress_rar (unsigned char *Win, unsigned char *In
   // #define PPMSIZE 216 * 1024 * 1024
   // memset (PPM,  0, PPMSIZE);
 
-  Unp->SetWin (Win);
-  Unp->SetPPM (PPM);
+  Unp.SetWin (Win);
+  Unp.SetPPM (PPM);
 
-  Unp->Init (WINSIZE, SOLID);
-  Unp->SetDestSize (UnpackSize);
+  Unp.Init (WINSIZE, SOLID);
+  Unp.SetDestSize (UnpackSize);
 
-  Unp->SetExternalBuffer (Inp, VM);
+  Unp.SetExternalBuffer (Inp, VM);
 
-  Unp->DoUnpack (METHOD, SOLID); // sets output
+  Unp.DoUnpack (METHOD, SOLID); // sets output
 
   unsigned int crc32 = (unsigned int) DataIO.UnpHash.GetCRC32 ();
-
-  delete Unp;
 
   return crc32;
 }


### PR DESCRIPTION
This is just a minor change that doesn't really affect speed (at least in my benchmark tests), but it makes the code more easy to read and cleaner.

We did use `new`/`delete` while it wasn't really required here (as far as I remember, it actually was used similarly within the UnRAR library itself, and therefore we used it like this). The reference to the `Unpack` object is not needed and therefore we can get rid of this extra reference and `new`/`delete` function invocations.

The `Unpack`` object of course will go out of scope automatically (after the function finished) and therefore we do not need to call any destructor or add any extra code to free memory or similar.

Thanks