### PR TITLE
Improved the hook's memory handling for -m 11600 = 7-Zip

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -41,6 +41,7 @@
 
 - Documentation: Added 3rd party licenses to docs/license_libs
 - Module Structure: Add 3rd party library hook management functions. This also requires an update to all existing module_init()
+- Hash-Mode 11600 (7-Zip): Improved memory handling (alloc and free) for the hook function
 - Hash-Mode 13200 (AxCrypt): Changed the name to AxCrypt 1 to avoid confusion
 - Hash-Mode 13300 (AxCrypt in-memory SHA1): Changed the name to AxCrypt 1 in-memory SHA1
 - OpenCL Runtime: Switched default OpenCL device type on macOS from GPU to CPU. Use -D 2 to enable GPU devices.

--- a/src/modules/module_11600.c
+++ b/src/modules/module_11600.c
@@ -92,6 +92,13 @@ typedef struct seven_zip_hook_salt
 
 } seven_zip_hook_salt_t;
 
+typedef struct seven_zip_hook_extra
+{
+  void **aes;
+  void **unp;
+
+} seven_zip_hook_extra_t;
+
 static const char *SIGNATURE_SEVEN_ZIP = "$7z$";
 
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
@@ -113,12 +120,67 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
   return jit_build_options;
 }
 
+bool module_hook_extra_param_init (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const folder_config_t *folder_config, MAYBE_UNUSED const backend_ctx_t *backend_ctx, void *hook_extra_param)
+{
+  seven_zip_hook_extra_t *seven_zip_hook_extra = (seven_zip_hook_extra_t *) hook_extra_param;
+
+  #define AESSIZE  320 * 1024
+  #define UNPSIZE 9766 * 1024 // or actually maximum is 9999999
+
+  seven_zip_hook_extra->aes = hccalloc (backend_ctx->backend_devices_cnt, sizeof (void *));
+
+  if (seven_zip_hook_extra->aes == NULL) return false;
+
+  seven_zip_hook_extra->unp = hccalloc (backend_ctx->backend_devices_cnt, sizeof (void *));
+
+  if (seven_zip_hook_extra->unp == NULL) return false;
+
+  for (int backend_devices_idx = 0; backend_devices_idx < backend_ctx->backend_devices_cnt; backend_devices_idx++)
+  {
+    hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
+
+    if (device_param->skipped == true) continue;
+
+    seven_zip_hook_extra->aes[backend_devices_idx] = hcmalloc (AESSIZE);
+
+    if (seven_zip_hook_extra->aes[backend_devices_idx] == NULL) return false;
+
+    seven_zip_hook_extra->unp[backend_devices_idx] = hcmalloc (UNPSIZE);
+
+    if (seven_zip_hook_extra->unp[backend_devices_idx] == NULL) return false;
+  }
+
+  return true;
+}
+
+bool module_hook_extra_param_term (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const folder_config_t *folder_config, MAYBE_UNUSED const backend_ctx_t *backend_ctx, void *hook_extra_param)
+{
+  seven_zip_hook_extra_t *seven_zip_hook_extra = (seven_zip_hook_extra_t *) hook_extra_param;
+
+  for (int backend_devices_idx = 0; backend_devices_idx < backend_ctx->backend_devices_cnt; backend_devices_idx++)
+  {
+    hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
+
+    if (device_param->skipped == true) continue;
+
+    hcfree (seven_zip_hook_extra->aes[backend_devices_idx]);
+    hcfree (seven_zip_hook_extra->unp[backend_devices_idx]);
+  }
+
+  hcfree (seven_zip_hook_extra->aes);
+  hcfree (seven_zip_hook_extra->unp);
+
+  return true;
+}
+
 void module_hook23 (hc_device_param_t *device_param, MAYBE_UNUSED const void *hook_extra_param, const void *hook_salts_buf, const u32 salt_pos, const u64 pw_pos)
 {
   seven_zip_hook_t *hook_items = (seven_zip_hook_t *) device_param->hooks_buf;
 
   seven_zip_hook_salt_t *seven_zips = (seven_zip_hook_salt_t *) hook_salts_buf;
   seven_zip_hook_salt_t *seven_zip  = &seven_zips[salt_pos];
+
+  seven_zip_hook_extra_t *seven_zip_hook_extra = (seven_zip_hook_extra_t *) hook_extra_param;
 
   u8   data_type   = seven_zip->data_type;
   u32 *data_buf    = seven_zip->data_buf;
@@ -149,7 +211,7 @@ void module_hook23 (hc_device_param_t *device_param, MAYBE_UNUSED const void *ho
   iv[2] = seven_zip->iv_buf[2];
   iv[3] = seven_zip->iv_buf[3];
 
-  u32 out_full[81882];
+  u32 *out_full = (u32 *) seven_zip_hook_extra->aes[device_param->device_id];
 
   // if aes_len > 16 we need to loop
 
@@ -226,9 +288,7 @@ void module_hook23 (hc_device_param_t *device_param, MAYBE_UNUSED const void *ho
 
     // output buffers and length
 
-    unsigned char *decompressed_data;
-
-    decompressed_data = (unsigned char *) hcmalloc (crc_len);
+    unsigned char *decompressed_data = (unsigned char *) seven_zip_hook_extra->unp[device_param->device_id];
 
     SizeT decompressed_data_len = crc_len;
 
@@ -276,14 +336,10 @@ void module_hook23 (hc_device_param_t *device_param, MAYBE_UNUSED const void *ho
     {
       hook_item->hook_success = 0;
 
-      hcfree (decompressed_data);
-
       return;
     }
 
     crc = cpu_crc32_buffer (decompressed_data, crc_len);
-
-    hcfree (decompressed_data);
   }
 
   if (crc == seven_zip_crc)
@@ -308,6 +364,13 @@ u64 module_hook_salt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UN
   const u64 hook_salt_size = (const u64) sizeof (seven_zip_hook_salt_t);
 
   return hook_salt_size;
+}
+
+u64 module_hook_extra_param_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 hook_extra_param_size = (const u64) sizeof (seven_zip_hook_extra_t);
+
+  return hook_extra_param_size;
 }
 
 u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
@@ -748,9 +811,9 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
   module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
   module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
-  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
-  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
-  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = module_hook_extra_param_size;
+  module_ctx->module_hook_extra_param_init    = module_hook_extra_param_init;
+  module_ctx->module_hook_extra_param_term    = module_hook_extra_param_term;
   module_ctx->module_hook12                   = MODULE_DEFAULT;
   module_ctx->module_hook23                   = module_hook23;
   module_ctx->module_hook_salt_size           = module_hook_salt_size;


### PR DESCRIPTION
This adds `module_hook_extra_param_init ()` and `module_hook_extra_param_term ()` to the -m 11600 = `7-Zip` module to avoid allocating and freeing the buffers each and every time a hook thread is run.

In my benchmark tests the speed wasn't improved that much, but it still makes sense to avoid doing these repetitive tasks if not needed. Some operating system do have slower routines to allocate and deallocate/free the memory and therefore it's also possible that for instance windows speed improves more significantly compared to the linux speed change/improvement.

I think, since we now have this opportunity/possibility to use `module_hook_extra_param_init` and `module_hook_extra_param_term`, we should definitely use these new functions wherever needed (it's also good to show other developers how this is normally been done and how you could theoretically refactor and move some code to these new functions to avoid unecessary repetitive tasks).

Thanks a lot