### PR TITLE
minor: use correct buffer size for AES decryption

### DIFF
--- a/OpenCL/m16300-pure.cl
+++ b/OpenCL/m16300-pure.cl
@@ -479,7 +479,7 @@ KERNEL_FQ void m16300_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, ethereum_
    * aes init
    */
 
-  #define KEYLEN 60
+  #define KEYLEN 44
 
   u32 ks[KEYLEN];
 

--- a/OpenCL/m23300-pure.cl
+++ b/OpenCL/m23300-pure.cl
@@ -306,7 +306,7 @@ KERNEL_FQ void m23300_comp (KERN_ATTR_TMPS_ESALT (iwork_tmp_t, iwork_t))
    * AES part
    */
 
-  u32 ukey[8];
+  u32 ukey[4];
 
   ukey[0] = tmps[gid].out[0];
   ukey[1] = tmps[gid].out[1];


### PR DESCRIPTION
I've found these 2 instances of incorrect (overlarge) buffers for AES decryption by accident.

These are not actual bugs that have any affect (no memory/buffer problem), it's just weird that we use larger buffer than actually needed.

I would advice to use the correct size all the time as proposed with this patch. I don't think we should add any changelog entry because these are minor corrections without any side-effects or implications to the actual compiled code (the compilers do figure this out anyway, that not all of these bytes are needed and that the buffer is actually larger than needed, and they optimize this).

Thanks