### PR TITLE
typo fixes and use https in user_manuals.txt

### DIFF
--- a/docs/user_manuals.txt
+++ b/docs/user_manuals.txt
@@ -1,3 +1,3 @@
-The user manuals are constantly updated. Thats why they are not part of the distribtion.
+The user manuals are constantly updated. That's why they are not part of the distribution.
 
-For more detailed Informations and advanced hashcat usage visit our Wiki: http://hashcat.net/wiki
+For more detailed information and advanced hashcat usage visit our Wiki: https://hashcat.net/wiki


### PR DESCRIPTION
This is a minor typo fix. Furthermore, I replaced `http` with `https` in `docs/user_manuals.txt`

Thank you very much