### PR TITLE
Added -m 23900 = BestCrypt v3 Volume Encryption

### DIFF
--- a/OpenCL/m23900-pure.cl
+++ b/OpenCL/m23900-pure.cl
@@ -1,0 +1,454 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_hash_sha256.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+#define MIN(a,b) (((a) < (b)) ? (a) : (b))
+
+typedef struct bestcrypt_tmp
+{
+  u32 salt_pw_buf[33];
+  u32 out[8];
+
+} bestcrypt_tmp_t;
+
+typedef struct bestcrypt
+{
+  u32 data[24];
+
+} bestcrypt_t;
+
+KERNEL_FQ void m23900_init (KERN_ATTR_TMPS_ESALT (bestcrypt_tmp_t, bestcrypt_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  const int salt_pw_len = 8 + pws[gid].pw_len;
+
+  u32 comb[16];
+
+  comb[ 0] = salt_bufs[salt_pos].salt_buf[0];
+  comb[ 1] = salt_bufs[salt_pos].salt_buf[1];
+
+  comb[ 2] = hc_swap32_S (pws[gid].i[ 0]); // in theory BE is faster because it
+  comb[ 3] = hc_swap32_S (pws[gid].i[ 1]); // avoids several other byte swaps later on
+  comb[ 4] = hc_swap32_S (pws[gid].i[ 2]);
+  comb[ 5] = hc_swap32_S (pws[gid].i[ 3]);
+  comb[ 6] = hc_swap32_S (pws[gid].i[ 4]);
+  comb[ 7] = hc_swap32_S (pws[gid].i[ 5]);
+  comb[ 8] = hc_swap32_S (pws[gid].i[ 6]);
+  comb[ 9] = hc_swap32_S (pws[gid].i[ 7]);
+  comb[10] = hc_swap32_S (pws[gid].i[ 8]);
+  comb[11] = hc_swap32_S (pws[gid].i[ 9]);
+  comb[12] = hc_swap32_S (pws[gid].i[10]);
+  comb[13] = hc_swap32_S (pws[gid].i[11]);
+  comb[14] = hc_swap32_S (pws[gid].i[12]);
+  comb[15] = hc_swap32_S (pws[gid].i[13]);
+
+  u32 salt_pw_buf[32 + 1] = { 0 }; // 8 + 56 + 64 = 128 bytes
+
+  for (int i = 0; i < 128; i += salt_pw_len)
+  {
+    const int idx = i / 4;
+    const int mod = i % 4;
+
+    const int full_len = MIN (salt_pw_len, 128 - i);
+
+    const int copy_len = (full_len + 3) / 4; // ceil () + convert to 4-byte block (u32)
+
+    for (int j = 0, k = idx; j < copy_len; j++, k++)
+    {
+      // salt_pw_buf[k] |= comb[j] >> (mod * 8);
+      // if (mod) salt_pw_buf[k + 1] |= comb[j] << ((4 - mod) * 8);
+
+      switch (mod)
+      {
+        case 0:
+          salt_pw_buf[k + 0] |= comb[j];
+          break;
+        case 1:
+          salt_pw_buf[k + 0] |= comb[j] >>  8;
+          salt_pw_buf[k + 1] |= comb[j] << 24;
+          break;
+        case 2:
+          salt_pw_buf[k + 0] |= comb[j] >> 16;
+          salt_pw_buf[k + 1] |= comb[j] << 16;
+          break;
+        case 3:
+          salt_pw_buf[k + 0] |= comb[j] >> 24;
+          salt_pw_buf[k + 1] |= comb[j] <<  8;
+          break;
+      }
+    }
+  }
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int i = 0; i < 33; i++)
+  {
+    tmps[gid].salt_pw_buf[i] = salt_pw_buf[i];
+  }
+}
+
+KERNEL_FQ void m23900_loop (KERN_ATTR_TMPS_ESALT (bestcrypt_tmp_t, bestcrypt_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  const int salt_pw_len = 8 + pws[gid].pw_len;
+
+  u32 salt_pw_buf[32 + 1]; // 8 + 56 + 64 = 128 bytes
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int i = 0; i < 33; i++)
+  {
+    salt_pw_buf[i] = tmps[gid].salt_pw_buf[i];
+  }
+
+  u32 tbl[1024] = { 0 }; // 4 KiB lookup table
+
+  for (int i = 0; i < 64; i++)
+  {
+    const int idx = i / 4;
+    const int mod = i % 4;
+
+    // init:
+
+    int k = i * 16;
+    int l = idx;
+
+    // tbl[k] |= salt_pw_buf[l] << (mod * 8);
+
+    switch (mod)
+    {
+      case 0:
+        tbl[k] |= salt_pw_buf[l];
+        break;
+      case 1:
+        tbl[k] |= salt_pw_buf[l] <<  8;
+        break;
+      case 2:
+        tbl[k] |= salt_pw_buf[l] << 16;
+        break;
+      case 3:
+        tbl[k] |= salt_pw_buf[l] << 24;
+        break;
+    }
+
+    k += 1;
+    l += 1;
+
+    // loop:
+
+    for (int j = 1; j < 16; j++, k++, l++)
+    {
+      // if (mod) tbl[k - 1] |= salt_pw_buf[l] >> ((4 - mod) * 8);
+      // tbl[k] |= salt_pw_buf[l] << (mod * 8);
+
+      switch (mod)
+      {
+        case 0:
+          tbl[k - 0] |= salt_pw_buf[l];
+          break;
+        case 1:
+          tbl[k - 0] |= salt_pw_buf[l] <<  8;
+          tbl[k - 1] |= salt_pw_buf[l] >> 24;
+          break;
+        case 2:
+          tbl[k - 0] |= salt_pw_buf[l] << 16;
+          tbl[k - 1] |= salt_pw_buf[l] >> 16;
+          break;
+        case 3:
+          tbl[k - 0] |= salt_pw_buf[l] << 24;
+          tbl[k - 1] |= salt_pw_buf[l] >>  8;
+          break;
+      }
+    }
+
+    // final:
+
+    // if (mod) tbl[k - 1] |= salt_pw_buf[l] >> ((4 - mod) * 8);
+
+    switch (mod)
+    {
+      case 0:
+        break;
+      case 1:
+        tbl[k - 1] |= salt_pw_buf[l] >> 24;
+        break;
+      case 2:
+        tbl[k - 1] |= salt_pw_buf[l] >> 16;
+        break;
+      case 3:
+        tbl[k - 1] |= salt_pw_buf[l] >>  8;
+        break;
+    }
+  }
+
+  u32 digest[8];
+
+  digest[0] = SHA256M_A;
+  digest[1] = SHA256M_B;
+  digest[2] = SHA256M_C;
+  digest[3] = SHA256M_D;
+  digest[4] = SHA256M_E;
+  digest[5] = SHA256M_F;
+  digest[6] = SHA256M_G;
+  digest[7] = SHA256M_H;
+
+  for (int i = 0; i < 65536; i += 64)
+  {
+    const int idx = (i % salt_pw_len) * 16;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = tbl[idx +  0];
+    w0[1] = tbl[idx +  1];
+    w0[2] = tbl[idx +  2];
+    w0[3] = tbl[idx +  3];
+    w1[0] = tbl[idx +  4];
+    w1[1] = tbl[idx +  5];
+    w1[2] = tbl[idx +  6];
+    w1[3] = tbl[idx +  7];
+    w2[0] = tbl[idx +  8];
+    w2[1] = tbl[idx +  9];
+    w2[2] = tbl[idx + 10];
+    w2[3] = tbl[idx + 11];
+    w3[0] = tbl[idx + 12];
+    w3[1] = tbl[idx + 13];
+    w3[2] = tbl[idx + 14];
+    w3[3] = tbl[idx + 15];
+
+    sha256_transform (w0, w1, w2, w3, digest);
+  }
+
+  tmps[gid].out[0] = digest[0];
+  tmps[gid].out[1] = digest[1];
+  tmps[gid].out[2] = digest[2];
+  tmps[gid].out[3] = digest[3];
+  tmps[gid].out[4] = digest[4];
+  tmps[gid].out[5] = digest[5];
+  tmps[gid].out[6] = digest[6];
+  tmps[gid].out[7] = digest[7];
+}
+
+KERNEL_FQ void m23900_comp (KERN_ATTR_TMPS_ESALT (bestcrypt_tmp_t, bestcrypt_t))
+{
+  const u64 gid = get_global_id  (0);
+  const u64 lid = get_local_id   (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  // final transform of sha256:
+
+  u32 digest[8];
+
+  digest[0] = tmps[gid].out[0];
+  digest[1] = tmps[gid].out[1];
+  digest[2] = tmps[gid].out[2];
+  digest[3] = tmps[gid].out[3];
+  digest[4] = tmps[gid].out[4];
+  digest[5] = tmps[gid].out[5];
+  digest[6] = tmps[gid].out[6];
+  digest[7] = tmps[gid].out[7];
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  w0[0] = 0x80000000;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 65536 * 8;
+
+  sha256_transform (w0, w1, w2, w3, digest);
+
+  /**
+   * AES part
+   */
+
+  #define KEYLEN 60
+
+  u32 ks[KEYLEN];
+
+  AES256_set_decrypt_key (ks, digest, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+  u32 iv[4] = { 0 };
+
+  u32 res[20]; // full would be 24 x u32 (96 bytes)
+
+  for (u32 i = 0; i < 20; i += 4) // 96 bytes output would contain the full 32 byte checksum
+  {
+    u32 data[4];
+
+    data[0] = esalt_bufs[digests_offset].data[i + 0];
+    data[1] = esalt_bufs[digests_offset].data[i + 1];
+    data[2] = esalt_bufs[digests_offset].data[i + 2];
+    data[3] = esalt_bufs[digests_offset].data[i + 3];
+
+    u32 out[4];
+
+    aes256_decrypt (ks, data, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    res[i + 0] = hc_swap32_S (out[0] ^ iv[0]);
+    res[i + 1] = hc_swap32_S (out[1] ^ iv[1]);
+    res[i + 2] = hc_swap32_S (out[2] ^ iv[2]);
+    res[i + 3] = hc_swap32_S (out[3] ^ iv[3]);
+
+    iv[0] = data[0];
+    iv[1] = data[1];
+    iv[2] = data[2];
+    iv[3] = data[3];
+  }
+
+  // checksum:
+
+  // sha256_ctx_t ctx;
+  // sha256_init (&ctx);
+  // sha256_update_swap (&ctx, res, 64);
+  // sha256_final (&ctx);
+
+  digest[0] = SHA256M_A;
+  digest[1] = SHA256M_B;
+  digest[2] = SHA256M_C;
+  digest[3] = SHA256M_D;
+  digest[4] = SHA256M_E;
+  digest[5] = SHA256M_F;
+  digest[6] = SHA256M_G;
+  digest[7] = SHA256M_H;
+
+  w0[0] = res[ 0];
+  w0[1] = res[ 1];
+  w0[2] = res[ 2];
+  w0[3] = res[ 3];
+  w1[0] = res[ 4];
+  w1[1] = res[ 5];
+  w1[2] = res[ 6];
+  w1[3] = res[ 7];
+  w2[0] = res[ 8];
+  w2[1] = res[ 9];
+  w2[2] = res[10];
+  w2[3] = res[11];
+  w3[0] = res[12];
+  w3[1] = res[13];
+  w3[2] = res[14];
+  w3[3] = res[15];
+
+  sha256_transform (w0, w1, w2, w3, digest);
+
+  w0[0] = 0x80000000;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 64 * 8;
+
+  sha256_transform (w0, w1, w2, w3, digest);
+
+  if ((digest[0] == res[16]) &&
+      (digest[1] == res[17]) &&
+      (digest[2] == res[18]) &&
+      (digest[3] == res[19]))
+  {
+    if (atomic_inc (&hashes_shown[digests_offset]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, salt_pos, digests_cnt, 0, digests_offset + 0, gid, 0, 0, 0);
+    }
+
+    return;
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -5,6 +5,7 @@
 ##
 
 - Added hash-mode: Bitwarden
+- Added hash-mode: BestCrypt v3 Volume Encryption
 - Added hash-mode: Apple iWork
 - Added hash-mode: AxCrypt 2 AES-128
 - Added hash-mode: AxCrypt 2 AES-256

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -253,6 +253,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - Android FDE (Samsung DEK)
 - Android FDE <= 4.3
 - Apple File System (APFS)
+- BestCrypt v3 Volume Encryption
 - TrueCrypt
 - PDF 1.1 - 1.3 (Acrobat 2 - 4)
 - PDF 1.1 - 1.3 (Acrobat 2 - 4), collider #1

--- a/src/modules/module_23900.c
+++ b/src/modules/module_23900.c
@@ -1,0 +1,273 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
+static const char *HASH_NAME      = "BestCrypt v3 Volume Encryption";
+static const u64   KERN_TYPE      = 23900;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_ST_HEX;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$bcve$3$08$234b8182cee7098b$35c12ef76a1e88175c4c222da3558310a0075bc7a06ecf46746d149c02a81fb8a97637d1103d2e13ddd5deaf982889594b18c12d7ca18a54875c5da4a47f90ae615ab94b8e3ed9e3c793d872a1b5ac35cfdb66c221d6d0853e9ff2e0f4435b43";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct bestcrypt_tmp
+{
+  u32 salt_pw_buf[33];
+  u32 out[8];
+
+} bestcrypt_tmp_t;
+
+typedef struct bestcrypt
+{
+  u32 data[24];
+
+} bestcrypt_t;
+
+static const char *SIGNATURE_BESTCRYPT  = "$bcve$";
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (bestcrypt_tmp_t);
+
+  return tmp_size;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (bestcrypt_t);
+
+  return esalt_size;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // this overrides the reductions of PW_MAX in case optimized kernel is selected
+  // IOW, even in optimized kernel mode it support length 56
+
+  const u32 pw_max = 56;
+
+  return pw_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  bestcrypt_t *bestcrypt = (bestcrypt_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt  = 5;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_BESTCRYPT;
+
+  token.len[0]     = 6;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.len_min[1] = 1;
+  token.len_max[1] = 1;
+  token.sep[1]     = '$';
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len_min[2] = 2;
+  token.len_max[2] = 2;
+  token.sep[2]     = '$';
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[3] = 16;
+  token.len_max[3] = 16;
+  token.sep[3]     = '$';
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len[4]     = 192;
+  token.attr[4]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *format_type_pos = token.buf[1];
+
+  if (format_type_pos[0] != '3') return (PARSER_SALT_VALUE);
+
+  const u8 *crypto_type_pos = token.buf[2];
+
+  if (crypto_type_pos[0] != '0') return (PARSER_SALT_VALUE);
+  if (crypto_type_pos[1] != '8') return (PARSER_SALT_VALUE);
+
+  salt->salt_iter = 1;
+
+  // salt
+
+  const u8 *salt_pos = token.buf[3];
+  const int salt_len = token.len[3];
+
+  const bool parse_rc = generic_salt_decode (hashconfig, salt_pos, salt_len, (u8 *) salt->salt_buf, (int *) &salt->salt_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  salt->salt_buf[0] = salt->salt_buf[0];
+  salt->salt_buf[1] = salt->salt_buf[1];
+
+  salt->salt_buf[0] = byte_swap_32 (salt->salt_buf[0]);
+  salt->salt_buf[1] = byte_swap_32 (salt->salt_buf[1]);
+
+  // data
+
+  const u8 *data_pos = token.buf[4];
+  const int data_len = token.len[4];
+
+  hex_decode (data_pos, data_len, (u8 *) bestcrypt->data);
+
+  // fake digest
+
+  digest[0] = bestcrypt->data[16]; // the encrypted checksum
+  digest[1] = bestcrypt->data[17];
+  digest[2] = bestcrypt->data[18];
+  digest[3] = bestcrypt->data[19];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const bestcrypt_t *bestcrypt = (const bestcrypt_t *) esalt_buf;
+
+  // salt
+
+  u32 tmp_salt[4] = { 0 };
+
+  tmp_salt[0] = byte_swap_32 (salt->salt_buf[0]);
+  tmp_salt[1] = byte_swap_32 (salt->salt_buf[1]);
+
+  char salt_hex[17] = { 0 };
+
+  generic_salt_encode (hashconfig, (const u8 *) tmp_salt, (const int) salt->salt_len, (u8 *) salt_hex);
+
+  // data
+
+  u8 data_hex[193] = { 0 };
+
+  hex_encode ((u8 *) bestcrypt->data, 96, data_hex);
+
+  int out_len = snprintf (line_buf, line_size, "%s3$08$%s$%s",
+    SIGNATURE_BESTCRYPT,
+    salt_hex,
+    data_hex
+  );
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m23900.pm
+++ b/tools/test_modules/m23900.pm
@@ -1,0 +1,125 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha256);
+use Crypt::CBC;
+
+sub module_constraints { [[0, 56], [8, 8], [-1, -1], [-1, -1], [-1, -1]] }
+
+my $BUF_SIZE = 0x10000;
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $data = shift;
+
+  my $comb = $salt . $word;
+  my $len  = length ($comb);
+
+  my $buf = "";
+
+  for (my $i = 0; $i < $BUF_SIZE; $i += $len)
+  {
+    $buf .= $comb;
+  }
+
+  # IMPORTANT: we need to truncate the buffer to $BUF_SIZE:
+
+  $buf = substr ($buf, 0, $BUF_SIZE);
+
+  my $key = sha256 ($buf);
+
+  my $aes = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    key         => $key,
+    iv          => "\x00" x 16,
+    keysize     => 32,
+    literal_key => 1,
+    header      => "none",
+    padding     => "none"
+  });
+
+  if (defined ($data)) # decrypt
+  {
+    my $plain_text = $aes->decrypt ($data);
+
+    my $part1 = substr ($plain_text,  0, 64);
+    my $part2 = substr ($plain_text, 64, 32);
+
+    my $hash = sha256 ($part1);
+
+    if ($hash ne $part2) # wrong => fake the data
+    {
+      $data = "\x00" x length ($data); # 64 + 32 = 96
+    }
+  }
+  else # encrypt
+  {
+    $data = random_bytes (64);
+
+    my $hash = sha256 ($data);
+
+    $data = $aes->encrypt ($data . $hash);
+  }
+
+  return sprintf ("\$bcve\$3\$08\$%s\$%s", unpack ("H*", $salt), unpack ("H*", $data));
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx1 = index ($line, ':');
+
+  return if ($idx1 < 1);
+
+  my $hash = substr ($line, 0, $idx1);
+  my $word = substr ($line, $idx1 + 1);
+
+  return if (substr ($hash, 0, 8) ne "\$bcve\$3\$");
+
+  $idx1 = index ($hash, '$', 8);
+
+  return if ($idx1 < 1);
+
+  # crypto type
+
+  my $crypto_type = substr ($hash, 8, $idx1 - 8);
+
+  return unless ($crypto_type eq "08");
+
+  # salt
+
+  my $idx2 = index ($hash, '$', $idx1 + 1);
+
+  my $salt = substr ($hash, $idx1 + 1, $idx2 - $idx1 - 1);
+
+  return unless ($salt =~ m/^[0-9a-fA-F]+$/);
+
+  # data
+
+  my $data = substr ($hash, $idx2 + 1);
+
+  return unless ($data =~ m/^[0-9a-fA-F]+$/);
+
+  # convert to hex:
+
+  $salt = pack ("H*", $salt);
+  $data = pack ("H*", $data);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $data);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This PR implements the V3 hash type requested in #2360 : 
```
-m 23900 = BestCrypt v3 Volume Encryption
```

For now, you can extract the hashes with https://github.com/trounce1/JohnTheRipper/blob/patch-1/run/bestcryptve2john.py

There is probably still some little room for optimizations (@jsteube already promised me that he will have a look at it soon), but for now it's implemented with the approach we discussed in #2360.

cc: @trounce1, @NilsOlze