### PR TITLE
minor: fix indentation issue in -m 17900 = Keccak-384

### DIFF
--- a/OpenCL/m17900_a3-optimized.cl
+++ b/OpenCL/m17900_a3-optimized.cl
@@ -80,7 +80,7 @@ DECLSPEC void m17500m (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
 
     #define Rho_Pi(ad,r)     \
       bc0 = ad;              \
-      ad = hc_rotl64 (t, r);    \
+      ad = hc_rotl64 (t, r); \
       t = bc0;               \
 
     #ifdef _unroll
@@ -278,7 +278,7 @@ DECLSPEC void m17500s (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
 
     #define Rho_Pi(ad,r)     \
       bc0 = ad;              \
-      ad = hc_rotl64 (t, r);    \
+      ad = hc_rotl64 (t, r); \
       t = bc0;               \
 
     #ifdef _unroll


### PR DESCRIPTION
This is just a minor code style/formatting issue in -m 17900 (`Keccak-384`) kernel code.

Thanks