### PR TITLE
Fixes a buffer problem in -m 23900 if pw_len is larger than expected

### DIFF
--- a/OpenCL/m23900-pure.cl
+++ b/OpenCL/m23900-pure.cl
@@ -35,7 +35,7 @@ KERNEL_FQ void m23900_init (KERN_ATTR_TMPS_ESALT (bestcrypt_tmp_t, bestcrypt_t))
 
   if (gid >= gid_max) return;
 
-  const int salt_pw_len = 8 + pws[gid].pw_len;
+  const int salt_pw_len = 8 + MIN (pws[gid].pw_len, 56);
 
   u32 comb[16];
 
@@ -109,7 +109,7 @@ KERNEL_FQ void m23900_loop (KERN_ATTR_TMPS_ESALT (bestcrypt_tmp_t, bestcrypt_t))
 
   if (gid >= gid_max) return;
 
-  const int salt_pw_len = 8 + pws[gid].pw_len;
+  const int salt_pw_len = 8 + MIN (pws[gid].pw_len, 56);
 
   u32 salt_pw_buf[32 + 1]; // 8 + 56 + 64 = 128 bytes
 


### PR DESCRIPTION
This is a minor bug fix (and follow-up commit) for the hash type we recently added here: https://github.com/hashcat/hashcat/pull/2559 (-m 23900 = `BestCrypt v3 Volume Encryption`).

Unfortunately, the `pw_len` variable could in some rare cases (like a cracking job run with special rules that append characters to the base password) end up with a password that is longer than expected (max is 56, plus 8 bytes salt = 64 total).

This should fix the problem reported here: https://github.com/hashcat/hashcat/issues/2360#issuecomment-703078020

Thanks