### PR TITLE
docs: fix simple typo, paramater -> parameter

### DIFF
--- a/deps/LZMA-SDK/C/Lzma2DecMt.h
+++ b/deps/LZMA-SDK/C/Lzma2DecMt.h
@@ -31,7 +31,7 @@ void Lzma2DecMtProps_Init(CLzma2DecMtProps *p);
 SRes:
   SZ_OK           - OK
   SZ_ERROR_MEM    - Memory allocation error
-  SZ_ERROR_PARAM  - Incorrect paramater in props
+  SZ_ERROR_PARAM  - Incorrect parameter in props
   SZ_ERROR_WRITE  - ISeqOutStream write callback error
   // SZ_ERROR_OUTPUT_EOF - output buffer overflow - version with (Byte *) output
   SZ_ERROR_PROGRESS - some break from progress callback

--- a/deps/LZMA-SDK/C/Lzma2Enc.h
+++ b/deps/LZMA-SDK/C/Lzma2Enc.h
@@ -29,7 +29,7 @@ void Lzma2EncProps_Normalize(CLzma2EncProps *p);
 SRes:
   SZ_OK           - OK
   SZ_ERROR_MEM    - Memory allocation error
-  SZ_ERROR_PARAM  - Incorrect paramater in props
+  SZ_ERROR_PARAM  - Incorrect parameter in props
   SZ_ERROR_WRITE  - ISeqOutStream write callback error
   SZ_ERROR_OUTPUT_EOF - output buffer overflow - version with (Byte *) output
   SZ_ERROR_PROGRESS - some break from progress callback

--- a/deps/LZMA-SDK/C/Lzma86.h
+++ b/deps/LZMA-SDK/C/Lzma86.h
@@ -56,7 +56,7 @@ RAM Requirements for compressing:
 Return code:
   SZ_OK               - OK
   SZ_ERROR_MEM        - Memory allocation error
-  SZ_ERROR_PARAM      - Incorrect paramater
+  SZ_ERROR_PARAM      - Incorrect parameter
   SZ_ERROR_OUTPUT_EOF - output buffer overflow
   SZ_ERROR_THREAD     - errors in multithreading functions (only for Mt version)
 */

--- a/deps/LZMA-SDK/C/LzmaEnc.h
+++ b/deps/LZMA-SDK/C/LzmaEnc.h
@@ -42,7 +42,7 @@ UInt32 LzmaEncProps_GetDictSize(const CLzmaEncProps *props2);
 SRes:
   SZ_OK           - OK
   SZ_ERROR_MEM    - Memory allocation error
-  SZ_ERROR_PARAM  - Incorrect paramater in props
+  SZ_ERROR_PARAM  - Incorrect parameter in props
   SZ_ERROR_WRITE  - ISeqOutStream write callback error
   SZ_ERROR_OUTPUT_EOF - output buffer overflow - version with (Byte *) output
   SZ_ERROR_PROGRESS - some break from progress callback

--- a/deps/LZMA-SDK/C/LzmaLib.h
+++ b/deps/LZMA-SDK/C/LzmaLib.h
@@ -88,7 +88,7 @@ Out:
 Returns:
   SZ_OK               - OK
   SZ_ERROR_MEM        - Memory allocation error
-  SZ_ERROR_PARAM      - Incorrect paramater
+  SZ_ERROR_PARAM      - Incorrect parameter
   SZ_ERROR_OUTPUT_EOF - output buffer overflow
   SZ_ERROR_THREAD     - errors in multithreading functions (only for Mt version)
 */


### PR DESCRIPTION
There is a small typo in deps/LZMA-SDK/C/Lzma2DecMt.h, deps/LZMA-SDK/C/Lzma2Enc.h, deps/LZMA-SDK/C/Lzma86.h, deps/LZMA-SDK/C/LzmaEnc.h, deps/LZMA-SDK/C/LzmaLib.h.

Should read `parameter` rather than `paramater`.

