### PR TITLE
tests: use python3/pip3 instead of just python/pip

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -64,13 +64,13 @@ cpan install Authen::Passphrase::LANManager \
 
 ERRORS=$((ERRORS+$?))
 
-pip install pygost
+pip3 install pygost
 
-# pip uninstall -y pycryptoplus pycrypto pycryptodome
+# pip3 uninstall -y pycryptoplus pycrypto pycryptodome
 
-pip install pycryptoplus
-pip uninstall -y pycryptodome
-pip install pycrypto
+pip3 install pycryptoplus
+pip3 uninstall -y pycryptodome
+pip3 install pycrypto
 
 ERRORS=$((ERRORS+$?))
 

--- a/tools/test_modules/m11700.pm
+++ b/tools/test_modules/m11700.pm
@@ -26,7 +26,7 @@ print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $hash = `python -c '$python_code'`;
+  my $hash = `python3 -c '$python_code'`;
 
   return $hash;
 }

--- a/tools/test_modules/m11750.pm
+++ b/tools/test_modules/m11750.pm
@@ -27,7 +27,7 @@ print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python -c '$python_code'`;
+  my $digest = `python3 -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m11760.pm
+++ b/tools/test_modules/m11760.pm
@@ -27,7 +27,7 @@ print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python -c '$python_code'`;
+  my $digest = `python3 -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m11800.pm
+++ b/tools/test_modules/m11800.pm
@@ -24,7 +24,7 @@ print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $hash = `python -c '$python_code'`;
+  my $hash = `python3 -c '$python_code'`;
 
   return $hash;
 }

--- a/tools/test_modules/m11850.pm
+++ b/tools/test_modules/m11850.pm
@@ -28,7 +28,7 @@ print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python -c '$python_code'`;
+  my $digest = `python3 -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m11860.pm
+++ b/tools/test_modules/m11860.pm
@@ -28,7 +28,7 @@ print (binascii.hexlify (digest[::-1]).decode (), end = "")
 
 END_CODE
 
-  my $digest = `python -c '$python_code'`;
+  my $digest = `python3 -c '$python_code'`;
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m20011.pm
+++ b/tools/test_modules/m20011.pm
@@ -48,7 +48,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -91,7 +91,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -136,7 +136,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -179,7 +179,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -224,7 +224,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -267,7 +267,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 

--- a/tools/test_modules/m20012.pm
+++ b/tools/test_modules/m20012.pm
@@ -48,7 +48,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -91,7 +91,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -136,7 +136,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -179,7 +179,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -224,7 +224,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -267,7 +267,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 

--- a/tools/test_modules/m20013.pm
+++ b/tools/test_modules/m20013.pm
@@ -48,7 +48,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -91,7 +91,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -136,7 +136,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -179,7 +179,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -224,7 +224,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 
@@ -267,7 +267,7 @@ END_CODE
   $python_code =~ s/key_tweak/"$key_tweak"/;
   $python_code =~ s/data/"$data_base64"/;
 
-  my $output_buf = `python -c '$python_code'`;
+  my $output_buf = `python3 -c '$python_code'`;
 
   $output_buf =~ s/[\r\n]//g;
 


### PR DESCRIPTION
Some devs/testers reported that just `python` or just `pip` do **not** work on there operating system because it is still using `python2`/`pip2`.

Note: We changed our test framework to use python3 with this commit https://github.com/hashcat/hashcat/commit/698d0fbbda6a3d390bf34ec6f7a9bcd8a8862c5b .

My suggestion here is to use `python3` and `pip3` for now explicitly and maybe change it in a few months / years when hopefully finally `Python 3` is default on every operating system (see https://www.python.org/doc/sunset-python-2/ , no more support since January 1st, 2020).

BTW: we already changed `docs/changes.txt` to document/explain the `Python 3` changes, so we shouldn't need an extra change for this commit.

Thanks