### PR TITLE
tests: remove requirement Convert::ASN1

### DIFF
--- a/tools/test_modules/m24410.pm
+++ b/tools/test_modules/m24410.pm
@@ -10,7 +10,6 @@ use warnings;
 
 use Crypt::CBC;
 use Crypt::PBKDF2;
-use Convert::ASN1 qw(:io);
 
 sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m24420.pm
+++ b/tools/test_modules/m24420.pm
@@ -10,7 +10,6 @@ use warnings;
 
 use Crypt::CBC;
 use Crypt::PBKDF2;
-use Convert::ASN1 qw(:io);
 
 sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
 


### PR DESCRIPTION
When I try to run `tools/test.sh` I get an error that `Convert::ASN1` is not available. `tools/install_modules.sh` also does not install it.

As I just found out `Convert::ASN1` isn't even used within the `tools/test_modules/m24410.pm` and `tools/test_modules/m24420.pm` perl modules that were added with this commit https://github.com/hashcat/hashcat/commit/fb219e0a69bf257c2e8c19cc8d02659cd8bbfadc#diff-8ce4aaad466e9834572972b9c3d1083b615ec62f65828818d6bfed177ec3894bR13 (PKCS#8 Private Keys support).

My suggestion is to just remove these perl module requirements from our test framework if we do not use it.

Thx