### PR TITLE
Added new feature: guessing hash type

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -4,7 +4,7 @@
 ## Features
 ##
 
-- Added guess hash type (-M)
+- Added Guess hash-type (-M)
 
 ##
 ## Algorithms

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,6 +1,12 @@
 * changes v6.1.1 -> v6.x.x
 
 ##
+## Features
+##
+
+- Added guess hash mode (-M)
+
+##
 ## Algorithms
 ##
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -4,7 +4,7 @@
 ## Features
 ##
 
-- Added guess hash mode (-M)
+- Added guess hash type (-M)
 
 ##
 ## Algorithms

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -19,6 +19,7 @@ Philipp "philsmd" Schmidt <philsmd@hashcat.net> (@philsmd)
 Gabriele "matrix" Gristina <matrix@hashcat.net> (@gm4tr1x)
 
 * Multiple kernel modules
+* Guess Hash feature
 * Compressed wordlist feature
 * OpenCL Info feature
 * Apple macOS port

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -19,7 +19,7 @@ Philipp "philsmd" Schmidt <philsmd@hashcat.net> (@philsmd)
 Gabriele "matrix" Gristina <matrix@hashcat.net> (@gm4tr1x)
 
 * Multiple kernel modules
-* Guess Hash feature
+* Guess hash-type feature
 * Compressed wordlist feature
 * OpenCL Info feature
 * Apple macOS port

--- a/include/types.h
+++ b/include/types.h
@@ -593,6 +593,7 @@ typedef enum user_options_defaults
   DEBUG_MODE               = 0,
   EXAMPLE_HASHES           = false,
   FORCE                    = false,
+  GUESS_HASH_MODE          = false,
   HWMON_DISABLE            = false,
   HWMON_TEMP_ABORT         = 90,
   HASH_MODE                = 0,
@@ -1933,6 +1934,7 @@ typedef struct user_options
   bool         limit_chgd;
 
   bool         advice_disable;
+  bool         guess_hash_mode;
   bool         benchmark;
   bool         benchmark_all;
   #ifdef WITH_BRAIN
@@ -2021,7 +2023,6 @@ typedef struct user_options
   u32          debug_mode;
   u32          hwmon_temp_abort;
   int          hash_mode;
-  int          guess_hash_mode;
   u32          hccapx_message_pair;
   u32          hook_threads;
   u32          increment_max;

--- a/include/types.h
+++ b/include/types.h
@@ -698,6 +698,7 @@ typedef enum user_options_map
   IDX_ENCODING_TO               = 0xff13,
   IDX_EXAMPLE_HASHES            = 0xff14,
   IDX_FORCE                     = 0xff15,
+  IDX_GUESS_HASH_MODE           = 'M',
   IDX_HWMON_DISABLE             = 0xff16,
   IDX_HWMON_TEMP_ABORT          = 0xff17,
   IDX_HASH_MODE                 = 'm',
@@ -2020,6 +2021,7 @@ typedef struct user_options
   u32          debug_mode;
   u32          hwmon_temp_abort;
   int          hash_mode;
+  int          guess_hash_mode;
   u32          hccapx_message_pair;
   u32          hook_threads;
   u32          increment_max;

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -1207,7 +1207,14 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
 
     rc_final = 1;
 
-    event_log_info (hashcat_ctx, "Starting guessing mode...\n");
+    event_log_info (hashcat_ctx, "Starting to guess the hash-type ...");
+
+    if (user_options->quiet == false)
+    {
+      event_log_info (hashcat_ctx, "For each hash-type guessed, the following fields will be printed: type, description and hash.");
+    }
+
+    event_log_info (hashcat_ctx, NULL);
 
     user_options->quiet = true;
 
@@ -1237,6 +1244,8 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
 
       hcfree (modulefile);
     }
+
+    event_log_info (hashcat_ctx, NULL);
 
     user_options->quiet = false;
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -639,7 +639,7 @@ int hashes_init_filename (hashcat_ctx_t *hashcat_ctx)
     {
       if (hc_path_read (user_options_extra->hc_hash) == false)
       {
-        event_log_error (hashcat_ctx, "%s: %s", user_options_extra->hc_hash, strerror (errno));
+        if (user_options->guess_hash_mode == false) event_log_error (hashcat_ctx, "%s: %s", user_options_extra->hc_hash, strerror (errno));
 
         return -1;
       }
@@ -730,7 +730,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
       if (stat (hashes->hashfile, &st) == -1)
       {
-        event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
+        if (user_options->guess_hash_mode == false) event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
 
         return -1;
       }
@@ -745,19 +745,19 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
         }
         else if (binary_count == 0)
         {
-          event_log_error (hashcat_ctx, "No hashes loaded.");
+          if (user_options->guess_hash_mode == false) event_log_error (hashcat_ctx, "No hashes loaded.");
 
           return -1;
         }
         else if (binary_count == PARSER_HAVE_ERRNO)
         {
-          event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
+          if (user_options->guess_hash_mode == false) event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
 
           return -1;
         }
         else
         {
-          event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (binary_count));
+          if (user_options->guess_hash_mode == false) event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (binary_count));
 
           return -1;
         }
@@ -973,12 +973,24 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status == PARSER_OK)
             {
+              if (user_options->guess_hash_mode == true)
+              {
+                if (user_options->machine_readable == false)
+                {
+                  event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+                }
+                else
+                {
+                  event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+                }
+              }
+
               hashes_buf[hashes_cnt].hash_info->split->split_group  = 0;
               hashes_buf[hashes_cnt].hash_info->split->split_origin = SPLIT_ORIGIN_LEFT;
 
               hashes_cnt++;
             }
-            else
+            else if (user_options->guess_hash_mode == false)
             {
               event_log_warning (hashcat_ctx, "Hash '%s': %s", input_buf, strparser (parser_status));
             }
@@ -989,12 +1001,24 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status == PARSER_OK)
             {
+              if (user_options->guess_hash_mode == true)
+              {
+                if (user_options->machine_readable == false)
+                {
+                  event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+                }
+                else
+                {
+                  event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+                }
+              }
+
               hashes_buf[hashes_cnt].hash_info->split->split_group  = 0;
               hashes_buf[hashes_cnt].hash_info->split->split_origin = SPLIT_ORIGIN_RIGHT;
 
               hashes_cnt++;
             }
-            else
+            else if (user_options->guess_hash_mode == false)
             {
               event_log_warning (hashcat_ctx, "Hash '%s': %s", input_buf, strparser (parser_status));
             }
@@ -1007,12 +1031,24 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status == PARSER_OK)
             {
+              if (user_options->guess_hash_mode == true)
+              {
+                if (user_options->machine_readable == false)
+                {
+                  event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+                }
+                else
+                {
+                  event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+                }
+              }
+
               hashes_buf[hashes_cnt].hash_info->split->split_group  = 0;
               hashes_buf[hashes_cnt].hash_info->split->split_origin = SPLIT_ORIGIN_NONE;
 
               hashes_cnt++;
             }
-            else
+            else if (user_options->guess_hash_mode == false)
             {
               event_log_warning (hashcat_ctx, "Hash '%s': %s", input_buf, strparser (parser_status));
             }
@@ -1026,9 +1062,21 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           if (parser_status == PARSER_OK)
           {
+            if (user_options->guess_hash_mode == true)
+            {
+              if (user_options->machine_readable == false)
+              {
+                event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+              }
+              else
+              {
+                event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+              }
+            }
+
             hashes_cnt++;
           }
-          else
+          else if (user_options->guess_hash_mode == false)
           {
             event_log_warning (hashcat_ctx, "Hash '%s': %s", input_buf, strparser (parser_status));
           }
@@ -1166,15 +1214,18 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              char *tmp_line_buf;
+              if (user_options->guess_hash_mode == false)
+              {
+                char *tmp_line_buf;
 
-              hc_asprintf (&tmp_line_buf, "%s", line_buf);
+                hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
-              compress_terminal_line_length (tmp_line_buf, 38, 32);
+                compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+                event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
-              hcfree (tmp_line_buf);
+                hcfree (tmp_line_buf);
+              }
 
               continue;
             }
@@ -1190,17 +1241,32 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              char *tmp_line_buf;
+              if (user_options->guess_hash_mode == false)
+              {
+                char *tmp_line_buf;
 
-              hc_asprintf (&tmp_line_buf, "%s", line_buf);
+                hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
-              compress_terminal_line_length (tmp_line_buf, 38, 32);
+                compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+                event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
-              hcfree (tmp_line_buf);
+                hcfree (tmp_line_buf);
+              }
 
               continue;
+            }
+
+            if (user_options->guess_hash_mode == true)
+            {
+              if (user_options->machine_readable == false)
+              {
+                event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
+              }
+              else
+              {
+                event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, line_buf);
+              }
             }
 
             hashes_buf[hashes_cnt].hash_info->split->split_group  = line_num;
@@ -1216,17 +1282,32 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             if (parser_status < PARSER_GLOBAL_ZERO)
             {
-              char *tmp_line_buf;
+              if (user_options->guess_hash_mode == false)
+              {
+                char *tmp_line_buf;
 
-              hc_asprintf (&tmp_line_buf, "%s", line_buf);
+                hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
-              compress_terminal_line_length (tmp_line_buf, 38, 32);
+                compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+                event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
-              hcfree (tmp_line_buf);
+                hcfree (tmp_line_buf);
+              }
 
               continue;
+            }
+
+            if (user_options->guess_hash_mode == true)
+            {
+              if (user_options->machine_readable == false)
+              {
+                event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
+              }
+              else
+              {
+                event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, line_buf);
+              }
             }
 
             hashes_buf[hashes_cnt].hash_info->split->split_group  = line_num;
@@ -1243,17 +1324,32 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
           if (parser_status < PARSER_GLOBAL_ZERO)
           {
-            char *tmp_line_buf;
+            if (user_options->guess_hash_mode == false)
+            {
+              char *tmp_line_buf;
 
-            hc_asprintf (&tmp_line_buf, "%s", line_buf);
+              hc_asprintf (&tmp_line_buf, "%s", line_buf);
 
-            compress_terminal_line_length (tmp_line_buf, 38, 32);
+              compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-            event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
-            hcfree (tmp_line_buf);
+              hcfree (tmp_line_buf);
+            }
 
             continue;
+          }
+
+          if (user_options->guess_hash_mode == true)
+          {
+            if (user_options->machine_readable == false)
+            {
+              event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
+            }
+            else
+            {
+              event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, line_buf);
+            }
           }
 
           hashes_cnt++;
@@ -1320,17 +1416,23 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
         {
           hashes_cnt = hashes_parsed;
         }
-        else if (hashes_parsed == 0)
-        {
-          event_log_warning (hashcat_ctx, "No hashes loaded.");
-        }
-        else if (hashes_parsed == PARSER_HAVE_ERRNO)
-        {
-          event_log_warning (hashcat_ctx, "Hashfile '%s': %s", hashes->hashfile, strerror (errno));
-        }
         else
         {
-          event_log_warning (hashcat_ctx, "Hashfile '%s': %s", hashes->hashfile, strparser (hashes_parsed));
+          if (user_options->guess_hash_mode == false)
+          {
+            if (hashes_parsed == 0)
+            {
+	      event_log_warning (hashcat_ctx, "No hashes loaded.");
+            }
+            else if (hashes_parsed == PARSER_HAVE_ERRNO)
+            {
+              event_log_warning (hashcat_ctx, "Hashfile '%s': %s", hashes->hashfile, strerror (errno));
+            }
+            else
+            {
+              event_log_warning (hashcat_ctx, "Hashfile '%s': %s", hashes->hashfile, strparser (hashes_parsed));
+            }
+          }
         }
       }
       else
@@ -1341,9 +1443,21 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
         if (parser_status == PARSER_OK)
         {
+          if (user_options->guess_hash_mode == true)
+          {
+            if (user_options->machine_readable == false)
+            {
+              event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+            }
+            else
+            {
+              event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+            }
+          }
+
           hashes_cnt++;
         }
-        else
+        else if (user_options->guess_hash_mode == false)
         {
           event_log_warning (hashcat_ctx, "Hash '%s': %s", input_buf, strparser (parser_status));
         }

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -841,6 +841,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
     if (hashconfig->esalt_size > 0)
     {
       esalts_buf = hccalloc (hashes_avail, hashconfig->esalt_size);
+
+      // a lot of calloc/malloc called globally, without check if works or not. why ?
+      // workaround for 22100/BitLocker, if calloc fail you got a Segmentation fault in the next for loop
+      // to reproduce comment the following line and run ./hashcat -m 22100 example0.hash
+      if (!esalts_buf) return -1;
     }
 
     if (hashconfig->hook_salt_size > 0)
@@ -977,11 +982,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
               {
                 if (user_options->machine_readable == false)
                 {
-                  event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+                  event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
                 }
                 else
                 {
-                  event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+                  event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
                 }
               }
 
@@ -1005,11 +1010,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
               {
                 if (user_options->machine_readable == false)
                 {
-                  event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+                  event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
                 }
                 else
                 {
-                  event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+                  event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
                 }
               }
 
@@ -1035,11 +1040,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
               {
                 if (user_options->machine_readable == false)
                 {
-                  event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+                  event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
                 }
                 else
                 {
-                  event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+                  event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
                 }
               }
 
@@ -1066,11 +1071,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
             {
               if (user_options->machine_readable == false)
               {
-                event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+                event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
               }
               else
               {
-                event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+                event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
               }
             }
 
@@ -1261,11 +1266,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
             {
               if (user_options->machine_readable == false)
               {
-                event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
+                event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
               }
               else
               {
-                event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, line_buf);
+                event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
               }
             }
 
@@ -1302,11 +1307,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
             {
               if (user_options->machine_readable == false)
               {
-                event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
+                event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
               }
               else
               {
-                event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, line_buf);
+                event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
               }
             }
 
@@ -1344,11 +1349,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
           {
             if (user_options->machine_readable == false)
             {
-              event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
+              event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
             }
             else
             {
-              event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, line_buf);
+              event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, line_buf);
             }
           }
 
@@ -1422,7 +1427,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
           {
             if (hashes_parsed == 0)
             {
-	      event_log_warning (hashcat_ctx, "No hashes loaded.");
+              event_log_warning (hashcat_ctx, "No hashes loaded.");
             }
             else if (hashes_parsed == PARSER_HAVE_ERRNO)
             {
@@ -1447,11 +1452,11 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
           {
             if (user_options->machine_readable == false)
             {
-              event_log_info (hashcat_ctx, "(%d) %s : %s\n", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
+              event_log_info (hashcat_ctx, "%6d | %50s | %s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
             }
             else
             {
-              event_log_info (hashcat_ctx, "%s:%d:%s\n", hashconfig->hash_name, hashconfig->hash_mode, input_buf);
+              event_log_info (hashcat_ctx, "%d:%s:%s", hashconfig->hash_mode, hashconfig->hash_name, input_buf);
             }
           }
 

--- a/src/status.c
+++ b/src/status.c
@@ -1933,7 +1933,7 @@ char *status_get_brain_link_send_bytes_sec_dev (const hashcat_ctx_t *hashcat_ctx
 
   char *display = (char *) hcmalloc (HCBUFSIZ_TINY);
 
- snprintf (display, HCBUFSIZ_TINY, "%.2f M", (double) (brain_link_send_bytes * 8) / 1024 / 1024);
+  snprintf (display, HCBUFSIZ_TINY, "%.2f M", (double) (brain_link_send_bytes * 8) / 1024 / 1024);
 
   return display;
 }

--- a/src/usage.c
+++ b/src/usage.c
@@ -80,6 +80,7 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   "     --veracrypt-keyfiles       | File | Keyfiles to use, separated with commas               | --veracrypt-keyf=x.txt",
   "     --veracrypt-pim-start      | Num  | VeraCrypt personal iterations multiplier start       | --veracrypt-pim-start=450",
   "     --veracrypt-pim-stop       | Num  | VeraCrypt personal iterations multiplier stop        | --veracrypt-pim-stop=500",
+  " -M, --guess-hash-type          |      | Try to guess hash type                               | -M",
   " -b, --benchmark                |      | Run benchmark of selected hash-modes                 |",
   "     --benchmark-all            |      | Run benchmark of all hash-modes (requires -b)        |",
   "     --speed-only               |      | Return expected speed of the attack, then quit       |",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -187,7 +187,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->encoding_to               = ENCODING_TO;
   user_options->example_hashes            = EXAMPLE_HASHES;
   user_options->force                     = FORCE;
-  user_options->guess_hash_mode           = false;
+  user_options->guess_hash_mode           = GUESS_HASH_MODE;
   user_options->hwmon_disable             = HWMON_DISABLE;
   user_options->hwmon_temp_abort          = HWMON_TEMP_ABORT;
   user_options->hash_mode                 = HASH_MODE;


### PR DESCRIPTION
Hi,

I added a feature to identify possible hash types starting from a single hash and / or hash list.
Example with single hash:

```
$ echo -n hashcat | openssl dgst -sha1
b89eaac7e61417341b710b727768294d0e6a277b
$ ./hashcat -M 'b89eaac7e61417341b710b727768294d0e6a277b' --quiet
Starting guessing mode...

(100) SHA1 : b89eaac7e61417341b710b727768294d0e6a277b

(300) MySQL4.1/MySQL5 : b89eaac7e61417341b710b727768294d0e6a277b

(4500) sha1(sha1($pass)) : b89eaac7e61417341b710b727768294d0e6a277b

(4700) sha1(md5($pass)) : b89eaac7e61417341b710b727768294d0e6a277b

(6000) RIPEMD-160 : b89eaac7e61417341b710b727768294d0e6a277b

(18500) sha1(md5(md5($pass))) : b89eaac7e61417341b710b727768294d0e6a277b

Started: Thu Oct 15 13:17:26 2020
Stopped: Thu Oct 15 13:17:26 2020
```
Example with hashlist

```
$ echo -n hashcat | openssl dgst -sha1 > test.hashes
$ echo -n hashcat | openssl dgst -sha512 >> test.hashes
$ ./hashcat -M test.hashes --quiet
Starting guessing mode...

(100) SHA1 : b89eaac7e61417341b710b727768294d0e6a277b

(300) MySQL4.1/MySQL5 : b89eaac7e61417341b710b727768294d0e6a277b

(1700) SHA2-512 : 82a9dda829eb7f8ffe9fbe49e45d47d2dad9664fbb7adf72492e3c81ebd3e29134d9bc12212bf83c6840f10e8246b9db54a4859b7ccd0123d86e5872c1e5082f

(4500) sha1(sha1($pass)) : b89eaac7e61417341b710b727768294d0e6a277b

(4700) sha1(md5($pass)) : b89eaac7e61417341b710b727768294d0e6a277b

(6000) RIPEMD-160 : b89eaac7e61417341b710b727768294d0e6a277b

(6100) Whirlpool : 82a9dda829eb7f8ffe9fbe49e45d47d2dad9664fbb7adf72492e3c81ebd3e29134d9bc12212bf83c6840f10e8246b9db54a4859b7ccd0123d86e5872c1e5082f

(11800) GOST R 34.11-2012 (Streebog) 512-bit, big-endian : 82a9dda829eb7f8ffe9fbe49e45d47d2dad9664fbb7adf72492e3c81ebd3e29134d9bc12212bf83c6840f10e8246b9db54a4859b7ccd0123d86e5872c1e5082f

(17600) SHA3-512 : 82a9dda829eb7f8ffe9fbe49e45d47d2dad9664fbb7adf72492e3c81ebd3e29134d9bc12212bf83c6840f10e8246b9db54a4859b7ccd0123d86e5872c1e5082f

(18000) Keccak-512 : 82a9dda829eb7f8ffe9fbe49e45d47d2dad9664fbb7adf72492e3c81ebd3e29134d9bc12212bf83c6840f10e8246b9db54a4859b7ccd0123d86e5872c1e5082f

(18500) sha1(md5(md5($pass))) : b89eaac7e61417341b710b727768294d0e6a277b

(21000) BitShares v0.x - sha512(sha512_bin(pass)) : 82a9dda829eb7f8ffe9fbe49e45d47d2dad9664fbb7adf72492e3c81ebd3e29134d9bc12212bf83c6840f10e8246b9db54a4859b7ccd0123d86e5872c1e5082f

Started: Thu Oct 15 13:18:24 2020
Stopped: Thu Oct 15 13:18:25 2020
```

Works also with "--machine-readable" option

```
$ echo -n hashcat | openssl dgst -sha256
127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935
$ ./hashcat -M '127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935' --quiet --machine-readable
Starting guessing mode...

SHA2-256:1400:127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935

GOST R 34.11-94:6900:127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935

GOST R 34.11-2012 (Streebog) 256-bit, big-endian:11700:127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935

SHA3-256:17400:127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935

Keccak-256:17800:127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935

sha256(md5($pass)):20800:127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935

sha256(sha256_bin($pass)):21400:127e6fbfe24a750e72930c220a8e138275656b8e5d8f48a98c3c92df2caba935

Started: Thu Oct 15 13:20:37 2020
Stopped: Thu Oct 15 13:20:38 2020
```

Exit status is set to return "0" if something is found, else is "1".

You like it ? ;)

Bye,
matrix