### PR TITLE
Fix types.h include guard

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -2613,8 +2613,6 @@ typedef struct token
 
 } token_t;
 
-#endif // _TYPES_H
-
 /**
  * hash category is relevant in usage.c (--help screen)
  */
@@ -2648,3 +2646,5 @@ typedef enum hash_category
 // hash specific
 
 typedef aes_ctx AES_KEY;
+
+#endif // _TYPES_H


### PR DESCRIPTION
Causes fire when double-include `types.h` in several files