### PR TITLE
Improve warning message wording

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -342,7 +342,7 @@ int hashconfig_init (hashcat_ctx_t *hashcat_ctx)
           if (user_options->quiet == false)
           {
             event_log_warning (hashcat_ctx, "Kernel %s:", source_file);
-            event_log_warning (hashcat_ctx, "Optimized kernel requested but not needed - falling back to pure kernel");
+            event_log_warning (hashcat_ctx, "Optimized kernel requested but not available - falling back to pure kernel");
             event_log_warning (hashcat_ctx, NULL);
           }
         }

--- a/src/interface.c
+++ b/src/interface.c
@@ -342,7 +342,7 @@ int hashconfig_init (hashcat_ctx_t *hashcat_ctx)
           if (user_options->quiet == false)
           {
             event_log_warning (hashcat_ctx, "Kernel %s:", source_file);
-            event_log_warning (hashcat_ctx, "Optimized kernel requested but not available - falling back to pure kernel");
+            event_log_warning (hashcat_ctx, "Optimized kernel requested but not available or not required - falling back to pure kernel");
             event_log_warning (hashcat_ctx, NULL);
           }
         }


### PR DESCRIPTION
The current warning message makes it sound like the optimized kernel exists but isn't being used.  This rewording makes it clear that the optimized kernel simply doesn't exist.