### PR TITLE
Fix some include headers macros

### DIFF
--- a/include/ext_lzma.h
+++ b/include/ext_lzma.h
@@ -4,6 +4,7 @@
  */
 
 #ifndef _EXT_LZMA_H
+#define _EXT_LZMA_H
 
 #include <LzmaDec.h>
 #include <Lzma2Dec.h>

--- a/include/folder.h
+++ b/include/folder.h
@@ -3,6 +3,9 @@
  * License.....: MIT
  */
 
+#ifndef _FOLDER_H
+#define _FOLDER_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -34,3 +37,5 @@ int  folder_config_init    (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char 
 void folder_config_destroy (hashcat_ctx_t *hashcat_ctx);
 
 int hc_mkdir (const char *name, MAYBE_UNUSED const int mode);
+
+#endif // _FOLDER_H


### PR DESCRIPTION
This fix is similar to https://github.com/hashcat/hashcat/pull/2585 , I double checked some header files and came to the conclusion that there are some minor, but nasty hidden problems with these macros. 

I think that this fix together with #2585 should fix all these problems.

Credits of course go to @ventaquil for finding these problems.

Thx