### PR TITLE
test.pl: add 'potthrough' (like passthrough, but hash:plain)

### DIFF
--- a/tools/test.pl
+++ b/tools/test.pl
@@ -23,7 +23,7 @@ if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"})
   $IS_OPTIMIZED = $ENV{"IS_OPTIMIZED"};
 }
 
-my $TYPES = [ 'single', 'passthrough', 'verify' ];
+my $TYPES = [ 'single', 'passthrough', 'potthrough', 'verify' ];
 
 my $TYPE = shift @ARGV;
 my $MODE = shift @ARGV;
@@ -52,6 +52,10 @@ if ($TYPE eq 'single')
 elsif ($TYPE eq 'passthrough')
 {
   passthrough ();
+}
+elsif ($TYPE eq 'potthrough')
+{
+  passthrough ('potthrough');
 }
 elsif ($TYPE eq "verify")
 {
@@ -164,6 +168,8 @@ sub single
 
 sub passthrough
 {
+  my $option = shift || '';
+
   while (my $word = <>)
   {
     chomp $word;
@@ -222,7 +228,14 @@ sub passthrough
 
       next unless defined $hash;
 
-      print "$hash\n";
+      if ($option eq 'potthrough')
+      {
+        print "$hash:$word\n";
+      }
+      else
+      {
+        print "$hash\n";
+      }
     }
   }
 }
@@ -576,6 +589,7 @@ sub usage_exit
     . "Usage:\n"
     . " $f single      <mode> [length]\n"
     . " $f passthrough <mode>\n"
+    . " $f potthrough  <mode>\n"
     . " $f verify      <mode> <hashfile> <cracksfile> <outfile>\n"
     . "\n"
     . "Single:\n"
@@ -586,11 +600,16 @@ sub usage_exit
     . "Passthrough:\n"
     . " Generates hashes for strings entered via stdin and prints them to stdout.\n"
     . "\n"
+    . "Potthrough:\n"
+    . " Like passthrough, but includes both the hash and the plain in hash:plain format,\n"
+    . " similar to the classic potfile format.\n"
+    . "\n"
     . "Verify:\n"
     . " Reads a list of hashes from <hashfile> and a list of hash:password pairs from\n"
     . " <cracksfile>. Hashes every password and compares the hash to the corresponding\n"
     . " entry in the <cracksfile>. If the hashes match and the hash is present in the\n"
-    . " list from <hashfile>, it will be written to the <outfile>.\n";
+    . " list from <hashfile>, it will be written to the <outfile>.\n"
+    . "\n";
 
   exit 1;
 }


### PR DESCRIPTION
New option 'potthrough' - like passthrough, but in classic potfile format (hash:plain) instead.