### PR TITLE
Added machine readable version of option --show

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1172,7 +1172,10 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              if (user_options->machine_readable == true)
+                event_log_warning (hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              else
+                event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
               hcfree (tmp_line_buf);
 
@@ -1196,7 +1199,10 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              if (user_options->machine_readable == true)
+                event_log_warning (hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              else
+                event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
               hcfree (tmp_line_buf);
 
@@ -1222,7 +1228,10 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              if (user_options->machine_readable == true)
+                event_log_warning (hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              else
+                event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
               hcfree (tmp_line_buf);
 
@@ -1249,7 +1258,10 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-            event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+            if (user_options->machine_readable == true)
+                event_log_warning (hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              else
+                event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
 
             hcfree (tmp_line_buf);
 


### PR DESCRIPTION
Example usage:
./hashcat example400.hash -m 0 --show --machine-readable
example400.hash:1:$H$9y5boZ2wsUlgl2tI6b5PrRoADzYfXD1:Token length exception

This output is more suitable for parsing by external tools. Current hashcat always prints:
./hashcat example400.hash -m 0 --show 
Hashfile 'example400.hash' on line 1 ($H$9y5boZ2wsUlgl2tI6b5PrRoADzYfXD1): Token length exception
