### PR TITLE
fix m04510_mxx

### DIFF
--- a/OpenCL/m04510_a0-pure.cl
+++ b/OpenCL/m04510_a0-pure.cl
@@ -28,7 +28,7 @@
 #define uint_to_hex_lower8_le(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
 #endif
 
-KERNEL_FQ void m04510_mxx (KERN_ATTR_VECTOR ())
+KERNEL_FQ void m04510_mxx (KERN_ATTR_RULES ())
 {
   /**
    * modifier


### PR DESCRIPTION

```
$ echo ciao | ./hashcat -m 4510 -a0 '3f786850e387550fdab836ed7e6dc881de23001b:abc'
[...]
clBuildProgram(): CL_BUILD_PROGRAM_FAILURE

<program source>:88:31: error: passing 'const __global u32 *' (aka 'const __global unsigned int *') to parameter of type 'const __constant u32 *' (aka 'const __constant unsigned int *') changes address space of pointer
    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
                              ^~~~~~~~~~~~~~~~~~~~~~
[...]/OpenCL/inc_rp.cl:769:50: note: passing argument to parameter 'cmds' here
DECLSPEC int apply_rules (CONSTANT_AS const u32 *cmds, u32 *buf, const int in_len)
                                                 ^

* Device #1: Kernel [...]/OpenCL/m04510_a0-pure.cl build failed.

```