### PR TITLE
Fixed build warnings on OSX

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -198,6 +198,12 @@ endif
 
 ## because UNRAR
 ifeq ($(USE_SYSTEM_UNRAR),0)
+ifneq ($(UNAME),Darwin)
+CFLAGS_UNRAR            += -Wno-misleading-indentation
+CFLAGS_UNRAR            += -Wno-class-memaccess
+else
+CFLAGS_UNRAR            += -Wno-missing-braces
+endif
 CFLAGS_UNRAR            += -Wno-unused-variable
 CFLAGS_UNRAR            += -Wno-unused-parameter
 CFLAGS_UNRAR            += -Wno-unused-function
@@ -205,11 +211,9 @@ CFLAGS_UNRAR            += -Wno-sign-compare
 CFLAGS_UNRAR            += -Wno-dangling-else
 CFLAGS_UNRAR            += -Wno-switch
 CFLAGS_UNRAR            += -Wno-parentheses
-CFLAGS_UNRAR            += -Wno-misleading-indentation
 CFLAGS_UNRAR            += -Wno-implicit-fallthrough
 CFLAGS_UNRAR            += -Wno-extra
 CFLAGS_UNRAR            += -Wno-unknown-pragmas
-CFLAGS_UNRAR            += -Wno-class-memaccess
 endif
 
 ifeq ($(DEBUG),0)


### PR DESCRIPTION
```
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/strlist.cpp -o obj/strlist.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/strfn.cpp -o obj/strfn.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/pathfn.cpp -o obj/pathfn.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/smallfn.cpp -o obj/smallfn.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/global.cpp -o obj/global.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/file.cpp -o obj/file.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/filefn.cpp -o obj/filefn.NATIVE.o -fpic
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/filcreat.cpp -o obj/filcreat.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/archive.cpp -o obj/archive.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/arcread.cpp -o obj/arcread.NATIVE.o -fpic
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/unicode.cpp -o obj/unicode.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/system.cpp -o obj/system.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/isnt.cpp -o obj/isnt.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/crypt.cpp -o obj/crypt.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/crc.cpp -o obj/crc.NATIVE.o -fpic
2 warnings generated.
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/rawread.cpp -o obj/rawread.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/encname.cpp -o obj/encname.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/resource.cpp -o obj/resource.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/match.cpp -o obj/match.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/timefn.cpp -o obj/timefn.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/rdwrfn.cpp -o obj/rdwrfn.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/consio.cpp -o obj/consio.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/options.cpp -o obj/options.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/errhnd.cpp -o obj/errhnd.NATIVE.o -fpic
2 warnings generated.
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/rarvm.cpp -o obj/rarvm.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/secpassword.cpp -o obj/secpassword.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/rijndael.cpp -o obj/rijndael.NATIVE.o -fpic
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/getbits.cpp -o obj/getbits.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/sha1.cpp -o obj/sha1.NATIVE.o -fpic
deps/unrar/rarvm.cpp:55:5: warning: suggest braces around initialization of subobject [-Wmissing-braces]
    53, 0xad576887, VMSF_E8,
    ^~~~~~~~~~~~~~~~~~~~~~~
    {                      }
deps/unrar/rarvm.cpp:56:5: warning: suggest braces around initialization of subobject [-Wmissing-braces]
    57, 0x3cd7e57e, VMSF_E8E9,
    ^~~~~~~~~~~~~~~~~~~~~~~~~
    {                        }
deps/unrar/rarvm.cpp:57:4: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   120, 0x3769893f, VMSF_ITANIUM,
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   {                            }
deps/unrar/rarvm.cpp:58:5: warning: suggest braces around initialization of subobject [-Wmissing-braces]
    29, 0x0e06077d, VMSF_DELTA,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~
    {                         }
deps/unrar/rarvm.cpp:59:4: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   149, 0x1c2c5dc8, VMSF_RGB,
   ^~~~~~~~~~~~~~~~~~~~~~~~~
   {                        }
deps/unrar/rarvm.cpp:60:4: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   216, 0xbc85e701, VMSF_AUDIO
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
   {                          }
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/sha256.cpp -o obj/sha256.NATIVE.o -fpic
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/blake2s.cpp -o obj/blake2s.NATIVE.o -fpic
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/hash.cpp -o obj/hash.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
8 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/extinfo.cpp -o obj/extinfo.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/extract.cpp -o obj/extract.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/volume.cpp -o obj/volume.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/list.cpp -o obj/list.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/find.cpp -o obj/find.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/unpack.cpp -o obj/unpack.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/headers.cpp -o obj/headers.NATIVE.o -fpic
2 warnings generated.
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/threadpool.cpp -o obj/threadpool.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/rs16.cpp -o obj/rs16.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/cmddata.cpp -o obj/cmddata.NATIVE.o -fpic
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/ui.cpp -o obj/ui.NATIVE.o -fpic
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/filestr.cpp -o obj/filestr.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/recvol.cpp -o obj/recvol.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/rs.cpp -o obj/rs.NATIVE.o -fpic
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/scantree.cpp -o obj/scantree.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/qopen.cpp -o obj/qopen.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
clang++ -c  -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-misleading-indentation -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-class-memaccess deps/unrar/hc_decompress_rar.cpp -o obj/hc_decompress_rar.NATIVE.o -fpic
warning: unknown warning option '-Wno-misleading-indentation'; did you mean '-Wno-binding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wno-class-memaccess'; did you mean '-Wno-class-varargs'? [-Wunknown-warning-option]
2 warnings generated.
2 warnings generated.
2 warnings generated.
2 warnings generated.
2 warnings generated.
2 warnings generated.
2 warnings generated.

```