### PR TITLE
minimized the test.sh false negatives with kernels 14000 14100 14900 15400, a1

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -655,15 +655,20 @@ function attack_1()
     cnt=0
 
     min=1
+    max=8
 
     if   [ "${hash_type}" -eq 14000 ]; then
       min=0
+      max=5
     elif [ "${hash_type}" -eq 14100 ]; then
       min=0
+      max=5
     elif [ "${hash_type}" -eq 14900 ]; then
       min=0
+      max=5
     elif [ "${hash_type}" -eq 15400 ]; then
       min=0
+      max=5
     fi
 
     echo "> Testing hash type $hash_type with attack mode 1, markov ${MARKOV}, single hash, Device-Type ${TYPE}, vector-width ${VECTOR}." >> "${OUTD}/logfull.txt" 2>> "${OUTD}/logfull.txt"
@@ -688,7 +693,9 @@ function attack_1()
 
         line_nr=1
 
-        if [ "${i}" -gt 1 ]; then
+        if [ "$min" -eq 0 ]; then
+          line_nr=$i
+        elif [ "${i}" -gt 1 ]; then
           line_nr=$((i - 1))
         fi
 
@@ -777,6 +784,8 @@ function attack_1()
         status ${ret}
 
       fi
+
+      if [ $i -eq ${max} ]; then break; fi
 
       i=$((i + 1))
 


### PR DESCRIPTION
before

```
[ test_1608994627 ] > Init test for hash type 14000.
[ test_1608994627 ] [ Type 14000, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > Error : 0/8 not found, 7/8 not matched, 0/8 timeout
[ test_1608994627 ] [ Type 14000, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > Error : 0/8 not found, 7/8 not matched, 0/8 timeout
[ test_1608994662 ] > Init test for hash type 14100.
[ test_1608994662 ] [ Type 14100, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > Error : 0/8 not found, 7/8 not matched, 0/8 timeout
[ test_1608994662 ] [ Type 14100, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > Error : 0/8 not found, 7/8 not matched, 0/8 timeout
[ test_1608994697 ] > Init test for hash type 14900.
[ test_1608994697 ] [ Type 14900, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1608994697 ] [ Type 14900, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1608994736 ] > Init test for hash type 15400.
[ test_1608994736 ] [ Type 15400, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > Error : 0/8 not found, 7/8 not matched, 0/8 timeout
[ test_1608994736 ] [ Type 15400, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > Error : 0/8 not found, 7/8 not matched, 0/8 timeout
```

after

```
[ test_1608994878 ] > Init test for hash type 14000.
[ test_1608994878 ] [ Type 14000, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1608994878 ] [ Type 14000, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1608994901 ] > Init test for hash type 14100.
[ test_1608994901 ] [ Type 14100, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1608994901 ] [ Type 14100, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1608994924 ] > Init test for hash type 14900.
[ test_1608994924 ] [ Type 14900, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1608994924 ] [ Type 14900, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1608994946 ] > Init test for hash type 15400.
[ test_1608994946 ] [ Type 15400, Attack 1, Mode single, Device-Type Gpu, Vector-Width 1 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1608994946 ] [ Type 15400, Attack 1, Mode single, Device-Type Gpu, Vector-Width 4 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout

```