### PR TITLE
Correct check for gz header.

### DIFF
--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -74,7 +74,7 @@ bool hc_fopen (HCFILE *fp, const char *path, char *mode)
 
     if (read (fd_tmp, check, sizeof (check)) > 0)
     {
-      if (check[0] == 0x1f && check[1] == 0x8b && check[2] == 0x08 && check[3] == 0x08) fp->is_gzip = true;
+      if (check[0] == 0x1f && check[1] == 0x8b && check[2] == 0x08) fp->is_gzip = true;
       if (check[0] == 0x50 && check[1] == 0x4b && check[2] == 0x03 && check[3] == 0x04) fp->is_zip = true;
     }
 


### PR DESCRIPTION
gzip format is described in rfc1952.
From there, first 2 bytes (0x1f8b) are header;
next is Compression method (0x08 for deflate, this is the general used method);
and 4th byte is Flags. Some compression tools don't set this and we can't process the gzips.
zlib plays well in this cases, so we can just drop the check for the 4th byte.