### PR TITLE
fixed memory leak in user_options_check_files()

### DIFF
--- a/src/user_options.c
+++ b/src/user_options.c
@@ -2921,19 +2921,25 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     NULL
   };
 
+  char *temp_filename = (char *) hcmalloc (HCBUFSIZ_LARGE);
+
   for (int i = 0; files_names[i] != NULL; i++)
   {
-    char *temp_filename = NULL;
+    memset (temp_filename, 0, HCBUFSIZ_LARGE);
 
-    hc_asprintf (&temp_filename, "%s/%s", folder_config->cpath_real, files_names[i]);
+    snprintf (temp_filename, HCBUFSIZ_LARGE - 1, "%s/%s", folder_config->cpath_real, files_names[i]);
 
     if (hc_path_read (temp_filename) == false)
     {
       event_log_error (hashcat_ctx, "%s: %s", temp_filename, strerror (errno));
 
+      hcfree (temp_filename);
+
       return -1;
     }
   }
+
+  hcfree (temp_filename);
 
   // return back to the folder we came from initially (workaround)
 


### PR DESCRIPTION
```
==37917== 1,792 bytes in 14 blocks are definitely lost in loss record 409 of 425
==37917==    at 0x100272086: malloc (in /usr/local/Cellar/valgrind/3.16.1/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==37917==    by 0x10071139E: _vasprintf (in /usr/lib/system/libsystem_c.dylib)
==37917==    by 0x1000663FB: hc_asprintf (shared.c:264)
==37917==    by 0x100080212: user_options_check_files (user_options.c:2957)
==37917==    by 0x10003C599: hashcat_session_init (hashcat.c:1104)
==37917==    by 0x100000D20: main (main.c:1157)

```