### PR TITLE
Added hash-mode: MS Office 2016 - SheetProtection

### DIFF
--- a/OpenCL/m29700-pure.cl
+++ b/OpenCL/m29700-pure.cl
@@ -1,0 +1,182 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha512.cl"
+#endif
+
+#define COMPARE_S "inc_comp_single.cl"
+#define COMPARE_M "inc_comp_multi.cl"
+
+typedef struct office2016_tmp
+{
+  u64 out[8];
+
+} office2016_tmp_t;
+
+KERNEL_FQ void m29700_init (KERN_ATTR_TMPS (office2016_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  sha512_ctx_t ctx;
+
+  sha512_init (&ctx);
+
+  sha512_update_global_swap (&ctx, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
+
+  sha512_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+  sha512_final (&ctx);
+
+  tmps[gid].out[0] = ctx.h[0];
+  tmps[gid].out[1] = ctx.h[1];
+  tmps[gid].out[2] = ctx.h[2];
+  tmps[gid].out[3] = ctx.h[3];
+  tmps[gid].out[4] = ctx.h[4];
+  tmps[gid].out[5] = ctx.h[5];
+  tmps[gid].out[6] = ctx.h[6];
+  tmps[gid].out[7] = ctx.h[7];
+}
+
+KERNEL_FQ void m29700_loop (KERN_ATTR_TMPS (office2016_tmp_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= gid_max) return;
+
+  u64x t0 = pack64v (tmps, out, gid, 0);
+  u64x t1 = pack64v (tmps, out, gid, 1);
+  u64x t2 = pack64v (tmps, out, gid, 2);
+  u64x t3 = pack64v (tmps, out, gid, 3);
+  u64x t4 = pack64v (tmps, out, gid, 4);
+  u64x t5 = pack64v (tmps, out, gid, 5);
+  u64x t6 = pack64v (tmps, out, gid, 6);
+  u64x t7 = pack64v (tmps, out, gid, 7);
+
+  u32x w0[4];
+  u32x w1[4];
+  u32x w2[4];
+  u32x w3[4];
+  u32x w4[4];
+  u32x w5[4];
+  u32x w6[4];
+  u32x w7[4];
+
+  w0[0] = 0;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+  w4[0] = 0;
+  w4[1] = 0x80000000;
+  w4[2] = 0;
+  w4[3] = 0;
+  w5[0] = 0;
+  w5[1] = 0;
+  w5[2] = 0;
+  w5[3] = 0;
+  w6[0] = 0;
+  w6[1] = 0;
+  w6[2] = 0;
+  w6[3] = 0;
+  w7[0] = 0;
+  w7[1] = 0;
+  w7[2] = 0;
+  w7[3] = (64 + 4) * 8;
+
+  for (u32 i = 0, j = loop_pos; i < loop_cnt; i++, j++)
+  {
+    w0[0] = h32_from_64 (t0);
+    w0[1] = l32_from_64 (t0);
+    w0[2] = h32_from_64 (t1);
+    w0[3] = l32_from_64 (t1);
+    w1[0] = h32_from_64 (t2);
+    w1[1] = l32_from_64 (t2);
+    w1[2] = h32_from_64 (t3);
+    w1[3] = l32_from_64 (t3);
+    w2[0] = h32_from_64 (t4);
+    w2[1] = l32_from_64 (t4);
+    w2[2] = h32_from_64 (t5);
+    w2[3] = l32_from_64 (t5);
+    w3[0] = h32_from_64 (t6);
+    w3[1] = l32_from_64 (t6);
+    w3[2] = h32_from_64 (t7);
+    w3[3] = l32_from_64 (t7);
+    w4[0] = hc_swap32 (j);
+
+    u64x digest[8];
+
+    digest[0] = SHA512M_A;
+    digest[1] = SHA512M_B;
+    digest[2] = SHA512M_C;
+    digest[3] = SHA512M_D;
+    digest[4] = SHA512M_E;
+    digest[5] = SHA512M_F;
+    digest[6] = SHA512M_G;
+    digest[7] = SHA512M_H;
+
+    sha512_transform_vector (w0, w1, w2, w3, w4, w5, w6, w7, digest);
+
+    t0 = digest[0];
+    t1 = digest[1];
+    t2 = digest[2];
+    t3 = digest[3];
+    t4 = digest[4];
+    t5 = digest[5];
+    t6 = digest[6];
+    t7 = digest[7];
+  }
+
+  unpack64v (tmps, out, gid, 0, t0);
+  unpack64v (tmps, out, gid, 1, t1);
+  unpack64v (tmps, out, gid, 2, t2);
+  unpack64v (tmps, out, gid, 3, t3);
+  unpack64v (tmps, out, gid, 4, t4);
+  unpack64v (tmps, out, gid, 5, t5);
+  unpack64v (tmps, out, gid, 6, t6);
+  unpack64v (tmps, out, gid, 7, t7);
+}
+
+KERNEL_FQ void m29700_comp (KERN_ATTR_TMPS (office2016_tmp_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  const u32 r0 = l32_from_64_S (tmps[gid].out[7]);
+  const u32 r1 = h32_from_64_S (tmps[gid].out[7]);
+  const u32 r2 = l32_from_64_S (tmps[gid].out[3]);
+  const u32 r3 = h32_from_64_S (tmps[gid].out[3]);
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Added hash-mode: RAR3-p (Uncompressed)
 - Added hash-mode: RSA/DSA/EC/OPENSSH Private Keys
 - Added hash-mode: sha1(sha1($pass).$salt)
+- Added hash-mode: MS Office 2016 - SheetProtection
 
 ##
 ## Bugs

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -271,6 +271,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - MS Office <= 2003 $3/$4, SHA1 + RC4
 - MS Office <= 2003 $3, SHA1 + RC4, collider #1
 - MS Office <= 2003 $3, SHA1 + RC4, collider #2
+- MS Office 2016 - SheetProtection
 - Open Document Format (ODF) 1.2 (SHA-256, AES)
 - Open Document Format (ODF) 1.1 (SHA-1, Blowfish)
 - Apple Keychain

--- a/src/modules/module_29700.c
+++ b/src/modules/module_29700.c
@@ -1,0 +1,330 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 14;
+static const u32   DGST_POS1      = 15;
+static const u32   DGST_POS2      = 6;
+static const u32   DGST_POS3      = 7;
+static const u32   DGST_SIZE      = DGST_SIZE_8_8;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_DOCUMENTS;
+static const char *HASH_NAME      = "MS Office 2016 - SheetProtection";
+static const u64   KERN_TYPE      = 29700;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_USES_BITS_64
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$office$2016$0$100000$876MLoKTq42+/DLp415iZQ==$TNDvpvYyvlSUy97UOLKNhXynhUDDA7H8kLql0ISH5SxcP6hbthdjaTo4Z3/MU0dcR2SAd+AduYb3TB5CLZ8+ow==";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct office2016
+{
+  u32 salt_buf[24 + 1];
+
+} office2016_t;
+
+typedef struct office2016_tmp
+{
+  u64 out[8];
+
+} office2016_tmp_t;
+
+static const char *SIGNATURE_OFFICE2016_SHEETPROTECTION = "$office$2016$0$";
+
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  char *jit_build_options = NULL;
+
+  // Extra treatment for Apple systems
+  if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
+  {
+    return jit_build_options;
+  }
+
+  // NVIDIA GPU
+  if (device_param->opencl_device_vendor_id == VENDOR_ID_NV)
+  {
+    hc_asprintf (&jit_build_options, "-D _unroll");
+  }
+
+  // ROCM
+  if ((device_param->opencl_device_vendor_id == VENDOR_ID_AMD) && (device_param->has_vperm == true))
+  {
+    hc_asprintf (&jit_build_options, "-D _unroll");
+  }
+
+  return jit_build_options;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (office2016_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (office2016_tmp_t);
+
+  return tmp_size;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // this overrides the reductions of PW_MAX in case optimized kernel is selected
+  // IOW, even in optimized kernel mode it support length 256
+
+  const u32 pw_max = PW_MAX;
+
+  return pw_max;
+}
+
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
+  {
+    // self-test failed
+    if ((device_param->opencl_device_vendor_id == VENDOR_ID_AMD) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+    {
+      return true;
+    }
+  }
+
+  // amdgpu-pro-19.30-934563-ubuntu-18.04: self-test failure.
+  if ((device_param->opencl_device_vendor_id == VENDOR_ID_AMD) && (device_param->has_vperm == false))
+  {
+    return true;
+  }
+
+  return false;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u64 *digest = (u64 *) digest_buf;
+
+  office2016_t *office2016 = (office2016_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt  = 4;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_OFFICE2016_SHEETPROTECTION;
+
+  token.len[0]     = 15;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '$';
+  token.len_min[1] = 6;
+  token.len_max[1] = 6;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[2]     = '$';
+  token.len_min[2] = 24;
+  token.len_max[2] = 24;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64A;
+
+  token.sep[3]     = '$';
+  token.len_min[3] = 88;
+  token.len_max[3] = 88;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64A;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *spinCount_pos = token.buf[1];
+
+  const u32 spinCount =  hc_strtoul ((const char *) spinCount_pos, NULL, 10);
+
+  if (spinCount != 100000) return (PARSER_SALT_VALUE);
+
+  /**
+   * salt
+   */
+
+  const u8 *salt_pos = token.buf[2];
+  const int salt_len = token.len[2];
+
+  memcpy (office2016->salt_buf, salt_pos, salt_len);
+
+  u8 tmp_buf[256];
+
+  memset (tmp_buf, 0, sizeof (tmp_buf));
+
+  int tmp_len = base64_decode (base64_to_int, salt_pos, salt_len, tmp_buf);
+
+  if (tmp_len != 16) return (PARSER_SALT_LENGTH);
+
+  memcpy (salt->salt_buf, tmp_buf, tmp_len);
+
+  salt->salt_len  = tmp_len;
+  salt->salt_iter = spinCount;
+
+  /**
+   * digest
+   */
+
+  const u8 *hash_pos = token.buf[3];
+  const int hash_len = token.len[3];
+
+  memset (tmp_buf, 0, sizeof (tmp_buf));
+
+  tmp_len = base64_decode (base64_to_int, hash_pos, hash_len, tmp_buf);
+
+  if (tmp_len != 64) return (PARSER_HASH_LENGTH);
+
+  memcpy (digest, tmp_buf, tmp_len);
+
+  digest[0] = byte_swap_64 (digest[0]);
+  digest[1] = byte_swap_64 (digest[1]);
+  digest[2] = byte_swap_64 (digest[2]);
+  digest[3] = byte_swap_64 (digest[3]);
+  digest[4] = byte_swap_64 (digest[4]);
+  digest[5] = byte_swap_64 (digest[5]);
+  digest[6] = byte_swap_64 (digest[6]);
+  digest[7] = byte_swap_64 (digest[7]);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u64 *digest = (const u64 *) digest_buf;
+
+  const office2016_t *office2016 = (const office2016_t *) esalt_buf;
+
+  const u32 spinCount = salt->salt_iter;
+
+  // hash
+
+  u64 tmp[8];
+
+  tmp[0] = byte_swap_64 (digest[0]);
+  tmp[1] = byte_swap_64 (digest[1]);
+  tmp[2] = byte_swap_64 (digest[2]);
+  tmp[3] = byte_swap_64 (digest[3]);
+  tmp[4] = byte_swap_64 (digest[4]);
+  tmp[5] = byte_swap_64 (digest[5]);
+  tmp[6] = byte_swap_64 (digest[6]);
+  tmp[7] = byte_swap_64 (digest[7]);
+
+  char hash_enc[256];
+
+  memset (hash_enc, 0, sizeof (hash_enc));
+
+  base64_encode (int_to_base64, (const u8 *) tmp, 64, (u8 *) hash_enc);
+
+  // output
+
+  const int line_len = snprintf (line_buf, line_size, "%s%u$%s$%s", SIGNATURE_OFFICE2016_SHEETPROTECTION, spinCount, (const char *) office2016->salt_buf, hash_enc);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m29700.pm
+++ b/tools/test_modules/m29700.pm
@@ -1,0 +1,72 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use MIME::Base64 qw (encode_base64 decode_base64);
+use Digest::SHA qw (sha512);
+use Encode;
+
+sub module_constraints { [[0, 64], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word  = shift;
+  my $salt  = shift;
+  my $iter  = shift // 100000;
+
+  my $tmp = sha512 ($salt . encode ("UTF-16LE", $word));
+
+  for (my $i = 0; $i < $iter; $i++)
+  {
+    my $num32 = pack ("L", $i);
+
+    $tmp = sha512 ($tmp . $num32);
+  }
+
+  my $salt_b64 = encode_base64 ($salt, "");
+  my $digest_b64 = encode_base64 ($tmp, "");
+
+  my $hash = sprintf ("\$office\$%d\$0\$%d\$%s\$%s", 2016, $iter, $salt_b64, $digest_b64);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split ":", $line;
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @data = split ('\$', $hash);
+
+  return unless scalar @data == 7;
+  return unless (shift @data eq 'office');
+  return unless (shift @data eq '2016');
+  return unless (shift @data eq '0');
+
+  my $iter   = shift @data;
+  my $salt   = shift @data;
+  my $digest = shift @data;
+
+  return unless defined $iter;
+  return unless defined $salt;
+  return unless defined $digest;
+
+  return unless length ($salt) == 24;
+  return unless length ($digest) == 88;
+
+  my $new_hash = module_generate_hash ($word, $salt, $iter);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Yes, if you want you can bypass the protection by removing the tag.
But if you want to crack and collect passwords ... you can use this :)

Slow hash anyway, so wordlist attack is preferred here (and -S).

```
$ ./tools/test.sh -m 29700 -a all -t all -D1
[ test_1612291451 ] > Init test for hash type 29700.
[ test_1612291451 ] [ Type 29700, Attack 0, Mode single, Device-Type Cpu, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1612291451 ] [ Type 29700, Attack 0, Mode multi,  Device-Type Cpu, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1612291451 ] [ Type 29700, Attack 0, Mode single, Device-Type Cpu, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1612291451 ] [ Type 29700, Attack 0, Mode multi,  Device-Type Cpu, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
```