### PR TITLE
Update BUILD_WSL.md

### DIFF
--- a/BUILD_WSL.md
+++ b/BUILD_WSL.md
@@ -8,7 +8,7 @@ Enable WSL.
 
 Press the win + r key on your keyboard simultaneously and in the "Run" popup window type bash and make sure to install additional dependencies necessary for hashcat compilation
 ```
-sudo apt install gcc-mingw-w64-x86-64 make git
+sudo apt install g++-mingw-w64-x86-64 make git
 git clone https://github.com/hashcat/hashcat
 git clone https://github.com/win-iconv/win-iconv
 cd win-iconv/


### PR DESCRIPTION
maybe a typo, but when following these instructions the build failes with
make: x86_64-w64-mingw32-g++: No such file or directory
g++-mingw-w64 or g++-mingw-w64-x86-64 has to be installed to run the build successfully