### PR TITLE
Added hash-mode 24900 - Dahua Authentication MD5

### DIFF
--- a/OpenCL/m24900_a0-optimized.cl
+++ b/OpenCL/m24900_a0-optimized.cl
@@ -1,0 +1,401 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp_optimized.h"
+#include "inc_rp_optimized.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#endif
+
+KERNEL_FQ void m24900_m04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * lookup table
+   */
+
+  const u8 sof_lut[64] =
+  {
+   0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+   0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46,
+   0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e,
+   0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56,
+   0x57, 0x58, 0x59, 0x5a, 0x61, 0x62, 0x63, 0x64,
+   0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+   0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74,
+   0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x00, 0x00
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    w3[2] = out_len * 8;
+    w3[3] = 0;
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u16 t_abcd = ((a & 0xff) + ((a >> 8) & 0xff));
+    u8 a_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((a >> 16 )& 0xff) + ((a >> 24) & 0xff));
+    u8 a_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((b & 0xff) + ((b >> 8) & 0xff));
+    u8 b_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((b >> 16) & 0xff) + ((b >> 24) & 0xff));
+    u8 b_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((c & 0xff) + ((c >> 8) & 0xff));
+    u8 c_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((c >> 16 )& 0xff) + ((c >> 24) & 0xff));
+    u8 c_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((d & 0xff) + ((d >> 8) & 0xff));
+    u8 d_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((d >> 16) & 0xff) + ((d >> 24) & 0xff));
+    u8 d_34 = (t_abcd % 0x3e);
+
+    a = (sof_lut[a_12]) + (sof_lut[a_34] << 8) + (sof_lut[b_12] << 16) + (sof_lut[b_34] << 24);
+    b = (sof_lut[c_12]) + (sof_lut[c_34] << 8) + (sof_lut[d_12] << 16) + (sof_lut[d_34] << 24);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (a, b, z, z);
+
+  }
+}
+
+KERNEL_FQ void m24900_m08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m24900_m16 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m24900_s04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * lookup table
+   */
+
+  const u8 sof_lut[64] = 
+  {
+   0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 
+   0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 
+   0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 
+   0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 
+   0x57, 0x58, 0x59, 0x5a, 0x61, 0x62, 0x63, 0x64, 
+   0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 
+   0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 
+   0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x00, 0x00
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    w3[2] = out_len * 8;
+    w3[3] = 0;
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u16 t_abcd = ((a & 0xff) + ((a >> 8) & 0xff));
+    u8 a_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((a >> 16 )& 0xff) + ((a >> 24) & 0xff));
+    u8 a_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((b & 0xff) + ((b >> 8) & 0xff));
+    u8 b_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((b >> 16) & 0xff) + ((b >> 24) & 0xff));
+    u8 b_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((c & 0xff) + ((c >> 8) & 0xff));
+    u8 c_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((c >> 16 )& 0xff) + ((c >> 24) & 0xff));
+    u8 c_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((d & 0xff) + ((d >> 8) & 0xff));
+    u8 d_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((d >> 16) & 0xff) + ((d >> 24) & 0xff));
+    u8 d_34 = (t_abcd % 0x3e);
+
+    a = (sof_lut[a_12]) + (sof_lut[a_34] << 8) + (sof_lut[b_12] << 16) + (sof_lut[b_34] << 24);
+    b = (sof_lut[c_12]) + (sof_lut[c_34] << 8) + (sof_lut[d_12] << 16) + (sof_lut[d_34] << 24);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (a, b, z, z);
+
+  }
+}
+
+KERNEL_FQ void m24900_s08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m24900_s16 (KERN_ATTR_RULES ())
+{
+}

--- a/OpenCL/m24900_a1-optimized.cl
+++ b/OpenCL/m24900_a1-optimized.cl
@@ -1,0 +1,516 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_scalar.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#endif
+
+KERNEL_FQ void m24900_m04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * lookup table
+   */
+
+  const u8 sof_lut[64] =
+  {
+   0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+   0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46,
+   0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e,
+   0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56,
+   0x57, 0x58, 0x59, 0x5a, 0x61, 0x62, 0x63, 0x64,
+   0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+   0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74,
+   0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x00, 0x00
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = pw_len * 8;
+    w3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u16 t_abcd = ((a & 0xff) + ((a >> 8) & 0xff));
+    u8 a_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((a >> 16 )& 0xff) + ((a >> 24) & 0xff));
+    u8 a_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((b & 0xff) + ((b >> 8) & 0xff));
+    u8 b_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((b >> 16) & 0xff) + ((b >> 24) & 0xff));
+    u8 b_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((c & 0xff) + ((c >> 8) & 0xff));
+    u8 c_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((c >> 16 )& 0xff) + ((c >> 24) & 0xff));
+    u8 c_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((d & 0xff) + ((d >> 8) & 0xff));
+    u8 d_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((d >> 16) & 0xff) + ((d >> 24) & 0xff));
+    u8 d_34 = (t_abcd % 0x3e);
+
+    a = (sof_lut[a_12]) + (sof_lut[a_34] << 8) + (sof_lut[b_12] << 16) + (sof_lut[b_34] << 24);
+    b = (sof_lut[c_12]) + (sof_lut[c_34] << 8) + (sof_lut[d_12] << 16) + (sof_lut[d_34] << 24);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (a, b, z, z);
+  }
+}
+
+KERNEL_FQ void m24900_m08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m24900_m16 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m24900_s04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * lookup table
+   */
+
+  const u8 sof_lut[64] =
+  {
+   0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+   0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46,
+   0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e,
+   0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56,
+   0x57, 0x58, 0x59, 0x5a, 0x61, 0x62, 0x63, 0x64,
+   0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+   0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74,
+   0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x00, 0x00
+  };
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (combs_mode == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = pw_len * 8;
+    w3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u16 t_abcd = ((a & 0xff) + ((a >> 8) & 0xff));
+    u8 a_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((a >> 16 )& 0xff) + ((a >> 24) & 0xff));
+    u8 a_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((b & 0xff) + ((b >> 8) & 0xff));
+    u8 b_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((b >> 16) & 0xff) + ((b >> 24) & 0xff));
+    u8 b_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((c & 0xff) + ((c >> 8) & 0xff));
+    u8 c_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((c >> 16 )& 0xff) + ((c >> 24) & 0xff));
+    u8 c_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((d & 0xff) + ((d >> 8) & 0xff));
+    u8 d_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((d >> 16) & 0xff) + ((d >> 24) & 0xff));
+    u8 d_34 = (t_abcd % 0x3e);
+
+    a = (sof_lut[a_12]) + (sof_lut[a_34] << 8) + (sof_lut[b_12] << 16) + (sof_lut[b_34] << 24);
+    b = (sof_lut[c_12]) + (sof_lut[c_34] << 8) + (sof_lut[d_12] << 16) + (sof_lut[d_34] << 24);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (a, b, z, z);
+  }
+}
+
+KERNEL_FQ void m24900_s08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m24900_s16 (KERN_ATTR_BASIC ())
+{
+}

--- a/OpenCL/m24900_a3-optimized.cl
+++ b/OpenCL/m24900_a3-optimized.cl
@@ -1,0 +1,661 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#endif
+
+DECLSPEC void m24900m (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+
+  /**
+   * lookup table
+   */
+
+  const u8 sof_lut[64] =
+  {
+   0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+   0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46,
+   0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e,
+   0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56,
+   0x57, 0x58, 0x59, 0x5a, 0x61, 0x62, 0x63, 0x64,
+   0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+   0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74,
+   0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x00, 0x00
+  };
+
+  /**
+   * loop
+   */
+
+  const u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x t0[4];
+    u32x t1[4];
+    u32x t2[4];
+    u32x t3[4];
+
+    t0[0] = w0lr;
+    t0[1] = w0[1];
+    t0[2] = w0[2];
+    t0[3] = w0[3];
+    t1[0] = w1[0];
+    t1[1] = w1[1];
+    t1[2] = w1[2];
+    t1[3] = w1[3];
+    t2[0] = w2[0];
+    t2[1] = w2[1];
+    t2[2] = w2[2];
+    t2[3] = w2[3];
+    t3[0] = w3[0];
+    t3[1] = w3[1];
+    t3[2] = pw_len * 8;
+    t3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, t0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, t0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, t1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, t0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u16 t_abcd = ((a & 0xff) + ((a >> 8) & 0xff));
+    u8 a_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((a >> 16 )& 0xff) + ((a >> 24) & 0xff));
+    u8 a_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((b & 0xff) + ((b >> 8) & 0xff));
+    u8 b_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((b >> 16) & 0xff) + ((b >> 24) & 0xff));
+    u8 b_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((c & 0xff) + ((c >> 8) & 0xff));
+    u8 c_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((c >> 16 )& 0xff) + ((c >> 24) & 0xff));
+    u8 c_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((d & 0xff) + ((d >> 8) & 0xff));
+    u8 d_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((d >> 16) & 0xff) + ((d >> 24) & 0xff));
+    u8 d_34 = (t_abcd % 0x3e);
+
+    a = (sof_lut[a_12]) + (sof_lut[a_34] << 8) + (sof_lut[b_12] << 16) + (sof_lut[b_34] << 24);
+    b = (sof_lut[c_12]) + (sof_lut[c_34] << 8) + (sof_lut[d_12] << 16) + (sof_lut[d_34] << 24);
+
+    u32x z = 0;
+
+    COMPARE_M_SIMD (a, b, z, z);
+  }
+}
+
+DECLSPEC void m24900s (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R1],
+    0,
+    0
+  };
+
+  /**
+   * lookup table
+   */
+
+  const u8 sof_lut[64] =
+  {
+   0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+   0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46,
+   0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e,
+   0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56,
+   0x57, 0x58, 0x59, 0x5a, 0x61, 0x62, 0x63, 0x64,
+   0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+   0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74,
+   0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x00, 0x00
+  };
+
+  /**
+   * loop
+   */
+
+  const u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x t0[4];
+    u32x t1[4];
+    u32x t2[4];
+    u32x t3[4];
+
+    t0[0] = w0lr;
+    t0[1] = w0[1];
+    t0[2] = w0[2];
+    t0[3] = w0[3];
+    t1[0] = w1[0];
+    t1[1] = w1[1];
+    t1[2] = w1[2];
+    t1[3] = w1[3];
+    t2[0] = w2[0];
+    t2[1] = w2[1];
+    t2[2] = w2[2];
+    t2[3] = w2[3];
+    t3[0] = w3[0];
+    t3[1] = w3[1];
+    t3[2] = pw_len * 8;
+    t3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, t0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, t0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, t1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, t0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t2[1], MD5C3f, MD5S33);
+
+    a += MD5M_A;
+    b += MD5M_B;
+    c += MD5M_C;
+    d += MD5M_D;
+
+    u16 t_abcd = ((a & 0xff) + ((a >> 8) & 0xff));
+    u8 a_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((a >> 16 )& 0xff) + ((a >> 24) & 0xff));
+    u8 a_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((b & 0xff) + ((b >> 8) & 0xff));
+    u8 b_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((b >> 16) & 0xff) + ((b >> 24) & 0xff));
+    u8 b_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((c & 0xff) + ((c >> 8) & 0xff));
+    u8 c_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((c >> 16 )& 0xff) + ((c >> 24) & 0xff));
+    u8 c_34 = (t_abcd % 0x3e);
+
+    t_abcd = ((d & 0xff) + ((d >> 8) & 0xff));
+    u8 d_12 = (t_abcd % 0x3e);
+
+    t_abcd = (((d >> 16) & 0xff) + ((d >> 24) & 0xff));
+    u8 d_34 = (t_abcd % 0x3e);
+
+    a = (sof_lut[a_12]) + (sof_lut[a_34] << 8) + (sof_lut[b_12] << 16) + (sof_lut[b_34] << 24);
+    b = (sof_lut[c_12]) + (sof_lut[c_34] << 8) + (sof_lut[d_12] << 16) + (sof_lut[d_34] << 24);
+
+    u32x z = 0;
+
+    COMPARE_S_SIMD (a, b, z, z);
+  }
+}
+
+KERNEL_FQ void m24900_m04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24900m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, SALT_POS, loop_pos, loop_cnt, il_cnt, digests_cnt, DIGESTS_OFFSET, combs_mode, pws_pos, gid_max);
+}
+
+KERNEL_FQ void m24900_m08 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24900m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, SALT_POS, loop_pos, loop_cnt, il_cnt, digests_cnt, DIGESTS_OFFSET, combs_mode, pws_pos, gid_max);
+}
+
+KERNEL_FQ void m24900_m16 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24900m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, SALT_POS, loop_pos, loop_cnt, il_cnt, digests_cnt, DIGESTS_OFFSET, combs_mode, pws_pos, gid_max);
+}
+
+KERNEL_FQ void m24900_s04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24900s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, SALT_POS, loop_pos, loop_cnt, il_cnt, digests_cnt, DIGESTS_OFFSET, combs_mode, pws_pos, gid_max);
+}
+
+KERNEL_FQ void m24900_s08 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24900s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, SALT_POS, loop_pos, loop_cnt, il_cnt, digests_cnt, DIGESTS_OFFSET, combs_mode, pws_pos, gid_max);
+}
+
+KERNEL_FQ void m24900_s16 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24900s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, bitmap_mask, bitmap_shift1, bitmap_shift2, SALT_POS, loop_pos, loop_cnt, il_cnt, digests_cnt, DIGESTS_OFFSET, combs_mode, pws_pos, gid_max);
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Added hash-mode: RAR3-p (Uncompressed)
 - Added hash-mode: RSA/DSA/EC/OPENSSH Private Keys
 - Added hash-mode: sha1(sha1($pass).$salt)
+- Added hash-mode: Dahua Authentication MD5
 
 ##
 ## Bugs

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -336,6 +336,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - Django (SHA-1)
 - Web2py pbkdf2-sha512
 - TOTP (HMAC-SHA1)
+- Dahua Authentication MD5
 
 ##
 ## Attack-Modes

--- a/src/modules/module_24900.c
+++ b/src/modules/module_24900.c
@@ -1,0 +1,184 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_RAW_HASH;
+static const char *HASH_NAME      = "Dahua Authentication MD5";
+static const u64   KERN_TYPE      = 24900;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_MEET_IN_MIDDLE
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_NOT_SALTED
+                                  | OPTI_TYPE_RAW_HASH;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS14;
+static const u32   SALT_TYPE      = SALT_TYPE_NONE;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "GRuHbyVp";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  token_t token;
+
+  token.token_cnt  = 1;
+
+  token.len_min[0] = 8;
+  token.len_max[0] = 8;
+  token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+  
+  u8 temp_hex_buf[17] = { 0 };
+
+  const u8 *hash_pos = token.buf[0];
+
+  hex_encode ((u8 *) hash_pos, 8, temp_hex_buf);
+
+  digest[0] = hex_to_u32 (temp_hex_buf +  0);
+  digest[1] = hex_to_u32 (temp_hex_buf +  8);
+  digest[2] = 0;
+  digest[3] = 0;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  // we can not change anything in the original buffer, otherwise destroying sorting
+  // therefore create some local buffer
+
+  u32 tmp[4];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = 0;
+  tmp[3] = 0;
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  u8 ht_buf[17] = { 0 };
+
+  u32_to_hex (tmp[0], ht_buf +  0);
+  u32_to_hex (tmp[1], ht_buf +  8);
+
+  hex_decode (ht_buf, 16, (u8 *) out_buf);
+
+  const int out_len = 8;
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}
+
+


### PR DESCRIPTION
This is equivalent to the Dahua MD5 format in JohnTheRipper(https://github.com/openwall/john/blob/b81ed703ceb7ca62df50c2fa0d4ea366ef713a4a/src/dahua_fmt_plug.c) but drops the superfluous `$dahua$` tag that prepends the hashes. If we want to stay directly compatible, I can add that to the tokenizer but I don't see a need to add the tag otherwise.

This is a collision prone algorithm, many passwords will match a given hash. 