### PR TITLE
Machine readable mode for show hash feature

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1187,7 +1187,17 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              if (user_options->machine_readable == true) {
+                event_log_warning(hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile,
+                                  line_num, tmp_line_buf,
+                                  strparser(parser_status));
+
+              } else {
+                event_log_warning(hashcat_ctx,
+                                  "Hashfile '%s' on line %u (%s): %s",
+                                  hashes->hashfile, line_num, tmp_line_buf,
+                                  strparser(parser_status));
+              }
 
               hcfree (tmp_line_buf);
 
@@ -1211,7 +1221,17 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              if (user_options->machine_readable == true) {
+                event_log_warning(hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile,
+                                  line_num, tmp_line_buf,
+                                  strparser(parser_status));
+
+              } else {
+                event_log_warning(hashcat_ctx,
+                                  "Hashfile '%s' on line %u (%s): %s",
+                                  hashes->hashfile, line_num, tmp_line_buf,
+                                  strparser(parser_status));
+              }
 
               hcfree (tmp_line_buf);
 
@@ -1237,7 +1257,17 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
               compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-              event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+              if (user_options->machine_readable == true) {
+                event_log_warning(hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile,
+                                  line_num, tmp_line_buf,
+                                  strparser(parser_status));
+
+              } else {
+                event_log_warning(hashcat_ctx,
+                                  "Hashfile '%s' on line %u (%s): %s",
+                                  hashes->hashfile, line_num, tmp_line_buf,
+                                  strparser(parser_status));
+              }
 
               hcfree (tmp_line_buf);
 
@@ -1264,7 +1294,17 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
             compress_terminal_line_length (tmp_line_buf, 38, 32);
 
-            event_log_warning (hashcat_ctx, "Hashfile '%s' on line %u (%s): %s", hashes->hashfile, line_num, tmp_line_buf, strparser (parser_status));
+            if (user_options->machine_readable == true) {
+              event_log_warning(hashcat_ctx, "%s:%u:%s:%s", hashes->hashfile,
+                                line_num, tmp_line_buf,
+                                strparser(parser_status));
+
+            } else {
+              event_log_warning(hashcat_ctx,
+                                "Hashfile '%s' on line %u (%s): %s",
+                                hashes->hashfile, line_num, tmp_line_buf,
+                                strparser(parser_status));
+            }
 
             hcfree (tmp_line_buf);
 


### PR DESCRIPTION
Prints hash-parser errors in a machine friendly format suitable for futher processing by some other tools.

./hashcat -m 100 example0.hash --show --machine-readable


```
...
example0.hash:4563:b6a62a3c9eb9c9f1c2a16dbb0608fed4:Token length exception
example0.hash:4564:b6a7d9402f8f8a28536a25142afbe5cd:Token length exception
example0.hash:4565:b6af37e4d70076e3cfccc085c2b018d9:Token length exception
example0.hash:4566:b6c12947a59fa4b6729807705e373c3e:Token length exception
example0.hash:4567:b6c5317760430b85b11a65d5ea2368f0:Token length exception
example0.hash:4568:b6ca4a29cdb685e386a172f79b0a3d95:Token length exception
...
```