### PR TITLE
Workaround for NVML and WSL2 shim

### DIFF
--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -566,7 +566,7 @@ static int hm_NVML_nvmlInit (hashcat_ctx_t *hashcat_ctx)
 
   const nvmlReturn_t nvml_rc = (nvmlReturn_t) nvml->nvmlInit ();
 
-  if (nvml_rc != NVML_SUCCESS)
+  if (nvml_rc != NVML_SUCCESS && nvml_rc != NVML_ERROR_DRIVER_NOT_LOADED)
   {
     const char *string = hm_NVML_nvmlErrorString (nvml, nvml_rc);
 
@@ -586,7 +586,7 @@ static int hm_NVML_nvmlShutdown (hashcat_ctx_t *hashcat_ctx)
 
   const nvmlReturn_t nvml_rc = (nvmlReturn_t) nvml->nvmlShutdown ();
 
-  if (nvml_rc != NVML_SUCCESS)
+  if (nvml_rc != NVML_SUCCESS && nvml_rc != NVML_ERROR_DRIVER_NOT_LOADED)
   {
     const char *string = hm_NVML_nvmlErrorString (nvml, nvml_rc);
 
@@ -606,7 +606,7 @@ static int hm_NVML_nvmlDeviceGetCount (hashcat_ctx_t *hashcat_ctx, unsigned int 
 
   const nvmlReturn_t nvml_rc = nvml->nvmlDeviceGetCount (deviceCount);
 
-  if (nvml_rc != NVML_SUCCESS)
+  if (nvml_rc != NVML_SUCCESS && nvml_rc != NVML_ERROR_DRIVER_NOT_LOADED)
   {
     const char *string = hm_NVML_nvmlErrorString (nvml, nvml_rc);
 


### PR DESCRIPTION
Win10 Build 21364 adds direct GPU access to WSL2. However, we do not actually have a GPU driver inside the WSL2 environment (utilizes a special host driver + shim) , and NVML seems to be highly confused by this. 

Despite the fact that nvmlInit() and friends are aware there is no driver and appropriately returns NVML_ERROR_DRIVER_NOT_LOADED, nvmlErrorString() and similar will return a garbage (non-null) pointer that causes segmentation faults. 

We can work around this issue by simply not calling nvmlErrorString() and friends if nvmlInit() and similar calls return NVML_ERROR_DRIVER_NOT_LOADED. This patch provides a clean, segfault-free user experience, as the user just sees a simple yet informative "No NVML adapters found" message.

WSL2 support is dedicated to Dan Kaminsky. 

![image](https://user-images.githubusercontent.com/4122154/115979660-c53ae180-a54c-11eb-8fe5-6c9e1f5c837a.png)
