### PR TITLE
update in module_13400.c

### DIFF
--- a/src/modules/module_13400.c
+++ b/src/modules/module_13400.c
@@ -128,7 +128,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[2]     = '*';
   token.len_min[2] = 1;
-  token.len_max[2] = 8;
+  token.len_max[2] = 10;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_DIGIT;
 


### PR DESCRIPTION
changed token.len_max[2] = 8; -> token.len_max[2] = 10;
max lenght of an u32 is 10,
use case: for manually user tuned keepass iterations above 99999999
see thread https://hashcat.net/forum/thread-10116-post-52700.html#pid52700