### PR TITLE
Added new feature: autodetect hash-mode

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -22,6 +22,12 @@
 - Added hash-mode: sha384(utf16le($pass).$salt)
 
 ##
+## Features
+##
+
+- Autodetect hash-type: performs an automatic analysis of the input hash(es), associating compatible algorithms, or executing the attack if only one compatible format is found.
+
+##
 ## Bugs
 ##
 
@@ -41,7 +47,6 @@
 - RC4 Kernels: Improved performance by 20%+ for hash-modes Kerberos 5 (etype 23), MS Office (<= 2003) and PDF (<= 1.6) by using new RC4 code
 - Status Screen: Show currently running kernel type (pure, optimized) and generator type (host, device)
 - UTF8-to-UTF16: Replaced naive UTF8 to UTF16 conversion with true conversion for RAR3, AES Crypt, MultiBit HD (scrypt) and Umbraco HMAC-SHA1
-- Autodetect hash-type: performs an automatic analysis of the hashlist, associating compatible algorithms, or executing the attack if only one compatible format is found.
 
 ##
 ## Technical

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -41,6 +41,7 @@
 - RC4 Kernels: Improved performance by 20%+ for hash-modes Kerberos 5 (etype 23), MS Office (<= 2003) and PDF (<= 1.6) by using new RC4 code
 - Status Screen: Show currently running kernel type (pure, optimized) and generator type (host, device)
 - UTF8-to-UTF16: Replaced naive UTF8 to UTF16 conversion with true conversion for RAR3, AES Crypt, MultiBit HD (scrypt) and Umbraco HMAC-SHA1
+- Autodetect hash-type: performs an automatic analysis of the hashlist, associating compatible algorithms, or executing the attack if only one compatible format is found.
 
 ##
 ## Technical

--- a/example0.cmd
+++ b/example0.cmd
@@ -1,2 +1,2 @@
-hashcat.exe -t 32 -a 7 example0.hash ?a?a?a?a example.dict
+hashcat.exe -m 0 -t 32 -a 7 example0.hash ?a?a?a?a example.dict
 pause

--- a/example0.sh
+++ b/example0.sh
@@ -1,1 +1,1 @@
-./hashcat -t 32 -a 7 example0.hash ?a?a?a?a example.dict
+./hashcat -m 0 -t 32 -a 7 example0.hash ?a?a?a?a example.dict

--- a/include/types.h
+++ b/include/types.h
@@ -210,6 +210,7 @@ typedef enum status_rc
   STATUS_ABORTED_RUNTIME    = 11,
   STATUS_ERROR              = 13,
   STATUS_ABORTED_FINISH     = 14,
+  STATUS_AUTODETECT         = 16,
 
 } status_rc_t;
 
@@ -443,6 +444,7 @@ typedef enum opts_type
   OPTS_TYPE_MP_MULTI_DISABLE  = (1ULL << 52), // do not multiply the kernel-accel with the multiprocessor count per device to allow more fine-tuned workload settings
   OPTS_TYPE_NATIVE_THREADS    = (1ULL << 53), // forces "native" thread count: CPU=1, GPU-Intel=8, GPU-AMD=64 (wavefront), GPU-NV=32 (warps)
   OPTS_TYPE_POST_AMP_UTF16LE  = (1ULL << 54), // run the utf8 to utf16le conversion kernel after they have been processed from amplifiers
+  OPTS_TYPE_AUTODETECT_DISABLE = (1ULL << 55), // skip autodetect engine
 
 } opts_type_t;
 
@@ -594,6 +596,7 @@ typedef enum user_options_defaults
 {
   ADVICE_DISABLE           = false,
   ATTACK_MODE              = ATTACK_MODE_STRAIGHT,
+  AUTODETECT               = false,
   BENCHMARK_ALL            = false,
   BENCHMARK                = false,
   BITMAP_MAX               = 18,
@@ -1939,6 +1942,7 @@ typedef struct user_options
   char       **hc_argv;
 
   bool         attack_mode_chgd;
+  bool         autodetect;
   #ifdef WITH_BRAIN
   bool         brain_host_chgd;
   bool         brain_port_chgd;

--- a/include/usage.h
+++ b/include/usage.h
@@ -9,7 +9,16 @@
 #include <stdio.h>
 #include <string.h>
 
+typedef struct usage_sort
+{
+  u32   hash_mode;
+  char *hash_name;
+  u32   hash_category;
+
+} usage_sort_t;
+
 void usage_mini_print (const char *progname);
 void usage_big_print  (hashcat_ctx_t *hashcat_ctx);
+int sort_by_usage (const void *p1, const void *p2);
 
 #endif // _USAGE_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -189,7 +189,6 @@ endif
 ## because LZMA SDK
 ifeq ($(CC),clang)
 CFLAGS                  += -Wno-enum-conversion
-CFLAGS                  += -Wno-typedef-redefinition
 endif
 
 ## because ZLIB

--- a/src/Makefile
+++ b/src/Makefile
@@ -189,6 +189,7 @@ endif
 ## because LZMA SDK
 ifeq ($(CC),clang)
 CFLAGS                  += -Wno-enum-conversion
+CFLAGS                  += -Wno-typedef-redefinition
 endif
 
 ## because ZLIB

--- a/src/interface.c
+++ b/src/interface.c
@@ -259,7 +259,7 @@ int hashconfig_init (hashcat_ctx_t *hashcat_ctx)
   {
     if ((hashconfig->opts_type & OPTS_TYPE_KEYBOARD_MAPPING) == 0)
     {
-      event_log_error (hashcat_ctx, "Parameter --keyboard-layout-mapping not valid for hash-type %u", hashconfig->hash_mode);
+      if (user_options->autodetect == false) event_log_error (hashcat_ctx, "Parameter --keyboard-layout-mapping not valid for hash-type %u", hashconfig->hash_mode);
 
       return -1;
     }
@@ -288,7 +288,7 @@ int hashconfig_init (hashcat_ctx_t *hashcat_ctx)
     }
     else
     {
-      event_log_error (hashcat_ctx, "Parameter --hex-salt not valid for hash-type %u", hashconfig->hash_mode);
+      if (user_options->autodetect == false) event_log_error (hashcat_ctx, "Parameter --hex-salt not valid for hash-type %u", hashconfig->hash_mode);
 
       return -1;
     }
@@ -302,7 +302,7 @@ int hashconfig_init (hashcat_ctx_t *hashcat_ctx)
   {
     if (hashconfig->opts_type & OPTS_TYPE_SUGGEST_KG)
     {
-      if (user_options->quiet == false)
+      if (user_options->quiet == false && user_options->autodetect == false)
       {
         event_log_warning (hashcat_ctx, "This hash-mode is known to emit multiple valid password candidates for the same hash.");
         event_log_warning (hashcat_ctx, "Use --keep-guessing to prevent hashcat from shutdown after the hash has been cracked.");

--- a/src/modules/module_02000.c
+++ b/src/modules/module_02000.c
@@ -20,7 +20,8 @@ static const u32   HASH_CATEGORY  = HASH_CATEGORY_PLAIN;
 static const char *HASH_NAME      = "STDOUT";
 static const u64   KERN_TYPE      = 2000;
 static const u32   OPTI_TYPE      = 0;
-static const u64   OPTS_TYPE      = OPTS_TYPE_SELF_TEST_DISABLE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_SELF_TEST_DISABLE
+                                  | OPTS_TYPE_AUTODETECT_DISABLE;
 static const u32   SALT_TYPE      = SALT_TYPE_NONE;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "hashcat";

--- a/src/modules/module_09000.c
+++ b/src/modules/module_09000.c
@@ -21,7 +21,8 @@ static const char *HASH_NAME      = "Password Safe v2";
 static const u64   KERN_TYPE      = 9000;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
-                                  | OPTS_TYPE_BINARY_HASHFILE;
+                                  | OPTS_TYPE_BINARY_HASHFILE
+                                  | OPTS_TYPE_AUTODETECT_DISABLE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "0a3f352686e5eb5be173e668a4fff5cd5df420927e1da2d5d4052340160637e3e6a5a92841a188ed240e13b919f3d91694bd4c0acba79271e9c08a83ea5ad387cbb74d5884066a1cb5a8caa80d847079168f84823847c631dbe3a834f1bc496acfebac3bff1608bf1c857717f8f428e07b5e2cb12aaeddfa83d7dcb6d840234d08b84f8ca6c6e562af73eea13148f7902bcaf0220d3e36eeeff1d37283dc421483a2791182614ebb";

--- a/src/modules/module_99999.c
+++ b/src/modules/module_99999.c
@@ -30,7 +30,8 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_RAW_HASH;
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_PT_ADD80
-                                  | OPTS_TYPE_PT_ADDBITS14;
+                                  | OPTS_TYPE_PT_ADDBITS14
+                                  | OPTS_TYPE_AUTODETECT_DISABLE;
 static const u32   SALT_TYPE      = SALT_TYPE_NONE;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "hashcat";

--- a/src/status.c
+++ b/src/status.c
@@ -34,6 +34,7 @@ static const char *ST_0012 = "Running (Checkpoint Quit requested)";
 static const char *ST_0013 = "Error";
 static const char *ST_0014 = "Aborted (Finish)";
 static const char *ST_0015 = "Running (Quit after attack requested)";
+static const char *ST_0016 = "Autodetect";
 static const char *ST_9999 = "Unknown! Bug!";
 
 static const char UNITS[7] = { ' ', 'k', 'M', 'G', 'T', 'P', 'E' };
@@ -292,6 +293,7 @@ const char *status_get_status_string (const hashcat_ctx_t *hashcat_ctx)
     case STATUS_ABORTED_RUNTIME:    return ST_0011;
     case STATUS_ERROR:              return ST_0013;
     case STATUS_ABORTED_FINISH:     return ST_0014;
+    case STATUS_AUTODETECT:         return ST_0016;
   }
 
   return ST_9999;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -68,7 +68,7 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
     event_log_info (hashcat_ctx, "%s (%s) starting in progress-only mode...", PROGNAME, version_tag);
     event_log_info (hashcat_ctx, NULL);
   }
-  else if (user_options->autodetect == true)
+  else if (user_options->hash_mode == 0 && user_options->hash_mode_chgd == false)
   {
     event_log_info (hashcat_ctx, "%s (%s) starting in autodetect mode...", PROGNAME, version_tag);
     event_log_info (hashcat_ctx, NULL);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -68,6 +68,11 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
     event_log_info (hashcat_ctx, "%s (%s) starting in progress-only mode...", PROGNAME, version_tag);
     event_log_info (hashcat_ctx, NULL);
   }
+  else if (user_options->autodetect == true)
+  {
+    event_log_info (hashcat_ctx, "%s (%s) starting in autodetect mode...", PROGNAME, version_tag);
+    event_log_info (hashcat_ctx, NULL);
+  }
   else
   {
     event_log_info (hashcat_ctx, "%s (%s) starting...", PROGNAME, version_tag);

--- a/src/usage.c
+++ b/src/usage.c
@@ -239,15 +239,7 @@ static const char *const USAGE_BIG_POST_HASHMODES[] =
   NULL
 };
 
-typedef struct usage_sort
-{
-  u32   hash_mode;
-  char *hash_name;
-  u32   hash_category;
-
-} usage_sort_t;
-
-static int sort_by_usage (const void *p1, const void *p2)
+int sort_by_usage (const void *p1, const void *p2)
 {
   const usage_sort_t *u1 = (const usage_sort_t *) p1;
   const usage_sort_t *u2 = (const usage_sort_t *) p2;

--- a/src/usage.c
+++ b/src/usage.c
@@ -26,7 +26,7 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   "",
   " Options Short / Long           | Type | Description                                          | Example",
   "================================+======+======================================================+=======================",
-  " -m, --hash-type                | Num  | Hash-type, see references below                      | -m 1000",
+  " -m, --hash-type                | Num  | Hash-type, references below (otherwise autodetect)   | -m 1000",
   " -a, --attack-mode              | Num  | Attack-mode, see references below                    | -a 3",
   " -V, --version                  |      | Print version                                        |",
   " -h, --help                     |      | Print help                                           |",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1894,7 +1894,7 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     user_options->potfile_disable = true;
   }
 
-  if (user_options->stdout_flag == false)
+  if (user_options->stdout_flag == false && user_options->benchmark == false)
   {
     if (user_options->hash_mode == 0 && user_options->hash_mode_chgd == false)
     {

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1894,7 +1894,7 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     user_options->potfile_disable = true;
   }
 
-  if (user_options->stdout_flag == false && user_options->benchmark == false)
+  if (user_options->stdout_flag == false && user_options->benchmark == false && user_options->keyspace == false)
   {
     if (user_options->hash_mode == 0 && user_options->hash_mode_chgd == false)
     {

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -665,11 +665,6 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  if (user_options->hash_mode == 0 && user_options->hash_mode_chgd == false)
-  {
-    user_options->autodetect = true;
-  }
-
   if (user_options->outfile_format == 0)
   {
     event_log_error (hashcat_ctx, "Invalid --outfile-format value specified.");
@@ -1897,6 +1892,14 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
   if (user_options->attack_mode == ATTACK_MODE_ASSOCIATION)
   {
     user_options->potfile_disable = true;
+  }
+
+  if (user_options->stdout_flag == false)
+  {
+    if (user_options->hash_mode == 0 && user_options->hash_mode_chgd == false)
+    {
+      user_options->autodetect = true;
+    }
   }
 }
 

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -157,6 +157,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
 
   user_options->advice_disable            = ADVICE_DISABLE;
   user_options->attack_mode               = ATTACK_MODE;
+  user_options->autodetect                = AUTODETECT;
   user_options->backend_devices           = NULL;
   user_options->backend_ignore_cuda       = BACKEND_IGNORE_CUDA;
   user_options->backend_ignore_opencl     = BACKEND_IGNORE_OPENCL;
@@ -662,6 +663,11 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     event_log_error (hashcat_ctx, "Invalid -m (hash type) value specified.");
 
     return -1;
+  }
+
+  if (user_options->hash_mode == 0 && user_options->hash_mode_chgd == false)
+  {
+    user_options->autodetect = true;
   }
 
   if (user_options->outfile_format == 0)


### PR DESCRIPTION
Hi, to make hashcat more user-friendly I have implemented a new feature: autodetect the hash-mode.

In essence, this new feature greatly simplifies the hashcat workflow :)

Specifically, if more than one compatible algorithm is found, a list of hash-modes to use will be shown.
In case the hash-mode is compatible with only one format supported by hashcat, the attack will be performed.

This new feature can be used by omitting the "-m" parameter, here are some examples:

**Multiple matches**
```
$ head -1 example0.hash > unknown_hash 
$ ./hashcat unknown_hash example.dict 
hashcat (v6.2.1-117-gdf6cafeba) starting...

OpenCL API (OpenCL 1.2 (May  7 2020 00:10:14)) - Platform #1 [Apple]
====================================================================
* Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, 8128/8192 MB (2048 MB allocatable), 4MCU
* Device #2: Iris, skipped

Match: 0 - MD5
Match: 70 - md5(utf16le($pass))
Match: 900 - MD4
Match: 1000 - NTLM
Match: 2600 - md5(md5($pass))
Match: 3000 - LM
Match: 3500 - md5(md5(md5($pass)))
Match: 4300 - md5(strtoupper(md5($pass)))
Match: 4400 - md5(sha1($pass))
Match: 8600 - Lotus Notes/Domino 5
Match: 9900 - Radmin2
Match: 20900 - md5(sha1($pass).md5($pass).sha1($pass))

Multiple match(s), please specify the hash-mode by argument (-m).

Started: Fri Jun  4 15:46:04 2021
Stopped: Fri Jun  4 15:46:05 2021
```

**Single match**

```
$ head -1 example400.hash > unknown_hash
$ ./hashcat unknown_hash example.dict 
hashcat (v6.2.1-117-gdf6cafeba) starting...

OpenCL API (OpenCL 1.2 (May  7 2020 00:10:14)) - Platform #1 [Apple]
====================================================================
* Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, 8128/8192 MB (2048 MB allocatable), 4MCU
* Device #2: Iris, skipped

Match: 400 - phpass

Minimum password length supported by kernel: 0
Maximum password length supported by kernel: 256

Hashes: 1 digests; 1 unique digests, 1 unique salts
Bitmaps: 16 bits, 65536 entries, 0x0000ffff mask, 262144 bytes, 5/13 rotates
Rules: 1

Optimizers applied:
* Zero-Byte
* Single-Hash
* Single-Salt

ATTENTION! Pure (unoptimized) backend kernels selected.
Using pure kernels enables cracking longer passwords but for the price of drastically reduced performance.
If you want to switch to optimized backend kernels, append -O to your commandline.
See the above message to find out about the exact limits.

Watchdog: Hardware monitoring interface not found on your system.
Watchdog: Temperature abort trigger disabled.

Host memory required for this attack: 1 MB

Dictionary cache built:
* Filename..: example.dict
* Passwords.: 128416
* Bytes.....: 1069601
* Keyspace..: 128416
* Runtime...: 0 secs

$H$9y5boZ2wsUlgl2tI6b5PrRoADzYfXD1:hash234                
                                                          
Session..........: hashcat
Status...........: Cracked
Hash.Name........: phpass
Hash.Target......: $H$9y5boZ2wsUlgl2tI6b5PrRoADzYfXD1
Time.Started.....: Fri Jun  4 15:47:02 2021 (6 secs)
Time.Estimated...: Fri Jun  4 15:47:08 2021 (0 secs)
Kernel.Feature...: Pure Kernel
Guess.Base.......: File (example.dict)
Guess.Queue......: 1/1 (100.00%)
Speed.#1.........:    12584 H/s (9.93ms) @ Accel:512 Loops:128 Thr:1 Vec:4
Recovered........: 1/1 (100.00%) Digests
Progress.........: 71680/128416 (55.82%)
Rejected.........: 0/71680 (0.00%)
Restore.Point....: 69632/128416 (54.22%)
Restore.Sub.#1...: Salt:0 Amplifier:0-1 Iteration:1920-2048
Candidate.Engine.: Device Generator
Candidates.#1....: h0n07u7u -> hhhpimp

Started: Fri Jun  4 15:46:54 2021
Stopped: Fri Jun  4 15:47:08 2021
```

Thanks :)