### PR TITLE
Fix warning with osx/clang build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -189,6 +189,7 @@ endif
 ## because LZMA SDK
 ifeq ($(CC),clang)
 CFLAGS                  += -Wno-enum-conversion
+CFLAGS                  += -Wno-typedef-redefinition
 endif
 
 ## because ZLIB


### PR DESCRIPTION
Hi,

below are the errors that are shown during the build with osx/clang

```
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/affinity.c -o obj/affinity.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/autotune.c -o obj/autotune.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/backend.c -o obj/backend.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/benchmark.c -o obj/benchmark.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/bitmap.c -o obj/bitmap.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/bitops.c -o obj/bitops.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/combinator.c -o obj/combinator.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/common.c -o obj/common.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-enum-conversion -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Iinclude/workarounds -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar src/convert.c -o obj/convert.NATIVE.o -fpic
In file included from src/affinity.c:7:
In file included from include/types.h:28:
In file included from include/ext_lzma.h:9:
In file included from deps/LZMA-SDK/C/LzmaDec.h:7:
deps/LZMA-SDK/C/7zTypes.h:199:24: warning: redefinition of typedef 'INT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef          long  INT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:133:23: note: previous definition is here
typedef          long INT_PTR;
                      ^
deps/LZMA-SDK/C/7zTypes.h:200:24: warning: redefinition of typedef 'UINT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef unsigned long  UINT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:134:23: note: previous definition is here
typedef unsigned long UINT_PTR;
                      ^
In file included from src/autotune.c:7:
In file included from include/types.h:28:
In file included from include/ext_lzma.h:9:
In file included from deps/LZMA-SDK/C/LzmaDec.h:7:
deps/LZMA-SDK/C/7zTypes.h:199:24: warning: redefinition of typedef 'INT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef          long  INT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:133:23: note: previous definition is here
typedef          long INT_PTR;
                      ^
deps/LZMA-SDK/C/7zTypes.h:200:24: warning: redefinition of typedef 'UINT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef unsigned long  UINT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:134:23: note: previous definition is here
typedef unsigned long UINT_PTR;
                      ^
In file included from src/backend.c:7:
In file included from include/types.h:28:
In file included from include/ext_lzma.h:9:
In file included from deps/LZMA-SDK/C/LzmaDec.h:7:
deps/LZMA-SDK/C/7zTypes.h:199:24: warning: redefinition of typedef 'INT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef          long  INT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:133:23: note: previous definition is here
typedef          long INT_PTR;
                      ^
deps/LZMA-SDK/C/7zTypes.h:200:24: warning: redefinition of typedef 'UINT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef unsigned long  UINT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:134:23: note: previous definition is here
typedef unsigned long UINT_PTR;
                      ^
In file included from src/combinator.c:7:
In file included from include/types.h:28:
In file included from include/ext_lzma.h:9:
In file included from deps/LZMA-SDK/C/LzmaDec.h:7:
deps/LZMA-SDK/C/7zTypes.h:199:24: warning: redefinition of typedef 'INT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef          long  INT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:133:23: note: previous definition is here
typedef          long INT_PTR;
                      ^
deps/LZMA-SDK/C/7zTypes.h:200:24: warning: redefinition of typedef 'UINT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef unsigned long  UINT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:134:23: note: previous definition is here
typedef unsigned long UINT_PTR;
                      ^
In file included from src/benchmark.c:7:
In file included from include/types.h:28:
In file included from include/ext_lzma.h:9:
In file included from deps/LZMA-SDK/C/LzmaDec.h:7:
deps/LZMA-SDK/C/7zTypes.h:199:24: warning: redefinition of typedef 'INT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef          long  INT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:133:23: note: previous definition is here
typedef          long INT_PTR;
                      ^
deps/LZMA-SDK/C/7zTypes.h:200:24: warning: redefinition of typedef 'UINT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef unsigned long  UINT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:134:23: note: previous definition is here
typedef unsigned long UINT_PTR;
                      ^
In file included from src/bitops.c:7:
In file included from include/types.h:28:
In file included from include/ext_lzma.h:9:
In file included from deps/LZMA-SDK/C/LzmaDec.h:7:
deps/LZMA-SDK/C/7zTypes.h:199:24: warning: redefinition of typedef 'INT_PTR' is a C11 feature [-Wtypedef-redefinition]
typedef          long  INT_PTR;
                       ^
deps/LZMA-SDK/C/7zTypes.h:133:23: note: previous definition is here
typedef          long INT_PTR;
                      ^
deps/LZMA-SDK/C/7zTypes.h:200:24: warning: redefinition of typedef 'UINT_PTR' is a C11 feature [-Wtypedef-redefinition]
[...]
```