### PR TITLE
Added -m 07010: Fortigate256 (prefixed with SH2 instead of AK1)

### DIFF
--- a/OpenCL/m07010_a0-pure.cl
+++ b/OpenCL/m07010_a0-pure.cl
@@ -16,7 +16,7 @@
 #include "inc_hash_sha256.cl"
 #endif
 
-KERNEL_FQ void m07000_mxx (KERN_ATTR_RULES ())
+KERNEL_FQ void m07010_mxx (KERN_ATTR_RULES ())
 {
   /**
    * modifier
@@ -92,7 +92,7 @@ KERNEL_FQ void m07000_mxx (KERN_ATTR_RULES ())
   }
 }
 
-KERNEL_FQ void m07000_sxx (KERN_ATTR_RULES ())
+KERNEL_FQ void m07010_sxx (KERN_ATTR_RULES ())
 {
   /**
    * modifier

--- a/OpenCL/m07010_a0-pure.cl
+++ b/OpenCL/m07010_a0-pure.cl
@@ -1,0 +1,181 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_rp.h"
+#include "inc_rp.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha256.cl"
+#endif
+
+KERNEL_FQ void m07000_mxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  sha256_ctx_t ctx0;
+
+  sha256_init (&ctx0);
+
+  sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    /**
+     * pepper
+     */
+
+    u32 p0[4];
+    u32 p1[4];
+    u32 p2[4];
+    u32 p3[4];
+
+    p0[0] = hc_swap32_S (FORTIGATE_A);
+    p0[1] = hc_swap32_S (FORTIGATE_B);
+    p0[2] = hc_swap32_S (FORTIGATE_C);
+    p0[3] = hc_swap32_S (FORTIGATE_D);
+    p1[0] = hc_swap32_S (FORTIGATE_E);
+    p1[1] = hc_swap32_S (FORTIGATE_F);
+    p1[2] = 0;
+    p1[3] = 0;
+    p2[0] = 0;
+    p2[1] = 0;
+    p2[2] = 0;
+    p2[3] = 0;
+    p3[0] = 0;
+    p3[1] = 0;
+    p3[2] = 0;
+    p3[3] = 0;
+
+    sha256_update_64 (&ctx, p0, p1, p2, p3, 24);
+
+    sha256_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m07000_sxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  sha256_ctx_t ctx0;
+
+  sha256_init (&ctx0);
+
+  sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_swap (&ctx, tmp.i, tmp.pw_len);
+
+    /**
+     * pepper
+     */
+
+    u32 p0[4];
+    u32 p1[4];
+    u32 p2[4];
+    u32 p3[4];
+
+    p0[0] = hc_swap32_S (FORTIGATE_A);
+    p0[1] = hc_swap32_S (FORTIGATE_B);
+    p0[2] = hc_swap32_S (FORTIGATE_C);
+    p0[3] = hc_swap32_S (FORTIGATE_D);
+    p1[0] = hc_swap32_S (FORTIGATE_E);
+    p1[1] = hc_swap32_S (FORTIGATE_F);
+    p1[2] = 0;
+    p1[3] = 0;
+    p2[0] = 0;
+    p2[1] = 0;
+    p2[2] = 0;
+    p2[3] = 0;
+    p3[0] = 0;
+    p3[1] = 0;
+    p3[2] = 0;
+    p3[3] = 0;
+
+    sha256_update_64 (&ctx, p0, p1, p2, p3, 24);
+
+    sha256_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m07010_a1-pure.cl
+++ b/OpenCL/m07010_a1-pure.cl
@@ -14,7 +14,7 @@
 #include "inc_hash_sha256.cl"
 #endif
 
-KERNEL_FQ void m07000_mxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m07010_mxx (KERN_ATTR_BASIC ())
 {
   /**
    * modifier
@@ -86,7 +86,7 @@ KERNEL_FQ void m07000_mxx (KERN_ATTR_BASIC ())
   }
 }
 
-KERNEL_FQ void m07000_sxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m07010_sxx (KERN_ATTR_BASIC ())
 {
   /**
    * modifier

--- a/OpenCL/m07010_a1-pure.cl
+++ b/OpenCL/m07010_a1-pure.cl
@@ -1,0 +1,171 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_scalar.cl"
+#include "inc_hash_sha256.cl"
+#endif
+
+KERNEL_FQ void m07000_mxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  sha256_ctx_t ctx0;
+
+  sha256_init (&ctx0);
+
+  sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
+
+  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    /**
+     * pepper
+     */
+
+    u32 p0[4];
+    u32 p1[4];
+    u32 p2[4];
+    u32 p3[4];
+
+    p0[0] = hc_swap32_S (FORTIGATE_A);
+    p0[1] = hc_swap32_S (FORTIGATE_B);
+    p0[2] = hc_swap32_S (FORTIGATE_C);
+    p0[3] = hc_swap32_S (FORTIGATE_D);
+    p1[0] = hc_swap32_S (FORTIGATE_E);
+    p1[1] = hc_swap32_S (FORTIGATE_F);
+    p1[2] = 0;
+    p1[3] = 0;
+    p2[0] = 0;
+    p2[1] = 0;
+    p2[2] = 0;
+    p2[3] = 0;
+    p3[0] = 0;
+    p3[1] = 0;
+    p3[2] = 0;
+    p3[3] = 0;
+
+    sha256_update_64 (&ctx, p0, p1, p2, p3, 24);
+
+    sha256_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m07000_sxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  sha256_ctx_t ctx0;
+
+  sha256_init (&ctx0);
+
+  sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
+
+  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos++)
+  {
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    /**
+     * pepper
+     */
+
+    u32 p0[4];
+    u32 p1[4];
+    u32 p2[4];
+    u32 p3[4];
+
+    p0[0] = hc_swap32_S (FORTIGATE_A);
+    p0[1] = hc_swap32_S (FORTIGATE_B);
+    p0[2] = hc_swap32_S (FORTIGATE_C);
+    p0[3] = hc_swap32_S (FORTIGATE_D);
+    p1[0] = hc_swap32_S (FORTIGATE_E);
+    p1[1] = hc_swap32_S (FORTIGATE_F);
+    p1[2] = 0;
+    p1[3] = 0;
+    p2[0] = 0;
+    p2[1] = 0;
+    p2[2] = 0;
+    p2[3] = 0;
+    p3[0] = 0;
+    p3[1] = 0;
+    p3[2] = 0;
+    p3[3] = 0;
+
+    sha256_update_64 (&ctx, p0, p1, p2, p3, 24);
+
+    sha256_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m07010_a3-pure.cl
+++ b/OpenCL/m07010_a3-pure.cl
@@ -14,7 +14,7 @@
 #include "inc_hash_sha256.cl"
 #endif
 
-KERNEL_FQ void m07000_mxx (KERN_ATTR_VECTOR ())
+KERNEL_FQ void m07010_mxx (KERN_ATTR_VECTOR ())
 {
   /**
    * modifier
@@ -103,7 +103,7 @@ KERNEL_FQ void m07000_mxx (KERN_ATTR_VECTOR ())
   }
 }
 
-KERNEL_FQ void m07000_sxx (KERN_ATTR_VECTOR ())
+KERNEL_FQ void m07010_sxx (KERN_ATTR_VECTOR ())
 {
   /**
    * modifier

--- a/OpenCL/m07010_a3-pure.cl
+++ b/OpenCL/m07010_a3-pure.cl
@@ -1,0 +1,205 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_sha256.cl"
+#endif
+
+KERNEL_FQ void m07000_mxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  sha256_ctx_t ctx0;
+
+  sha256_init (&ctx0);
+
+  sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha256_ctx_vector_t ctx;
+
+    sha256_init_vector_from_scalar (&ctx, &ctx0);
+
+    sha256_update_vector (&ctx, w, pw_len);
+
+    /**
+     * pepper
+     */
+
+    u32x p0[4];
+    u32x p1[4];
+    u32x p2[4];
+    u32x p3[4];
+
+    p0[0] = hc_swap32 (FORTIGATE_A);
+    p0[1] = hc_swap32 (FORTIGATE_B);
+    p0[2] = hc_swap32 (FORTIGATE_C);
+    p0[3] = hc_swap32 (FORTIGATE_D);
+    p1[0] = hc_swap32 (FORTIGATE_E);
+    p1[1] = hc_swap32 (FORTIGATE_F);
+    p1[2] = 0;
+    p1[3] = 0;
+    p2[0] = 0;
+    p2[1] = 0;
+    p2[2] = 0;
+    p2[3] = 0;
+    p3[0] = 0;
+    p3[1] = 0;
+    p3[2] = 0;
+    p3[3] = 0;
+
+    sha256_update_vector_64 (&ctx, p0, p1, p2, p3, 24);
+
+    sha256_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m07000_sxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  sha256_ctx_t ctx0;
+
+  sha256_init (&ctx0);
+
+  sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < il_cnt; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha256_ctx_vector_t ctx;
+
+    sha256_init_vector_from_scalar (&ctx, &ctx0);
+
+    sha256_update_vector (&ctx, w, pw_len);
+
+    /**
+     * pepper
+     */
+
+    u32x p0[4];
+    u32x p1[4];
+    u32x p2[4];
+    u32x p3[4];
+
+    p0[0] = hc_swap32 (FORTIGATE_A);
+    p0[1] = hc_swap32 (FORTIGATE_B);
+    p0[2] = hc_swap32 (FORTIGATE_C);
+    p0[3] = hc_swap32 (FORTIGATE_D);
+    p1[0] = hc_swap32 (FORTIGATE_E);
+    p1[1] = hc_swap32 (FORTIGATE_F);
+    p1[2] = 0;
+    p1[3] = 0;
+    p2[0] = 0;
+    p2[1] = 0;
+    p2[2] = 0;
+    p2[3] = 0;
+    p3[0] = 0;
+    p3[1] = 0;
+    p3[2] = 0;
+    p3[3] = 0;
+
+    sha256_update_vector_64 (&ctx, p0, p1, p2, p3, 24);
+
+    sha256_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/src/modules/module_07010.c
+++ b/src/modules/module_07010.c
@@ -21,7 +21,7 @@ static const u32   DGST_POS3      = 6;
 static const u32   DGST_SIZE      = DGST_SIZE_4_8;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_OS;
 static const char *HASH_NAME      = "FortiGate256 (FortiOS256)";
-static const u64   KERN_TYPE      = 7000;
+static const u64   KERN_TYPE      = 7010;
 static const u32   OPTI_TYPE      = OPTI_TYPE_PRECOMPUTE_INIT
                                   | OPTI_TYPE_EARLY_SKIP
                                   | OPTI_TYPE_NOT_ITERATED;

--- a/src/modules/module_07010.c
+++ b/src/modules/module_07010.c
@@ -1,0 +1,277 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ *
+ * based on work by Nicolas B. <mrtchuss at gmail.com>
+ *
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 3;
+static const u32   DGST_POS1      = 7;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 6;
+static const u32   DGST_SIZE      = DGST_SIZE_4_8;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_OS;
+static const char *HASH_NAME      = "FortiGate256 (FortiOS256)";
+static const u64   KERN_TYPE      = 7000;
+static const u32   OPTI_TYPE      = OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_EARLY_SKIP
+                                  | OPTI_TYPE_NOT_ITERATED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "backup";
+static const char *ST_HASH        = "SH2MCKr6kt9rLQKbn/YTlncOnR6OtcJ1YL/h8hw2wWicjSRf3bbkSrL+q6cDpg=";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+static const char *SIGNATURE_FORTIGATE = "SH2";
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  u32 pw_max = PW_MAX;
+
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  if (optimized_kernel == true)
+  {
+    pw_max = 31;
+  }
+
+  return pw_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  token_t token;
+
+  token.token_cnt  = 2;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_FORTIGATE;
+
+  token.len[0]  = 3;
+  token.attr[0] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.len[1]  = 60;
+  token.attr[1] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_BASE64A;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  /**
+   * verify data
+   */
+
+  const u8 *hash_pos = token.buf[1];
+  const int hash_len = token.len[1];
+
+  // decode salt + SHA1 hash (12 + 20 = 32)
+  //new 12+32=44
+
+  u8 tmp_buf[100] = { 0 };
+
+  const int decoded_len = base64_decode (base64_to_int, hash_pos, hash_len, tmp_buf);
+
+  if (decoded_len != 44) return (PARSER_HASH_LENGTH);
+
+  /**
+   * store data
+   */
+
+  // salt
+
+  u32 salt_len = 12;
+
+  memcpy (salt->salt_buf, tmp_buf, salt_len);
+
+  salt->salt_len = salt_len;
+
+  // digest
+
+  memcpy (digest, tmp_buf + salt_len, 32);
+
+  digest[0] = byte_swap_32 (digest[0]);
+  digest[1] = byte_swap_32 (digest[1]);
+  digest[2] = byte_swap_32 (digest[2]);
+  digest[3] = byte_swap_32 (digest[3]);
+  digest[4] = byte_swap_32 (digest[4]);
+  digest[5] = byte_swap_32 (digest[5]);
+  digest[6] = byte_swap_32 (digest[6]);
+  digest[7] = byte_swap_32 (digest[7]);
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    digest[0] -= SHA256M_A;
+    digest[1] -= SHA256M_B;
+    digest[2] -= SHA256M_C;
+    digest[3] -= SHA256M_D;
+    digest[4] -= SHA256M_E;
+    digest[5] -= SHA256M_F;
+    digest[6] -= SHA256M_G;
+    digest[7] -= SHA256M_H;
+  }
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  char tmp_buf[64];
+
+  // salt
+
+  memcpy (tmp_buf, salt->salt_buf, 12);
+
+  // digest
+
+  u32 tmp[8];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = digest[2];
+  tmp[3] = digest[3];
+  tmp[4] = digest[4];
+  tmp[5] = digest[5];
+  tmp[6] = digest[6];
+  tmp[7] = digest[7];
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    tmp[0] += SHA256M_A;
+    tmp[1] += SHA256M_B;
+    tmp[2] += SHA256M_C;
+    tmp[3] += SHA256M_D;
+    tmp[4] += SHA256M_E;
+    tmp[5] += SHA256M_F;
+    tmp[6] += SHA256M_G;
+    tmp[7] += SHA256M_H;
+  }
+
+  tmp[0] = byte_swap_32 (tmp[0]);
+  tmp[1] = byte_swap_32 (tmp[1]);
+  tmp[2] = byte_swap_32 (tmp[2]);
+  tmp[3] = byte_swap_32 (tmp[3]);
+  tmp[4] = byte_swap_32 (tmp[4]);
+  tmp[5] = byte_swap_32 (tmp[5]);
+  tmp[6] = byte_swap_32 (tmp[6]);
+  tmp[7] = byte_swap_32 (tmp[7]);
+
+  memcpy (tmp_buf + 12, tmp, 32);
+
+  // base64 encode (salt + SHA1)
+  // new would be salt+sha256
+
+  char ptr_plain[64];
+
+  base64_encode (int_to_base64, (const u8 *) tmp_buf, 12 + 32, (u8 *) ptr_plain);
+
+  ptr_plain[60] = 0;
+
+  const int line_len = snprintf (line_buf, line_size, "%s%s", SIGNATURE_FORTIGATE, ptr_plain);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m07010.pm
+++ b/tools/test_modules/m07010.pm
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA  qw (sha256);
+use MIME::Base64 qw (encode_base64 decode_base64);
+
+sub module_constraints { [[0, 256], [24, 24], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $FORTIGATE_SIGNATURE = "SH2";
+  my $FORTIGATE_MAGIC     = pack ("H*", "a388ba2e424cb04a537930c13107cc3fa1329029a9815b70");
+
+  my $salt_bin = pack ("H*", $salt);
+
+  my $hash_buf = sha256 ($salt_bin . $word . $FORTIGATE_MAGIC);
+
+  $hash_buf = encode_base64 ($salt_bin . $hash_buf, "");
+
+  my $hash = sprintf ("%s%s", $FORTIGATE_SIGNATURE, $hash_buf);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $index1 = index ($line, ":");
+
+  return if $index1 != 63;
+
+  my $hash_in = substr ($line, 0, $index1);
+
+  my $word = substr ($line, $index1 + 1);
+
+  my $decoded = decode_base64 (substr ($hash_in, 3));
+
+  my $salt = substr ($decoded, 0, 12);
+
+  $salt = unpack ("H*", $salt);
+
+  return unless defined $salt;
+  return unless defined $word;
+
+  $word = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word, $salt);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This is a updated to the existing format 07000 Fortigate/Fortinet, for an updated hash type.


As documented in [the equivalent John the Ripper format](https://github.com/openwall/john/blob/bleeding-jumbo/src/FGT_fmt_plug.c), the original Fortigate hash format is 
```
AK1|base64encode(salt|hashed_password)
where hashed_password is `SHA1(salt|password|fortinet_magic)

salt is 12 bytes long
hashed_password is 20 bytes long (SHA1 salt)
encoded password is 47 bytes long (3 bytes for AK1 and 44 bytes of base64encode(salt|hashed_password))
```

This 07010 format is for a slight update to the Fortinet hash that uses SHA256 instead of SHA1. To quote [the equivalent updated John format](https://github.com/openwall/john/blob/bleeding-jumbo/src/FG2_fmt_plug.c), these hashes are constructed as
```
SH2|base64encode(salt|hashed_password)
where hashed_password is SHA256(salt|password|fortinet_magic)

salt is 12 bytes long
hashed_password is 32 bytes long (SHA256) 
encoded password is 63 bytes long (3 bytes for SH2 and 60 bytes of base64encode(salt|hashed_password))
```