### PR TITLE
Allow users to ignore the password length limit.

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -51,6 +51,8 @@
 - RC4 Kernels: Improved performance by 20%+ for hash-modes Kerberos 5 (etype 23), MS Office (<= 2003) and PDF (<= 1.6) by using new RC4 code
 - Status Screen: Show currently running kernel type (pure, optimized) and generator type (host, device)
 - UTF8-to-UTF16: Replaced naive UTF8 to UTF16 conversion with true conversion for RAR3, AES Crypt, MultiBit HD (scrypt) and Umbraco HMAC-SHA1
+- Use --len-limit-ignore option to solve the length missmatch problem in -a 0 mode.
+
 
 ##
 ## Technical

--- a/include/types.h
+++ b/include/types.h
@@ -629,6 +629,7 @@ typedef enum user_options_defaults
   KEYSPACE                 = false,
   LEFT                     = false,
   LIMIT                    = 0,
+  LEN_LIMIT_IGNORE         = false,
   LOGFILE_DISABLE          = false,
   LOOPBACK                 = false,
   MACHINE_READABLE         = false,
@@ -737,6 +738,7 @@ typedef enum user_options_map
   IDX_KEYSPACE                  = 0xff22,
   IDX_LEFT                      = 0xff23,
   IDX_LIMIT                     = 'l',
+  IDX_LEN_LIMIT_IGNORE          = 0xfe00,
   IDX_LOGFILE_DISABLE           = 0xff24,
   IDX_LOOPBACK                  = 0xff25,
   IDX_MACHINE_READABLE          = 0xff26,
@@ -1986,6 +1988,7 @@ typedef struct user_options
   bool         keep_guessing;
   bool         keyspace;
   bool         left;
+  bool         len_limit_ignore;
   bool         logfile_disable;
   bool         loopback;
   bool         machine_readable;

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -1415,7 +1415,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
             }
 
             if (attack_kern == ATTACK_KERN_STRAIGHT)
-            {        
+            {
               if (((line_len < hashconfig->pw_min) && (user_options->len_limit_ignore == false)) || ((line_len > hashconfig->pw_max) && (user_options->len_limit_ignore == false)))
               {
                 words_extra++;

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -258,7 +258,7 @@ static int calc_stdin (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_par
 
       if (attack_kern == ATTACK_KERN_STRAIGHT)
       {
-        if ((line_len < hashconfig->pw_min) || (line_len > hashconfig->pw_max))
+        if (((line_len < hashconfig->pw_min) && (user_options->len_limit_ignore == false)) || ((line_len > hashconfig->pw_max) && (user_options->len_limit_ignore == false)))
         {
           words_extra_total++;
 
@@ -1415,8 +1415,8 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
             }
 
             if (attack_kern == ATTACK_KERN_STRAIGHT)
-            {
-              if ((line_len < hashconfig->pw_min) || (line_len > hashconfig->pw_max))
+            {        
+              if (((line_len < hashconfig->pw_min) && (user_options->len_limit_ignore == false)) || ((line_len > hashconfig->pw_max) && (user_options->len_limit_ignore == false)))
               {
                 words_extra++;
 

--- a/src/usage.c
+++ b/src/usage.c
@@ -43,6 +43,7 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   "     --keep-guessing            |      | Keep guessing the hash after it has been cracked     |",
   "     --self-test-disable        |      | Disable self-test functionality on startup           |",
   "     --loopback                 |      | Add new plains to induct directory                   |",
+  "     --len-limit-ignore         |      | Ignore the password length limit in hash module      |",
   "     --markov-hcstat2           | File | Specify hcstat2 file to use                          | --markov-hcstat2=my.hcstat2",
   "     --markov-disable           |      | Disables markov-chains, emulates classic brute-force |",
   "     --markov-classic           |      | Enables classic markov-chains, no per-position       |",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -63,6 +63,7 @@ static const struct option long_options[] =
   {"hex-salt",                  no_argument,       NULL, IDX_HEX_SALT},
   {"hex-wordlist",              no_argument,       NULL, IDX_HEX_WORDLIST},
   {"hook-threads",              required_argument, NULL, IDX_HOOK_THREADS},
+  {"len-limit-ignore",          no_argument,       NULL, IDX_LEN_LIMIT_IGNORE},
   {"increment-max",             required_argument, NULL, IDX_INCREMENT_MAX},
   {"increment-min",             required_argument, NULL, IDX_INCREMENT_MIN},
   {"increment",                 no_argument,       NULL, IDX_INCREMENT},
@@ -208,6 +209,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->keyspace                  = KEYSPACE;
   user_options->left                      = LEFT;
   user_options->limit                     = LIMIT;
+  user_options->len_limit_ignore          = LEN_LIMIT_IGNORE;
   user_options->logfile_disable           = LOGFILE_DISABLE;
   user_options->loopback                  = LOOPBACK;
   user_options->machine_readable          = MACHINE_READABLE;
@@ -433,6 +435,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_HEX_CHARSET:               user_options->hex_charset               = true;                            break;
       case IDX_HEX_SALT:                  user_options->hex_salt                  = true;                            break;
       case IDX_HEX_WORDLIST:              user_options->hex_wordlist              = true;                            break;
+      case IDX_LEN_LIMIT_IGNORE:          user_options->len_limit_ignore          = true;                            break;
       case IDX_CPU_AFFINITY:              user_options->cpu_affinity              = optarg;                          break;
       case IDX_BACKEND_IGNORE_CUDA:       user_options->backend_ignore_cuda       = true;                            break;
       case IDX_BACKEND_IGNORE_OPENCL:     user_options->backend_ignore_opencl     = true;                            break;
@@ -3028,6 +3031,7 @@ void user_options_logger (hashcat_ctx_t *hashcat_ctx)
   logfile_top_uint   (user_options->hex_charset);
   logfile_top_uint   (user_options->hex_salt);
   logfile_top_uint   (user_options->hex_wordlist);
+  logfile_top_uint   (user_options->len_limit_ignore);
   logfile_top_uint   (user_options->hook_threads);
   logfile_top_uint   (user_options->increment);
   logfile_top_uint   (user_options->increment_max);


### PR DESCRIPTION
In the straight attack mode "-a 0", we use weak password dictionaries to crack hashes. 
If a password length not matched to the hash mode, the password will not be add into the Hashcat wordlist

The Unix standard password valid length is 8.

```
$ openssl passwd -crypt -salt C9 oelinux123
Warning: truncating password to 8 characters
C98ULvDZe7zQ2

$ openssl passwd -crypt -salt C9 oelinux1
Warning: truncating password to 8 characters
C98ULvDZe7zQ2
```

Use hashcat to crack, 17 passwords were rejected.
```
./hashcat C98ULvDZe7zQ2 -m 1500 -w 3 -a 0 -O /tmp/test.txt

Dictionary cache hit:
* Filename..: /tmp/test.txt
* Passwords.: 76
* Bytes.....: 641
* Keyspace..: 76

Recovered........: 0/1 (0.00%) Digests
Progress.........: 76/76 (100.00%)
Rejected.........: 17/76 (22.37%)
```

Add ```--len-limit-ignore``` option to the cmdline, all passwords were used in the hashcat context.

```
./hashcat C98ULvDZe7zQ2 -m 1500 -w 3 -a 0 -O /tmp/test.txt --len-limit-ignore --force
C98ULvDZe7zQ2:oelinux1                            
Hash.Name........: descrypt, DES (Unix), Traditional DES
Hash.Target......: C98ULvDZe7zQ2
Recovered........: 1/1 (100.00%) Digests
Progress.........: 76/76 (100.00%)
Candidates.#4....: 000000 -> oelinux1
```