### PR TITLE
Prepare FBE support for m84000

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -2682,7 +2682,7 @@ typedef enum hash_category
   HASH_CATEGORY_PRIVATE_KEY             = 20,
   HASH_CATEGORY_IMS                     = 21,
   HASH_CATEGORY_CRYPTOCURRENCY_WALLET   = 22,
-
+  HASH_CATEGORY_FBE                     = 23
 } hash_category_t;
 
 // hash specific


### PR DESCRIPTION
Add new type in order to add Android FBE (File Based Encryption) support.