### PR TITLE
Fix memory leak with status (with brain enabled)

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -1775,6 +1775,8 @@ int hashcat_get_status (hashcat_ctx_t *hashcat_ctx, hashcat_status_t *hashcat_st
   #ifdef WITH_BRAIN
   hashcat_status->brain_session               = status_get_brain_session              (hashcat_ctx);
   hashcat_status->brain_attack                = status_get_brain_attack               (hashcat_ctx);
+  hashcat_status->brain_rx_all                = status_get_brain_rx_all               (hashcat_ctx);
+  hashcat_status->brain_tx_all                = status_get_brain_tx_all               (hashcat_ctx);
   #endif
   hashcat_status->status_string               = status_get_status_string              (hashcat_ctx);
   hashcat_status->status_number               = status_get_status_number              (hashcat_ctx);
@@ -1827,8 +1829,6 @@ int hashcat_get_status (hashcat_ctx_t *hashcat_ctx, hashcat_status_t *hashcat_st
     device_info->brain_link_send_bytes_dev      = status_get_brain_link_send_bytes_dev      (hashcat_ctx, device_id);
     device_info->brain_link_recv_bytes_sec_dev  = status_get_brain_link_recv_bytes_sec_dev  (hashcat_ctx, device_id);
     device_info->brain_link_send_bytes_sec_dev  = status_get_brain_link_send_bytes_sec_dev  (hashcat_ctx, device_id);
-    hashcat_status->brain_rx_all   = status_get_brain_rx_all   (hashcat_ctx);
-    hashcat_status->brain_tx_all   = status_get_brain_tx_all   (hashcat_ctx);
     #endif
   }
 

--- a/src/status.c
+++ b/src/status.c
@@ -2268,6 +2268,10 @@ void status_status_destroy (hashcat_ctx_t *hashcat_ctx, hashcat_status_t *hashca
   hcfree (hashcat_status->guess_mod);
   hcfree (hashcat_status->guess_charset);
   hcfree (hashcat_status->cpt);
+  #ifdef WITH_BRAIN
+  hcfree (hashcat_status->brain_rx_all);
+  hcfree (hashcat_status->brain_tx_all);
+  #endif
 
   hashcat_status->hash_target             = NULL;
   hashcat_status->hash_name               = NULL;
@@ -2281,6 +2285,10 @@ void status_status_destroy (hashcat_ctx_t *hashcat_ctx, hashcat_status_t *hashca
   hashcat_status->guess_mod               = NULL;
   hashcat_status->guess_charset           = NULL;
   hashcat_status->cpt                     = NULL;
+  #ifdef WITH_BRAIN
+  hashcat_status->brain_rx_all            = NULL;
+  hashcat_status->brain_tx_all            = NULL;
+  #endif
 
   for (int device_id = 0; device_id < hashcat_status->device_info_cnt; device_id++)
   {


### PR DESCRIPTION
When brain is enabled `status_get_brain_rx_all` and `status_get_brain_tx_all` would be called once per device (instead of a single time), so we only keep the pointer from the last call of each function, and lose previous ones.

But at the same time `status_status_destroy` didn't free the memory for `brain_rx_all` and `brain_tx_all`.