### PR TITLE
-m 24800 = Umbraco HMAC-SHA1 is not salted

### DIFF
--- a/src/modules/module_24800.c
+++ b/src/modules/module_24800.c
@@ -23,7 +23,7 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_NOT_ITERATED;
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
                                   | OPTS_TYPE_PT_UTF16LE;
-static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const u32   SALT_TYPE      = SALT_TYPE_NONE;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "8uigXlGMNI7BzwLCJlDbcKR2FP4=";
 


### PR DESCRIPTION
This is a minor bug fix.

This new hash type was incorrectly marked as salted (`SALT_TYPE_EMBEDDED`) while it is not.

This also looked stranged/wrong in the `--hash-info` (old `--example-hashes`) output, because there is no salt involved here.

I would suggest to change it to `SALT_TYPE_NONE`.

Thanks