### PR TITLE
Fix starting message

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -32,7 +32,12 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
   if (user_options->left        == true) return;
   if (user_options->identify    == true) return;
 
-  if (user_options->benchmark == true)
+  if (user_options->usage == true)
+  {
+    event_log_info (hashcat_ctx, "%s (%s) starting in help mode...", PROGNAME, version_tag);
+    event_log_info (hashcat_ctx, NULL);
+  }
+  else if (user_options->benchmark == true)
   {
     if (user_options->machine_readable == false)
     {
@@ -77,6 +82,11 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
   else if (user_options->hash_mode_chgd == false)
   {
     event_log_info (hashcat_ctx, "%s (%s) starting in autodetect mode...", PROGNAME, version_tag);
+    event_log_info (hashcat_ctx, NULL);
+  }
+  else if (user_options->hash_info == true)
+  {
+    event_log_info (hashcat_ctx, "%s (%s) starting in hash-info mode...", PROGNAME, version_tag);
     event_log_info (hashcat_ctx, NULL);
   }
   else

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1174,7 +1174,7 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
 
     if (user_options->hash_info == true)
     {
-      event_log_error (hashcat_ctx, "Use of --hash-info/example is not allowed in benchmark mode.");
+      event_log_error (hashcat_ctx, "Use of --hash-info is not allowed in benchmark mode.");
 
       return -1;
     }

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1172,6 +1172,13 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
       return -1;
     }
 
+    if (user_options->hash_info == true)
+    {
+      event_log_error (hashcat_ctx, "Use of --hash-info/example is not allowed in benchmark mode.");
+
+      return -1;
+    }
+
     if (user_options->increment == true)
     {
       event_log_error (hashcat_ctx, "Can't change --increment (-i) in benchmark mode.");


### PR DESCRIPTION
Hi,

this patch fix two issues:

```
$ ./hashcat -h
hashcat (v6.2.2-18-g05125eb67) starting in autodetect mode...
[...]
```
and

```
$ ./hashcat -b --hash-info -m 0
hashcat (v6.2.2-18-g05125eb67) starting in benchmark mode...

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

Hash Info:
==========

Hash mode #0
  Name................: MD5
  Category............: Raw Hash
  Slow.Hash...........: No
  Password.Len.Min....: 0
  Password.Len.Max....: 256
  Kernel.Type(s)......: pure, optimized
  Example.Hash.Format.: plain
  Example.Hash........: 8743b52063cd84097a65d1633f5c74f5
  Example.Pass........: hashcat
  Benchmark.Mask......: ?b?b?b?b?b?b?b

```