### PR TITLE
Fix access violation in hashconfig_destroy if hashcat_ctx_t is only p…

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -495,20 +495,21 @@ void hashconfig_destroy (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
-  if (hashconfig->hook_extra_param_size)
+  if (module_ctx->hook_extra_params)
   {
-    const int hook_threads = (int) user_options->hook_threads;
-
-    for (int i = 0; i < hook_threads; i++)
+    if (hashconfig->hook_extra_param_size)
     {
-      hcfree (module_ctx->hook_extra_params[i]);
-    }
+      const int hook_threads = (int) user_options->hook_threads;
 
-    hcfree (module_ctx->hook_extra_params);
-  }
-  else
-  {
-    hcfree (module_ctx->hook_extra_params[0]);
+      for (int i = 0; i < hook_threads; i++)
+      {
+        hcfree (module_ctx->hook_extra_params[i]);
+      }
+    }
+    else
+    {
+      hcfree (module_ctx->hook_extra_params[0]);
+    }
 
     hcfree (module_ctx->hook_extra_params);
   }

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -2865,7 +2865,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
       event_log_warning (hashcat_ctx, "For example, using \"7z e\" instead of using \"7z x\".");
       event_log_warning (hashcat_ctx, NULL);
     }
-    
+
     hashconfig_destroy (hashcat_ctx);
 
     return -1;
@@ -2893,7 +2893,7 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
       return -1;
     }
   }
-  
+
   // loopback - can't check at this point
 
   // tuning file check already done

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -2845,27 +2845,6 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
-  // single kernel and module existence check to detect "7z e" errors
-
-  char *modulefile = (char *) hcmalloc (HCBUFSIZ_TINY);
-
-  module_filename (folder_config, 0, modulefile, HCBUFSIZ_TINY);
-
-  if (hc_path_exist (modulefile) == false)
-  {
-    event_log_error (hashcat_ctx, "%s: %s", modulefile, strerror (errno));
-
-    event_log_warning (hashcat_ctx, "If you are using the hashcat binary package, this may be an extraction issue.");
-    event_log_warning (hashcat_ctx, "For example, using \"7z e\" instead of using \"7z x\".");
-    event_log_warning (hashcat_ctx, NULL);
-
-    hcfree (modulefile);
-
-    return -1;
-  }
-
-  hcfree (modulefile);
-
   const bool quiet_save = user_options->quiet;
 
   user_options->quiet = true;
@@ -2874,31 +2853,47 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
 
   user_options->quiet = quiet_save;
 
-  if (rc == -1) return -1;
-
-  hashconfig_destroy (hashcat_ctx);
-
-  // same check but for an backend kernel
-
-  char *kernelfile = (char *) hcmalloc (HCBUFSIZ_TINY);
-
-  generate_source_kernel_filename (false, ATTACK_EXEC_OUTSIDE_KERNEL, ATTACK_KERN_STRAIGHT, 400, 0, folder_config->shared_dir, kernelfile);
-
-  if (hc_path_read (kernelfile) == false)
+  if (rc == -1)
   {
-    event_log_error (hashcat_ctx, "%s: %s", kernelfile, strerror (errno));
+    // module existence check to detect "7z e" errors
 
-    event_log_warning (hashcat_ctx, "If you are using the hashcat binary package, this may be an extraction issue.");
-    event_log_warning (hashcat_ctx, "For example, using \"7z e\" instead of using \"7z x\".");
-    event_log_warning (hashcat_ctx, NULL);
+    const module_ctx_t* module_ctx = hashcat_ctx->module_ctx;
 
-    hcfree (kernelfile);
+    if (module_ctx->module_handle == NULL)
+    {
+      event_log_warning (hashcat_ctx, "If you are using the hashcat binary package, this may be an extraction issue.");
+      event_log_warning (hashcat_ctx, "For example, using \"7z e\" instead of using \"7z x\".");
+      event_log_warning (hashcat_ctx, NULL);
+    }
+    
+    hashconfig_destroy (hashcat_ctx);
 
     return -1;
   }
+  else
+  {
+    // same check but for an backend kernel
 
-  hcfree (kernelfile);
+    const hashconfig_t* hashconfig = hashcat_ctx->hashconfig;
 
+    char kernelfile[HCBUFSIZ_TINY] = { 0 };
+
+    generate_source_kernel_filename (user_options->slow_candidates, hashconfig->attack_exec, user_options_extra->attack_kern, hashconfig->kern_type, hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL, folder_config->shared_dir, kernelfile);
+
+    hashconfig_destroy (hashcat_ctx);
+
+    if (hc_path_read (kernelfile) == false)
+    {
+      event_log_error (hashcat_ctx, "%s: %s", kernelfile, strerror(errno));
+
+      event_log_warning (hashcat_ctx, "If you are using the hashcat binary package, this may be an extraction issue.");
+      event_log_warning (hashcat_ctx, "For example, using \"7z e\" instead of using \"7z x\".");
+      event_log_warning (hashcat_ctx, NULL);
+
+      return -1;
+    }
+  }
+  
   // loopback - can't check at this point
 
   // tuning file check already done


### PR DESCRIPTION
Fix access violation in hashconfig_destroy if hashcat_ctx_t is only partially initialized; early return from hashconfig_init. Fix hashcat_ctx leak and refactor module and kernel existence checks. Now checks existence of requested module and kernel. In case of module_kern_type_dynamic checks existence of default kernel type.
