### PR TITLE
fixes #2839: change example pass for FortiGate256

### DIFF
--- a/src/modules/module_26300.c
+++ b/src/modules/module_26300.c
@@ -27,8 +27,8 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_PRECOMPUTE_INIT
                                   | OPTI_TYPE_NOT_ITERATED;
 static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
-static const char *ST_PASS        = "backup";
-static const char *ST_HASH        = "SH2MCKr6kt9rLQKbn/YTlncOnR6OtcJ1YL/h8hw2wWicjSRf3bbkSrL+q6cDpg=";
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "SH2lpcpFXM5QRlWYwY5vL9+5svfYyb+c79qENpxEoB3NtZpVxKwHjuq/9TH88U=";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }


### PR DESCRIPTION
This commit fixes the minor problem reported in #2839 (example/default password, that is also shown in --hash-info, was non-standard i.e. not the "hashcat" password).

To fix the problem I just changed the `ST_HASH` and `ST_PASS` variables. I think this way it's much better, otherwise users are confused why the standard "hashcat" password doesn't work for this hash algorithm.

thanks