### PR TITLE
Hexify plains with delimiter in debug rules

### DIFF
--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -23,14 +23,17 @@ static void debugfile_format_plain (hashcat_ctx_t *hashcat_ctx, const u8 *plain_
     if (plain_ptr[i] < 0x20)
     {
       needs_hexify = 1;
-
       break;
     }
 
     if (plain_ptr[i] > 0x7f)
     {
       needs_hexify = 1;
-
+      break;
+    }
+    if (plain_ptr[i] == 0x3a)
+    {
+      needs_hexify = 1;
       break;
     }
   }

--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -31,7 +31,8 @@ static void debugfile_format_plain (hashcat_ctx_t *hashcat_ctx, const u8 *plain_
       needs_hexify = 1;
       break;
     }
-    if (plain_ptr[i] == 0x3a)
+    
+    if (plain_ptr[i] == ':')
     {
       needs_hexify = 1;
       break;


### PR DESCRIPTION
Hexify plains if the plain contains the : separator for debug rules
Required for mode 3 and 4 to actually make sense otherwise you get issues as mentioned in https://github.com/hashcat/hashcat/issues/2852 and https://github.com/hashcat/hashcat/issues/2493