### PR TITLE
fix tuning_db_search() bug

### DIFF
--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -435,7 +435,7 @@ tuning_db_entry_t *tuning_db_search (hashcat_ctx_t *hashcat_ctx, const char *dev
 
   const char *NV_prefix = (const char *) "NVIDIA ";
 
-  if (memcmp (device_name, NV_prefix, strlen (NV_prefix)) == 0)
+  if (strlen(device_name) >= strlen(NV_prefix) && memcmp (device_name, NV_prefix, strlen (NV_prefix)) == 0)
   {
     entry = tuning_db_search_real (hashcat_ctx, device_name + strlen (NV_prefix), device_type, attack_mode, hash_mode);
 


### PR DESCRIPTION
found with DEBUG=2 on osx

```
Initializing backend runtime for device #2. Please be patient...=================================================================
==93766==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000006e95 at pc 0x000110200707 bp 0x7ffee032cb70 sp 0x7ffee032c2f8
READ of size 7 at 0x602000006e95 thread T0
    #0 0x110200706 in wrap_memcmp (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1d706)
    #1 0x10fa84371 in tuning_db_search tuningdb.c:438
    #2 0x10f92baed in backend_session_begin backend.c:8314
    #3 0x10f9abd97 in outer_loop hashcat.c:716
    #4 0x10f9a9d82 in hashcat_session_execute hashcat.c:1615
    #5 0x10f8cc261 in main main.c:1237
    #6 0x7fff66b1a014 in start (libdyld.dylib:x86_64+0x1014)

0x602000006e95 is located 0 bytes to the right of 5-byte region [0x602000006e90,0x602000006e95)
allocated by thread T0 here:
    #0 0x11023aa07 in wrap_calloc (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x57a07)
    #1 0x10f9f7f5c in hccalloc memory.c:12
    #2 0x10f9f800b in hcmalloc memory.c:27
    #3 0x10f918b95 in backend_ctx_devices_init backend.c:6163
    #4 0x10f9a5b08 in hashcat_session_init hashcat.c:1139
    #5 0x10f8cc096 in main main.c:1207
    #6 0x7fff66b1a014 in start (libdyld.dylib:x86_64+0x1014)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1d706) in wrap_memcmp
Shadow bytes around the buggy address:
  0x1c0400000d80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400000d90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400000da0: fa fa fa fa fa fa 00 00 fa fa 00 fa fa fa 06 fa
  0x1c0400000db0: fa fa 00 04 fa fa 00 06 fa fa fa fa fa fa 04 fa
  0x1c0400000dc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x1c0400000dd0: fa fa[05]fa fa fa 06 fa fa fa 00 04 fa fa 00 06
  0x1c0400000de0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400000df0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400000e00: fa fa 00 00 fa fa fd fa fa fa fd fa fa fa fa fa
  0x1c0400000e10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c0400000e20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==93766==ABORTING
Abort trap: 6
```