### PR TITLE
Fix several backend leaks

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -7827,6 +7827,9 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
       const int rc_nvrtcCompileProgram = hc_nvrtcCompileProgram (hashcat_ctx, program, num_options, (const char * const *) nvrtc_options);
 
+      hcfree(nvrtc_options_string);
+      hcfree(nvrtc_options);
+
       size_t build_log_size = 0;
 
       hc_nvrtcGetProgramLogSize (hashcat_ctx, program, &build_log_size);
@@ -7839,7 +7842,14 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
       {
         char *build_log = (char *) hcmalloc (build_log_size + 1);
 
-        if (hc_nvrtcGetProgramLog (hashcat_ctx, program, build_log) == -1) return false;
+        if (hc_nvrtcGetProgramLog (hashcat_ctx, program, build_log) == -1)
+        {
+          hcfree (build_log);
+
+          return false;
+        }
+
+        build_log[build_log_size] = 0;
 
         puts (build_log);
 
@@ -7852,9 +7862,6 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
         return false;
       }
-
-      hcfree (nvrtc_options);
-      hcfree (nvrtc_options_string);
 
       size_t binary_size = 0;
 
@@ -8056,7 +8063,14 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
         const int rc_clGetProgramBuildInfo = hc_clGetProgramBuildInfo (hashcat_ctx, p1, device_param->opencl_device, CL_PROGRAM_BUILD_LOG, build_log_size, build_log, NULL);
 
-        if (rc_clGetProgramBuildInfo == -1) return false;
+        if (rc_clGetProgramBuildInfo == -1)
+        {
+          hcfree(build_log);
+
+          return false;
+        }
+
+        build_log[build_log_size] = 0;
 
         puts (build_log);
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -6142,7 +6142,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
         #define CHECK_BOARD_NAME_AMD 1
 
-        cl_int rc_board_name_amd = 0;
+        cl_int rc_board_name_amd = CL_INVALID_VALUE;
 
         if (CHECK_BOARD_NAME_AMD)
         {

--- a/src/backend.c
+++ b/src/backend.c
@@ -7827,8 +7827,8 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
       const int rc_nvrtcCompileProgram = hc_nvrtcCompileProgram (hashcat_ctx, program, num_options, (const char * const *) nvrtc_options);
 
-      hcfree(nvrtc_options_string);
-      hcfree(nvrtc_options);
+      hcfree (nvrtc_options_string);
+      hcfree (nvrtc_options);
 
       size_t build_log_size = 0;
 
@@ -8065,7 +8065,7 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
         if (rc_clGetProgramBuildInfo == -1)
         {
-          hcfree(build_log);
+          hcfree (build_log);
 
           return false;
         }

--- a/src/backend.c
+++ b/src/backend.c
@@ -5415,7 +5415,12 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         char *opencl_platform_vendor = (char *) hcmalloc (param_value_size);
 
-        if (hc_clGetPlatformInfo (hashcat_ctx, opencl_platform, CL_PLATFORM_VENDOR, param_value_size, opencl_platform_vendor, NULL) == -1) return -1;
+        if (hc_clGetPlatformInfo (hashcat_ctx, opencl_platform, CL_PLATFORM_VENDOR, param_value_size, opencl_platform_vendor, NULL) == -1)
+        {
+          hcfree (opencl_platform_vendor);
+
+          return -1;
+        }
 
         opencl_platforms_vendor[opencl_platforms_idx] = opencl_platform_vendor;
 
@@ -5425,7 +5430,12 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         char *opencl_platform_name = (char *) hcmalloc (param_value_size);
 
-        if (hc_clGetPlatformInfo (hashcat_ctx, opencl_platform, CL_PLATFORM_NAME, param_value_size, opencl_platform_name, NULL) == -1) return -1;
+        if (hc_clGetPlatformInfo (hashcat_ctx, opencl_platform, CL_PLATFORM_NAME, param_value_size, opencl_platform_name, NULL) == -1)
+        {
+          hcfree (opencl_platform_name);
+
+          return -1;
+        }
 
         opencl_platforms_name[opencl_platforms_idx] = opencl_platform_name;
 
@@ -5435,7 +5445,12 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         char *opencl_platform_version = (char *) hcmalloc (param_value_size);
 
-        if (hc_clGetPlatformInfo (hashcat_ctx, opencl_platform, CL_PLATFORM_VERSION, param_value_size, opencl_platform_version, NULL) == -1) return -1;
+        if (hc_clGetPlatformInfo (hashcat_ctx, opencl_platform, CL_PLATFORM_VERSION, param_value_size, opencl_platform_version, NULL) == -1)
+        {
+          hcfree (opencl_platform_version);
+
+          return -1;
+        }
 
         opencl_platforms_version[opencl_platforms_idx] = opencl_platform_version;
 
@@ -5724,6 +5739,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
       if (hc_cuDeviceGetName (hashcat_ctx, device_name, HCBUFSIZ_TINY, cuda_device) == -1)
       {
         device_param->skipped = true;
+        hcfree (device_name);
         continue;
       }
 
@@ -6150,6 +6166,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
           if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_BOARD_NAME_AMD, param_value_size, device_name, NULL) == -1)
           {
             device_param->skipped = true;
+            hcfree (device_name);
             continue;
           }
 
@@ -6168,6 +6185,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
           if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_NAME, param_value_size, device_name, NULL) == -1)
           {
             device_param->skipped = true;
+            hcfree (device_name);
             continue;
           }
 
@@ -6191,6 +6209,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
         if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_VENDOR, param_value_size, opencl_device_vendor, NULL) == -1)
         {
           device_param->skipped = true;
+          hcfree (opencl_device_vendor);
           continue;
         }
 
@@ -6266,6 +6285,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
         if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_VERSION, param_value_size, opencl_device_version, NULL) == -1)
         {
           device_param->skipped = true;
+          hcfree (opencl_device_version);
           continue;
         }
 
@@ -6284,6 +6304,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
         if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_OPENCL_C_VERSION, param_value_size, opencl_device_c_version, NULL) == -1)
         {
           device_param->skipped = true;
+          hcfree (opencl_device_c_version);
           continue;
         }
 
@@ -6438,6 +6459,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
         if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_EXTENSIONS, device_extensions_size, device_extensions, NULL) == -1)
         {
           device_param->skipped = true;
+          hcfree (device_extensions);
           continue;
         }
 
@@ -6686,6 +6708,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
         if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DRIVER_VERSION, param_value_size, opencl_driver_version, NULL) == -1)
         {
           device_param->skipped = true;
+          hcfree (opencl_driver_version);
           continue;
         }
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -7399,8 +7399,6 @@ void backend_ctx_devices_destroy (hashcat_ctx_t *hashcat_ctx)
   {
     hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
 
-    if (device_param->skipped == true) continue;
-
     hcfree (device_param->device_name);
 
     if (device_param->is_opencl == true)

--- a/src/backend.c
+++ b/src/backend.c
@@ -8773,7 +8773,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
      * device_name_chksum_amp_mp
      */
 
-    char *device_name_chksum_amp_mp = (char *) hcmalloc (HCBUFSIZ_TINY);
+    char device_name_chksum_amp_mp[HCBUFSIZ_TINY] = { 0 };
 
     const size_t dnclen_amp_mp = snprintf (device_name_chksum_amp_mp, HCBUFSIZ_TINY, "%d-%d-%d-%u-%s-%s-%s",
       backend_ctx->comptime,
@@ -9008,7 +9008,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
        * device_name_chksum
        */
 
-      char *device_name_chksum = (char *) hcmalloc (HCBUFSIZ_TINY);
+      char device_name_chksum[HCBUFSIZ_TINY] = { 0 };
 
       // The kernel source can depend on some JiT compiler macros which themself depend on the attack_modes.
       // ATM this is relevant only for ATTACK_MODE_ASSOCIATION which slightly modifies ATTACK_MODE_STRAIGHT kernels.
@@ -9073,8 +9073,6 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       }
 
       hcfree (build_options_module_buf);
-
-      hcfree (device_name_chksum);
     }
 
     /**
@@ -9185,8 +9183,6 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_clUnloadPlatformCompiler (hashcat_ctx, platform_id) == -1) return -1;
     }
-
-    hcfree (device_name_chksum_amp_mp);
 
     // some algorithm collide too fast, make that impossible
 


### PR DESCRIPTION
There are numerous reasons why device_param->skipped can be true, but it is not indicating that resources should not be freed in backend_ctx_devices_destroy. Fixed obvious early return leaks in backend_ctx_init, backend_ctx_devices_init, backend_session_begin and load_kernel. Ensure build log is always null-terminated.

Locally defined IGNORE_DEVICE_NOT_FOUND and CHECK_BOARD_NAME_AMD are bit strange. Should we move these to Makefile and refactor code specially around IGNORE_DEVICE_NOT_FOUND? clGetDeviceIDs is called twice only to get the actual error code.