### PR TITLE
Avoid deadlocks in brain server

### DIFF
--- a/src/brain.c
+++ b/src/brain.c
@@ -2245,6 +2245,8 @@ void *brain_server_handle_client (void *p)
 
       brain_server_dbs->client_slots[client_idx] = 0;
 
+      hc_thread_mutex_unlock (brain_server_dbs->mux_dbs);
+
       close (client_fd);
 
       return NULL;
@@ -2278,6 +2280,8 @@ void *brain_server_handle_client (void *p)
       brain_logging (stderr, 0, "too many attacks\n");
 
       brain_server_dbs->client_slots[client_idx] = 0;
+
+      hc_thread_mutex_unlock (brain_server_dbs->mux_dbs);
 
       close (client_fd);
 
@@ -2317,6 +2321,10 @@ void *brain_server_handle_client (void *p)
   if (recv_buf == NULL)
   {
     brain_logging (stderr, 0, "%s\n", MSG_ENOMEM);
+
+    brain_server_dbs->client_slots[client_idx] = 0;
+
+    close (client_fd);
 
     return NULL;
   }


### PR DESCRIPTION
Risk is small, but if brain server has "too many sessions" or "too many attacks", it will deadlock.