### PR TITLE
Use critical section instead of mutex in Windows

### DIFF
--- a/include/thread.h
+++ b/include/thread.h
@@ -22,17 +22,17 @@
 #define hc_thread_exit(t)           ExitThread (t)
 #define hc_thread_detach(t)         CloseHandle (t)
 
-/*
+#define hc_thread_mutex_init(m)     InitializeCriticalSection (&m)
 #define hc_thread_mutex_lock(m)     EnterCriticalSection      (&m)
 #define hc_thread_mutex_unlock(m)   LeaveCriticalSection      (&m)
-#define hc_thread_mutex_init(m)     InitializeCriticalSection (&m)
 #define hc_thread_mutex_delete(m)   DeleteCriticalSection     (&m)
-*/
 
+/*
 #define hc_thread_mutex_init(m)     m = CreateMutex     (NULL, FALSE, NULL)
 #define hc_thread_mutex_lock(m)     WaitForSingleObject (m, INFINITE)
 #define hc_thread_mutex_unlock(m)   ReleaseMutex        (m)
 #define hc_thread_mutex_delete(m)   CloseHandle         (m)
+*/
 
 #define hc_thread_sem_init(s)       s = CreateSemaphore (NULL, 0, INT_MAX, NULL)
 #define hc_thread_sem_post(s)       ReleaseSemaphore    (s, 1, NULL)

--- a/include/types.h
+++ b/include/types.h
@@ -81,13 +81,13 @@ typedef struct timespec   hc_timer_t;
 #endif
 
 #if defined (_WIN)
-typedef HANDLE          hc_thread_t;
-typedef HANDLE          hc_thread_mutex_t;
-typedef HANDLE          hc_thread_semaphore_t;
+typedef HANDLE           hc_thread_t;
+typedef CRITICAL_SECTION hc_thread_mutex_t;
+typedef HANDLE           hc_thread_semaphore_t;
 #else
-typedef pthread_t       hc_thread_t;
-typedef pthread_mutex_t hc_thread_mutex_t;
-typedef sem_t           hc_thread_semaphore_t;
+typedef pthread_t        hc_thread_t;
+typedef pthread_mutex_t  hc_thread_mutex_t;
+typedef sem_t            hc_thread_semaphore_t;
 #endif
 
 // enums


### PR DESCRIPTION
Before 6092308324e3c1fd1d3f59f0d14a63442862aa55 critical section was used, but it was replaced with mutex. I cannot find any reasoning why the change was made.

It is well known that critical section gives better performance. As most of serialization spots are short, and some should be made even shorter, in most cases critical section don't need context switching and access to kernel space. Critical section is more compatible with pthread_mutex, and we can test if we need to spin/yield/sleep using TryEnterCriticalSection/pthread_mutex_trylock. If EnterCriticalSection takes long time, it will behave exactly like mutex right now.

As we have only single process, only benefit to use mutex would be to create named mutex to check if another instance of hashcat is already running in [pidfile.c](https://github.com/hashcat/hashcat/blob/master/src/pidfile.c), check_running_process().
