### PR TITLE
Fix bug on hm_SYSFS_CPU_get_syspath_hwmon()

### DIFF
--- a/src/ext_sysfs_cpu.c
+++ b/src/ext_sysfs_cpu.c
@@ -63,7 +63,7 @@ char *hm_SYSFS_CPU_get_syspath_hwmon ()
 
     if (hc_fopen_raw (&fp, path, "rb") == false) continue;
 
-    char buf[16];
+    char buf[32] = { 0 };
 
     const size_t line_len = fgetl (&fp, buf, sizeof (buf));
 


### PR DESCRIPTION
buf[16] is not enough, I increased it to 32.

```
$ ./hashcat -m 0 -b -D1
hashcat (v6.2.2-119-g5d05c95a2) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Unstable OpenCL driver detected!

This OpenCL driver may fail kernel compilation or produce false negatives.
You can use --force to override, but do not report related errors.


Oversized line detected! Truncated 12 bytes

Oversized line detected! Truncated 12 bytes
free(): invalid pointer
Aborted
```