### PR TITLE
Added hash-mode: SNMPv3 HMAC-MD5-96

### DIFF
--- a/OpenCL/m25100-pure.cl
+++ b/OpenCL/m25100-pure.cl
@@ -1,0 +1,353 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_simd.cl"
+#include "inc_hash_md5.cl"
+#endif
+
+#define COMPARE_S "inc_comp_single.cl"
+#define COMPARE_M "inc_comp_multi.cl"
+
+#define SNMPV3_SALT_MAX             1500
+#define SNMPV3_ENGINEID_MAX         32
+#define SNMPV3_MSG_AUTH_PARAMS_MAX  12
+#define SNMPV3_ROUNDS               1048576
+#define SNMPV3_MAX_PW_LENGTH        64
+
+#define SNMPV3_TMP_ELEMS            4096 // 4096 = (256 (max pw length) * 64) / sizeof (u32)
+#define SNMPV3_HASH_ELEMS           4
+
+#define SNMPV3_MAX_SALT_ELEMS       512 // 512 * 4 = 2048 > 1500, also has to be multiple of 64
+#define SNMPV3_MAX_ENGINE_ELEMS     16  // 16 * 4 = 64 > 32, also has to be multiple of 64
+#define SNMPV3_MAX_PNUM_ELEMS       4   // 4 * 4 = 16 > 9
+
+typedef struct hmac_md5_tmp
+{
+  u32 tmp[SNMPV3_TMP_ELEMS];
+  u32 h[SNMPV3_HASH_ELEMS];
+
+} hmac_md5_tmp_t;
+
+typedef struct snmpv3
+{
+  u32 salt_buf[SNMPV3_MAX_SALT_ELEMS];
+  u32 salt_len;
+
+  u32 engineID_buf[SNMPV3_MAX_ENGINE_ELEMS];
+  u32 engineID_len;
+
+  u32 packet_number[SNMPV3_MAX_PNUM_ELEMS];
+
+} snmpv3_t;
+
+KERNEL_FQ void m25100_init (KERN_ATTR_TMPS_ESALT (hmac_md5_tmp_t, snmpv3_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  u8 *src_ptr = (u8 *) w;
+
+  // password 64 times, also swapped
+
+  u32 dst_buf[16];
+
+  u8 *dst_ptr = (u8 *) dst_buf;
+
+  int tmp_idx = 0;
+
+  for (int i = 0; i < 64; i++)
+  {
+    for (int j = 0; j < pw_len; j++)
+    {
+      const int dst_idx = tmp_idx & 63;
+
+      dst_ptr[dst_idx] = src_ptr[j];
+
+      // write to global memory every time 64 byte are written into cache
+
+      if (dst_idx == 63)
+      {
+        const int tmp_idx4 = (tmp_idx - 63) / 4;
+
+        tmps[gid].tmp[tmp_idx4 +  0] = dst_buf[ 0];
+        tmps[gid].tmp[tmp_idx4 +  1] = dst_buf[ 1];
+        tmps[gid].tmp[tmp_idx4 +  2] = dst_buf[ 2];
+        tmps[gid].tmp[tmp_idx4 +  3] = dst_buf[ 3];
+        tmps[gid].tmp[tmp_idx4 +  4] = dst_buf[ 4];
+        tmps[gid].tmp[tmp_idx4 +  5] = dst_buf[ 5];
+        tmps[gid].tmp[tmp_idx4 +  6] = dst_buf[ 6];
+        tmps[gid].tmp[tmp_idx4 +  7] = dst_buf[ 7];
+        tmps[gid].tmp[tmp_idx4 +  8] = dst_buf[ 8];
+        tmps[gid].tmp[tmp_idx4 +  9] = dst_buf[ 9];
+        tmps[gid].tmp[tmp_idx4 + 10] = dst_buf[10];
+        tmps[gid].tmp[tmp_idx4 + 11] = dst_buf[11];
+        tmps[gid].tmp[tmp_idx4 + 12] = dst_buf[12];
+        tmps[gid].tmp[tmp_idx4 + 13] = dst_buf[13];
+        tmps[gid].tmp[tmp_idx4 + 14] = dst_buf[14];
+        tmps[gid].tmp[tmp_idx4 + 15] = dst_buf[15];
+     }
+
+      tmp_idx++;
+    }
+  }
+
+  // hash
+
+  tmps[gid].h[0] = MD5M_A;
+  tmps[gid].h[1] = MD5M_B;
+  tmps[gid].h[2] = MD5M_C;
+  tmps[gid].h[3] = MD5M_D;
+}
+
+KERNEL_FQ void m25100_loop (KERN_ATTR_TMPS_ESALT (hmac_md5_tmp_t, snmpv3_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 h[4];
+
+  h[0] = tmps[gid].h[0];
+  h[1] = tmps[gid].h[1];
+  h[2] = tmps[gid].h[2];
+  h[3] = tmps[gid].h[3];
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  const int pw_len64 = pw_len * 64;
+
+  #define SNMPV3_TMP_ELEMS_OPT 1024 // 1024 = (64 max pw length * 64) / sizeof (u32)
+                                    // for pw length > 64 we use global memory reads
+
+  u32 tmp[SNMPV3_TMP_ELEMS_OPT];
+
+  if (pw_len < 64)
+  {
+    for (int i = 0; i < pw_len64 / 4; i++)
+    {
+      tmp[i] = tmps[gid].tmp[i];
+    }
+
+    for (int i = 0, j = loop_pos; i < loop_cnt; i += 64, j += 64)
+    {
+      const int idx = (j % pw_len64) / 4; // the optimization trick is to be able to do this
+
+      u32 w0[4];
+      u32 w1[4];
+      u32 w2[4];
+      u32 w3[4];
+
+      w0[0] = tmp[idx +  0];
+      w0[1] = tmp[idx +  1];
+      w0[2] = tmp[idx +  2];
+      w0[3] = tmp[idx +  3];
+      w1[0] = tmp[idx +  4];
+      w1[1] = tmp[idx +  5];
+      w1[2] = tmp[idx +  6];
+      w1[3] = tmp[idx +  7];
+      w2[0] = tmp[idx +  8];
+      w2[1] = tmp[idx +  9];
+      w2[2] = tmp[idx + 10];
+      w2[3] = tmp[idx + 11];
+      w3[0] = tmp[idx + 12];
+      w3[1] = tmp[idx + 13];
+      w3[2] = tmp[idx + 14];
+      w3[3] = tmp[idx + 15];
+
+      md5_transform (w0, w1, w2, w3, h);
+    }
+  }
+  else
+  {
+    for (int i = 0, j = loop_pos; i < loop_cnt; i += 64, j += 64)
+    {
+      const int idx = (j % pw_len64) / 4; // the optimization trick is to be able to do this
+
+      u32 w0[4];
+      u32 w1[4];
+      u32 w2[4];
+      u32 w3[4];
+
+      w0[0] = tmps[gid].tmp[idx +  0];
+      w0[1] = tmps[gid].tmp[idx +  1];
+      w0[2] = tmps[gid].tmp[idx +  2];
+      w0[3] = tmps[gid].tmp[idx +  3];
+      w1[0] = tmps[gid].tmp[idx +  4];
+      w1[1] = tmps[gid].tmp[idx +  5];
+      w1[2] = tmps[gid].tmp[idx +  6];
+      w1[3] = tmps[gid].tmp[idx +  7];
+      w2[0] = tmps[gid].tmp[idx +  8];
+      w2[1] = tmps[gid].tmp[idx +  9];
+      w2[2] = tmps[gid].tmp[idx + 10];
+      w2[3] = tmps[gid].tmp[idx + 11];
+      w3[0] = tmps[gid].tmp[idx + 12];
+      w3[1] = tmps[gid].tmp[idx + 13];
+      w3[2] = tmps[gid].tmp[idx + 14];
+      w3[3] = tmps[gid].tmp[idx + 15];
+
+      md5_transform (w0, w1, w2, w3, h);
+    }
+  }
+
+  tmps[gid].h[0] = h[0];
+  tmps[gid].h[1] = h[1];
+  tmps[gid].h[2] = h[2];
+  tmps[gid].h[3] = h[3];
+}
+
+KERNEL_FQ void m25100_comp (KERN_ATTR_TMPS_ESALT (hmac_md5_tmp_t, snmpv3_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  w0[0] = 0x00000080;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 1048576 * 8;
+  w3[3] = 0;
+
+  u32 h[4];
+
+  h[0] = tmps[gid].h[0];
+  h[1] = tmps[gid].h[1];
+  h[2] = tmps[gid].h[2];
+  h[3] = tmps[gid].h[3];
+
+  md5_transform (w0, w1, w2, w3, h);
+
+  md5_ctx_t ctx;
+
+  md5_init (&ctx);
+
+  u32 w[16];
+
+  w[ 0] = h[0];
+  w[ 1] = h[1];
+  w[ 2] = h[2];
+  w[ 3] = h[3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  md5_update (&ctx, w, 16);
+
+  md5_update_global (&ctx, esalt_bufs[DIGESTS_OFFSET].engineID_buf, esalt_bufs[DIGESTS_OFFSET].engineID_len);
+
+  w[ 0] = h[0];
+  w[ 1] = h[1];
+  w[ 2] = h[2];
+  w[ 3] = h[3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  md5_update (&ctx, w, 16);
+
+  md5_final (&ctx);
+
+  w[ 0] = ctx.h[0];
+  w[ 1] = ctx.h[1];
+  w[ 2] = ctx.h[2];
+  w[ 3] = ctx.h[3];
+  w[ 4] = 0;
+  w[ 5] = 0;
+  w[ 6] = 0;
+  w[ 7] = 0;
+  w[ 8] = 0;
+  w[ 9] = 0;
+  w[10] = 0;
+  w[11] = 0;
+  w[12] = 0;
+  w[13] = 0;
+  w[14] = 0;
+  w[15] = 0;
+
+  md5_hmac_ctx_t hmac_ctx;
+
+  md5_hmac_init (&hmac_ctx, w, 16);
+
+  md5_hmac_update_global (&hmac_ctx, esalt_bufs[DIGESTS_OFFSET].salt_buf, esalt_bufs[DIGESTS_OFFSET].salt_len);
+
+  md5_hmac_final (&hmac_ctx);
+
+  const u32 r0 = hmac_ctx.opad.h[DGST_R0];
+  const u32 r1 = hmac_ctx.opad.h[DGST_R1];
+  const u32 r2 = hmac_ctx.opad.h[DGST_R2];
+  const u32 r3 = 0;
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -38,6 +38,7 @@
 ##
 
 - Added hash-mode: SNMPv3 HMAC-SHA1-96
+- Added hash-mode: SNMPv3 HMAC-MD5-96
 
 * changes v6.2.2 -> v6.2.3
 

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -155,6 +155,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - SIP digest authentication (MD5)
 - IKE-PSK MD5
 - IKE-PSK SHA1
+- SNMPv3 HMAC-MD5-96
 - SNMPv3 HMAC-SHA1-96
 - WPA-EAPOL-PBKDF2
 - WPA-EAPOL-PMK

--- a/src/modules/module_25100.c
+++ b/src/modules/module_25100.c
@@ -1,0 +1,316 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "memory.h"
+#include "emu_inc_hash_md5.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4; // 4_3
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "SNMPv3 HMAC-MD5-96";
+static const u64   KERN_TYPE      = 25100;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$SNMPv3$1$76$3081b10201033011020430f6f3d5020300ffe304010702010304373035040d80001f888059dc486145a2632202010802020ab90405706970706f040c00000000000000000000000004080000000103d5321a0460826ecf6443956d4c364bfc6f6ffc8ee0df000ffd0955af12d2c0f3c60fadea417d2bb80c0b2c1fa7a46ce44f9f16e15ee830a49881f60ecfa757d2f04000eb39a94058121d88ca20eeef4e6bf06784c67c15f144915d9bc2c6a0461da92a4abe$80001f888059dc486145a26322$c51ba677ad96869c1cb32196";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+static const char *SIGNATURE_SNMPV3 = "$SNMPv3$1$";
+
+#define SNMPV3_SALT_MAX             1500
+#define SNMPV3_ENGINEID_MAX         32
+#define SNMPV3_MSG_AUTH_PARAMS_MAX  12
+#define SNMPV3_ROUNDS               1048576
+#define SNMPV3_MAX_PW_LENGTH        64
+
+#define SNMPV3_TMP_ELEMS            4096 // 4096 = (256 (max pw length) * 64) / sizeof (u32)
+#define SNMPV3_HASH_ELEMS           4
+
+#define SNMPV3_MAX_SALT_ELEMS       512 // 512 * 4 = 2048 > 1500, also has to be multiple of 64
+#define SNMPV3_MAX_ENGINE_ELEMS     16  // 16 * 4 = 64 > 32, also has to be multiple of 64
+#define SNMPV3_MAX_PNUM_ELEMS       4   // 4 * 4 = 16 > 9
+
+typedef struct hmac_md5_tmp
+{
+  u32 tmp[SNMPV3_TMP_ELEMS];
+  u32 h[SNMPV3_HASH_ELEMS];
+
+} hmac_md5_tmp_t;
+
+typedef struct snmpv3
+{
+  u32 salt_buf[SNMPV3_MAX_SALT_ELEMS];
+  u32 salt_len;
+
+  u32 engineID_buf[SNMPV3_MAX_ENGINE_ELEMS];
+  u32 engineID_len;
+
+  u32 packet_number[SNMPV3_MAX_PNUM_ELEMS];
+
+} snmpv3_t;
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (snmpv3_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (hmac_md5_tmp_t);
+
+  return tmp_size;
+}
+
+u32 module_kernel_loops_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // we need to fix iteration count to guarantee the loop count is a multiple of 64
+  // 2k calls to md5_transform typically is enough to overtime pcie bottleneck
+
+  const u32 kernel_loops_min = 2048 * 64;
+
+  return kernel_loops_min;
+}
+
+u32 module_kernel_loops_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_max = 2048 * 64;
+
+  return kernel_loops_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  snmpv3_t *snmpv3 = (snmpv3_t *) esalt_buf;
+
+  token_t token;
+
+  token.token_cnt  = 5;
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_SNMPV3;
+
+  token.len[0]     = 10;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // packet number
+  token.len_min[1] = 1;
+  token.len_max[1] = 8;
+  token.sep[1]     = '$';
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+  // salt
+  token.len_min[2] = 12 * 2;
+  token.len_max[2] = SNMPV3_SALT_MAX * 2;
+  token.sep[2]     = '$';
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // engineid
+  token.len_min[3] = 5;
+  token.len_max[3] = SNMPV3_ENGINEID_MAX;
+  token.sep[3]     = '$';
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // digest
+  token.len_min[4] = SNMPV3_MSG_AUTH_PARAMS_MAX * 2;
+  token.len_max[4] = SNMPV3_MSG_AUTH_PARAMS_MAX * 2;
+  token.sep[4]     = '$';
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // packet number
+
+  const u8 *packet_number_pos = token.buf[1];
+  const int packet_number_len = token.len[1];
+
+  memset (snmpv3->packet_number, 0, sizeof (snmpv3->packet_number));
+
+  strncpy ((char *) snmpv3->packet_number, (char *) packet_number_pos, packet_number_len);
+
+  // salt
+
+  const u8 *salt_pos = token.buf[2];
+  const int salt_len = token.len[2];
+
+  u8 *salt_ptr = (u8 *) snmpv3->salt_buf;
+
+  snmpv3->salt_len = hex_decode (salt_pos, salt_len, salt_ptr);
+
+  salt->salt_iter = SNMPV3_ROUNDS;
+
+  // handle unique salts detection
+
+  md5_ctx_t md5_ctx;
+
+  md5_init   (&md5_ctx);
+  md5_update (&md5_ctx, snmpv3->salt_buf, snmpv3->salt_len);
+  md5_final  (&md5_ctx);
+
+  // store md5(snmpv3->salt_buf) in salt_buf
+
+  salt->salt_len = 16;
+
+  memcpy (salt->salt_buf, md5_ctx.h, salt->salt_len);
+
+  // engineid
+
+  const u8 *engineID_pos = token.buf[3];
+  const int engineID_len = token.len[3];
+
+  u8 *engineID_ptr = (u8 *) snmpv3->engineID_buf;
+
+  snmpv3->engineID_len = hex_decode (engineID_pos, engineID_len, engineID_ptr);
+
+  // digest
+
+  const u8 *hash_pos = token.buf[4];
+
+  digest[0] = hex_to_u32 (hash_pos +  0);
+  digest[1] = hex_to_u32 (hash_pos +  8);
+  digest[2] = hex_to_u32 (hash_pos + 16);
+  digest[3] = 0;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  snmpv3_t *snmpv3 = (snmpv3_t *) esalt_buf;
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  int out_len = snprintf (line_buf, line_size, "%s%s$", SIGNATURE_SNMPV3, (char *) snmpv3->packet_number);
+
+  out_len += hex_encode ((u8 *) snmpv3->salt_buf, snmpv3->salt_len, out_buf + out_len);
+
+  out_buf[out_len] = '$';
+
+  out_len++;
+
+  out_len += hex_encode ((u8 *) snmpv3->engineID_buf, snmpv3->engineID_len, out_buf + out_len);
+
+  out_buf[out_len] = '$';
+
+  out_len++;
+
+  u32_to_hex (digest[0], out_buf + out_len); out_len += 8;
+  u32_to_hex (digest[1], out_buf + out_len); out_len += 8;
+  u32_to_hex (digest[2], out_buf + out_len); out_len += 8;
+
+  out_buf[out_len] = 0;
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = module_kernel_loops_max;
+  module_ctx->module_kernel_loops_min         = module_kernel_loops_min;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m25100.pm
+++ b/tools/test_modules/m25100.pm
@@ -1,0 +1,79 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::MD5 qw (md5 md5_hex);
+use Digest::HMAC qw (hmac hmac_hex);
+
+sub module_constraints { [[1, 256], [24, 3000], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $pkt_num = shift // int(rand(99999999));
+  my $engineID = shift // random_hex_string(6);
+
+  # make even if needed
+
+  if (length($salt) %2 == 1)
+  {
+    $salt = $salt . "8";
+  }
+
+  my $string1 = $word x 1048576;
+
+  $string1 = substr ($string1, 0, 1048576);
+
+  my $md5_digest1 = md5_hex ($string1);
+
+  my $buf = join '', $md5_digest1, $engineID, $md5_digest1;
+
+  my $md5_digest2 = md5(pack("H*", $buf));
+
+  my $digest = hmac_hex (pack("H*", $salt), $md5_digest2, \&md5);
+
+  $digest = substr ($digest, 0, 24);
+
+  my $hash = sprintf ("\$SNMPv3\$1\$%s\$%s\$%s\$%s", $pkt_num, $salt, $engineID, $digest);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless length ($word) gt 0;
+  return unless substr ($hash, 0, 10) eq '$SNMPv3$1$';
+
+  my (undef, $signature, $version, $pkt_num, $salt, $engineID, $digest) = split '\$', $hash;
+
+  return unless defined $signature;
+  return unless defined $version;
+  return unless defined $pkt_num;
+  return unless defined $salt;
+  return unless defined $engineID;
+  return unless defined $digest;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $pkt_num, $engineID); #, $digest);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
with very good @jsteube optimizations, but fail with osx Iris.

```
hashcat (v6.2.3-44-g3a31b669b) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (May  7 2020 00:10:14)) - Platform #1 [Apple]
====================================================================
* Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, skipped
* Device #2: Iris, 1472/1536 MB (384 MB allocatable), 40MCU

Benchmark relevant options:
===========================
* --opencl-device-types=2
* --optimized-kernel-enable

Hashmode: 25100 - SNMPv3 HMAC-MD5-96 (Iterations: 1048576)

* Device #2: Not enough allocatable device memory for this attack.

Started: Sat Jul 24 13:58:39 2021
Stopped: Sat Jul 24 13:58:51 2021
```

Same issue with sha1 version / https://github.com/hashcat/hashcat/commit/3a31b669b52d8bba5d61573c24f3d1593c160af8