### PR TITLE
Added GPG module and kernel

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -1711,6 +1711,15 @@ DECLSPEC u32 hc_bfe_S (const u32 a, const u32 b, const u32 c)
   return r;
 }
 
+DECLSPEC u32 hc_bytealign_be_S (const u32 a, const u32 b, const int c)
+{
+  const int c_mod_4 = c & 3;
+
+  const u32 r = hc_byte_perm_S (b, a, (0x76543210 >> (c_mod_4 * 4)) & 0xffff);
+
+  return r;
+}
+
 DECLSPEC u32x hc_bytealign (const u32x a, const u32x b, const int c)
 {
   const int c_mod_4 = c & 3;

--- a/OpenCL/m17010-pure.cl
+++ b/OpenCL/m17010-pure.cl
@@ -1,0 +1,444 @@
+/**
+ * Author......: Netherlands Forensic Institute
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.cl"
+#include "inc_common.cl"
+#include "inc_hash_sha1.cl"
+#include "inc_cipher_aes.cl"
+#endif
+
+typedef struct gpg
+{
+  u32 cipher_algo;
+  u32 iv[4];
+  u32 modulus_size; 
+  u32 encrypted_data[384];
+  u32 encrypted_data_size; 
+
+} gpg_t;
+
+typedef struct gpg_tmp
+{
+  // buffer for a maximum of 256 + 8 characters, we extend it to 320 characters so it's always 64 byte aligned
+  u32 salted_pw_block[80];
+  // actual number of bytes in 'salted_pwd' that are used since salt and password are copied multiple times into the buffer
+  u32 salted_pw_block_len;
+
+  u32 h[10];
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  u32 len;
+
+} gpg_tmp_t;
+
+DECLSPEC void memcat_be_S (u32 *block, const u32 offset, const u32 *append, u32 len)
+{
+  const u32 start_index = (offset - 1) >> 2;
+  const u32 count = ((offset + len + 3) >> 2) - start_index;
+  const int off_mod_4 = offset & 3;
+  const int off_minus_4 = 4 - off_mod_4;
+
+  block[start_index] |= hc_bytealign_be_S (append[0], 0, off_minus_4);
+
+  for (u32 idx = 1; idx < count; idx++)
+  {
+    block[start_index + idx] = hc_bytealign_be_S (append[idx], append[idx - 1], off_minus_4);
+  }
+}
+
+DECLSPEC void memzero_be_S (u32 *block, const u32 start_offset, const u32 end_offset)
+{
+  const u32 start_idx = (start_offset + 3) / 4;
+  const u32 end_idx = (end_offset + 3) / 4;
+
+  // zero out bytes in the first u32 starting from 'start_offset'
+   block[start_idx - 1] &= 0xffffffff >> (((4 - start_offset) & 3) * 8);
+
+  // zero out bytes in u32 units -- note that the last u32 is completely zeroed!
+  for (u32 i = start_idx; i < end_idx; i++)
+  {
+    block[i] = 0;
+  }
+}
+
+DECLSPEC void aes128_decrypt_cfb (GLOBAL_AS const u32 *encrypted_data, int data_len, const u32 *iv, const u32 *key, u32 *decrypted_data,
+                                  SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 ks[44];
+  u32 essiv[4];
+
+  // Copy the IV, since this will be modified
+  essiv[0] = iv[0];
+  essiv[1] = iv[1];
+  essiv[2] = iv[2];
+  essiv[3] = iv[3];
+
+  aes128_set_encrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3);
+
+  // Decrypt an AES-128 encrypted block
+  for (u32 i = 0; i < (data_len + 3) / 4; i += 4)
+  {
+    aes128_encrypt (ks, essiv, decrypted_data + i, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+    decrypted_data[i + 0] ^= encrypted_data[i + 0];
+    decrypted_data[i + 1] ^= encrypted_data[i + 1];
+    decrypted_data[i + 2] ^= encrypted_data[i + 2];
+    decrypted_data[i + 3] ^= encrypted_data[i + 3];
+
+    // Note: Not necessary if you are only decrypting a single block!
+    essiv[0] = encrypted_data[i + 0];
+    essiv[1] = encrypted_data[i + 1];
+    essiv[2] = encrypted_data[i + 2];
+    essiv[3] = encrypted_data[i + 3];
+  }
+}
+
+DECLSPEC void aes256_decrypt_cfb (GLOBAL_AS const u32 *encrypted_data, int data_len, const u32 *iv, const u32 *key, u32 *decrypted_data,
+                                  SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 ks[60];
+  u32 essiv[4];
+
+  // Copy the IV, since this will be modified
+  essiv[0] = iv[0];
+  essiv[1] = iv[1];
+  essiv[2] = iv[2];
+  essiv[3] = iv[3];
+
+  aes256_set_encrypt_key (ks, key, s_te0, s_te1, s_te2, s_te3);
+
+  // Decrypt an AES-256 encrypted block
+  for (u32 i = 0; i < (data_len + 3) / 4; i += 4)
+  {
+    aes256_encrypt (ks, essiv, decrypted_data + i, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+    decrypted_data[i + 0] ^= encrypted_data[i + 0];
+    decrypted_data[i + 1] ^= encrypted_data[i + 1];
+    decrypted_data[i + 2] ^= encrypted_data[i + 2];
+    decrypted_data[i + 3] ^= encrypted_data[i + 3];
+
+    // Note: Not necessary if you are only decrypting a single block!
+    essiv[0] = encrypted_data[i + 0];
+    essiv[1] = encrypted_data[i + 1];
+    essiv[2] = encrypted_data[i + 2];
+    essiv[3] = encrypted_data[i + 3];
+  }
+}
+
+DECLSPEC int check_decoded_data (u32 *decoded_data, const u32 decoded_data_size)
+{
+  // Check the SHA-1 of the decrypted data which is stored at the end of the decrypted data
+  const u32 sha1_byte_off = (decoded_data_size - 20);
+  const u32 sha1_u32_off = sha1_byte_off / 4;
+
+  u32 expected_sha1[5];
+  expected_sha1[0] = hc_bytealign_be_S (decoded_data[sha1_u32_off + 1], decoded_data[sha1_u32_off + 0], sha1_byte_off);
+  expected_sha1[1] = hc_bytealign_be_S (decoded_data[sha1_u32_off + 2], decoded_data[sha1_u32_off + 1], sha1_byte_off);
+  expected_sha1[2] = hc_bytealign_be_S (decoded_data[sha1_u32_off + 3], decoded_data[sha1_u32_off + 2], sha1_byte_off);
+  expected_sha1[3] = hc_bytealign_be_S (decoded_data[sha1_u32_off + 4], decoded_data[sha1_u32_off + 3], sha1_byte_off);
+  expected_sha1[4] = hc_bytealign_be_S (decoded_data[sha1_u32_off + 5], decoded_data[sha1_u32_off + 4], sha1_byte_off);
+
+  memzero_be_S (decoded_data, sha1_byte_off, 384 * sizeof(u32));
+
+  sha1_ctx_t ctx;
+
+  sha1_init (&ctx);
+
+  sha1_update_swap (&ctx, decoded_data, sha1_byte_off);
+
+  sha1_final (&ctx);
+
+  return (expected_sha1[0] == hc_swap32_S (ctx.h[0]))
+      && (expected_sha1[1] == hc_swap32_S (ctx.h[1]))
+      && (expected_sha1[2] == hc_swap32_S (ctx.h[2]))
+      && (expected_sha1[3] == hc_swap32_S (ctx.h[3]))
+      && (expected_sha1[4] == hc_swap32_S (ctx.h[4]));
+}
+
+KERNEL_FQ void m17010_init (KERN_ATTR_TMPS_ESALT (gpg_tmp_t, gpg_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  const u32 pw_len = pws[gid].pw_len;
+  const u32 salted_pw_len = (salt_bufs[SALT_POS].salt_len + pw_len);
+
+  u32 salted_pw_block[80];
+
+  // concatenate salt and password -- the salt is always 8 bytes
+  salted_pw_block[0] = salt_bufs[SALT_POS].salt_buf[0];
+  salted_pw_block[1] = salt_bufs[SALT_POS].salt_buf[1];
+
+  for (u32 idx = 0; idx < 64; idx++) salted_pw_block[idx + 2] = pws[gid].i[idx];
+
+  // zero remainder of buffer
+  for (u32 idx = 66; idx < 80; idx++) salted_pw_block[idx] = 0;
+
+  // create a number of copies for efficiency
+  const u32 copies = 80 * sizeof(u32) / salted_pw_len;
+  for (u32 idx = 1; idx < copies; idx++)
+  {
+    memcat_be_S (salted_pw_block, idx * salted_pw_len, salted_pw_block, salted_pw_len);
+  }
+
+  for (u32 idx = 0; idx < 80; idx++) tmps[gid].salted_pw_block[idx] = salted_pw_block[idx];
+
+  tmps[gid].salted_pw_block_len = (copies * salted_pw_len);
+}
+
+KERNEL_FQ void m17010_loop_prepare (KERN_ATTR_TMPS_ESALT (gpg_tmp_t, gpg_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+
+  /**
+   * context save
+   */
+
+  sha1_ctx_t ctx;
+
+  sha1_init (&ctx);
+
+  // padd with one or more zeroes for larger target key sizes, e.g. for AES-256
+  if (salt_repeat > 0)
+  {
+    u32 zeroes[16] = {0};
+
+    sha1_update (&ctx, zeroes, salt_repeat);
+  }
+
+  const u32 sha_offset = salt_repeat * 5;
+
+  for (int i = 0; i < 5; i++) tmps[gid].h[sha_offset + i] = ctx.h[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w0[i] = ctx.w0[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w1[i] = ctx.w1[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w2[i] = ctx.w2[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w3[i] = ctx.w3[i];
+
+  tmps[gid].len = ctx.len;
+}
+
+KERNEL_FQ void m17010_loop (KERN_ATTR_TMPS_ESALT (gpg_tmp_t, gpg_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= gid_max) return;
+ 
+  // get the prepared buffer from the gpg_tmp_t struct into a local buffer
+  u32 salted_pw_block[80];
+  for (int i = 0; i < 80; i++) salted_pw_block[i] = tmps[gid].salted_pw_block[i];
+
+  const u32 salted_pw_block_len = tmps[gid].salted_pw_block_len;
+  if (salted_pw_block_len == 0) return;
+
+  /**
+   * context load
+   */
+
+  sha1_ctx_t ctx;
+
+  const u32 sha_offset = salt_repeat * 5;
+
+  for (int i = 0; i < 5; i++) ctx.h[i] = tmps[gid].h[sha_offset + i];
+  for (int i = 0; i < 4; i++) ctx.w0[i] = tmps[gid].w0[i];
+  for (int i = 0; i < 4; i++) ctx.w1[i] = tmps[gid].w1[i];
+  for (int i = 0; i < 4; i++) ctx.w2[i] = tmps[gid].w2[i];
+  for (int i = 0; i < 4; i++) ctx.w3[i] = tmps[gid].w3[i];
+
+  ctx.len = tmps[gid].len;
+
+  // sha-1 of salt and password, up to 'salt_iter' bytes
+  const u32 salt_iter = salt_bufs[SALT_POS].salt_iter;
+
+  const u32 salted_pw_block_pos = loop_pos % salted_pw_block_len;
+  const u32 rounds = (loop_cnt + salted_pw_block_pos) / salted_pw_block_len;
+
+  for (u32 i = 0; i < rounds; i++)
+  {
+    sha1_update_swap (&ctx, salted_pw_block, salted_pw_block_len);
+  }
+
+  if ((loop_pos + loop_cnt) == salt_iter)
+  {
+    const u32 remaining_bytes = salt_iter % salted_pw_block_len;
+
+    if (remaining_bytes)
+    {
+      memzero_be_S (salted_pw_block, remaining_bytes, salted_pw_block_len);
+
+      sha1_update_swap (&ctx, salted_pw_block, remaining_bytes);
+    }
+
+    sha1_final (&ctx);
+  }
+
+  /**
+   * context save
+   */
+
+  for (int i = 0; i < 5; i++) tmps[gid].h[sha_offset + i] = ctx.h[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w0[i] = ctx.w0[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w1[i] = ctx.w1[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w2[i] = ctx.w2[i];
+  for (int i = 0; i < 4; i++) tmps[gid].w3[i] = ctx.w3[i];
+
+  tmps[gid].len = ctx.len;
+}
+
+KERNEL_FQ void m17010_comp (KERN_ATTR_TMPS_ESALT (gpg_tmp_t, gpg_t))
+{
+  // not in use here, special case...
+}
+
+KERNEL_FQ void m17010_aux1 (KERN_ATTR_TMPS_ESALT (gpg_tmp_t, gpg_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  // retrieve and use the SHA-1 as the key for AES
+
+  u32 aes_key[4];
+
+  for (int i = 0; i < 4; i++) aes_key[i] = hc_swap32_S (tmps[gid].h[i]);
+
+  u32 iv[4] = {0};
+
+  for (int idx = 0; idx < 4; idx++) iv[idx] = esalt_bufs[DIGESTS_OFFSET].iv[idx];
+
+  u32 decoded_data[384];
+
+  const u32 enc_data_size = esalt_bufs[DIGESTS_OFFSET].encrypted_data_size;
+
+  aes128_decrypt_cfb (esalt_bufs[DIGESTS_OFFSET].encrypted_data, enc_data_size, iv, aes_key, decoded_data, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  if (check_decoded_data (decoded_data, enc_data_size))
+  {
+    if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, SALT_POS, digests_cnt, 0, DIGESTS_OFFSET + 0, gid, 0, 0, 0);
+    }
+  }
+}
+
+KERNEL_FQ void m17010_aux2 (KERN_ATTR_TMPS_ESALT (gpg_tmp_t, gpg_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= gid_max) return;
+
+  // retrieve and use the SHA-1 as the key for AES
+
+  u32 aes_key[8];
+
+  for (int i = 0; i < 8; i++) aes_key[i] = hc_swap32_S (tmps[gid].h[i]);
+
+  u32 iv[4] = {0};
+
+  for (int idx = 0; idx < 4; idx++) iv[idx] = esalt_bufs[DIGESTS_OFFSET].iv[idx];
+
+  u32 decoded_data[384];
+
+  const u32 enc_data_size = esalt_bufs[DIGESTS_OFFSET].encrypted_data_size;
+
+  aes256_decrypt_cfb (esalt_bufs[DIGESTS_OFFSET].encrypted_data, enc_data_size, iv, aes_key, decoded_data, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  if (check_decoded_data (decoded_data, enc_data_size))
+  {
+    if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, SALT_POS, digests_cnt, 0, DIGESTS_OFFSET + 0, gid, 0, 0, 0);
+    }
+  }
+}

--- a/src/modules/module_17010.c
+++ b/src/modules/module_17010.c
@@ -72,6 +72,8 @@ typedef struct gpg_tmp
 
 } gpg_tmp_t;
 
+static const char *SIGNATURE_GPG = "$gpg$";
+
 u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
   const u64 esalt_size = (const u64) sizeof (gpg_t);
@@ -81,7 +83,7 @@ u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED
 
 u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
-  const u64 tmp_size = (const u64) sizeof (gpg_tmp_t); 
+  const u64 tmp_size = (const u64) sizeof (gpg_tmp_t);
 
   return tmp_size;
 }
@@ -129,148 +131,167 @@ u32 module_deep_comp_kernel (MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED c
 
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
-  
   u32 *digest = (u32 *) digest_buf;
 
   gpg_t *gpg = (gpg_t *) esalt_buf;
 
   token_t token;
- 
+
   token.token_cnt = 13;
-  
+
   // signature $gpg$
   token.signatures_cnt = 1;
-  token.signatures_buf[0] = "$gpg$";
-  
+  token.signatures_buf[0] = SIGNATURE_GPG;
+
   // signature $gpg$
-  token.len_min[0] = 5;
-  token.len_max[0] = 5;
-  token.sep[0]     = '*';
-  token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
-                    |TOKEN_ATTR_VERIFY_SIGNATURE;
- 
+  token.len_min[0]  = 5;
+  token.len_max[0]  = 5;
+  token.sep[0]      = '*';
+  token.attr[0]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_SIGNATURE;
+
   // "1" -- unknown option
-  token.len_min[1] = 1;
-  token.len_max[1] = 1;
-  token.sep[1]     = '*';
-  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[1]  = 1;
+  token.len_max[1]  = 1;
+  token.sep[1]      = '*';
+  token.attr[1]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // size of the encrypted data in bytes
-  token.len_min[2] = 3;
-  token.len_max[2] = 4;
-  token.sep[2]     = '*';
-  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[2]  = 3;
+  token.len_max[2]  = 4;
+  token.sep[2]      = '*';
+  token.attr[2]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // size of the key: 1024, 2048, 4096, etc.
-  token.len_min[3] = 3;
-  token.len_max[3] = 4;
-  token.sep[3]     = '*';
-  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[3]  = 3;
+  token.len_max[3]  = 4;
+  token.sep[3]      = '*';
+  token.attr[3]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // encrypted key -- twice the amount of byte because its interpreted as characters
-  token.len_min[4] = 256;
-  token.len_max[4] = 3072;
-  token.sep[4]     = '*';
-  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_HEX;
+  token.len_min[4]  = 256;
+  token.len_max[4]  = 3072;
+  token.sep[4]      = '*';
+  token.attr[4]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
 
   // "3" - String2Key parameter
-  token.len_min[5] = 1;
-  token.len_max[5] = 1;
-  token.sep[5]     = '*';
-  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[5]  = 1;
+  token.len_max[5]  = 1;
+  token.sep[5]      = '*';
+  token.attr[5]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // "254" - String2Key parameters
-  token.len_min[6] = 3;
-  token.len_max[6] = 3;
-  token.sep[6]     = '*';
-  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[6]  = 3;
+  token.len_max[6]  = 3;
+  token.sep[6]      = '*';
+  token.attr[6]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // "2" - String2Key parameters
-  token.len_min[7] = 1;
-  token.len_max[7] = 1;
-  token.sep[7]     = '*';
-  token.attr[7]    = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[7]  = 1;
+  token.len_max[7]  = 1;
+  token.sep[7]      = '*';
+  token.attr[7]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // cipher mode: 7 or 9
-  token.len_min[8] = 1;
-  token.len_max[8] = 1;
-  token.sep[8]     = '*';
-  token.attr[8]    = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[8]  = 1;
+  token.len_max[8]  = 1;
+  token.sep[8]      = '*';
+  token.attr[8]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // size of initial vector in bytes: 16
-  token.len_min[9]= 2;
-  token.len_max[9]= 2;
-  token.sep[9]    = '*';
-  token.attr[9]   = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[9]  = 2;
+  token.len_max[9]  = 2;
+  token.sep[9]      = '*';
+  token.attr[9]     = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // initial vector - twice the amount of bytes because its interpreted as characters
-  token.len_min[10]= 32;
-  token.len_max[10]= 32;
-  token.sep[10]    = '*';
-  token.attr[10]   = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_HEX;
+  token.len_min[10] = 32;
+  token.len_max[10] = 32;
+  token.sep[10]     = '*';
+  token.attr[10]    = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
 
   // iteration count
-  token.len_min[11]= 1;
-  token.len_max[11]= 8;
-  token.sep[11]    = '*';
-  token.attr[11]   = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_DIGIT;
+  token.len_min[11] = 1;
+  token.len_max[11] = 8;
+  token.sep[11]     = '*';
+  token.attr[11]    = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   // salt - 8 bytes / 16 characters
-  token.len_min[12]= 16;
-  token.len_max[12]= 16;
-  token.attr[12]   = TOKEN_ATTR_VERIFY_LENGTH 
-                    |TOKEN_ATTR_VERIFY_HEX;
+  token.len_min[12] = 16;
+  token.len_max[12] = 16;
+  token.attr[12]    = TOKEN_ATTR_VERIFY_LENGTH
+                    | TOKEN_ATTR_VERIFY_HEX;
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
 
   if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
 
   // Modulus size
-  int enc_data_size = hc_strtoul ((const char *) token.buf[2], NULL, 10);
-  gpg->modulus_size = hc_strtoul ((const char *) token.buf[3], NULL, 10);
 
-  if ((gpg->modulus_size < 256) || (gpg->modulus_size > 16384)) return (PARSER_UNKNOWN_ERROR);
+  const int modulus_size = hc_strtoul ((const char *) token.buf[3], NULL, 10);
+
+  if ((modulus_size < 256) || (modulus_size > 16384)) return (PARSER_SALT_LENGTH);
+
+  gpg->modulus_size = modulus_size;
 
   // Encrypted data
-  gpg->encrypted_data_size = exec_unhexify ((u8 *) (token.buf[4] - 5), token.len[4] + 6, (u8 *) gpg->encrypted_data, sizeof(gpg->encrypted_data));
 
-  if (gpg->encrypted_data_size != enc_data_size) return (PARSER_UNKNOWN_ERROR);
+  const int enc_data_size = hc_strtoul ((const char *) token.buf[2], NULL, 10);
+
+  const int encrypted_data_size = hex_decode ((const u8 *) token.buf[4], token.len[4], (u8 *) gpg->encrypted_data);
+
+  if (enc_data_size != encrypted_data_size) return (PARSER_CT_LENGTH);
+
+  gpg->encrypted_data_size = encrypted_data_size;
 
   // Check String2Key parameters
-  if (hc_strtoul ((const char *) token.buf[5], NULL, 10) != 3) return (PARSER_UNKNOWN_ERROR);
-  if (hc_strtoul ((const char *) token.buf[6], NULL, 10) != 254) return (PARSER_UNKNOWN_ERROR);
-  if (hc_strtoul ((const char *) token.buf[7], NULL, 10) != 2) return (PARSER_UNKNOWN_ERROR);
+
+  if (hc_strtoul ((const char *) token.buf[5], NULL, 10) !=   3) return (PARSER_HASH_VALUE);
+  if (hc_strtoul ((const char *) token.buf[6], NULL, 10) != 254) return (PARSER_HASH_VALUE);
+  if (hc_strtoul ((const char *) token.buf[7], NULL, 10) !=   2) return (PARSER_HASH_VALUE);
 
   // Cipher algo
-  gpg->cipher_algo = hc_strtoul (token.buf[8], NULL, 10);
 
-  if ((gpg->cipher_algo != 7) && (gpg->cipher_algo != 9)) return (PARSER_UNKNOWN_ERROR);
+  const int cipher_algo = hc_strtoul ((const char *) token.buf[8], NULL, 10);
+
+  if ((cipher_algo != 7) && (cipher_algo != 9)) return (PARSER_CIPHER);
+
+  gpg->cipher_algo = cipher_algo;
 
   // IV (size)
-  if (hc_strtoul ((const char *) token.buf[9], NULL, 10) != sizeof(gpg->iv)) return (PARSER_IV_LENGTH);
 
-  size_t iv_size = exec_unhexify (token.buf[10] - 5, token.len[10] + 6, (u8 *) gpg->iv, sizeof(gpg->iv));
-  if (iv_size != sizeof(gpg->iv)) return (PARSER_IV_LENGTH); 
+  if (hc_strtoul ((const char *) token.buf[9], NULL, 10) != sizeof (gpg->iv)) return (PARSER_IV_LENGTH);
+
+  const int iv_size = hex_decode ((const u8 *) token.buf[10], token.len[10], (u8 *) gpg->iv);
+
+  if (iv_size != sizeof (gpg->iv)) return (PARSER_IV_LENGTH);
+
+  // Salt Iter
 
   const u32 salt_iter = hc_strtoul ((const char *) token.buf[11], NULL, 10);
-  if (salt_iter < 8 || salt_iter > 1000000) return (PARSER_SALT_ITERATION); 
+
+  if (salt_iter < 8 || salt_iter > 1000000) return (PARSER_SALT_ITERATION);
 
   salt->salt_iter = salt_iter;
-  salt->salt_repeats = gpg->cipher_algo == 7 ? 0 : 1; // "minus one", see also the scrypt module!
-  salt->salt_len = exec_unhexify (token.buf[12] - 5, token.len[12] + 6, (u8 *) salt->salt_buf, sizeof(salt->salt_buf));
 
-  if (salt->salt_len != 8) return (PARSER_UNKNOWN_ERROR);
+  // Salt Value
+
+  salt->salt_repeats = gpg->cipher_algo == 7 ? 0 : 1; // "minus one"
+
+  salt->salt_len = hex_decode ((const u8 *) token.buf[12], token.len[12], (u8 *) salt->salt_buf);
+
+  if (salt->salt_len != 8) return (PARSER_SALT_LENGTH);
 
   // hash fake
   digest[0] = gpg->iv[0];
@@ -283,37 +304,31 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
 int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
 {
-  const u32 *digest = (const u32 *) digest_buf;
+  const gpg_t *gpg = (const gpg_t *) esalt_buf;
 
-  const gpg_t *gpg = (const gpg_t *) esalt_buf; 
+  u8 encrypted_data[(384 * 8) + 1];
 
-  u8 hex_encrypted[(384 * 8) + 1] = { 0 }; 
-  u8 *encrypted_data = (u8 *) gpg->encrypted_data; 
+  hex_encode ((const u8 *) gpg->encrypted_data, gpg->encrypted_data_size, (u8 *) encrypted_data);
 
-  for (u32 i = 0, j = 0; i < gpg->encrypted_data_size; i++, j += 2) 
-  { 
-    u8_to_hex (encrypted_data[i], hex_encrypted + j); 
-  } 
+  const int line_len = snprintf (line_buf, line_size, "%s*%d*%d*%d*%s*%d*%d*%d*%d*%d*%08x%08x%08x%08x*%d*%08x%08x",
+    SIGNATURE_GPG,
+    1, /* unknown field */
+    gpg->encrypted_data_size,
+    gpg->modulus_size,
+    encrypted_data,
+    3, /* version (major?) */
+    254, /* version (minor?) */
+    2, /* key cipher (sha-1) */
+    gpg->cipher_algo,
+    16, /*iv_size*/
+    byte_swap_32 (gpg->iv[0]),
+    byte_swap_32 (gpg->iv[1]),
+    byte_swap_32 (gpg->iv[2]),
+    byte_swap_32 (gpg->iv[3]),
+    salt->salt_iter,
+    byte_swap_32 (salt->salt_buf[0]),
+    byte_swap_32 (salt->salt_buf[1]));
 
-  const int line_len = snprintf (line_buf, line_size, "%s*%d*%d*%d*%s*%d*%d*%d*%d*%d*%08x%08x%08x%08x*%d*%08x%08x", 
-   "$gpg$", 
-   1, /* unknown field */ 
-   gpg->encrypted_data_size, 
-   gpg->modulus_size, 
-   hex_encrypted, 
-   3, /* version (major?) */ 
-   254, /* version (minor?) */ 
-   2, /* key cipher (sha-1) */ 
-   gpg->cipher_algo, 
-   16, /*iv_size*/ 
-   byte_swap_32 (gpg->iv[0]),
-   byte_swap_32 (gpg->iv[1]),
-   byte_swap_32 (gpg->iv[2]),
-   byte_swap_32 (gpg->iv[3]),
-   salt->salt_iter,
-   byte_swap_32 (salt->salt_buf[0]),
-   byte_swap_32 (salt->salt_buf[1]));
-  
   return line_len;
 }
 
@@ -329,6 +344,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
   module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
   module_ctx->module_deep_comp_kernel         = module_deep_comp_kernel;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
   module_ctx->module_dgst_pos0                = module_dgst_pos0;
   module_ctx->module_dgst_pos1                = module_dgst_pos1;
   module_ctx->module_dgst_pos2                = module_dgst_pos2;
@@ -338,6 +354,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_esalt_size               = module_esalt_size;
   module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
   module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
   module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
   module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
   module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;

--- a/src/modules/module_17010.c
+++ b/src/modules/module_17010.c
@@ -1,0 +1,394 @@
+/**
+ * Author......: Netherlands Forensic Institute
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_RAW_HASH;
+static const char *HASH_NAME      = "GPG (AES-128/AES-256 (SHA-1($pass)))";
+static const u64   KERN_TYPE      = 17010;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_LOOP_PREPARE
+                                  | OPTS_TYPE_AUX1
+                                  | OPTS_TYPE_AUX2
+                                  | OPTS_TYPE_DEEP_COMP_KERNEL;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$gpg$*1*348*1024*8833fa3812b5500aa9eb7e46febfa31a0584b7e4a5b13c198f5c9b0814243895cce45ac3714e79692fb5a130a1c943b9130315ce303cb7e6831be68ce427892858f313fc29f533434dbe0ef26573f2071bbcc1499dc49bda90648221ef3823757e2fba6099a18c0c83386b21d8c9b522ec935ecd540210dbf0f21c859429fd4d35fa056415d8087f27b3e66b16081ea18c544d8b2ea414484f17097bc83b773d92743f76eb2ccb4df8ba5f5ff84a5474a5e8a8e5179a5b0908503c55e428de04b40628325739874e1b4aa004c4cbdf09b0b620990a8479f1c9b4187e33e63fe48a565bc1264bbf4062559631bef9e346a7217f1cabe101a38ac4be9fa94f6dafe6b0301e67792ed51bca04140cddd5cb6e80ac6e95e9a09378c9651588fe360954b622c258a3897f11246c944a588822cc6daf1cb81ccc95098c3bea8432f1ee0c663b193a7c7f1cdfeb91eee0195296bf4783025655cbebd7c70236*3*254*2*7*16*a47ef38987beab0a0b9bfe74b72822e8*65536*1f5c90d9820997db";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct gpg
+{
+  u32 cipher_algo;
+  u32 iv[4];
+  u32 modulus_size;
+  u32 encrypted_data[384];
+  u32 encrypted_data_size;
+
+} gpg_t;
+
+typedef struct gpg_tmp
+{
+  u32 salted_pw_block[80];
+
+  u32 salted_pw_block_len;
+
+  u32 h[10];
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  u32 len;
+
+} gpg_tmp_t;
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (gpg_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (gpg_tmp_t); 
+
+  return tmp_size;
+}
+
+bool module_hlfmt_disable (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool hlfmt_disable = true;
+
+  return hlfmt_disable;
+}
+
+u32 module_kernel_loops_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_min = 1024;
+
+  return kernel_loops_min;
+}
+
+u32 module_kernel_loops_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_max = 65536;
+
+  return kernel_loops_max;
+}
+
+u32 module_deep_comp_kernel (MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const u32 salt_pos, MAYBE_UNUSED const u32 digest_pos)
+{
+  const u32 digests_offset = hashes->salts_buf[salt_pos].digests_offset;
+
+  gpg_t *gpgs = (gpg_t *) hashes->esalts_buf;
+
+  gpg_t *gpg = &gpgs[digests_offset + digest_pos];
+
+  if (gpg->cipher_algo == 7)
+  {
+    return KERN_RUN_AUX1;
+  }
+  else if (gpg->cipher_algo == 9)
+  {
+    return KERN_RUN_AUX2;
+  }
+
+  return 0;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  
+  u32 *digest = (u32 *) digest_buf;
+
+  gpg_t *gpg = (gpg_t *) esalt_buf;
+
+  token_t token;
+ 
+  token.token_cnt = 13;
+  
+  // signature $gpg$
+  token.signatures_cnt = 1;
+  token.signatures_buf[0] = "$gpg$";
+  
+  // signature $gpg$
+  token.len_min[0] = 5;
+  token.len_max[0] = 5;
+  token.sep[0]     = '*';
+  token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
+                    |TOKEN_ATTR_VERIFY_SIGNATURE;
+ 
+  // "1" -- unknown option
+  token.len_min[1] = 1;
+  token.len_max[1] = 1;
+  token.sep[1]     = '*';
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // size of the encrypted data in bytes
+  token.len_min[2] = 3;
+  token.len_max[2] = 4;
+  token.sep[2]     = '*';
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // size of the key: 1024, 2048, 4096, etc.
+  token.len_min[3] = 3;
+  token.len_max[3] = 4;
+  token.sep[3]     = '*';
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // encrypted key -- twice the amount of byte because its interpreted as characters
+  token.len_min[4] = 256;
+  token.len_max[4] = 3072;
+  token.sep[4]     = '*';
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_HEX;
+
+  // "3" - String2Key parameter
+  token.len_min[5] = 1;
+  token.len_max[5] = 1;
+  token.sep[5]     = '*';
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // "254" - String2Key parameters
+  token.len_min[6] = 3;
+  token.len_max[6] = 3;
+  token.sep[6]     = '*';
+  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // "2" - String2Key parameters
+  token.len_min[7] = 1;
+  token.len_max[7] = 1;
+  token.sep[7]     = '*';
+  token.attr[7]    = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // cipher mode: 7 or 9
+  token.len_min[8] = 1;
+  token.len_max[8] = 1;
+  token.sep[8]     = '*';
+  token.attr[8]    = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // size of initial vector in bytes: 16
+  token.len_min[9]= 2;
+  token.len_max[9]= 2;
+  token.sep[9]    = '*';
+  token.attr[9]   = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // initial vector - twice the amount of bytes because its interpreted as characters
+  token.len_min[10]= 32;
+  token.len_max[10]= 32;
+  token.sep[10]    = '*';
+  token.attr[10]   = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_HEX;
+
+  // iteration count
+  token.len_min[11]= 1;
+  token.len_max[11]= 8;
+  token.sep[11]    = '*';
+  token.attr[11]   = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_DIGIT;
+
+  // salt - 8 bytes / 16 characters
+  token.len_min[12]= 16;
+  token.len_max[12]= 16;
+  token.attr[12]   = TOKEN_ATTR_VERIFY_LENGTH 
+                    |TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // Modulus size
+  int enc_data_size = hc_strtoul ((const char *) token.buf[2], NULL, 10);
+  gpg->modulus_size = hc_strtoul ((const char *) token.buf[3], NULL, 10);
+
+  if ((gpg->modulus_size < 256) || (gpg->modulus_size > 16384)) return (PARSER_UNKNOWN_ERROR);
+
+  // Encrypted data
+  gpg->encrypted_data_size = exec_unhexify ((u8 *) (token.buf[4] - 5), token.len[4] + 6, (u8 *) gpg->encrypted_data, sizeof(gpg->encrypted_data));
+
+  if (gpg->encrypted_data_size != enc_data_size) return (PARSER_UNKNOWN_ERROR);
+
+  // Check String2Key parameters
+  if (hc_strtoul ((const char *) token.buf[5], NULL, 10) != 3) return (PARSER_UNKNOWN_ERROR);
+  if (hc_strtoul ((const char *) token.buf[6], NULL, 10) != 254) return (PARSER_UNKNOWN_ERROR);
+  if (hc_strtoul ((const char *) token.buf[7], NULL, 10) != 2) return (PARSER_UNKNOWN_ERROR);
+
+  // Cipher algo
+  gpg->cipher_algo = hc_strtoul (token.buf[8], NULL, 10);
+
+  if ((gpg->cipher_algo != 7) && (gpg->cipher_algo != 9)) return (PARSER_UNKNOWN_ERROR);
+
+  // IV (size)
+  if (hc_strtoul ((const char *) token.buf[9], NULL, 10) != sizeof(gpg->iv)) return (PARSER_IV_LENGTH);
+
+  size_t iv_size = exec_unhexify (token.buf[10] - 5, token.len[10] + 6, (u8 *) gpg->iv, sizeof(gpg->iv));
+  if (iv_size != sizeof(gpg->iv)) return (PARSER_IV_LENGTH); 
+
+  const u32 salt_iter = hc_strtoul ((const char *) token.buf[11], NULL, 10);
+  if (salt_iter < 8 || salt_iter > 1000000) return (PARSER_SALT_ITERATION); 
+
+  salt->salt_iter = salt_iter;
+  salt->salt_repeats = gpg->cipher_algo == 7 ? 0 : 1; // "minus one", see also the scrypt module!
+  salt->salt_len = exec_unhexify (token.buf[12] - 5, token.len[12] + 6, (u8 *) salt->salt_buf, sizeof(salt->salt_buf));
+
+  if (salt->salt_len != 8) return (PARSER_UNKNOWN_ERROR);
+
+  // hash fake
+  digest[0] = gpg->iv[0];
+  digest[1] = gpg->iv[1];
+  digest[2] = gpg->iv[2];
+  digest[3] = gpg->iv[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  const gpg_t *gpg = (const gpg_t *) esalt_buf; 
+
+  u8 hex_encrypted[(384 * 8) + 1] = { 0 }; 
+  u8 *encrypted_data = (u8 *) gpg->encrypted_data; 
+
+  for (u32 i = 0, j = 0; i < gpg->encrypted_data_size; i++, j += 2) 
+  { 
+    u8_to_hex (encrypted_data[i], hex_encrypted + j); 
+  } 
+
+  const int line_len = snprintf (line_buf, line_size, "%s*%d*%d*%d*%s*%d*%d*%d*%d*%d*%08x%08x%08x%08x*%d*%08x%08x", 
+   "$gpg$", 
+   1, /* unknown field */ 
+   gpg->encrypted_data_size, 
+   gpg->modulus_size, 
+   hex_encrypted, 
+   3, /* version (major?) */ 
+   254, /* version (minor?) */ 
+   2, /* key cipher (sha-1) */ 
+   gpg->cipher_algo, 
+   16, /*iv_size*/ 
+   byte_swap_32 (gpg->iv[0]),
+   byte_swap_32 (gpg->iv[1]),
+   byte_swap_32 (gpg->iv[2]),
+   byte_swap_32 (gpg->iv[3]),
+   salt->salt_iter,
+   byte_swap_32 (salt->salt_buf[0]),
+   byte_swap_32 (salt->salt_buf[1]));
+  
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = module_deep_comp_kernel;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = module_hlfmt_disable;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = module_kernel_loops_max;
+  module_ctx->module_kernel_loops_min         = module_kernel_loops_min;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}


### PR DESCRIPTION
We would like to add a new algorithm to hashcat, the OpenPGP message format. Our implementation supports the following two modes : AES-128 & AES-256

Link to rfc: https://datatracker.ietf.org/doc/html/rfc4880

The algorithm: The salt and password are iterated through a SHA-1 engine until a certain number of bytes have been processed. In the testhashes this is usually 65536 bytes but this may vary. The generated hash will be used as a key to decrypt some data. The decryption is verified by hashing the decrypted data excluding the last 20 bytes. The last 20 bytes contain the expected SHA-1 hash of the decrypted data. 

The plugin does not support hash files that contain hashes from both modes. The input format is based on the hash you get when using gpg2john.c to extract the hash from a private key (secring.gpg).

Here is a short explanation on how to create a private key for testing:

We used gnupg-w32cli v1.4.22 for windows:

Link to binary : http://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/binary/

output of 'gpg.exe --help':

 gpg (GnuPG) 1.4.22
 Copyright (C) 2015 Free Software Foundation, Inc.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

command used to generate key with AES-128: 
 gpg.exe --gen-key

command used to generate key with AES-256: 
 gpg.exe --s2k-cipher-algo aes256 --gen-key

next run gpg2john on the secring.gpg: 
 gpg2john.exe C:\Users\user\AppData\Roaming\gnupg\secring.gpg

Output from generating a key : 
 test_user:$gpg$*1*348*1024*8833fa3812b5500aa9eb7e46febfa31a0584b7e4a5b13c198f5c9b0814243895cce45ac3714e79692fb5a130a1c943b9130315ce303cb7e6831be68ce427892858f313fc29f533434dbe0ef26573f2071bbcc1499dc49bda90648221ef3823757e2fba6099a18c0c83386b21d8c9b522ec935ecd540210dbf0f21c859429fd4d35fa056415d8087f27b3e66b16081ea18c544d8b2ea414484f17097bc83b773d92743f76eb2ccb4df8ba5f5ff84a5474a5e8a8e5179a5b0908503c55e428de04b40628325739874e1b4aa004c4cbdf09b0b620990a8479f1c9b4187e33e63fe48a565bc1264bbf4062559631bef9e346a7217f1cabe101a38ac4be9fa94f6dafe6b0301e67792ed51bca04140cddd5cb6e80ac6e95e9a09378c9651588fe360954b622c258a3897f11246c944a588822cc6daf1cb81ccc95098c3bea8432f1ee0c663b193a7c7f1cdfeb91eee0195296bf4783025655cbebd7c70236*3*254*2*7*16*a47ef38987beab0a0b9bfe74b72822e8*65536*1f5c90d9820997db:::test_user <user@email.com>::C:\Users\user\AppData\Roaming\gnupg\secring.gpg

Before you can use this hash in hashcat, you must strip the 'test_user:' prefix and everything from ':::test_user <user@email.com>' to the e
 $gpg$*1*348*1024*8833fa3812b5500aa9eb7e46febfa31a0584b7e4a5b13c198f5c9b0814243895cce45ac3714e79692fb5a130a1c943b9130315ce303cb7e6831be68ce427892858f313fc29f533434dbe0ef26573f2071bbcc1499dc49bda90648221ef3823757e2fba6099a18c0c83386b21d8c9b522ec935ecd540210dbf0f21c859429fd4d35fa056415d8087f27b3e66b16081ea18c544d8b2ea414484f17097bc83b773d92743f76eb2ccb4df8ba5f5ff84a5474a5e8a8e5179a5b0908503c55e428de04b40628325739874e1b4aa004c4cbdf09b0b620990a8479f1c9b4187e33e63fe48a565bc1264bbf4062559631bef9e346a7217f1cabe101a38ac4be9fa94f6dafe6b0301e67792ed51bca04140cddd5cb6e80ac6e95e9a09378c9651588fe360954b622c258a3897f11246c944a588822cc6daf1cb81ccc95098c3bea8432f1ee0c663b193a7c7f1cdfeb91eee0195296bf4783025655cbebd7c70236*3*254*2*7*16*a47ef38987beab0a0b9bfe74b72822e8*65536*1f5c90d9820997db

Here is a break-down of the hash format ('*' is used as separator between parameters) : 
 $gpg$  = signature
 1      = unknown option
 348    = size of the encrypted data in bytes
 1024   = size of the key
 c9f5.. = Encrypted data in hex (348 bytes in this case)
 3      = String2Key parameter
 254    = String2Key parameter
 2      = String2Key parameter
 7      = cipher mode, 7 means AES-128, 9 means AES-265
 16     = size of AES IV in bytes
 c861b4767199f768db4bf3529f422bb7 = the AES IV in hex 
 65536  = number of bytes that need to be processed with the salt and password
 052dc56b1700346e = the salt in hex

Note that we tested using an older version of GPG. It should probably work on newer versions just as well, but it might require a new version of gpg2john or you need to write such a conversion script yourself.

For testing we have added some example hashes from both modes. 

Example Hashes AES-128
password: Po32
$gpg$*1*348*1024*fb5aa50a0e54fe3d7206e8f77d9d5618b35340ca27bb3bc7396fafb5d7c085fb27a4af31232f2ede3f2cbb907c003c1d6f46aae78183bd5027d2f4bf82d066579ac6aec25283f73cbb5acdc0b418defbc965a9c8644cc72d69c42775dcce64ec5b9edaa1bee708ea9a28e58efd41c0b2355ce721cfd18ba4714efef1ffa79bf5cef22d8bcb6bfbd9027b1bcebd33946cde7c8f5002074a4842a000be8ed1cbb1efada5a7faef1510a0fc6778172ba3a4aa835f6bbefcf4dc0e87a23c7005855ee6e5cc842bec266dda70ec24ff52839f7b07a6b7f2431e3d04d97b3498929f5a7aa2e16db51b16d33bf79a4dee3ad52edf864743ca5117f4c54bbf6aaad0b437a72e9cc595f908a403979439b18a7e729641bfba6a1233b154ef65224c528d97b57b701a784070b29414da8752360c6b63d6f45915c3868349d83f71444f4248614ce40cec24bc6de95ca3ea918c4f3fa6bb10b29bf6060e7d7b3d1d*3*254*2*7*16*9a897d59006908ca9c5e4971d563d59d*65536*48be153e3e6d0280

password: Ka12
$gpg$*1*348*1024*858e0b2bcf135adc57516b2b1149feae91bbc9bac5355470997f2122b167fcce14cb04ba3ccb3d902c49ca01c48e8f357415e1b28bcc48a158caf350b10c30c2fd3202da0bb845077e3db85ecefccda55b3bd1092fcb5bbaf68b5902f05fc430686becd14ee135a4033125a94e5edc127893b92f046a77fb3c6b829fbb8b39f094223a2ad923127fdc5885fc076e06e33fea677af076c853f7f59b0256374ed1aa044caaa4dc98d46d66b9d16b3f6ec84063ab722eedf5ceecbbb574f0c700520e2619c5988b031e8ef1754a4edd0754c42a4308d94f42f6b43e54964a3256e5922304002d21f4ce5721e6906ccd3e1116a9bb8eec96066cc0e46149591876abe7f6b198576ef2c8ae7e089c9e88e2c9f7793872b8f75844b82fb53c9a677fa8e340dbcf0445e05fd3ae82fc964183a6c85bbf8171d5ca1bef5fbdc48e0c160d71a62b0c766eca37f35a2e7167a34b7239a88e79eea45cad9dca5e4c*3*254*2*7*16*b88548156b227c090967a4bebaf7077a*65536*c2315b4c46ce82ee

password: So12
$gpg$*1*348*1024*96bf41f773ebf6742df73a745f23540555a5af118eb70e1ab19acbd0eb785d552cfdaf0664d3206ac9382ca2d4c263fec4de7aa848f2eabb26c5292145f7027e115bcbcdd6da3eaf070e652d4f0bf236b1ddf599aa22ff1771c825aae945c83700a3effc7fb3aab7c77646caa95721bbacec6154688397f582acff3570471d630e9e693ab9c701686487a4b3ae99ceea487184afca434811a22b63e377715fb88b18865554cfefd5040022715ae513061d8bfd23bdfab51aa8b838c527f5f17d18c5c0cd1fdd22ceac1af49888c4ece40dd62dee04cb5b0edfe84b90177b0bea313f6c4ed5dae5425e10a17a71719cca66f6ac641e7b7211a5c2d7f3b5dfabe26208c54611ce0dd2f05df048b716d85a40eb726feeacffc5b0fa0ef65fe184bd0f0de595f6f57263965c8922b77d6ec6605b9eec1f834bcc49ed3fd8d92b80acc75355c7f6038ab300ce2159b763b4dd82bd33c3605ddd1b58e8e4d3*3*254*2*7*16*e38bbdbb3d9491cc0662b0919999dad4*65536*5a16e8d1751f6f29

Example Hashes AES-256 
password: POES
$gpg$*1*668*2048*d47c79fa7851f367185a7c9496bbe56dffdf0e62738030a74968c5c2295b19cfb4cb5ea33f0059e0e5384c52bc179927048b888223747903236d938e32a277718a5f87e7b9c7a6d4ece46284f0ca436672bee26f9fd086d253c0c35a095c216f32feca7ffce6f0c8da7906683ad055e4cb6bea0c35384d9000091396ccd2e2ea9a3e06595bdb99c40e33532dbed6d67a055ebe550d2e89def6932f96d4dce8903e53ebd146807ea63af45c73f6d42679c22e3eb239673c572f484a0c48c91e171fddaf107485930146f211811428960804b3c2400e1d3b6bb58e9df24e39adf4ad28b4ac2feb733824ed903a66e5329932a5c2ed3f4e9ef3787008d41fa959654346fb6f2bd056691324af17925389536d17008e45c10bb0141990d93623e4e885918d24a1111f5de71ebab9e176ec6eb3fcbfe22614db48edf833f7f787ed37704341905d4aa136d60b0aff29ecd8dc4ba89359ebc0520acf9c5ecab5ca51a1d1ff646bb35a18e5ef341090614c95d97f1cb564244b2bf16058c6796ef4dfffa204fe8654dee215062c2afa7e3b6780a33fdc235817ab5344e799e42df8511afe0d417b0443e3a4dc9039a06c19eda7969c9f5e27488451790ac01e8339d04126587320045358f5c60e69f0d8c8a5ca89388c8c077fc0048b861386365c33629d98d7d54280883240f6b7bfe06d35cb223a73ebc90c6996c4456cd94c16b7737d1926eff6ce5d6997e546cfe92e4f349ba40d9e6602937a1d05a807fff0dd31be7ddde528a4f2b09cb9de003835ca8bfcde1492a61c40cac714722a37bc8a5698ca36fd5eee39eb197252dc3c3e1db1150c829525ca3729d8830001d6fc68b178246233664e364e0a5fff5e734ab60b92345fd5fcea8c5b140ae721c1eeea2b4e53fb530b6ca0515292980a62514d18b9cb98e3732cfbb63fd8bb64*3*254*2*9*16*414a26e83b1d1cbd95e26a4c8a5edef6*65536*c62bd64b8f199fd3

password: KAAS
$gpg$*1*668*2048*315e8ddabba29fcf60f355994588ee44f16111abbe6957676fd791b4d2ca7af70e1dd48b479c46ed61f1c2f6f401749c7b3ae2d73151b46315c3d31d051a197ae1ee34b4c415bc4cd301f1ce9fae6bfa2112bcf035210a9bd42815d6108903567514ca3b17814175c675a05b3ce1ffa0f42b502a6858b5bdf31e59b55fca8a0b192c37178bc90c47fc7d501155fb1bfffd2999eb845508ed5828d0e68cd7cc269fa36a1652031e3eedb489ace139c47948f7b98c58bcfb7509359a5f9b46c199bacd30c29e6886119e5d092bf83d852a6bda293dbba68788268e30618aa1523e76d11cea95a9f34fe87fe0158df25c0d3b228dd9f7a8960d2c5d9cba9fe45e94bcfdf90651234845b6e8fabcaaf300b6f795da1fc8c3f233926089a835746c41647963b3b4e1e6c5b20c41a47316e254bc44884504fa9e4070165a2a755087599bda388b90e69325b28c3e48ffdd98c047f2132cf1b57a6fd5352be5902728b7fbdb548367de13a0c346bbe03ebbc24d64e3a5c7641f13b27df7509b50a51f95e7b0f79639b3958fa0e8a1f2f14bf5ecd56c9537644e918140ae1785525b070149c8cec8d3cfefd67d8ed5ee99bce011461aba5f44cef671e691f6b316976524e9439d319ecdb757624ac5661623bf43f1d25a4e55f9a5b7e75954c197f336e7530238f7553961b995644674b7e741fe570b1917c40116ae2ee50da40cddcb936d00781c54d27221fd0847d8a3b1d6884f33d4c10dbd11434e09e2a3fc202e07a9e4f9a6a000856f07c4352bc70e510fd064fe65a46f80e54aab8d611dd127911e7a2820bc7f5e29b73132d4b22cf44898b46f83ee5a75791e3df6aa66547b271313ba28dd5bd2f17f827e78911743ea4212467e1afd0231a337e1203fcc43c59b31511f499173bbb81d0cda53e0671cba8badeaf79724a4effc6160*3*254*2*9*16*815887ba9370c5b9449b1edd64e58f5b*65536*50b730e002bce5f9

password: SOEP
$gpg$*1*668*2048*1c8833a88569d210db3f0843e36f5b3a073ca263c94cbcb1b0e6bb3b6e14505013f3863f5f8a281aafc93932e7d670a35328f75b779bcc8ab9aafd4bf8bf0cb47ad58fb94c3f630a1406f57af0d74ba7334dbad394a6e1cd0691b977df9060c85b6a0b0097126e7541813a43fb02230cf9deb640f74cdcf5094485e23dbbd6124ecdca148c3ba95d8843fcd02801b39ad6b1679ec595f3efbd2c55ef560b4b009b5ff5b47365260b4bbe6a934811b5a8037427c6683ad393ce86d895b3f2ea90e1e78425269950a659af5731d2ae484e38f89332d45f458645ed1a760ca1deac7546998f7b04f47a1c3d6f5c2becef537cf72bfb1939acf54e8a3407538f171adc4ddf5996a3ceb382866cf2ed52fa46248b34ba534763179c8a3d52722f4288792f19887f8c6aa74e187c5bdc36fca811bf242999cd4e0d77f11351f2ca1ecdeff494adfb8974b9b48947c1faaf5a88935cadb03759ce10deecd42abf815825c0922a16b6c7a47f9984e90def74184ae5caf836d5703e45a9901a98d1e387ab9f720e4909f9d2e8a1d617764dae32912e2e1f5569113e29c45f66f78d7bb45bfa810bf7cbe0a0c02a91e417343f390454d424309d8b5d3896df322fe3246b0ed5b7da4e9edcd25b71afafe046b0979fa6d34a3819c088f1e2321b8bee17873fe86266c6d7113f494073d316060af541137cef62d1f3b72bbfb9866057c8af2fb2b174fbcf35087e6f9bd03de4f7110648209b892131cb814262b27db4cfd99f100f6d9c70b594e59a0557a330bb892ef10a2647cd26de88822bae29c2754db1f26e1de67e209e957fd8d0509b6f5e17a3a8a2f8e1e3d4e063db344da9d16ee966cbb76df8bda99e8bb928b53ecb7bcaa331c178107f4a4b54a723a6d5d2cab02f0ec28b010f32c27dde51cfa4274296b4e72b74ef8a44967a7188ba*3*254*2*9*16*dc5d83e58b609edfe217cac7eb49a565*65536*953c48ed09742757

Kind regards,

Team FSE-A at NFI
