### PR TITLE
fix buffer sizes for -m 13600 = WinZip

### DIFF
--- a/OpenCL/m13600-pure.cl
+++ b/OpenCL/m13600-pure.cl
@@ -37,7 +37,7 @@ typedef struct zip2
   u32 verify_bytes;
   u32 compress_length;
   u32 data_len;
-  u32 data_buf[0x4000000];
+  u32 data_buf[0x200000];
   u32 auth_len;
   u32 auth_buf[4];
 


### PR DESCRIPTION
This minor change just corrects the buffer sizes of the WinZip algorithm:
the correct maximum data length is 16 MB in hexadecimal, but "only" 8 MB raw data.

related to : https://github.com/hashcat/hashcat/commit/4730cf6e79709912882636d77e0867b0be954f0e

thank you very much.

PS: I don't think that we need to update `docs/changes.txt` here, since as far as I see the file correctly states that 16 MB long hashes are supported... the only problem here is that the buffer was too large within the code