### PR TITLE
Increase buffer sizes for -m 11600 = 7-Zip

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -41,6 +41,7 @@
 - Kernel Cache: Add kernel threads into hash computation which is later used in the kernel cache filename
 - Memory Management: Refactored the code responsible for limiting kernel accel in order to avoid out of -host- memory situations
 - SCRYPT Kernels: Add more optimized values for some new NV/AMD GPUs
+- 7-Zip Hook: Increase supported data length from 320kb to 8mb
 
 ##
 ## Algorithms

--- a/src/modules/module_11600.c
+++ b/src/modules/module_11600.c
@@ -80,7 +80,7 @@ typedef struct seven_zip_hook_salt
 
   u8  data_type;
 
-  u32 data_buf[81882];
+  u32 data_buf[0x200000];
   u32 data_len;
 
   u32 unpack_size;
@@ -130,8 +130,8 @@ bool module_hook_extra_param_init (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 {
   seven_zip_hook_extra_t *seven_zip_hook_extra = (seven_zip_hook_extra_t *) hook_extra_param;
 
-  #define AESSIZE  320 * 1024
-  #define UNPSIZE 9766 * 1024 // or actually maximum is 9999999
+  #define AESSIZE 8 * 1024 * 1024
+  #define UNPSIZE 9999999
 
   seven_zip_hook_extra->aes = hccalloc (backend_ctx->backend_devices_cnt, sizeof (void *));
 
@@ -500,7 +500,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[10]     = '$';
   token.len_min[10] = 2;
-  token.len_max[10] = 655056;
+  token.len_max[10] = 0x200000 * 4 * 2;
   token.attr[10]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
@@ -592,7 +592,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if ((data_len * 2) != data_buf_len) return (PARSER_SALT_VALUE);
 
-  if (data_len > 327528) return (PARSER_SALT_VALUE);
+  if (data_len > 0x200000 * 4) return (PARSER_SALT_VALUE);
 
   if (unpack_size > data_len) return (PARSER_SALT_VALUE);
 


### PR DESCRIPTION
We recently changed several limits in our hash line reading code (+ memory allocation with alloc/free) that make this change now possible: we can support larger data sizes for 7-Zip files (e.g. converted by `7z2hashcat`).

related commits: https://github.com/hashcat/hashcat/commit/56c2243dfb39cd090f05a5e9b5a81cce2d3761ae (see HCBUFSIZ_LARGE change etc).

I would therefore suggest that we increase the supported data length for the -m 11600 = 7-Zip algorithm similar to the -m 113600 = WinZip one (see https://github.com/hashcat/hashcat/commit/4730cf6e79709912882636d77e0867b0be954f0e).

Thank you very much