### PR TITLE
Fixed buffer overflow in Stuffit5 module

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Fixed autotune unitialized tmps variable for slow hashes by calling _init kernel before calling _loop kernel
 - Fixed datatype in function sha384_hmac_init_vector_128() that could come into effect if vector datatype was manually set
 - Fixed false negative in all VeraCrypt hash-modes if both conditions are met: 1. use CPU for cracking and 2. PIM range was used
+- Fixed buffer overflow in Stuffit5 module
 
 ##
 ## Improvements

--- a/src/modules/module_24700.c
+++ b/src/modules/module_24700.c
@@ -52,9 +52,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 1;
 
-  token.len_min[0] = 10;
-  token.len_max[0] = 10;
-  token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
+  token.len[0]     = 10;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
@@ -62,9 +61,14 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
 
   const u8 *hash_pos = token.buf[0];
+  const u32 hash_len = token.len[0];
 
-  digest[0] = hex_to_u32 (hash_pos +  0);
-  digest[1] = hex_to_u32 (hash_pos +  8);
+  u8 digest_tmp[16] = { 0 };
+
+  memcpy (digest_tmp, hash_pos, hash_len);
+
+  digest[0] = hex_to_u32 (digest_tmp +  0);
+  digest[1] = hex_to_u32 (digest_tmp +  8);
 
   if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
   {


### PR DESCRIPTION
```
$ ./hashcat -m 24700 -b -D1
[...]
==28110==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7fdcd042504b at pc 0x7fdcd03ee54e bp 0x7ffc78dc7ab0 sp 0x7ffc78dc7aa8
READ of size 1 at 0x7fdcd042504b thread T0
    #0 0x7fdcd03ee54d in hex_to_u32 [redacted]/hashcat/src/convert.c:399:28
    #1 0x7fdcd03ecf9e in module_hash_decode [redacted]/hashcat/src/modules/module_24700.c:67:15
    #2 0x4dcd69 in hashes_init_selftest [redacted]/hashcat/src/hashes.c:1992:23
    #3 0x4cfa37 in outer_loop [redacted]/hashcat/src/hashcat.c:610:7
    #4 0x4cee06 in hashcat_session_execute [redacted]/hashcat/src/hashcat.c:1589:18
    #5 0x4c6f8d in main [redacted]/hashcat/src/main.c:1237:18
    #6 0x7fdcf582cd09 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26d09)
    #7 0x41f739 in _start ([redacted]/hashcat/hashcat+0x41f739)

0x7fdcd042504b is located 53 bytes to the left of global variable '<string literal>' defined in 'src/modules/module_24700.c:29:37' (0x7fdcd0425080) of size 8
  '<string literal>' is ascii string 'hashcat'
0x7fdcd042504b is located 0 bytes to the right of global variable '<string literal>' defined in 'src/modules/module_24700.c:30:37' (0x7fdcd0425040) of size 11
  '<string literal>' is ascii string '66a75cb059'
AddressSanitizer:DEADLYSIGNAL
AddressSanitizer: nested bug in the same thread, aborting.
```

CPU tests with: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz, 31707/31771 MB (7942 MB allocatable), 8MCU

```
[ test_1627738638 ] > Init test for hash type 24700.
[ test_1627738638 ] [ Type 24700, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627738638 ] [ Type 24700, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738638 ] [ Type 24700, Attack 1, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 1, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738638 ] [ Type 24700, Attack 3, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 3, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738638 ] [ Type 24700, Attack 6, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 6, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 7, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 7, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627738638 ] [ Type 24700, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738638 ] [ Type 24700, Attack 1, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 1, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738638 ] [ Type 24700, Attack 3, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 3, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738638 ] [ Type 24700, Attack 6, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 6, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 7, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738638 ] [ Type 24700, Attack 7, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
```

GPU tests with: GeForce GTX 1080 Ti, 11031/11178 MB, 28MCU

```
[ test_1627738418 ] > Init test for hash type 24700.
[ test_1627738418 ] [ Type 24700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627738418 ] [ Type 24700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738418 ] [ Type 24700, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738418 ] [ Type 24700, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738418 ] [ Type 24700, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/6 not found, 0/6 not matched, 0/6 timeout
[ test_1627738418 ] [ Type 24700, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627738418 ] [ Type 24700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738418 ] [ Type 24700, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738418 ] [ Type 24700, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627738418 ] [ Type 24700, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/6 not found, 0/6 not matched, 0/6 timeout
[ test_1627738418 ] [ Type 24700, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627738418 ] [ Type 24700, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
```

Thanks :)