### PR TITLE
Fixed buffer overflow in Stargazer Stellar Wallet XLM module

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Fixed autotune unitialized tmps variable for slow hashes by calling _init kernel before calling _loop kernel
 - Fixed datatype in function sha384_hmac_init_vector_128() that could come into effect if vector datatype was manually set
 - Fixed false negative in all VeraCrypt hash-modes if both conditions are met: 1. use CPU for cracking and 2. PIM range was used
+- Fixed buffer overflow in Stargazer Stellar Wallet XLM module
 
 ##
 ## Improvements

--- a/src/modules/module_25500.c
+++ b/src/modules/module_25500.c
@@ -247,9 +247,9 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define SALT_LEN_BASE64 ((16 * 8) / 6) + 3
-  #define IV_LEN_BASE64   ((12 * 8) / 6) + 3
-  #define CT_LEN_BASE64   ((72 * 8) / 6) + 3
+  #define SALT_LEN_BASE64 ((16 * 8) / 6) + 3 + 1 // 25 vs 24
+  #define IV_LEN_BASE64   ((12 * 8) / 6) + 1     // 17 vs 16
+  #define CT_LEN_BASE64   ((72 * 8) / 6) + 1     // 97 vs 96
 
   u8 salt_buf[SALT_LEN_BASE64] = { 0 };
 


### PR DESCRIPTION
```
==22577==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff3d6a6458 at pc 0x00000043e29f bp 0x7fff3d6a5a90 sp 0x7fff3d6a5218
READ of size 25 at 0x7fff3d6a6458 thread T0
    #0 0x43e29e in printf_common(void*, char const*, __va_list_tag*) ([redacted]/hashcat/hashcat+0x43e29e)
    #1 0x43fb30 in snprintf ([redacted]/hashcat/hashcat+0x43fb30)
    #2 0x7f84b832831b in module_hash_encode [redacted]/hashcat/src/modules/module_25500.c:287:17
    #3 0x4d40ad in hash_encode [redacted]/hashcat/src/hashes.c:149:23
    #4 0x51832a in status_get_hash_target [redacted]/hashcat/src/status.c:358:25
    #5 0x4d0b16 in hashcat_get_status [redacted]/hashcat/src/hashcat.c:1766:49
    #6 0x4d2f6f in inner2_loop [redacted]/hashcat/src/hashcat.c:319:7
    #7 0x4d20d3 in inner1_loop [redacted]/hashcat/src/hashcat.c:420:9
    #8 0x4d03aa in outer_loop [redacted]/hashcat/src/hashcat.c:833:11
    #9 0x4cee06 in hashcat_session_execute [redacted]/hashcat/src/hashcat.c:1589:18
    #10 0x4c6f8d in main [redacted]/hashcat/src/main.c:1237:18
    #11 0x7f84dd775d09 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26d09)
    #12 0x41f739 in _start ([redacted]/hashcat/hashcat+0x41f739)

Address 0x7fff3d6a6458 is located in stack of thread T0 at offset 56 in frame
    #0 0x7f84b8327e6f in module_hash_encode [redacted]/hashcat/src/modules/module_25500.c:243

  This frame has 5 object(s):
    [32, 56) 'salt_buf' (line 254) <== Memory access at offset 56 overflows this variable
    [96, 108) 'tmp_iv_buf' (line 260)
    [128, 147) 'iv_buf13' (line 266)
    [192, 264) 'tmp_buf' (line 272)
    [304, 403) 'ct_buf35' (line 281)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow ([redacted]/hashcat/hashcat+0x43e29e) in printf_common(void*, char const*, __va_list_tag*)
Shadow bytes around the buggy address:
  0x100067accc30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100067accc40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100067accc50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100067accc60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100067accc70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x100067accc80: 00 00 00 00 f1 f1 f1 f1 00 00 00[f2]f2 f2 f2 f2
  0x100067accc90: 00 04 f2 f2 00 00 03 f2 f2 f2 f2 f2 00 00 00 00
  0x100067accca0: 00 00 00 00 00 f2 f2 f2 f2 f2 00 00 00 00 00 00
  0x100067acccb0: 00 00 00 00 00 00 03 f3 f3 f3 f3 f3 00 00 00 00
  0x100067acccc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100067acccd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==22577==ABORTING
```

CPU tests with: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz, 31707/31771 MB (7942 MB allocatable), 8MCU

```
[ test_1627740984 ] > Init test for hash type 25500.
[ test_1627740984 ] [ Type 25500, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627740984 ] [ Type 25500, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627740984 ] [ Type 25500, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627740984 ] [ Type 25500, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
```

GPU tests with: GeForce GTX 1080 Ti, 11031/11178 MB, 28MCU

```
[ test_1627740959 ] > Init test for hash type 25500.
[ test_1627740959 ] [ Type 25500, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627740959 ] [ Type 25500, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627740959 ] [ Type 25500, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627740959 ] [ Type 25500, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
```

Thanks :)