### PR TITLE
Fixed buffer overflow in Mozilla key3.db module and Unit tests timeout issues with attack 6

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Fixed autotune unitialized tmps variable for slow hashes by calling _init kernel before calling _loop kernel
 - Fixed datatype in function sha384_hmac_init_vector_128() that could come into effect if vector datatype was manually set
 - Fixed false negative in all VeraCrypt hash-modes if both conditions are met: 1. use CPU for cracking and 2. PIM range was used
+- Fixed buffer overflow in Mozilla key3.db module
 
 ##
 ## Improvements
@@ -41,6 +42,7 @@
 - Kernel Cache: Add kernel threads into hash computation which is later used in the kernel cache filename
 - Memory Management: Refactored the code responsible for limiting kernel accel in order to avoid out of -host- memory situations
 - SCRYPT Kernels: Add more optimized values for some new NV/AMD GPUs
+- Unit tests: Updated test.sh to set limits with attack 6 and Mozilla key3.db
 
 ##
 ## Algorithms

--- a/src/modules/module_26000.c
+++ b/src/modules/module_26000.c
@@ -77,9 +77,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 5;
 
-  token.signatures_cnt    = 2;
+  token.signatures_cnt    = 1;
   token.signatures_buf[0] = SIGNATURE_MOZILLA;
-  token.signatures_buf[1] = SIGNATURE_MOZILLA_3DES;
 
   token.sep[0]     = '*';
   token.len_min[0] = 9;
@@ -90,8 +89,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.sep[1]     = '*';
   token.len_min[1] = 4;
   token.len_max[1] = 4;
-  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   token.sep[2]     = '*';
   token.len_min[2] = 40;
@@ -114,6 +112,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
 
   if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const char *sig_pos = (char *) token.buf[1];
+
+  if (strcmp (sig_pos, SIGNATURE_MOZILLA_3DES) == 0) return PARSER_SIGNATURE_UNMATCHED;
 
   // global salt buffer + entry salt buffer combined
   // this also requires us to copy to local variables in kernel

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1592,6 +1592,12 @@ function attack_6()
       max=6
     elif [ "${hash_type}" -eq 22000 ]; then
       max=6
+    elif [ "${hash_type}" -eq 26000 ]; then
+      if [ "${TYPE}" == "Gpu" ]; then
+        max=5
+      else
+        max=6
+      fi
     fi
 
     # special case: we need to split the first line


### PR DESCRIPTION
1

```
$ ./hashcat -m 26000 -b -D1
[...]
==26869==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7fee30b8b205 at pc 0x000000436b12 bp 0x7fff8bfdd010 sp 0x7fff8bfdc7b8
READ of size 9 at 0x7fee30b8b205 thread T0
    #0 0x436b11 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) ([redacted]/hashcat/hashcat+0x436b11)
    #1 0x436f1a in bcmp ([redacted]/hashcat/hashcat+0x436f1a)
    #2 0x7fee30b59762 in input_tokenizer [redacted]/hashcat/src/shared.c:1184:13
    #3 0x7fee30b52277 in module_hash_decode [redacted]/hashcat/src/modules/module_26000.c:114:28
    #4 0x4dcd69 in hashes_init_selftest [redacted]/hashcat/src/hashes.c:1992:23
    #5 0x4cfa37 in outer_loop [redacted]/hashcat/src/hashcat.c:610:7
    #6 0x4cee06 in hashcat_session_execute [redacted]/hashcat/src/hashcat.c:1589:18
    #7 0x4c6f8d in main [redacted]/hashcat/src/main.c:1237:18
    #8 0x7fee55f99d09 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26d09)
    #9 0x41f739 in _start ([redacted]/hashcat/hashcat+0x41f739)

0x7fee30b8b205 is located 0 bytes to the right of global variable '<string literal>' defined in 'src/modules/module_26000.c:51:45' (0x7fee30b8b200) of size 5
  '<string literal>' is ascii string '3DES'
AddressSanitizer:DEADLYSIGNAL
AddressSanitizer: nested bug in the same thread, aborting.
```

2

```
[ test_1627741988 ] > Init test for hash type 26000.
[...]
[ test_1627741988 ] [ Type 26000, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 1/7 timeout
[...]
[ test_1627741988 ] [ Type 26000, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > Warning : 0/7 not found, 0/7 not matched, 1/7 timeout
[...]
```

CPU tests with: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz, 31707/31771 MB (7942 MB allocatable), 8MCU

```
[ test_1627747091 ] [ Type 26000, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627747091 ] [ Type 26000, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747091 ] [ Type 26000, Attack 1, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 1, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747091 ] [ Type 26000, Attack 3, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 3, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747091 ] [ Type 26000, Attack 6, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1627747091 ] [ Type 26000, Attack 6, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 7, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 7, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627747091 ] [ Type 26000, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747091 ] [ Type 26000, Attack 1, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 1, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747091 ] [ Type 26000, Attack 3, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 3, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747091 ] [ Type 26000, Attack 6, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/5 not found, 0/5 not matched, 0/5 timeout
[ test_1627747091 ] [ Type 26000, Attack 6, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 7, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747091 ] [ Type 26000, Attack 7, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
```

GPU tests with: GeForce GTX 1080 Ti, 11031/11178 MB, 28MCU

```
[ test_1627747090 ] > Init test for hash type 26000.
[ test_1627747090 ] [ Type 26000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627747090 ] [ Type 26000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747090 ] [ Type 26000, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747090 ] [ Type 26000, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747090 ] [ Type 26000, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/4 not found, 0/4 not matched, 0/4 timeout
[ test_1627747090 ] [ Type 26000, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627747090 ] [ Type 26000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747090 ] [ Type 26000, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747090 ] [ Type 26000, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627747090 ] [ Type 26000, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/4 not found, 0/4 not matched, 0/4 timeout
[ test_1627747090 ] [ Type 26000, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
[ test_1627747090 ] [ Type 26000, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout
```

Thanks :)