### PR TITLE
Fixed buffer overflow in Mozilla key4.db module

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 - Fixed autotune unitialized tmps variable for slow hashes by calling _init kernel before calling _loop kernel
 - Fixed datatype in function sha384_hmac_init_vector_128() that could come into effect if vector datatype was manually set
 - Fixed false negative in all VeraCrypt hash-modes if both conditions are met: 1. use CPU for cracking and 2. PIM range was used
+- Fixed buffer overflow in Mozilla key4.db module
 
 ##
 ## Improvements

--- a/src/modules/module_26100.c
+++ b/src/modules/module_26100.c
@@ -95,9 +95,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 7;
 
-  token.signatures_cnt    = 2;
+  token.signatures_cnt    = 1;
   token.signatures_buf[0] = SIGNATURE_MOZILLA;
-  token.signatures_buf[1] = SIGNATURE_MOZILLA_AES;
 
   token.sep[0]     = '*';
   token.len_min[0] = 9;
@@ -108,8 +107,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.sep[1]     = '*';
   token.len_min[1] = 3;
   token.len_max[1] = 3;
-  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   token.sep[2]     = '*';
   token.len_min[2] = 40;
@@ -144,6 +142,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
 
   if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const char *sig_pos = (char *) token.buf[1];
+
+  if (strcmp (sig_pos, SIGNATURE_MOZILLA_AES) == 0) return PARSER_SIGNATURE_UNMATCHED;
 
   // global salt buffer + entry salt buffer combined
   // we do this because both buffer are accessed before the _loop kernel


### PR DESCRIPTION
```
$ ./hashcat -m 26100 -b -D1
[...]
==24202==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f8f59659244 at pc 0x000000436b12 bp 0x7ffe6c139eb0 sp 0x7ffe6c139658
READ of size 9 at 0x7f8f59659244 thread T0
    #0 0x436b11 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) ([redacted]/hashcat/hashcat+0x436b11)
    #1 0x436f1a in bcmp ([redacted]/hashcat/hashcat+0x436f1a)
    #2 0x7f8f59626d62 in input_tokenizer [redacted]/hashcat/src/shared.c:1184:13
    #3 0x7f8f5961f3cd in module_hash_decode [redacted]/hashcat/src/modules/module_26100.c:144:28
    #4 0x4dcd69 in hashes_init_selftest [redacted]/hashcat/src/hashes.c:1992:23
    #5 0x4cfa37 in outer_loop [redacted]/hashcat/src/hashcat.c:610:7
    #6 0x4cee06 in hashcat_session_execute [redacted]/hashcat/src/hashcat.c:1589:18
    #7 0x4c6f8d in main [redacted]/hashcat/src/main.c:1237:18
    #8 0x7f8f7ea6ad09 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26d09)
    #9 0x41f739 in _start ([redacted]/hashcat/hashcat+0x41f739)

0x7f8f59659244 is located 0 bytes to the right of global variable '<string literal>' defined in 'src/modules/module_26100.c:62:44' (0x7f8f59659240) of size 4
  '<string literal>' is ascii string 'AES'
SUMMARY: AddressSanitizer: global-buffer-overflow ([redacted]/hashcat/hashcat+0x436b11) in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long)
Shadow bytes around the buggy address:
  0x0ff26b2c31f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff26b2c3200: 00 00 00 00 00 00 00 00 00 00 00 00 01 f9 f9 f9
  0x0ff26b2c3210: f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x0ff26b2c3220: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff26b2c3230: 00 00 00 00 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
=>0x0ff26b2c3240: 00 02 f9 f9 f9 f9 f9 f9[04]f9 f9 f9 f9 f9 f9 f9
  0x0ff26b2c3250: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff26b2c3260: 00 00 f9 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0ff26b2c3270: 00 00 f9 f9 f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9
  0x0ff26b2c3280: 00 00 00 00 f9 f9 f9 f9 00 00 00 00 00 00 00 00
  0x0ff26b2c3290: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==24202==ABORTING
```

CPU tests with: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz, 31707/31771 MB (7942 MB allocatable), 8MCU

```
[ test_1627748496 ] > Init test for hash type 26100.
[ test_1627748496 ] [ Type 26100, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627748496 ] [ Type 26100, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627748496 ] [ Type 26100, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627748496 ] [ Type 26100, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
```

GPU tests with: GeForce GTX 1080 Ti, 11031/11178 MB, 28MCU

```
[ test_1627748147 ] > Init test for hash type 26100.
[ test_1627748147 ] [ Type 26100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627748147 ] [ Type 26100, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
[ test_1627748147 ] [ Type 26100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1627748147 ] [ Type 26100, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
```

Thanks :)