### PR TITLE
Code cleanup and small fixes

### DIFF
--- a/include/backend.h
+++ b/include/backend.h
@@ -174,8 +174,6 @@ int gidd_to_pw_t (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, c
 
 int choose_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u32 highest_pw_len, const u64 pws_pos, const u64 pws_cnt, const u32 fast_iteration, const u32 salt_pos);
 
-void rebuild_pws_compressed_append (hc_device_param_t *device_param, const u64 pws_cnt, const u8 chr);
-
 int run_cuda_kernel_atinit          (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 num);
 int run_cuda_kernel_utf8toutf16le   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 num);
 int run_cuda_kernel_memset          (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 offset, const u8  value, const u64 size);

--- a/include/types.h
+++ b/include/types.h
@@ -1073,8 +1073,6 @@ typedef struct hc_fp
   gzFile      gfp; //  gzip fp
   unzFile     ufp; //   zip fp
 
-  bool        is_gzip;
-  bool        is_zip;
   int         bom_size;
 
   const char *mode;

--- a/src/backend.c
+++ b/src/backend.c
@@ -6519,7 +6519,7 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
 
               if (device_param->is_opencl == true)
               {
-                if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_combs_c, CL_TRUE, 0, innerloop_left * sizeof (pw_t), device_param->combs_buf, 0, NULL, NULL) == -1) return -1;
+                if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_combs_c, CL_FALSE, 0, innerloop_left * sizeof (pw_t), device_param->combs_buf, 0, NULL, NULL) == -1) return -1;
               }
             }
             else if (user_options->attack_mode == ATTACK_MODE_HYBRID1)

--- a/src/backend.c
+++ b/src/backend.c
@@ -5348,8 +5348,6 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
 
     if (hc_cuEventSynchronize (hashcat_ctx, device_param->cuda_event2) == -1) return -1;
 
-    if (hc_cuEventSynchronize (hashcat_ctx, device_param->cuda_event1) == -1) return -1;
-
     float exec_ms;
 
     if (hc_cuEventElapsedTime (hashcat_ctx, &exec_ms, device_param->cuda_event1, device_param->cuda_event2) == -1) return -1;

--- a/src/backend.c
+++ b/src/backend.c
@@ -41,6 +41,9 @@ static double TARGET_MSEC_PROFILE[4] = { 2, 12, 96, 480 };
 HC_ALIGN(16)
 static const u32 bzeros[4] = { 0, 0, 0, 0 };
 
+/* forward declarations */
+static void rebuild_pws_compressed_append (hc_device_param_t *device_param, const u64 pws_cnt, const u8 chr);
+
 static bool is_same_device (const hc_device_param_t *src, const hc_device_param_t *dst)
 {
   // First check by PCI address
@@ -4827,7 +4830,7 @@ int choose_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, 
   return 0;
 }
 
-void rebuild_pws_compressed_append (hc_device_param_t *device_param, const u64 pws_cnt, const u8 chr)
+static void rebuild_pws_compressed_append (hc_device_param_t *device_param, const u64 pws_cnt, const u8 chr)
 {
   // this function is used if we have to modify the compressed pws buffer in order to
   // append some data to each password candidate
@@ -4871,11 +4874,11 @@ void rebuild_pws_compressed_append (hc_device_param_t *device_param, const u64 p
     pw_idx_dst_next->off = pw_idx_dst->off + pw_idx_dst->cnt;
   }
 
-  memcpy (device_param->pws_comp, tmp_pws_comp, device_param->size_pws_comp);
-  memcpy (device_param->pws_idx,  tmp_pws_idx,  device_param->size_pws_idx);
+  hcfree (device_param->pws_comp);
+  hcfree (device_param->pws_idx);
 
-  hcfree (tmp_pws_comp);
-  hcfree (tmp_pws_idx);
+  device_param->pws_comp = tmp_pws_comp;
+  device_param->pws_idx  = tmp_pws_idx;
 }
 
 int run_cuda_kernel_atinit (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 num)

--- a/src/backend.c
+++ b/src/backend.c
@@ -15649,6 +15649,8 @@ int backend_session_update_mp (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_root_css_buf,   CL_FALSE, 0, device_param->size_root_css,   mask_ctx->root_css_buf,   0, NULL, NULL) == -1) return -1;
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_markov_css_buf, CL_FALSE, 0, device_param->size_markov_css, mask_ctx->markov_css_buf, 0, NULL, NULL) == -1) return -1;
+
+      if (hc_clFlush (hashcat_ctx, device_param->opencl_command_queue) == -1) return -1;
     }
   }
 
@@ -15720,6 +15722,8 @@ int backend_session_update_mp_rl (hashcat_ctx_t *hashcat_ctx, const u32 css_cnt_
 
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_root_css_buf,   CL_FALSE, 0, device_param->size_root_css,   mask_ctx->root_css_buf,   0, NULL, NULL) == -1) return -1;
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_markov_css_buf, CL_FALSE, 0, device_param->size_markov_css, mask_ctx->markov_css_buf, 0, NULL, NULL) == -1) return -1;
+
+      if (hc_clFlush (hashcat_ctx, device_param->opencl_command_queue) == -1) return -1;
     }
   }
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -161,8 +161,6 @@ static int backend_ctx_find_alias_devices (hashcat_ctx_t *hashcat_ctx)
 
 static bool is_same_device_type (const hc_device_param_t *src, const hc_device_param_t *dst)
 {
-  if (strcmp (src->device_name, dst->device_name) != 0) return false;
-
   if (src->is_cuda   != dst->is_cuda)   return false;
   if (src->is_hip    != dst->is_hip)    return false;
   if (src->is_opencl != dst->is_opencl) return false;
@@ -5281,29 +5279,26 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
   {
     CUfunction cuda_function = NULL;
 
-    if (device_param->is_cuda == true)
+    switch (kern_run)
     {
-      switch (kern_run)
-      {
-        case KERN_RUN_1:      cuda_function = device_param->cuda_function1;       break;
-        case KERN_RUN_12:     cuda_function = device_param->cuda_function12;      break;
-        case KERN_RUN_2P:     cuda_function = device_param->cuda_function2p;      break;
-        case KERN_RUN_2:      cuda_function = device_param->cuda_function2;       break;
-        case KERN_RUN_2E:     cuda_function = device_param->cuda_function2e;      break;
-        case KERN_RUN_23:     cuda_function = device_param->cuda_function23;      break;
-        case KERN_RUN_3:      cuda_function = device_param->cuda_function3;       break;
-        case KERN_RUN_4:      cuda_function = device_param->cuda_function4;       break;
-        case KERN_RUN_INIT2:  cuda_function = device_param->cuda_function_init2;  break;
-        case KERN_RUN_LOOP2P: cuda_function = device_param->cuda_function_loop2p; break;
-        case KERN_RUN_LOOP2:  cuda_function = device_param->cuda_function_loop2;  break;
-        case KERN_RUN_AUX1:   cuda_function = device_param->cuda_function_aux1;   break;
-        case KERN_RUN_AUX2:   cuda_function = device_param->cuda_function_aux2;   break;
-        case KERN_RUN_AUX3:   cuda_function = device_param->cuda_function_aux3;   break;
-        case KERN_RUN_AUX4:   cuda_function = device_param->cuda_function_aux4;   break;
-      }
-
-      if (hc_cuFuncSetAttribute (hashcat_ctx, cuda_function, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, dynamic_shared_mem) == -1) return -1;
+      case KERN_RUN_1:      cuda_function = device_param->cuda_function1;       break;
+      case KERN_RUN_12:     cuda_function = device_param->cuda_function12;      break;
+      case KERN_RUN_2P:     cuda_function = device_param->cuda_function2p;      break;
+      case KERN_RUN_2:      cuda_function = device_param->cuda_function2;       break;
+      case KERN_RUN_2E:     cuda_function = device_param->cuda_function2e;      break;
+      case KERN_RUN_23:     cuda_function = device_param->cuda_function23;      break;
+      case KERN_RUN_3:      cuda_function = device_param->cuda_function3;       break;
+      case KERN_RUN_4:      cuda_function = device_param->cuda_function4;       break;
+      case KERN_RUN_INIT2:  cuda_function = device_param->cuda_function_init2;  break;
+      case KERN_RUN_LOOP2P: cuda_function = device_param->cuda_function_loop2p; break;
+      case KERN_RUN_LOOP2:  cuda_function = device_param->cuda_function_loop2;  break;
+      case KERN_RUN_AUX1:   cuda_function = device_param->cuda_function_aux1;   break;
+      case KERN_RUN_AUX2:   cuda_function = device_param->cuda_function_aux2;   break;
+      case KERN_RUN_AUX3:   cuda_function = device_param->cuda_function_aux3;   break;
+      case KERN_RUN_AUX4:   cuda_function = device_param->cuda_function_aux4;   break;
     }
+
+    if (hc_cuFuncSetAttribute (hashcat_ctx, cuda_function, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, dynamic_shared_mem) == -1) return -1;
 
     if (kernel_threads == 0) kernel_threads = 1;
 
@@ -5380,29 +5375,26 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
   {
     hipFunction_t hip_function = NULL;
 
-    if (device_param->is_hip == true)
+    switch (kern_run)
     {
-      switch (kern_run)
-      {
-        case KERN_RUN_1:      hip_function = device_param->hip_function1;       break;
-        case KERN_RUN_12:     hip_function = device_param->hip_function12;      break;
-        case KERN_RUN_2P:     hip_function = device_param->hip_function2p;      break;
-        case KERN_RUN_2:      hip_function = device_param->hip_function2;       break;
-        case KERN_RUN_2E:     hip_function = device_param->hip_function2e;      break;
-        case KERN_RUN_23:     hip_function = device_param->hip_function23;      break;
-        case KERN_RUN_3:      hip_function = device_param->hip_function3;       break;
-        case KERN_RUN_4:      hip_function = device_param->hip_function4;       break;
-        case KERN_RUN_INIT2:  hip_function = device_param->hip_function_init2;  break;
-        case KERN_RUN_LOOP2P: hip_function = device_param->hip_function_loop2p; break;
-        case KERN_RUN_LOOP2:  hip_function = device_param->hip_function_loop2;  break;
-        case KERN_RUN_AUX1:   hip_function = device_param->hip_function_aux1;   break;
-        case KERN_RUN_AUX2:   hip_function = device_param->hip_function_aux2;   break;
-        case KERN_RUN_AUX3:   hip_function = device_param->hip_function_aux3;   break;
-        case KERN_RUN_AUX4:   hip_function = device_param->hip_function_aux4;   break;
-      }
-
-      //if (hc_hipFuncSetAttribute (hashcat_ctx, hip_function, HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, dynamic_shared_mem) == -1) return -1;
+      case KERN_RUN_1:      hip_function = device_param->hip_function1;       break;
+      case KERN_RUN_12:     hip_function = device_param->hip_function12;      break;
+      case KERN_RUN_2P:     hip_function = device_param->hip_function2p;      break;
+      case KERN_RUN_2:      hip_function = device_param->hip_function2;       break;
+      case KERN_RUN_2E:     hip_function = device_param->hip_function2e;      break;
+      case KERN_RUN_23:     hip_function = device_param->hip_function23;      break;
+      case KERN_RUN_3:      hip_function = device_param->hip_function3;       break;
+      case KERN_RUN_4:      hip_function = device_param->hip_function4;       break;
+      case KERN_RUN_INIT2:  hip_function = device_param->hip_function_init2;  break;
+      case KERN_RUN_LOOP2P: hip_function = device_param->hip_function_loop2p; break;
+      case KERN_RUN_LOOP2:  hip_function = device_param->hip_function_loop2;  break;
+      case KERN_RUN_AUX1:   hip_function = device_param->hip_function_aux1;   break;
+      case KERN_RUN_AUX2:   hip_function = device_param->hip_function_aux2;   break;
+      case KERN_RUN_AUX3:   hip_function = device_param->hip_function_aux3;   break;
+      case KERN_RUN_AUX4:   hip_function = device_param->hip_function_aux4;   break;
     }
+
+    //if (hc_hipFuncSetAttribute (hashcat_ctx, hip_function, HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, dynamic_shared_mem) == -1) return -1;
 
     if (kernel_threads == 0) kernel_threads = 1;
 
@@ -5477,26 +5469,23 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
   {
     cl_kernel opencl_kernel = NULL;
 
-    if (device_param->is_opencl == true)
+    switch (kern_run)
     {
-      switch (kern_run)
-      {
-        case KERN_RUN_1:      opencl_kernel = device_param->opencl_kernel1;       break;
-        case KERN_RUN_12:     opencl_kernel = device_param->opencl_kernel12;      break;
-        case KERN_RUN_2P:     opencl_kernel = device_param->opencl_kernel2p;      break;
-        case KERN_RUN_2:      opencl_kernel = device_param->opencl_kernel2;       break;
-        case KERN_RUN_2E:     opencl_kernel = device_param->opencl_kernel2e;      break;
-        case KERN_RUN_23:     opencl_kernel = device_param->opencl_kernel23;      break;
-        case KERN_RUN_3:      opencl_kernel = device_param->opencl_kernel3;       break;
-        case KERN_RUN_4:      opencl_kernel = device_param->opencl_kernel4;       break;
-        case KERN_RUN_INIT2:  opencl_kernel = device_param->opencl_kernel_init2;  break;
-        case KERN_RUN_LOOP2P: opencl_kernel = device_param->opencl_kernel_loop2p; break;
-        case KERN_RUN_LOOP2:  opencl_kernel = device_param->opencl_kernel_loop2;  break;
-        case KERN_RUN_AUX1:   opencl_kernel = device_param->opencl_kernel_aux1;   break;
-        case KERN_RUN_AUX2:   opencl_kernel = device_param->opencl_kernel_aux2;   break;
-        case KERN_RUN_AUX3:   opencl_kernel = device_param->opencl_kernel_aux3;   break;
-        case KERN_RUN_AUX4:   opencl_kernel = device_param->opencl_kernel_aux4;   break;
-      }
+      case KERN_RUN_1:      opencl_kernel = device_param->opencl_kernel1;       break;
+      case KERN_RUN_12:     opencl_kernel = device_param->opencl_kernel12;      break;
+      case KERN_RUN_2P:     opencl_kernel = device_param->opencl_kernel2p;      break;
+      case KERN_RUN_2:      opencl_kernel = device_param->opencl_kernel2;       break;
+      case KERN_RUN_2E:     opencl_kernel = device_param->opencl_kernel2e;      break;
+      case KERN_RUN_23:     opencl_kernel = device_param->opencl_kernel23;      break;
+      case KERN_RUN_3:      opencl_kernel = device_param->opencl_kernel3;       break;
+      case KERN_RUN_4:      opencl_kernel = device_param->opencl_kernel4;       break;
+      case KERN_RUN_INIT2:  opencl_kernel = device_param->opencl_kernel_init2;  break;
+      case KERN_RUN_LOOP2P: opencl_kernel = device_param->opencl_kernel_loop2p; break;
+      case KERN_RUN_LOOP2:  opencl_kernel = device_param->opencl_kernel_loop2;  break;
+      case KERN_RUN_AUX1:   opencl_kernel = device_param->opencl_kernel_aux1;   break;
+      case KERN_RUN_AUX2:   opencl_kernel = device_param->opencl_kernel_aux2;   break;
+      case KERN_RUN_AUX3:   opencl_kernel = device_param->opencl_kernel_aux3;   break;
+      case KERN_RUN_AUX4:   opencl_kernel = device_param->opencl_kernel_aux4;   break;
     }
 
     for (u32 i = 0; i <= 23; i++)

--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -133,9 +133,15 @@ int debugfile_init (hashcat_ctx_t *hashcat_ctx)
   }
   else
   {
-    debugfile_ctx->fp.is_gzip = false;
-    debugfile_ctx->fp.pfp = stdout;
-    debugfile_ctx->fp.fd = fileno (stdout);
+    HCFILE *fp = &debugfile_ctx->fp;
+
+    fp->fd       = fileno (stdout);
+    fp->pfp      = stdout;
+    fp->gfp      = NULL;
+    fp->ufp      = NULL;
+    fp->bom_size = 0;
+    fp->path     = NULL;
+    fp->mode     = NULL;
   }
 
   return 0;

--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -199,11 +199,11 @@ size_t hc_fread (void *ptr, size_t size, size_t nmemb, HCFILE *fp)
 
   if (fp == NULL) return n;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     n = gzfread (ptr, size, nmemb, fp->gfp);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     unsigned s = size * nmemb;
 
@@ -263,11 +263,11 @@ size_t hc_fwrite (const void *ptr, size_t size, size_t nmemb, HCFILE *fp)
 
   if (fp == NULL) return n;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     n = gzfwrite (ptr, size, nmemb, fp->gfp);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
   }
   else if (fp->pfp)
@@ -324,11 +324,11 @@ int hc_fseek (HCFILE *fp, off_t offset, int whence)
 
   if (fp == NULL) return r;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     r = gzseek (fp->gfp, offset, whence);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     /*
     // untested and not used in wordlist engine
@@ -361,11 +361,11 @@ void hc_rewind (HCFILE *fp)
 {
   if (fp == NULL) return;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     gzrewind (fp->gfp);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     unzGoToFirstFile (fp->ufp);
   }
@@ -381,11 +381,11 @@ off_t hc_ftell (HCFILE *fp)
 
   if (fp == NULL) return -1;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     n = (off_t) gztell (fp->gfp);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     n = unztell (fp->ufp);
   }
@@ -403,11 +403,11 @@ int hc_fputc (int c, HCFILE *fp)
 
   if (fp == NULL) return r;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     r = gzputc (fp->gfp, c);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
   }
   else if (fp->pfp)
@@ -424,11 +424,11 @@ int hc_fgetc (HCFILE *fp)
 
   if (fp == NULL) return r;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     r = gzgetc (fp->gfp);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     unsigned char c = 0;
 
@@ -448,11 +448,11 @@ char *hc_fgets (char *buf, int len, HCFILE *fp)
 
   if (fp == NULL) return r;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     r = gzgets (fp->gfp, buf, len);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     if (unzReadCurrentFile (fp->ufp, buf, len) > 0) r = buf;
   }
@@ -470,11 +470,11 @@ int hc_vfprintf (HCFILE *fp, const char *format, va_list ap)
 
   if (fp == NULL) return r;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     r = gzvprintf (fp->gfp, format, ap);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
   }
   else if (fp->pfp)
@@ -495,11 +495,11 @@ int hc_fprintf (HCFILE *fp, const char *format, ...)
 
   va_start (ap, format);
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     r = gzvprintf (fp->gfp, format, ap);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
   }
   else if (fp->pfp)
@@ -543,11 +543,11 @@ int hc_feof (HCFILE *fp)
 
   if (fp == NULL) return r;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     r = gzeof (fp->gfp);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     r = unzeof (fp->ufp);
   }
@@ -563,11 +563,11 @@ void hc_fflush (HCFILE *fp)
 {
   if (fp == NULL) return;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     gzflush (fp->gfp, Z_SYNC_FLUSH);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
   }
   else if (fp->pfp)
@@ -580,11 +580,11 @@ void hc_fclose (HCFILE *fp)
 {
   if (fp == NULL) return;
 
-  if (fp->is_gzip)
+  if (fp->gfp)
   {
     gzclose (fp->gfp);
   }
-  else if (fp->is_zip)
+  else if (fp->ufp)
   {
     unzCloseCurrentFile (fp->ufp);
 

--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -596,7 +596,7 @@ void hc_fclose (HCFILE *fp)
 
     unzClose (fp->ufp);
   }
-  else
+  else if (fp->pfp)
   {
     fclose (fp->pfp);
   }

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -128,9 +128,8 @@ int potfile_init (hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->potfile_path == NULL)
   {
-    potfile_ctx->fp.pfp   = NULL;
-
     hc_asprintf (&potfile_ctx->filename, "%s/hashcat.potfile", folder_config->profile_dir);
+    potfile_ctx->fp.pfp   = NULL;
   }
   else
   {
@@ -173,15 +172,13 @@ int potfile_init (hashcat_ctx_t *hashcat_ctx)
 
 void potfile_destroy (hashcat_ctx_t *hashcat_ctx)
 {
-  hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
   potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return;
 
-  if (hashconfig->potfile_disable == true) return;
-
-  hcfree (potfile_ctx->out_buf);
   hcfree (potfile_ctx->tmp_buf);
+  hcfree (potfile_ctx->out_buf);
+  hcfree (potfile_ctx->filename);
 
   memset (potfile_ctx, 0, sizeof (potfile_ctx_t));
 }

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -185,9 +185,12 @@ void potfile_destroy (hashcat_ctx_t *hashcat_ctx)
 
 int potfile_read_open (hashcat_ctx_t *hashcat_ctx)
 {
-  potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
+  const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
+  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return 0;
+
+  if (hashconfig->potfile_disable == true) return 0;
 
   if (hc_fopen (&potfile_ctx->fp, potfile_ctx->filename, "rb") == false)
   {
@@ -201,8 +204,8 @@ int potfile_read_open (hashcat_ctx_t *hashcat_ctx)
 
 void potfile_read_close (hashcat_ctx_t *hashcat_ctx)
 {
-  hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
-  potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
+  const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
+  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return;
 
@@ -215,9 +218,12 @@ void potfile_read_close (hashcat_ctx_t *hashcat_ctx)
 
 int potfile_write_open (hashcat_ctx_t *hashcat_ctx)
 {
-  potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
+  const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
+  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return 0;
+
+  if (hashconfig->potfile_disable == true) return 0;
 
   if (hc_fopen (&potfile_ctx->fp, potfile_ctx->filename, "ab") == false)
   {
@@ -231,8 +237,8 @@ int potfile_write_open (hashcat_ctx_t *hashcat_ctx)
 
 void potfile_write_close (hashcat_ctx_t *hashcat_ctx)
 {
-  hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
-  potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
+  const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
+  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return;
 

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -211,8 +211,6 @@ void potfile_read_close (hashcat_ctx_t *hashcat_ctx)
 
   if (hashconfig->potfile_disable == true) return;
 
-  if (potfile_ctx->fp.pfp == NULL) return;
-
   hc_fclose (&potfile_ctx->fp);
 }
 

--- a/src/stdout.c
+++ b/src/stdout.c
@@ -83,9 +83,15 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
   }
   else
   {
-    out.fp.is_gzip = false;
-    out.fp.pfp = stdout;
-    out.fp.fd = fileno (stdout);
+    HCFILE *fp = &out.fp;
+
+    fp->fd       = fileno (stdout);
+    fp->pfp      = stdout;
+    fp->gfp      = NULL;
+    fp->ufp      = NULL;
+    fp->bom_size = 0;
+    fp->path     = NULL;
+    fp->mode     = NULL;
   }
 
   out.len = 0;


### PR DESCRIPTION
In is_same_device_type() device name is compared twice, I removed the first one as boolean comparisons are quicker. In run_kernel() inside "if (device_param->is_cuda == true)" we have another "if (device_param->is_cuda == true)" and same repeats with other APIs. Finally hc_cuEventSynchronize() seems to be a leftover from previous merge that I did, and not needed as we only need to synchronize with the end, not with the beginning.

Also could we replace all separate "if (device_param->is_cuda == true)", "if (device_param->is_hip == true)" and "if (device_param->is_opencl == true)" with a if-else if-else (or if-else if-else if ) structure? Is there a reason to this? As device can only be one of these types at any moment.

Added some flushes needed by OpenCL per device.