### PR TITLE
Fixed segfault in potfile_handle_show()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -22,9 +22,9 @@
 - Fixed out-of-boundary read in input_tokenizer() if the signature in the hash is longer than the length of the plugin's signature constant
 - Fixed out-of-boundary read in the Stuffit5 module in hash_decode()
 - Fixed random rule generator option --generate-rules-func-min by fixing switch() case to not select a not existing option group type
+- Fixed segfault when a combination of the flags --user and --show is given and a hash was specified directly on the command line
 - Fixed syntax check of HAS_VPERM macro in several kernel includes causing invalid error message for AMD GPUs on Windows
 - Fixed uninitialized tmps variable in autotune for slow hashes by calling _init and _prepare kernel before calling _loop kernel
-- Fixed segfault in potfile_handle_show()
 
 ##
 ## Performance

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -24,6 +24,7 @@
 - Fixed random rule generator option --generate-rules-func-min by fixing switch() case to not select a not existing option group type
 - Fixed syntax check of HAS_VPERM macro in several kernel includes causing invalid error message for AMD GPUs on Windows
 - Fixed uninitialized tmps variable in autotune for slow hashes by calling _init and _prepare kernel before calling _loop kernel
+- Fixed segfault in potfile_handle_show()
 
 ##
 ## Performance

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1119,6 +1119,49 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
         int parser_status = PARSER_OK;
 
+        if (user_options->username == true)
+        {
+          char *user_buf = NULL;
+          int   user_len = 0;
+
+          hlfmt_user (hashcat_ctx, hashlist_format, input_buf, input_len, &user_buf, &user_len);
+
+          // special case:
+          // both hash_t need to have the username info if the pwdump format is used (i.e. we have 2 hashes for 3000, both with same user)
+
+          u32 hashes_per_user = 1;
+
+          if (hashconfig->opts_type & OPTS_TYPE_HASH_SPLIT)
+          {
+            // the following conditions should be true if (hashlist_format == HLFMT_PWDUMP)
+
+            if (hash_len == 32)
+            {
+              hashes_per_user = 2;
+            }
+          }
+
+          for (u32 i = 0; i < hashes_per_user; i++)
+          {
+            user_t **user = &hashes_buf[hashes_cnt + i].hash_info->user;
+
+            *user = (user_t *) hcmalloc (sizeof (user_t));
+
+            user_t *user_ptr = *user;
+
+            if (user_buf != NULL)
+            {
+              user_ptr->user_name = hcstrdup (user_buf);
+            }
+            else
+            {
+              user_ptr->user_name = hcstrdup ("");
+            }
+
+            user_ptr->user_len = (u32) user_len;
+          }
+        }
+
         if (hashconfig->opts_type & OPTS_TYPE_HASH_SPLIT)
         {
           if (hash_len == 32)


### PR DESCRIPTION
PoC

```
$ ./hashcat 'user_1234:b4b9b02e6f09a9bd760f388b67351e2b' -m 1000 -a3 hashca?l --user -D1 --quiet
b4b9b02e6f09a9bd760f388b67351e2b:hashcat
$ ./hashcat 'user_1234:b4b9b02e6f09a9bd760f388b67351e2b' -m 1000 -a3 hashca?l --user -D1 --quiet --show
AddressSanitizer:DEADLYSIGNAL
=================================================================
==34278==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000102b55184 bp 0x7ffeed241c70 sp 0x7ffeed23f440 T0)
==34278==The signal is caused by a WRITE memory access.
==34278==Hint: address points to the zero page.
    #0 0x102b55183 in potfile_handle_show potfile.c:809
    #1 0x102ad6617 in outer_loop hashcat.c:583
    #2 0x102ad4de2 in hashcat_session_execute hashcat.c:1657
    #3 0x1029be1c7 in main main.c:1271
    #4 0x7fff66b1a014 in start (libdyld.dylib:x86_64+0x1014)

==34278==Register values:
rax = 0x0000000000000000  rbx = 0x00007ffeed2415a0  rcx = 0x00006020000028d8  rdx = 0x0000000000000000  
rdi = 0x0000100000000000  rsi = 0x0000000000000000  rbp = 0x00007ffeed241c70  rsp = 0x00007ffeed23f440  
 r8 = 0x0000100021176a00   r9 = 0x0000616000002400  r10 = 0x0000000000000000  r11 = 0x0000000000000000  
r12 = 0x0000000000000000  r13 = 0x0000000000000000  r14 = 0x0000000000000000  r15 = 0x0000000000000000  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV potfile.c:809 in potfile_handle_show
==34278==ABORTING
Abort trap: 6
```