### PR TITLE
Assume hashconfig->tmp_size is the element size

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -987,7 +987,6 @@ typedef struct hashconfig
   u64   hook_extra_param_size;
   u64   hook_salt_size;
   u64   tmp_size;
-  u64   extra_tmp_size;
   u64   hook_size;
 
   // password length limit

--- a/src/backend.c
+++ b/src/backend.c
@@ -14581,7 +14581,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       // size_tmps
 
-      size_tmps = kernel_power_max * (hashconfig->tmp_size + hashconfig->extra_tmp_size);
+      size_tmps = kernel_power_max * hashconfig->tmp_size;
 
       // size_hooks
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1954,7 +1954,7 @@ int hashes_init_stage4 (hashcat_ctx_t *hashcat_ctx)
       return -1;
     }
 
-    hashconfig->extra_tmp_size = extra_tmp_size;
+    hashconfig->tmp_size = extra_tmp_size;
   }
 
   // at this point we no longer need hash_t* structure


### PR DESCRIPTION
In hashes.c, check_hash() if OPTS_TYPE_COPY_TMPS is true, we allocate buffer for tmps (actually only for one, not plural) which size is hashconfig->tmp_size. Hashconfig->tmp_size is a element/unit size, and we use it to calculate offset as multiply of plain->gidvid in following lines.

But there is small problem with hashconfig->tmp_size. It is not hashconfig->extra_tmp_size and it does not include the hashconfig->extra_tmp_size. In backend.c, backend_session_begin() we calculate size_tmps which is the total tmps device buffer size. Element size is calculated as sum of tmp_size + extra_tmp_size. In hashes.c, hashes_init_stage4() hashconfig->extra_tmp_size is acquired from module. 

After reading documents on OPTS_TYPE_COPY_TMPS and comment in hashes.c line 1944, and checking the current module implementations, I think better naming would have been module_ctx->module_dynamic_tmp_size.

But to fix potential bug, I have dropped hashconfig->extra_tmp_size. Return value of module_extra_tmp_size is the total size that should be used for tmp_size. Other possibility would have been in hashes.c line 1957, hashconfig->tmp_size += extra_tmp_size

But in the end, hashconfig->tmp_size must be the element size or we will have problem in check_hash().