### PR TITLE
workaround to 'clEnqueueWriteBuffer(): CL_INVALID_VALUE' with apple gpu

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -5156,6 +5156,15 @@ int run_opencl_kernel_bzero (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *devi
   const u64 num16d = size / 16;
   const u64 num16m = size % 16;
 
+  // with apple GPU clEnqueueWriteBuffer() return CL_INVALID_VALUE, workaround
+
+  if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE && \
+     (device_param->opencl_device_vendor_id == VENDOR_ID_INTEL_SDK || device_param->opencl_device_vendor_id == VENDOR_ID_APPLE) && \
+     device_param->opencl_device_type & CL_DEVICE_TYPE_GPU)
+  {
+    return run_opencl_kernel_memset (hashcat_ctx, device_param, buf, 0, 0, size);
+  }
+
   if (num16d)
   {
     const u64 kernel_threads = device_param->kernel_wgs_bzero;
@@ -5175,23 +5184,7 @@ int run_opencl_kernel_bzero (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *devi
 
   if (num16m)
   {
-    // with apple GPU clEnqueueWriteBuffer() return CL_INVALID_VALUE
-    // following a workaround
-
-    if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE && \
-       (device_param->opencl_device_vendor_id == VENDOR_ID_INTEL_SDK || device_param->opencl_device_vendor_id == VENDOR_ID_APPLE) && \
-       device_param->opencl_device_type & CL_DEVICE_TYPE_GPU)
-    {
-      u8 *bzeros_apple = (u8 *) hccalloc (num16m, sizeof (u8));
-
-      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, buf, CL_TRUE, num16d * 16, num16m, bzeros_apple, 0, NULL, NULL) == -1) return -1;
-
-      hcfree (bzeros_apple);
-    }
-    else
-    {
-      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, buf, CL_FALSE, num16d * 16, num16m, bzeros, 0, NULL, NULL) == -1) return -1;
-    }
+    if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, buf, CL_FALSE, num16d * 16, num16m, bzeros, 0, NULL, NULL) == -1) return -1;
   }
 
   return 0;

--- a/src/backend.c
+++ b/src/backend.c
@@ -5175,7 +5175,23 @@ int run_opencl_kernel_bzero (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *devi
 
   if (num16m)
   {
-    if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, buf, CL_FALSE, num16d * 16, num16m, bzeros, 0, NULL, NULL) == -1) return -1;
+    // with apple GPU clEnqueueWriteBuffer() return CL_INVALID_VALUE
+    // following a workaround
+
+    if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE && \
+       (device_param->opencl_device_vendor_id == VENDOR_ID_INTEL_SDK || device_param->opencl_device_vendor_id == VENDOR_ID_APPLE) && \
+       device_param->opencl_device_type & CL_DEVICE_TYPE_GPU)
+    {
+      u8 *bzeros_apple = (u8 *) hccalloc (num16m, sizeof (u8));
+
+      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, buf, CL_TRUE, num16d * 16, num16m, bzeros_apple, 0, NULL, NULL) == -1) return -1;
+
+      hcfree (bzeros_apple);
+    }
+    else
+    {
+      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, buf, CL_FALSE, num16d * 16, num16m, bzeros, 0, NULL, NULL) == -1) return -1;
+    }
   }
 
   return 0;


### PR DESCRIPTION
Hi,

the latest engine changes have broken gpu support on apple.

```
$ ./hashcat -b -m 0 -D2
hashcat (v6.2.3-220-gbeaa4e0da) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (May  7 2020 00:10:14)) - Platform #1 [Apple]
====================================================================
* Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, skipped
* Device #2: Iris, 1472/1536 MB (384 MB allocatable), 40MCU

Benchmark relevant options:
===========================
* --opencl-device-types=2
* --optimized-kernel-enable

Hashmode: 0 - MD5

clEnqueueWriteBuffer(): CL_INVALID_VALUE

Started: Fri Aug 13 15:59:40 2021
Stopped: Fri Aug 13 15:59:45 2021
```

@jtojanen please check this patch

Thanks