### PR TITLE
Use pinned host buffers for device <-> host transfers

### DIFF
--- a/include/backend.h
+++ b/include/backend.h
@@ -73,6 +73,8 @@ int hc_cuMemcpyDtoDAsync         (hashcat_ctx_t *hashcat_ctx, CUdeviceptr dstDev
 int hc_cuMemcpyDtoHAsync         (hashcat_ctx_t *hashcat_ctx, void *dstHost, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream);
 int hc_cuMemcpyHtoDAsync         (hashcat_ctx_t *hashcat_ctx, CUdeviceptr dstDevice, const void *srcHost, size_t ByteCount, CUstream hStream);
 int hc_cuMemFree                 (hashcat_ctx_t *hashcat_ctx, CUdeviceptr dptr);
+int hc_cuMemFreeHost             (hashcat_ctx_t *hashcat_ctx, void *p);
+int hc_cuMemHostAlloc            (hashcat_ctx_t *hashcat_ctx, void **pp, size_t bytesize, unsigned int Flags);
 int hc_cuMemsetD32Async          (hashcat_ctx_t *hashcat_ctx, CUdeviceptr dstDevice, unsigned int ui, size_t N, CUstream hStream);
 int hc_cuMemsetD8Async           (hashcat_ctx_t *hashcat_ctx, CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream);
 int hc_cuModuleGetFunction       (hashcat_ctx_t *hashcat_ctx, CUfunction *hfunc, CUmodule hmod, const char *name);
@@ -115,6 +117,8 @@ int hc_hipEventQuery             (hashcat_ctx_t *hashcat_ctx, hipEvent_t hEvent)
 int hc_hipEventRecord            (hashcat_ctx_t *hashcat_ctx, hipEvent_t hEvent, hipStream_t hStream);
 int hc_hipEventSynchronize       (hashcat_ctx_t *hashcat_ctx, hipEvent_t hEvent);
 int hc_hipFuncGetAttribute       (hashcat_ctx_t *hashcat_ctx, int *pi, hipFunction_attribute attrib, hipFunction_t hfunc);
+int hc_hipHostFree               (hashcat_ctx_t *hashcat_ctx, void *p);
+int hc_hipHostMalloc             (hashcat_ctx_t *hashcat_ctx, void **pp, size_t bytesize, unsigned int flags);
 int hc_hipInit                   (hashcat_ctx_t *hashcat_ctx, unsigned int Flags);
 int hc_hipLaunchKernel           (hashcat_ctx_t *hashcat_ctx, hipFunction_t f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t hStream, void **kernelParams, void **extra);
 int hc_hipMemAlloc               (hashcat_ctx_t *hashcat_ctx, hipDeviceptr_t *dptr, size_t bytesize);

--- a/include/ext_cuda.h
+++ b/include/ext_cuda.h
@@ -987,6 +987,28 @@ typedef enum CUjitInputType_enum
     CU_JIT_NUM_INPUT_TYPES
 } CUjitInputType;
 
+
+/**
+ * If set, host memory is portable between CUDA contexts.
+ * Flag for ::cuMemHostAlloc()
+ */
+#define CU_MEMHOSTALLOC_PORTABLE        0x01
+
+/**
+ * If set, host memory is mapped into CUDA address space and
+ * ::cuMemHostGetDevicePointer() may be called on the host pointer.
+ * Flag for ::cuMemHostAlloc()
+ */
+#define CU_MEMHOSTALLOC_DEVICEMAP       0x02
+
+/**
+ * If set, host memory is allocated as write-combined - fast to write,
+ * faster to DMA, slow to read except via SSE4 streaming load instruction
+ * (MOVNTDQA).
+ * Flag for ::cuMemHostAlloc()
+ */
+#define CU_MEMHOSTALLOC_WRITECOMBINED   0x04
+
 #ifdef _WIN32
 #define CUDAAPI __stdcall
 #else
@@ -1027,13 +1049,13 @@ typedef CUresult (CUDA_API_CALL *CUDA_CUGETERRORSTRING)         (CUresult, const
 typedef CUresult (CUDA_API_CALL *CUDA_CUINIT)                   (unsigned int);
 typedef CUresult (CUDA_API_CALL *CUDA_CULAUNCHKERNEL)           (CUfunction, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, CUstream, void **, void **);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMALLOC)               (CUdeviceptr *, size_t);
-typedef CUresult (CUDA_API_CALL *CUDA_CUMEMALLOCHOST)           (void **, size_t);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMCPYDTODASYNC)        (CUdeviceptr, CUdeviceptr, size_t, CUstream);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMCPYDTOHASYNC)        (void *, CUdeviceptr, size_t, CUstream);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMCPYHTODASYNC)        (CUdeviceptr, const void *, size_t, CUstream);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMFREE)                (CUdeviceptr);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMFREEHOST)            (void *);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMGETINFO)             (size_t *, size_t *);
+typedef CUresult (CUDA_API_CALL *CUDA_CUMEMHOSTALLOC)           (void **, size_t, unsigned int);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMSETD32ASYNC)         (CUdeviceptr, unsigned int, size_t, CUstream);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMEMSETD8ASYNC)          (CUdeviceptr, unsigned char, size_t, CUstream);
 typedef CUresult (CUDA_API_CALL *CUDA_CUMODULEGETFUNCTION)      (CUfunction *, CUmodule, const char *);
@@ -1089,13 +1111,13 @@ typedef struct hc_cuda_lib
   CUDA_CUINIT                   cuInit;
   CUDA_CULAUNCHKERNEL           cuLaunchKernel;
   CUDA_CUMEMALLOC               cuMemAlloc;
-  CUDA_CUMEMALLOCHOST           cuMemAllocHost;
   CUDA_CUMEMCPYDTODASYNC        cuMemcpyDtoDAsync;
   CUDA_CUMEMCPYDTOHASYNC        cuMemcpyDtoHAsync;
   CUDA_CUMEMCPYHTODASYNC        cuMemcpyHtoDAsync;
   CUDA_CUMEMFREE                cuMemFree;
   CUDA_CUMEMFREEHOST            cuMemFreeHost;
   CUDA_CUMEMGETINFO             cuMemGetInfo;
+  CUDA_CUMEMHOSTALLOC           cuMemHostAlloc;
   CUDA_CUMEMSETD32ASYNC         cuMemsetD32Async;
   CUDA_CUMEMSETD8ASYNC          cuMemsetD8Async;
   CUDA_CUMODULEGETFUNCTION      cuModuleGetFunction;

--- a/include/ext_hip.h
+++ b/include/ext_hip.h
@@ -309,6 +309,15 @@ typedef enum hipDeviceAttribute_t {
                 /// no-op on CUDA platforms.
 
 
+//! Flags that can be used with hipHostMalloc:
+#define hipHostMallocDefault        0x0
+#define hipHostMallocPortable       0x1
+#define hipHostMallocMapped         0x2
+#define hipHostMallocWriteCombined  0x4
+#define hipHostMallocCoherent       0x40000000
+#define hipHostMallocNonCoherent    0x80000000
+
+
 #define hipDeviceScheduleAuto 0x0  ///< Automatically select between Spin and Yield
 #define hipDeviceScheduleSpin                                                                      \
     0x1  ///< Dedicate a CPU core to spin-wait.  Provides lowest latency, but burns a CPU core and
@@ -372,6 +381,8 @@ typedef hipError_t (HIP_API_CALL *HIP_HIPEVENTSYNCHRONIZE)       (hipEvent_t);
 typedef hipError_t (HIP_API_CALL *HIP_HIPFUNCGETATTRIBUTE)       (int *, hipFunction_attribute, hipFunction_t);
 typedef hipError_t (HIP_API_CALL *HIP_HIPGETERRORNAME)           (hipError_t, const char **);
 typedef hipError_t (HIP_API_CALL *HIP_HIPGETERRORSTRING)         (hipError_t, const char **);
+typedef hipError_t (HIP_API_CALL *HIP_HIPHOSTMALLOC)             (void **, size_t, unsigned int);
+typedef hipError_t (HIP_API_CALL *HIP_HIPHOSTFREE)               (void *);
 typedef hipError_t (HIP_API_CALL *HIP_HIPINIT)                   (unsigned int);
 typedef hipError_t (HIP_API_CALL *HIP_HIPLAUNCHKERNEL)           (hipFunction_t, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, hipStream_t, void **, void **);
 typedef hipError_t (HIP_API_CALL *HIP_HIPMEMALLOC)               (hipDeviceptr_t *, size_t);
@@ -415,6 +426,8 @@ typedef struct hc_hip_lib
   HIP_HIPFUNCGETATTRIBUTE       hipFuncGetAttribute;
   HIP_HIPGETERRORNAME           hipGetErrorName;
   HIP_HIPGETERRORSTRING         hipGetErrorString;
+  HIP_HIPHOSTFREE               hipHostFree;
+  HIP_HIPHOSTMALLOC             hipHostMalloc;
   HIP_HIPINIT                   hipInit;
   HIP_HIPLAUNCHKERNEL           hipLaunchKernel;
   HIP_HIPMEMALLOC               hipMemAlloc;

--- a/include/types.h
+++ b/include/types.h
@@ -1668,10 +1668,12 @@ typedef struct hc_device_param
   cl_mem            opencl_d_st_salts_buf;
   cl_mem            opencl_d_st_esalts_buf;
 
+  cl_mem            opencl_h_hooks;
   cl_mem            opencl_h_plain_bufs;
   cl_mem            opencl_h_results;
   cl_mem            opencl_h_tmps;
 
+  /* TODO: possible relocate and rename these?? */
   void             *h_plain_bufs;
   void             *h_results;
   void             *h_tmps;

--- a/include/types.h
+++ b/include/types.h
@@ -1669,13 +1669,14 @@ typedef struct hc_device_param
   cl_mem            opencl_d_st_esalts_buf;
 
   cl_mem            opencl_h_hooks;
+  cl_mem            opencl_h_pws_idx;
   cl_mem            opencl_h_plain_bufs;
   cl_mem            opencl_h_results;
   cl_mem            opencl_h_tmps;
 
   /* TODO: possible relocate and rename these?? */
   void             *h_plain_bufs;
-  void             *h_results;
+  u32              *h_results;
   void             *h_tmps;
 
 } hc_device_param_t;

--- a/include/types.h
+++ b/include/types.h
@@ -1669,8 +1669,10 @@ typedef struct hc_device_param
   cl_mem            opencl_d_st_esalts_buf;
 
   cl_mem            opencl_h_results;
+  cl_mem            opencl_h_tmps;
 
   u32              *h_results;
+  void             *h_tmps;
 
 } hc_device_param_t;
 

--- a/include/types.h
+++ b/include/types.h
@@ -1490,7 +1490,7 @@ typedef struct hc_device_param
   CUdeviceptr       cuda_d_esalt_bufs;
   CUdeviceptr       cuda_d_tmps;
   CUdeviceptr       cuda_d_hooks;
-  CUdeviceptr       cuda_d_result;
+  CUdeviceptr       cuda_d_results;
   CUdeviceptr       cuda_d_extra0_buf;
   CUdeviceptr       cuda_d_extra1_buf;
   CUdeviceptr       cuda_d_extra2_buf;
@@ -1572,7 +1572,7 @@ typedef struct hc_device_param
   hipDeviceptr_t    hip_d_esalt_bufs;
   hipDeviceptr_t    hip_d_tmps;
   hipDeviceptr_t    hip_d_hooks;
-  hipDeviceptr_t    hip_d_result;
+  hipDeviceptr_t    hip_d_results;
   hipDeviceptr_t    hip_d_extra0_buf;
   hipDeviceptr_t    hip_d_extra1_buf;
   hipDeviceptr_t    hip_d_extra2_buf;
@@ -1658,7 +1658,7 @@ typedef struct hc_device_param
   cl_mem            opencl_d_esalt_bufs;
   cl_mem            opencl_d_tmps;
   cl_mem            opencl_d_hooks;
-  cl_mem            opencl_d_result;
+  cl_mem            opencl_d_results;
   cl_mem            opencl_d_extra0_buf;
   cl_mem            opencl_d_extra1_buf;
   cl_mem            opencl_d_extra2_buf;

--- a/include/types.h
+++ b/include/types.h
@@ -1669,6 +1669,10 @@ typedef struct hc_device_param
   cl_mem            opencl_d_st_salts_buf;
   cl_mem            opencl_d_st_esalts_buf;
 
+  cl_mem            opencl_h_results;
+
+  u32              *h_results;
+
 } hc_device_param_t;
 
 typedef struct backend_ctx

--- a/include/types.h
+++ b/include/types.h
@@ -1673,7 +1673,7 @@ typedef struct hc_device_param
   cl_mem            opencl_h_tmps;
 
   void             *h_plain_bufs;
-  u32              *h_results;
+  void             *h_results;
   void             *h_tmps;
 
 } hc_device_param_t;

--- a/include/types.h
+++ b/include/types.h
@@ -1668,9 +1668,11 @@ typedef struct hc_device_param
   cl_mem            opencl_d_st_salts_buf;
   cl_mem            opencl_d_st_esalts_buf;
 
+  cl_mem            opencl_h_plain_bufs;
   cl_mem            opencl_h_results;
   cl_mem            opencl_h_tmps;
 
+  void             *h_plain_bufs;
   u32              *h_results;
   void             *h_tmps;
 

--- a/src/autotune.c
+++ b/src/autotune.c
@@ -431,7 +431,7 @@ static int autotune (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_digests_shown, device_param->size_shown) == -1) return -1;
 
-    if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_result, device_param->size_results) == -1) return -1;
+    if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_results, device_param->size_results) == -1) return -1;
 
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_tmps, device_param->size_tmps) == -1) return -1;
   }
@@ -444,7 +444,7 @@ static int autotune (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_digests_shown, device_param->size_shown) == -1) return -1;
 
-    if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_result, device_param->size_results) == -1) return -1;
+    if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_results, device_param->size_results) == -1) return -1;
 
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_tmps, device_param->size_tmps) == -1) return -1;
   }
@@ -457,7 +457,7 @@ static int autotune (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
     if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_digests_shown, device_param->size_shown) == -1) return -1;
 
-    if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_result, device_param->size_results) == -1) return -1;
+    if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_results, device_param->size_results) == -1) return -1;
 
     if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_tmps, device_param->size_tmps) == -1) return -1;
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -12085,9 +12085,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_st_digests_buf, size_st_digests)         == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_st_salts_buf,   size_st_salts)           == -1) return -1;
 
-      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_plain_bufs, size_plains, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
-      /* assert size_results == sizeof(u32) */
-      if (hc_cuMemHostAlloc (hashcat_ctx, (void **) &device_param->h_results, size_results, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_plain_bufs, size_plains,  CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_results,    size_results, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
 
       if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_bitmap_s1_a, bitmap_ctx->bitmap_s1_a, bitmap_ctx->bitmap_size, device_param->cuda_stream) == -1) return -1;
       if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_bitmap_s1_b, bitmap_ctx->bitmap_s1_b, bitmap_ctx->bitmap_size, device_param->cuda_stream) == -1) return -1;
@@ -12199,9 +12198,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_st_digests_buf, size_st_digests)         == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_st_salts_buf,   size_st_salts)           == -1) return -1;
 
-      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_plain_bufs, size_plains, hipHostMallocPortable) == -1) return -1;
-      /* assert size_results == sizeof(u32) */
-      if (hc_hipHostMalloc (hashcat_ctx, (void **) &device_param->h_results, size_results, hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_plain_bufs, size_plains,  hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_results,    size_results, hipHostMallocPortable) == -1) return -1;
 
       if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_bitmap_s1_a, bitmap_ctx->bitmap_s1_a, bitmap_ctx->bitmap_size, device_param->hip_stream) == -1) return -1;
       if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_bitmap_s1_b, bitmap_ctx->bitmap_s1_b, bitmap_ctx->bitmap_size, device_param->hip_stream) == -1) return -1;
@@ -12313,12 +12311,11 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_ONLY,   size_st_digests,         NULL, &device_param->opencl_d_st_digests_buf) == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_ONLY,   size_st_salts,           NULL, &device_param->opencl_d_st_salts_buf)   == -1) return -1;
 
-      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY | CL_MEM_WRITE_ONLY, size_plains,  NULL, &device_param->opencl_h_plain_bufs) == -1) return -1;
-      /* assert size_results == sizeof(u32) */
-      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY | CL_MEM_WRITE_ONLY, size_results, NULL, &device_param->opencl_h_results   ) == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, size_plains,  NULL, &device_param->opencl_h_plain_bufs) == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, size_results, NULL, &device_param->opencl_h_results   ) == -1) return -1;
 
-      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_plain_bufs, CL_FALSE, CL_MAP_READ, 0, size_plains,  0, NULL, NULL, &device_param->h_plain_bufs)        == -1) return -1;
-      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_results,    CL_FALSE, CL_MAP_READ, 0, size_results, 0, NULL, NULL, (void **) &device_param->h_results) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_plain_bufs, CL_FALSE, CL_MAP_READ, 0, size_plains,  0, NULL, NULL, &device_param->h_plain_bufs) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_results,    CL_FALSE, CL_MAP_READ, 0, size_results, 0, NULL, NULL, &device_param->h_results   ) == -1) return -1;
 
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_bitmap_s1_a, CL_FALSE, 0, bitmap_ctx->bitmap_size, bitmap_ctx->bitmap_s1_a, 0, NULL, NULL) == -1) return -1;
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_bitmap_s1_b, CL_FALSE, 0, bitmap_ctx->bitmap_size, bitmap_ctx->bitmap_s1_b, 0, NULL, NULL) == -1) return -1;

--- a/src/backend.c
+++ b/src/backend.c
@@ -12077,7 +12077,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_digests_buf,    size_digests)            == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_digests_shown,  size_shown)              == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_salt_bufs,      size_salts)              == -1) return -1;
-      if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_result,         size_results)            == -1) return -1;
+      if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_results,        size_results)            == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_extra0_buf,     size_extra_buffer / 4)   == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_extra1_buf,     size_extra_buffer / 4)   == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_extra2_buf,     size_extra_buffer / 4)   == -1) return -1;
@@ -12187,7 +12187,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_digests_buf,    size_digests)            == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_digests_shown,  size_shown)              == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_salt_bufs,      size_salts)              == -1) return -1;
-      if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_result,         size_results)            == -1) return -1;
+      if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_results,        size_results)            == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_extra0_buf,     size_extra_buffer / 4)   == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_extra1_buf,     size_extra_buffer / 4)   == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_extra2_buf,     size_extra_buffer / 4)   == -1) return -1;
@@ -12297,7 +12297,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_ONLY,   size_digests,            NULL, &device_param->opencl_d_digests_buf)    == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_shown,              NULL, &device_param->opencl_d_digests_shown)  == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_ONLY,   size_salts,              NULL, &device_param->opencl_d_salt_bufs)      == -1) return -1;
-      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_results,            NULL, &device_param->opencl_d_result)         == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_results,            NULL, &device_param->opencl_d_results)        == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_extra_buffer / 4,   NULL, &device_param->opencl_d_extra0_buf)     == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_extra_buffer / 4,   NULL, &device_param->opencl_d_extra1_buf)     == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_extra_buffer / 4,   NULL, &device_param->opencl_d_extra2_buf)     == -1) return -1;
@@ -12412,7 +12412,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[16] = &device_param->cuda_d_digests_shown;
       device_param->kernel_params[17] = &device_param->cuda_d_salt_bufs;
       device_param->kernel_params[18] = &device_param->cuda_d_esalt_bufs;
-      device_param->kernel_params[19] = &device_param->cuda_d_result;
+      device_param->kernel_params[19] = &device_param->cuda_d_results;
       device_param->kernel_params[20] = &device_param->cuda_d_extra0_buf;
       device_param->kernel_params[21] = &device_param->cuda_d_extra1_buf;
       device_param->kernel_params[22] = &device_param->cuda_d_extra2_buf;
@@ -12440,7 +12440,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[16] = &device_param->hip_d_digests_shown;
       device_param->kernel_params[17] = &device_param->hip_d_salt_bufs;
       device_param->kernel_params[18] = &device_param->hip_d_esalt_bufs;
-      device_param->kernel_params[19] = &device_param->hip_d_result;
+      device_param->kernel_params[19] = &device_param->hip_d_results;
       device_param->kernel_params[20] = &device_param->hip_d_extra0_buf;
       device_param->kernel_params[21] = &device_param->hip_d_extra1_buf;
       device_param->kernel_params[22] = &device_param->hip_d_extra2_buf;
@@ -12468,7 +12468,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[16] = &device_param->opencl_d_digests_shown;
       device_param->kernel_params[17] = &device_param->opencl_d_salt_bufs;
       device_param->kernel_params[18] = &device_param->opencl_d_esalt_bufs;
-      device_param->kernel_params[19] = &device_param->opencl_d_result;
+      device_param->kernel_params[19] = &device_param->opencl_d_results;
       device_param->kernel_params[20] = &device_param->opencl_d_extra0_buf;
       device_param->kernel_params[21] = &device_param->opencl_d_extra1_buf;
       device_param->kernel_params[22] = &device_param->opencl_d_extra2_buf;
@@ -13267,7 +13267,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_plain_bufs,    device_param->size_plains)  == -1) return -1;
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_digests_shown, device_param->size_shown)   == -1) return -1;
-      if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_result,        device_param->size_results) == -1) return -1;
+      if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_results,       device_param->size_results) == -1) return -1;
 
       /**
        * special buffers
@@ -13869,7 +13869,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_plain_bufs,    device_param->size_plains)  == -1) return -1;
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_digests_shown, device_param->size_shown)   == -1) return -1;
-      if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_result,        device_param->size_results) == -1) return -1;
+      if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_results,       device_param->size_results) == -1) return -1;
 
       /**
        * special buffers
@@ -14473,7 +14473,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_plain_bufs,    device_param->size_plains)   == -1) return -1;
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_digests_shown, device_param->size_shown)    == -1) return -1;
-      if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_result,        device_param->size_results)  == -1) return -1;
+      if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_results,       device_param->size_results)  == -1) return -1;
 
       /**
        * special buffers
@@ -15221,7 +15221,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->cuda_d_esalt_bufs)     hc_cuMemFree (hashcat_ctx, device_param->cuda_d_esalt_bufs);
       if (device_param->cuda_d_tmps)           hc_cuMemFree (hashcat_ctx, device_param->cuda_d_tmps);
       if (device_param->cuda_d_hooks)          hc_cuMemFree (hashcat_ctx, device_param->cuda_d_hooks);
-      if (device_param->cuda_d_result)         hc_cuMemFree (hashcat_ctx, device_param->cuda_d_result);
+      if (device_param->cuda_d_results)        hc_cuMemFree (hashcat_ctx, device_param->cuda_d_results);
       if (device_param->cuda_d_extra0_buf)     hc_cuMemFree (hashcat_ctx, device_param->cuda_d_extra0_buf);
       if (device_param->cuda_d_extra1_buf)     hc_cuMemFree (hashcat_ctx, device_param->cuda_d_extra1_buf);
       if (device_param->cuda_d_extra2_buf)     hc_cuMemFree (hashcat_ctx, device_param->cuda_d_extra2_buf);
@@ -15271,7 +15271,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       device_param->cuda_d_esalt_bufs         = 0;
       device_param->cuda_d_tmps               = 0;
       device_param->cuda_d_hooks              = 0;
-      device_param->cuda_d_result             = 0;
+      device_param->cuda_d_results            = 0;
       device_param->cuda_d_extra0_buf         = 0;
       device_param->cuda_d_extra1_buf         = 0;
       device_param->cuda_d_extra2_buf         = 0;
@@ -15350,7 +15350,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->hip_d_esalt_bufs)     hc_hipMemFree (hashcat_ctx, device_param->hip_d_esalt_bufs);
       if (device_param->hip_d_tmps)           hc_hipMemFree (hashcat_ctx, device_param->hip_d_tmps);
       if (device_param->hip_d_hooks)          hc_hipMemFree (hashcat_ctx, device_param->hip_d_hooks);
-      if (device_param->hip_d_result)         hc_hipMemFree (hashcat_ctx, device_param->hip_d_result);
+      if (device_param->hip_d_results)        hc_hipMemFree (hashcat_ctx, device_param->hip_d_results);
       if (device_param->hip_d_extra0_buf)     hc_hipMemFree (hashcat_ctx, device_param->hip_d_extra0_buf);
       if (device_param->hip_d_extra1_buf)     hc_hipMemFree (hashcat_ctx, device_param->hip_d_extra1_buf);
       if (device_param->hip_d_extra2_buf)     hc_hipMemFree (hashcat_ctx, device_param->hip_d_extra2_buf);
@@ -15400,7 +15400,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       device_param->hip_d_esalt_bufs         = 0;
       device_param->hip_d_tmps               = 0;
       device_param->hip_d_hooks              = 0;
-      device_param->hip_d_result             = 0;
+      device_param->hip_d_results            = 0;
       device_param->hip_d_extra0_buf         = 0;
       device_param->hip_d_extra1_buf         = 0;
       device_param->hip_d_extra2_buf         = 0;
@@ -15479,7 +15479,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->opencl_d_esalt_bufs)     hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_esalt_bufs);
       if (device_param->opencl_d_tmps)           hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_tmps);
       if (device_param->opencl_d_hooks)          hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_hooks);
-      if (device_param->opencl_d_result)         hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_result);
+      if (device_param->opencl_d_results)        hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_results);
       if (device_param->opencl_d_extra0_buf)     hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_extra0_buf);
       if (device_param->opencl_d_extra1_buf)     hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_extra1_buf);
       if (device_param->opencl_d_extra2_buf)     hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_extra2_buf);
@@ -15551,7 +15551,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       device_param->opencl_d_esalt_bufs        = NULL;
       device_param->opencl_d_tmps              = NULL;
       device_param->opencl_d_hooks             = NULL;
-      device_param->opencl_d_result            = NULL;
+      device_param->opencl_d_results           = NULL;
       device_param->opencl_d_extra0_buf        = NULL;
       device_param->opencl_d_extra1_buf        = NULL;
       device_param->opencl_d_extra2_buf        = NULL;

--- a/src/backend.c
+++ b/src/backend.c
@@ -12077,8 +12077,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_st_digests_buf, size_st_digests)         == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_st_salts_buf,   size_st_salts)           == -1) return -1;
 
-      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_plain_bufs, size_plains,  CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
-      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_results,    size_results, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, (void **) &device_param->h_plain_bufs, size_plains,  CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, (void **) &device_param->h_results,    size_results, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
 
       if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_bitmap_s1_a, bitmap_ctx->bitmap_s1_a, bitmap_ctx->bitmap_size, device_param->cuda_stream) == -1) return -1;
       if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_bitmap_s1_b, bitmap_ctx->bitmap_s1_b, bitmap_ctx->bitmap_size, device_param->cuda_stream) == -1) return -1;
@@ -12189,8 +12189,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_st_digests_buf, size_st_digests)         == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_st_salts_buf,   size_st_salts)           == -1) return -1;
 
-      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_plain_bufs, size_plains,  hipHostMallocPortable) == -1) return -1;
-      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_results,    size_results, hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, (void **) &device_param->h_plain_bufs, size_plains,  hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, (void **) &device_param->h_results,    size_results, hipHostMallocPortable) == -1) return -1;
 
       if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_bitmap_s1_a, bitmap_ctx->bitmap_s1_a, bitmap_ctx->bitmap_size, device_param->hip_stream) == -1) return -1;
       if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_bitmap_s1_b, bitmap_ctx->bitmap_s1_b, bitmap_ctx->bitmap_size, device_param->hip_stream) == -1) return -1;
@@ -12304,8 +12304,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, size_plains,  NULL, &device_param->opencl_h_plain_bufs) == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, size_results, NULL, &device_param->opencl_h_results   ) == -1) return -1;
 
-      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_plain_bufs, CL_FALSE, CL_MAP_READ, 0, size_plains,  0, NULL, NULL, &device_param->h_plain_bufs) == -1) return -1;
-      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_results,    CL_FALSE, CL_MAP_READ, 0, size_results, 0, NULL, NULL, &device_param->h_results   ) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_plain_bufs, CL_FALSE, CL_MAP_READ, 0, size_plains,  0, NULL, NULL, (void **) &device_param->h_plain_bufs) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_results,    CL_FALSE, CL_MAP_READ, 0, size_results, 0, NULL, NULL, (void **) &device_param->h_results   ) == -1) return -1;
 
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_bitmap_s1_a, CL_FALSE, 0, bitmap_ctx->bitmap_size, bitmap_ctx->bitmap_s1_a, 0, NULL, NULL) == -1) return -1;
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_bitmap_s1_b, CL_FALSE, 0, bitmap_ctx->bitmap_size, bitmap_ctx->bitmap_s1_b, 0, NULL, NULL) == -1) return -1;
@@ -12420,8 +12420,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[22] = &device_param->cuda_d_extra2_buf;
       device_param->kernel_params[23] = &device_param->cuda_d_extra3_buf;
     }
-
-    if (device_param->is_hip == true)
+    else if (device_param->is_hip == true)
     {
       device_param->kernel_params[ 0] = NULL; // &device_param->hip_d_pws_buf;
       device_param->kernel_params[ 1] = &device_param->hip_d_rules_c;
@@ -12448,8 +12447,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[22] = &device_param->hip_d_extra2_buf;
       device_param->kernel_params[23] = &device_param->hip_d_extra3_buf;
     }
-
-    if (device_param->is_opencl == true)
+    else /* if (device_param->is_opencl == true) */
     {
       device_param->kernel_params[ 0] = NULL; // &device_param->opencl_d_pws_buf;
       device_param->kernel_params[ 1] = &device_param->opencl_d_rules_c;
@@ -12509,13 +12507,11 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         {
           device_param->kernel_params_mp[0] = &device_param->cuda_d_combs;
         }
-
-        if (device_param->is_hip == true)
+        else if (device_param->is_hip == true)
         {
           device_param->kernel_params_mp[0] = &device_param->hip_d_combs;
         }
-
-        if (device_param->is_opencl == true)
+        else /* if (device_param->is_opencl == true) */
         {
           device_param->kernel_params_mp[0] = &device_param->opencl_d_combs;
         }
@@ -12528,13 +12524,11 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
           {
             device_param->kernel_params_mp[0] = &device_param->cuda_d_combs;
           }
-
-          if (device_param->is_hip == true)
+          else if (device_param->is_hip == true)
           {
             device_param->kernel_params_mp[0] = &device_param->hip_d_combs;
           }
-
-          if (device_param->is_opencl == true)
+          else /* if (device_param->is_opencl == true) */
           {
             device_param->kernel_params_mp[0] = &device_param->opencl_d_combs;
           }
@@ -12552,14 +12546,12 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         device_param->kernel_params_mp[1] = &device_param->cuda_d_root_css_buf;
         device_param->kernel_params_mp[2] = &device_param->cuda_d_markov_css_buf;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         device_param->kernel_params_mp[1] = &device_param->hip_d_root_css_buf;
         device_param->kernel_params_mp[2] = &device_param->hip_d_markov_css_buf;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         device_param->kernel_params_mp[1] = &device_param->opencl_d_root_css_buf;
         device_param->kernel_params_mp[2] = &device_param->opencl_d_markov_css_buf;
@@ -12589,14 +12581,12 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         device_param->kernel_params_mp_l[1] = &device_param->cuda_d_root_css_buf;
         device_param->kernel_params_mp_l[2] = &device_param->cuda_d_markov_css_buf;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         device_param->kernel_params_mp_l[1] = &device_param->hip_d_root_css_buf;
         device_param->kernel_params_mp_l[2] = &device_param->hip_d_markov_css_buf;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         device_param->kernel_params_mp_l[1] = &device_param->opencl_d_root_css_buf;
         device_param->kernel_params_mp_l[2] = &device_param->opencl_d_markov_css_buf;
@@ -12623,15 +12613,13 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         device_param->kernel_params_mp_r[1] = &device_param->cuda_d_root_css_buf;
         device_param->kernel_params_mp_r[2] = &device_param->cuda_d_markov_css_buf;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         device_param->kernel_params_mp_r[0] = &device_param->hip_d_bfs;
         device_param->kernel_params_mp_r[1] = &device_param->hip_d_root_css_buf;
         device_param->kernel_params_mp_r[2] = &device_param->hip_d_markov_css_buf;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         device_param->kernel_params_mp_r[0] = &device_param->opencl_d_bfs;
         device_param->kernel_params_mp_r[1] = &device_param->opencl_d_root_css_buf;
@@ -12656,8 +12644,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         device_param->kernel_params_amp[3] = &device_param->cuda_d_combs_c;
         device_param->kernel_params_amp[4] = &device_param->cuda_d_bfs_c;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         device_param->kernel_params_amp[0] = NULL; // &device_param->hip_d_pws_buf;
         device_param->kernel_params_amp[1] = NULL; // &device_param->hip_d_pws_amp_buf;
@@ -12665,8 +12652,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         device_param->kernel_params_amp[3] = &device_param->hip_d_combs_c;
         device_param->kernel_params_amp[4] = &device_param->hip_d_bfs_c;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         device_param->kernel_params_amp[0] = NULL; // &device_param->opencl_d_pws_buf;
         device_param->kernel_params_amp[1] = NULL; // &device_param->opencl_d_pws_amp_buf;
@@ -12683,14 +12669,12 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         device_param->kernel_params_tm[0] = &device_param->cuda_d_bfs_c;
         device_param->kernel_params_tm[1] = &device_param->cuda_d_tm_c;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         device_param->kernel_params_tm[0] = &device_param->hip_d_bfs_c;
         device_param->kernel_params_tm[1] = &device_param->hip_d_tm_c;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         device_param->kernel_params_tm[0] = &device_param->opencl_d_bfs_c;
         device_param->kernel_params_tm[1] = &device_param->opencl_d_tm_c;
@@ -12729,8 +12713,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
                                                         // ? &device_param->cuda_d_pws_buf
                                                         // : &device_param->cuda_d_pws_amp_buf;
     }
-
-    if (device_param->is_hip == true)
+    else if (device_param->is_hip == true)
     {
       device_param->kernel_params_decompress[0] = NULL; // &device_param->hip_d_pws_idx;
       device_param->kernel_params_decompress[1] = NULL; // &device_param->hip_d_pws_comp_buf;
@@ -12738,8 +12721,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
                                                         // ? &device_param->hip_d_pws_buf
                                                         // : &device_param->hip_d_pws_amp_buf;
     }
-
-    if (device_param->is_opencl == true)
+    else /* if (device_param->is_opencl == true) */
     {
       device_param->kernel_params_decompress[0] = NULL; // &device_param->opencl_d_pws_idx;
       device_param->kernel_params_decompress[1] = NULL; // &device_param->opencl_d_pws_comp_buf;
@@ -14879,8 +14861,9 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_tmps,         size_tmps)     == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_hooks,        size_hooks)    == -1) return -1;
 
-      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->hooks_buf, size_hooks,           CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
-      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_tmps,    hashconfig->tmp_size, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, (void **) &device_param->hooks_buf, size_hooks,           CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, (void **) &device_param->pws_idx,   size_pws_idx,         CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, (void **) &device_param->h_tmps,    hashconfig->tmp_size, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
 
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_pws_buf,       device_param->size_pws)      == -1) return -1;
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_pws_amp_buf,   device_param->size_pws_amp)  == -1) return -1;
@@ -14898,8 +14881,9 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_tmps,         size_tmps)     == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_hooks,        size_hooks)    == -1) return -1;
 
-      if (hc_hipHostMalloc (hashcat_ctx, &device_param->hooks_buf, size_hooks,           hipHostMallocPortable) == -1) return -1;
-      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_tmps,    hashconfig->tmp_size, hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, (void **) &device_param->hooks_buf, size_hooks,           hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, (void **) &device_param->pws_idx,   size_pws_idx,         hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, (void **) &device_param->h_tmps,    hashconfig->tmp_size, hipHostMallocPortable) == -1) return -1;
 
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_pws_buf,       device_param->size_pws)      == -1) return -1;
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_pws_amp_buf,   device_param->size_pws_amp)  == -1) return -1;
@@ -14917,11 +14901,13 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_tmps,     NULL, &device_param->opencl_d_tmps)         == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_hooks,    NULL, &device_param->opencl_d_hooks)        == -1) return -1;
 
-      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR,                         size_hooks,           NULL, &device_param->opencl_h_hooks) == -1) return -1;
-      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, hashconfig->tmp_size, NULL, &device_param->opencl_h_tmps ) == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR,                         size_hooks,           NULL, &device_param->opencl_h_hooks  ) == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR,                         size_pws_idx,         NULL, &device_param->opencl_h_pws_idx) == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, hashconfig->tmp_size, NULL, &device_param->opencl_h_tmps   ) == -1) return -1;
 
-      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_hooks, CL_FALSE, 0,           0, size_hooks,           0, NULL, NULL, &device_param->hooks_buf) == -1) return -1;
-      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_tmps,  CL_FALSE, CL_MAP_READ, 0, hashconfig->tmp_size, 0, NULL, NULL, &device_param->h_tmps   ) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_hooks,   CL_FALSE, 0,           0, size_hooks,           0, NULL, NULL, (void **) &device_param->hooks_buf) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_pws_idx, CL_FALSE, 0,           0, size_pws_idx,         0, NULL, NULL, (void **) &device_param->pws_idx  ) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_tmps,    CL_FALSE, CL_MAP_READ, 0, hashconfig->tmp_size, 0, NULL, NULL, (void **) &device_param->h_tmps   ) == -1) return -1;
 
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_pws_buf,       device_param->size_pws)      == -1) return -1;
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_pws_amp_buf,   device_param->size_pws_amp)  == -1) return -1;
@@ -14938,10 +14924,6 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
     u32 *pws_comp = (u32 *) hcmalloc (size_pws_comp);
 
     device_param->pws_comp = pws_comp;
-
-    pw_idx_t *pws_idx = (pw_idx_t *) hcmalloc (size_pws_idx);
-
-    device_param->pws_idx = pws_idx;
 
     pw_t *combs_buf = (pw_t *) hccalloc (KERNEL_COMBS, sizeof (pw_t));
 
@@ -15191,7 +15173,6 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
     if (device_param->skipped == true) continue;
 
     hcfree (device_param->pws_comp);
-    hcfree (device_param->pws_idx);
     hcfree (device_param->pws_pre_buf);
     hcfree (device_param->pws_base_buf);
     hcfree (device_param->combs_buf);
@@ -15241,6 +15222,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->cuda_d_st_esalts_buf)  hc_cuMemFree (hashcat_ctx, device_param->cuda_d_st_esalts_buf);
 
       if (device_param->hooks_buf)             hc_cuMemFreeHost (hashcat_ctx, device_param->hooks_buf);
+      if (device_param->pws_idx)               hc_cuMemFreeHost (hashcat_ctx, device_param->pws_idx);
       if (device_param->h_plain_bufs)          hc_cuMemFreeHost (hashcat_ctx, device_param->h_plain_bufs);
       if (device_param->h_results)             hc_cuMemFreeHost (hashcat_ctx, device_param->h_results);
       if (device_param->h_tmps)                hc_cuMemFreeHost (hashcat_ctx, device_param->h_tmps);
@@ -15334,8 +15316,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
 
       device_param->cuda_context              = NULL;
     }
-
-    if (device_param->is_hip == true)
+    else if (device_param->is_hip == true)
     {
       if (device_param->hip_d_pws_buf)        hc_hipMemFree (hashcat_ctx, device_param->hip_d_pws_buf);
       if (device_param->hip_d_pws_amp_buf)    hc_hipMemFree (hashcat_ctx, device_param->hip_d_pws_amp_buf);
@@ -15375,6 +15356,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->hip_d_st_esalts_buf)  hc_hipMemFree (hashcat_ctx, device_param->hip_d_st_esalts_buf);
 
       if (device_param->hooks_buf)            hc_hipHostFree (hashcat_ctx, device_param->hooks_buf);
+      if (device_param->pws_idx)              hc_hipHostFree (hashcat_ctx, device_param->pws_idx);
       if (device_param->h_plain_bufs)         hc_hipHostFree (hashcat_ctx, device_param->h_plain_bufs);
       if (device_param->h_results)            hc_hipHostFree (hashcat_ctx, device_param->h_results);
       if (device_param->h_tmps)               hc_hipHostFree (hashcat_ctx, device_param->h_tmps);
@@ -15468,8 +15450,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
 
       device_param->hip_context              = NULL;
     }
-
-    if (device_param->is_opencl == true)
+    else /* if (device_param->is_opencl == true) */
     {
       if (device_param->opencl_d_pws_buf)        hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_pws_buf);
       if (device_param->opencl_d_pws_amp_buf)    hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_pws_amp_buf);
@@ -15509,11 +15490,13 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->opencl_d_st_esalts_buf)  hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_st_esalts_buf);
 
       if (device_param->hooks_buf)               hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_hooks,      device_param->hooks_buf,    0, NULL, NULL);
+      if (device_param->pws_idx)                 hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_pws_idx,    device_param->pws_idx,      0, NULL, NULL);
       if (device_param->h_plain_bufs)            hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_plain_bufs, device_param->h_plain_bufs, 0, NULL, NULL);
       if (device_param->h_results)               hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_results,    device_param->h_results,    0, NULL, NULL);
       if (device_param->h_tmps)                  hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_tmps,       device_param->h_tmps,       0, NULL, NULL);
 
       if (device_param->opencl_h_hooks)          hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_hooks);
+      if (device_param->opencl_h_pws_idx)        hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_pws_idx);
       if (device_param->opencl_h_plain_bufs)     hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_plain_bufs);
       if (device_param->opencl_h_results)        hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_results);
       if (device_param->opencl_h_tmps)           hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_tmps);
@@ -15590,6 +15573,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       device_param->opencl_d_st_salts_buf      = NULL;
       device_param->opencl_d_st_esalts_buf     = NULL;
       device_param->opencl_h_hooks             = NULL;
+      device_param->opencl_h_pws_idx           = NULL;
       device_param->opencl_h_plain_bufs        = NULL;
       device_param->opencl_h_results           = NULL;
       device_param->opencl_h_tmps              = NULL;

--- a/src/backend.c
+++ b/src/backend.c
@@ -4590,15 +4590,13 @@ int choose_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, 
 
           if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return -1;
         }
-
-        if (device_param->is_hip == true)
+        else if (device_param->is_hip == true)
         {
           if (hc_hipMemcpyDtoHAsync (hashcat_ctx, device_param->hooks_buf, device_param->hip_d_hooks, pws_cnt * hashconfig->hook_size, device_param->hip_stream) == -1) return -1;
 
           if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
         }
-
-        if (device_param->is_opencl == true)
+        else /* if (device_param->is_opencl == true) */
         {
           /* blocking */
           if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_TRUE, 0, pws_cnt * hashconfig->hook_size, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
@@ -4640,13 +4638,11 @@ int choose_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, 
         {
           if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_hooks, device_param->hooks_buf, pws_cnt * hashconfig->hook_size, device_param->cuda_stream) == -1) return -1;
         }
-
-        if (device_param->is_hip == true)
+        else if (device_param->is_hip == true)
         {
           if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_hooks, device_param->hooks_buf, pws_cnt * hashconfig->hook_size, device_param->hip_stream) == -1) return -1;
         }
-
-        if (device_param->is_opencl == true)
+        else /* if (device_param->is_opencl == true) */
         {
           if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_FALSE, 0, pws_cnt * hashconfig->hook_size, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
         }
@@ -4736,15 +4732,13 @@ int choose_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, 
 
               if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return -1;
             }
-
-            if (device_param->is_hip == true)
+            else if (device_param->is_hip == true)
             {
               if (hc_hipMemcpyDtoHAsync (hashcat_ctx, device_param->hooks_buf, device_param->hip_d_hooks, pws_cnt * hashconfig->hook_size, device_param->hip_stream) == -1) return -1;
 
               if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
             }
-
-            if (device_param->is_opencl == true)
+            else /* if (device_param->is_opencl == true) */
             {
               /* blocking */
               if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_TRUE, 0, pws_cnt * hashconfig->hook_size, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
@@ -4786,13 +4780,11 @@ int choose_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, 
             {
               if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_hooks, device_param->hooks_buf, pws_cnt * hashconfig->hook_size, device_param->cuda_stream) == -1) return -1;
             }
-
-            if (device_param->is_hip == true)
+            else if (device_param->is_hip == true)
             {
               if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_hooks, device_param->hooks_buf, pws_cnt * hashconfig->hook_size, device_param->hip_stream) == -1) return -1;
             }
-
-            if (device_param->is_opencl == true)
+            else /* if (device_param->is_opencl == true) */
             {
               if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_FALSE, 0, pws_cnt * hashconfig->hook_size, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
             }
@@ -12175,8 +12167,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         }
       }
     }
-
-    if (device_param->is_hip == true)
+    else if (device_param->is_hip == true)
     {
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_bitmap_s1_a,    bitmap_ctx->bitmap_size) == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_bitmap_s1_b,    bitmap_ctx->bitmap_size) == -1) return -1;
@@ -12288,8 +12279,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         }
       }
     }
-
-    if (device_param->is_opencl == true)
+    else /* if (device_param->is_opencl == true) */
     {
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_ONLY,   bitmap_ctx->bitmap_size, NULL, &device_param->opencl_d_bitmap_s1_a)    == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_ONLY,   bitmap_ctx->bitmap_size, NULL, &device_param->opencl_d_bitmap_s1_b)    == -1) return -1;
@@ -14889,7 +14879,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_tmps,         size_tmps)     == -1) return -1;
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_hooks,        size_hooks)    == -1) return -1;
 
-      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_tmps, hashconfig->tmp_size, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->hooks_buf, size_hooks,           CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
+      if (hc_cuMemHostAlloc (hashcat_ctx, &device_param->h_tmps,    hashconfig->tmp_size, CU_MEMHOSTALLOC_PORTABLE) == -1) return -1;
 
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_pws_buf,       device_param->size_pws)      == -1) return -1;
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_pws_amp_buf,   device_param->size_pws_amp)  == -1) return -1;
@@ -14898,8 +14889,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_tmps,          device_param->size_tmps)     == -1) return -1;
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_hooks,         device_param->size_hooks)    == -1) return -1;
     }
-
-    if (device_param->is_hip == true)
+    else if (device_param->is_hip == true)
     {
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_pws_buf,      size_pws)      == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_pws_amp_buf,  size_pws_amp)  == -1) return -1;
@@ -14908,7 +14898,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_tmps,         size_tmps)     == -1) return -1;
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_hooks,        size_hooks)    == -1) return -1;
 
-      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_tmps, hashconfig->tmp_size, hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, &device_param->hooks_buf, size_hooks,           hipHostMallocPortable) == -1) return -1;
+      if (hc_hipHostMalloc (hashcat_ctx, &device_param->h_tmps,    hashconfig->tmp_size, hipHostMallocPortable) == -1) return -1;
 
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_pws_buf,       device_param->size_pws)      == -1) return -1;
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_pws_amp_buf,   device_param->size_pws_amp)  == -1) return -1;
@@ -14917,8 +14908,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_tmps,          device_param->size_tmps)     == -1) return -1;
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_hooks,         device_param->size_hooks)    == -1) return -1;
     }
-
-    if (device_param->is_opencl == true)
+    else /* if (device_param->is_opencl == true) */
     {
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_pws,      NULL, &device_param->opencl_d_pws_buf)      == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_pws_amp,  NULL, &device_param->opencl_d_pws_amp_buf)  == -1) return -1;
@@ -14927,8 +14917,11 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_tmps,     NULL, &device_param->opencl_d_tmps)         == -1) return -1;
       if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_READ_WRITE,  size_hooks,    NULL, &device_param->opencl_d_hooks)        == -1) return -1;
 
-      if (hc_clCreateBuffer     (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY | CL_MEM_WRITE_ONLY, hashconfig->tmp_size, NULL, &device_param->opencl_h_tmps) == -1) return -1;
-      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_tmps, CL_FALSE, CL_MAP_READ, 0, hashconfig->tmp_size, 0, NULL, NULL, &device_param->h_tmps    ) == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR,                         size_hooks,           NULL, &device_param->opencl_h_hooks) == -1) return -1;
+      if (hc_clCreateBuffer (hashcat_ctx, device_param->opencl_context, CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_READ_ONLY, hashconfig->tmp_size, NULL, &device_param->opencl_h_tmps ) == -1) return -1;
+
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_hooks, CL_FALSE, 0,           0, size_hooks,           0, NULL, NULL, &device_param->hooks_buf) == -1) return -1;
+      if (hc_clEnqueueMapBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_tmps,  CL_FALSE, CL_MAP_READ, 0, hashconfig->tmp_size, 0, NULL, NULL, &device_param->h_tmps   ) == -1) return -1;
 
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_pws_buf,       device_param->size_pws)      == -1) return -1;
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_pws_amp_buf,   device_param->size_pws_amp)  == -1) return -1;
@@ -14953,10 +14946,6 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
     pw_t *combs_buf = (pw_t *) hccalloc (KERNEL_COMBS, sizeof (pw_t));
 
     device_param->combs_buf = combs_buf;
-
-    void *hooks_buf = hcmalloc (size_hooks);
-
-    device_param->hooks_buf = hooks_buf;
 
     char *scratch_buf = (char *) hcmalloc (HCBUFSIZ_LARGE);
 
@@ -15206,7 +15195,6 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
     hcfree (device_param->pws_pre_buf);
     hcfree (device_param->pws_base_buf);
     hcfree (device_param->combs_buf);
-    hcfree (device_param->hooks_buf);
     hcfree (device_param->scratch_buf);
     #ifdef WITH_BRAIN
     hcfree (device_param->brain_link_in_buf);
@@ -15252,6 +15240,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->cuda_d_st_salts_buf)   hc_cuMemFree (hashcat_ctx, device_param->cuda_d_st_salts_buf);
       if (device_param->cuda_d_st_esalts_buf)  hc_cuMemFree (hashcat_ctx, device_param->cuda_d_st_esalts_buf);
 
+      if (device_param->hooks_buf)             hc_cuMemFreeHost (hashcat_ctx, device_param->hooks_buf);
       if (device_param->h_plain_bufs)          hc_cuMemFreeHost (hashcat_ctx, device_param->h_plain_bufs);
       if (device_param->h_results)             hc_cuMemFreeHost (hashcat_ctx, device_param->h_results);
       if (device_param->h_tmps)                hc_cuMemFreeHost (hashcat_ctx, device_param->h_tmps);
@@ -15385,6 +15374,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->hip_d_st_salts_buf)   hc_hipMemFree (hashcat_ctx, device_param->hip_d_st_salts_buf);
       if (device_param->hip_d_st_esalts_buf)  hc_hipMemFree (hashcat_ctx, device_param->hip_d_st_esalts_buf);
 
+      if (device_param->hooks_buf)            hc_hipHostFree (hashcat_ctx, device_param->hooks_buf);
       if (device_param->h_plain_bufs)         hc_hipHostFree (hashcat_ctx, device_param->h_plain_bufs);
       if (device_param->h_results)            hc_hipHostFree (hashcat_ctx, device_param->h_results);
       if (device_param->h_tmps)               hc_hipHostFree (hashcat_ctx, device_param->h_tmps);
@@ -15518,10 +15508,12 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       if (device_param->opencl_d_st_salts_buf)   hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_st_salts_buf);
       if (device_param->opencl_d_st_esalts_buf)  hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_d_st_esalts_buf);
 
+      if (device_param->hooks_buf)               hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_hooks,      device_param->hooks_buf,    0, NULL, NULL);
       if (device_param->h_plain_bufs)            hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_plain_bufs, device_param->h_plain_bufs, 0, NULL, NULL);
       if (device_param->h_results)               hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_results,    device_param->h_results,    0, NULL, NULL);
       if (device_param->h_tmps)                  hc_clEnqueueUnmapMemObject (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_h_tmps,       device_param->h_tmps,       0, NULL, NULL);
 
+      if (device_param->opencl_h_hooks)          hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_hooks);
       if (device_param->opencl_h_plain_bufs)     hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_plain_bufs);
       if (device_param->opencl_h_results)        hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_results);
       if (device_param->opencl_h_tmps)           hc_clReleaseMemObject (hashcat_ctx, device_param->opencl_h_tmps);
@@ -15597,6 +15589,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       device_param->opencl_d_st_digests_buf    = NULL;
       device_param->opencl_d_st_salts_buf      = NULL;
       device_param->opencl_d_st_esalts_buf     = NULL;
+      device_param->opencl_h_hooks             = NULL;
       device_param->opencl_h_plain_bufs        = NULL;
       device_param->opencl_h_results           = NULL;
       device_param->opencl_h_tmps              = NULL;

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -562,14 +562,14 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->cuda_d_result, sizeof (u32), device_param->cuda_stream) == -1) return -1;
+    if (hc_cuMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->cuda_d_results, sizeof (u32), device_param->cuda_stream) == -1) return -1;
 
     if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return -1;
   }
 
   if (device_param->is_hip == true)
   {
-    if (hc_hipMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->hip_d_result, sizeof (u32), device_param->hip_stream) == -1) return -1;
+    if (hc_hipMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->hip_d_results, sizeof (u32), device_param->hip_stream) == -1) return -1;
 
     if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
   }
@@ -577,7 +577,7 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
   if (device_param->is_opencl == true)
   {
     /* blocking */
-    if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_result, CL_TRUE, 0, sizeof (u32), &num_cracked, 0, NULL, NULL) == -1) return -1;
+    if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_results, CL_TRUE, 0, sizeof (u32), &num_cracked, 0, NULL, NULL) == -1) return -1;
   }
 
   if (num_cracked == 0 || user_options->speed_only == true)
@@ -743,17 +743,17 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
   if (device_param->is_cuda == true)
   {
-    if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_result, sizeof (u32)) == -1) return -1;
+    if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_results, sizeof (u32)) == -1) return -1;
   }
 
   if (device_param->is_hip == true)
   {
-    if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_result, sizeof (u32)) == -1) return -1;
+    if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_results, sizeof (u32)) == -1) return -1;
   }
 
   if (device_param->is_opencl == true)
   {
-    if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_result, sizeof (u32)) == -1) return -1;
+    if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_results, sizeof (u32)) == -1) return -1;
 
     if (hc_clFlush (hashcat_ctx, device_param->opencl_command_queue) == -1) return -1;
   }

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -536,7 +536,7 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
     if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_results, CL_TRUE, 0, sizeof (u32), device_param->h_results, 0, NULL, NULL) == -1) return -1;
   }
 
-  const u32 num_cracked = *device_param->h_results;
+  const u32 num_cracked = *(const u32 *) device_param->h_results;
 
   if (num_cracked == 0 || user_options->speed_only == true)
   {

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -522,15 +522,13 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
     if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return -1;
   }
-
-  if (device_param->is_hip == true)
+  else if (device_param->is_hip == true)
   {
     if (hc_hipMemcpyDtoHAsync (hashcat_ctx, device_param->h_results, device_param->hip_d_results, sizeof (u32), device_param->hip_stream) == -1) return -1;
 
     if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
   }
-
-  if (device_param->is_opencl == true)
+  else /* if (device_param->is_opencl == true) */
   {
     /* blocking */
     if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_results, CL_TRUE, 0, sizeof (u32), device_param->h_results, 0, NULL, NULL) == -1) return -1;
@@ -554,15 +552,13 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
     if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return -1;
   }
-
-  if (device_param->is_hip == true)
+  else if (device_param->is_hip == true)
   {
     if (hc_hipMemcpyDtoHAsync (hashcat_ctx, cracked, device_param->hip_d_plain_bufs, num_cracked * sizeof (plain_t), device_param->hip_stream) == -1) return -1;
 
     if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
   }
-
-  if (device_param->is_opencl == true)
+  else /* if (device_param->is_opencl == true) */
   {
     /* blocking */
     if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_plain_bufs, CL_TRUE, 0, num_cracked * sizeof (plain_t), cracked, 0, NULL, NULL) == -1) return -1;
@@ -623,8 +619,7 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
           break;
         }
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         rc = run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_digests_shown + (salt_buf->digests_offset * sizeof (u32)), salt_buf->digests_cnt * sizeof (u32));
 
@@ -633,8 +628,7 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
           break;
         }
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         /* NOTE: run_opencl_kernel_bzero() does not handle buffer offset */
         rc = run_opencl_kernel_memset32 (hashcat_ctx, device_param, device_param->opencl_d_digests_shown, salt_buf->digests_offset * sizeof (u32), 0, salt_buf->digests_cnt * sizeof (u32));
@@ -674,13 +668,11 @@ int check_cracked (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
   {
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_results, sizeof (u32)) == -1) return -1;
   }
-
-  if (device_param->is_hip == true)
+  else if (device_param->is_hip == true)
   {
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_results, sizeof (u32)) == -1) return -1;
   }
-
-  if (device_param->is_opencl == true)
+  else /* if (device_param->is_opencl == true) */
   {
     if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_results, sizeof (u32)) == -1) return -1;
 

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -689,21 +689,21 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->cuda_d_result, sizeof (u32), device_param->cuda_stream) == -1) return -1;
+    if (hc_cuMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->cuda_d_results, sizeof (u32), device_param->cuda_stream) == -1) return -1;
 
     if (hc_cuEventRecord (hashcat_ctx, device_param->cuda_event3, device_param->cuda_stream) == -1) return -1;
   }
 
   if (device_param->is_hip == true)
   {
-    if (hc_hipMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->hip_d_result, sizeof (u32), device_param->hip_stream) == -1) return -1;
+    if (hc_hipMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->hip_d_results, sizeof (u32), device_param->hip_stream) == -1) return -1;
 
     if (hc_hipEventRecord (hashcat_ctx, device_param->hip_event3, device_param->hip_stream) == -1) return -1;
   }
 
   if (device_param->is_opencl == true)
   {
-    if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_result, CL_FALSE, 0, sizeof (u32), &num_cracked, 0, NULL, &opencl_event) == -1) return -1;
+    if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_results, CL_FALSE, 0, sizeof (u32), &num_cracked, 0, NULL, &opencl_event) == -1) return -1;
 
     if (hc_clFlush (hashcat_ctx, device_param->opencl_command_queue) == -1) return -1;
   }
@@ -729,7 +729,7 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_hooks,         device_param->size_hooks)   == -1) return -1;
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_plain_bufs,    device_param->size_plains)  == -1) return -1;
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_digests_shown, device_param->size_shown)   == -1) return -1;
-    if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_result,        device_param->size_results) == -1) return -1;
+    if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_results,       device_param->size_results) == -1) return -1;
   }
 
   if (device_param->is_hip == true)
@@ -743,7 +743,7 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_hooks,         device_param->size_hooks)   == -1) return -1;
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_plain_bufs,    device_param->size_plains)  == -1) return -1;
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_digests_shown, device_param->size_shown)   == -1) return -1;
-    if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_result,        device_param->size_results) == -1) return -1;
+    if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_results,       device_param->size_results) == -1) return -1;
   }
 
   if (device_param->is_opencl == true)
@@ -757,7 +757,7 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_hooks,         device_param->size_hooks)   == -1) return -1;
     if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_plain_bufs,    device_param->size_plains)  == -1) return -1;
     if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_digests_shown, device_param->size_shown)   == -1) return -1;
-    if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_result,        device_param->size_results) == -1) return -1;
+    if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_results,       device_param->size_results) == -1) return -1;
   }
 
   if (user_options->slow_candidates == true)

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -505,15 +505,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
         if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return -1;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         if (hc_hipMemcpyDtoHAsync (hashcat_ctx, device_param->hooks_buf, device_param->hip_d_hooks, device_param->size_hooks, device_param->hip_stream) == -1) return -1;
 
         if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         /* blocking */
         if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_TRUE, 0, device_param->size_hooks, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
@@ -525,13 +523,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       {
         if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_hooks, device_param->hooks_buf, device_param->size_hooks, device_param->cuda_stream) == -1) return -1;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_hooks, device_param->hooks_buf, device_param->size_hooks, device_param->hip_stream) == -1) return -1;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_FALSE, 0, device_param->size_hooks, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
       }
@@ -583,15 +579,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
           if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return -1;
         }
-
-        if (device_param->is_hip == true)
+        else if (device_param->is_hip == true)
         {
           if (hc_hipMemcpyDtoHAsync (hashcat_ctx, device_param->hooks_buf, device_param->hip_d_hooks, device_param->size_hooks, device_param->hip_stream) == -1) return -1;
 
           if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
         }
-
-        if (device_param->is_opencl == true)
+        else /* if (device_param->is_opencl == true) */
         {
           /* blocking */
           if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_TRUE, 0, device_param->size_hooks, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
@@ -603,13 +597,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
         {
           if (hc_cuMemcpyHtoDAsync (hashcat_ctx, device_param->cuda_d_hooks, device_param->hooks_buf, device_param->size_hooks, device_param->cuda_stream) == -1) return -1;
         }
-
-        if (device_param->is_hip == true)
+        else if (device_param->is_hip == true)
         {
           if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_hooks, device_param->hooks_buf, device_param->size_hooks, device_param->hip_stream) == -1) return -1;
         }
-
-        if (device_param->is_opencl == true)
+        else /* if (device_param->is_opencl == true) */
         {
           if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_hooks, CL_FALSE, 0, device_param->size_hooks, device_param->hooks_buf, 0, NULL, NULL) == -1) return -1;
         }

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -675,27 +675,23 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
   // check : check if cracked
 
-  u32 num_cracked = 0;
-
   cl_event opencl_event;
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->cuda_d_results, sizeof (u32), device_param->cuda_stream) == -1) return -1;
+    if (hc_cuMemcpyDtoHAsync (hashcat_ctx, device_param->h_results, device_param->cuda_d_results, sizeof (u32), device_param->cuda_stream) == -1) return -1;
 
     if (hc_cuEventRecord (hashcat_ctx, device_param->cuda_event3, device_param->cuda_stream) == -1) return -1;
   }
-
-  if (device_param->is_hip == true)
+  else if (device_param->is_hip == true)
   {
-    if (hc_hipMemcpyDtoHAsync (hashcat_ctx, &num_cracked, device_param->hip_d_results, sizeof (u32), device_param->hip_stream) == -1) return -1;
+    if (hc_hipMemcpyDtoHAsync (hashcat_ctx, device_param->h_results, device_param->hip_d_results, sizeof (u32), device_param->hip_stream) == -1) return -1;
 
     if (hc_hipEventRecord (hashcat_ctx, device_param->hip_event3, device_param->hip_stream) == -1) return -1;
   }
-
-  if (device_param->is_opencl == true)
+  else /* if (device_param->is_opencl == true) */
   {
-    if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_results, CL_FALSE, 0, sizeof (u32), &num_cracked, 0, NULL, &opencl_event) == -1) return -1;
+    if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_results, CL_FALSE, 0, sizeof (u32), device_param->h_results, 0, NULL, &opencl_event) == -1) return -1;
 
     if (hc_clFlush (hashcat_ctx, device_param->opencl_command_queue) == -1) return -1;
   }
@@ -723,8 +719,7 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_digests_shown, device_param->size_shown)   == -1) return -1;
     if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_results,       device_param->size_results) == -1) return -1;
   }
-
-  if (device_param->is_hip == true)
+  else if (device_param->is_hip == true)
   {
     device_param->kernel_params[15] = &device_param->hip_d_digests_buf;
     device_param->kernel_params[17] = &device_param->hip_d_salt_bufs;
@@ -737,8 +732,7 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_digests_shown, device_param->size_shown)   == -1) return -1;
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_results,       device_param->size_results) == -1) return -1;
   }
-
-  if (device_param->is_opencl == true)
+  else /* if (device_param->is_opencl == true) */
   {
     device_param->kernel_params[15] = &device_param->opencl_d_digests_buf;
     device_param->kernel_params[17] = &device_param->opencl_d_salt_bufs;
@@ -758,13 +752,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     {
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_rules_c, device_param->size_rules_c) == -1) return -1;
     }
-
-    if (device_param->is_hip == true)
+    else if (device_param->is_hip == true)
     {
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_rules_c, device_param->size_rules_c) == -1) return -1;
     }
-
-    if (device_param->is_opencl == true)
+    else /* if (device_param->is_opencl == true) */
     {
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_rules_c, device_param->size_rules_c) == -1) return -1;
     }
@@ -777,13 +769,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       {
         if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_rules_c, device_param->size_rules_c) == -1) return -1;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_rules_c, device_param->size_rules_c) == -1) return -1;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_rules_c, device_param->size_rules_c) == -1) return -1;
       }
@@ -794,13 +784,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       {
         if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_combs_c, device_param->size_combs) == -1) return -1;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_combs_c, device_param->size_combs) == -1) return -1;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_combs_c, device_param->size_combs) == -1) return -1;
       }
@@ -811,13 +799,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       {
         if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_bfs_c, device_param->size_bfs) == -1) return -1;
       }
-
-      if (device_param->is_hip == true)
+      else if (device_param->is_hip == true)
       {
         if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_bfs_c, device_param->size_bfs) == -1) return -1;
       }
-
-      if (device_param->is_opencl == true)
+      else /* if (device_param->is_opencl == true) */
       {
         if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_bfs_c, device_param->size_bfs) == -1) return -1;
       }
@@ -829,13 +815,11 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
   {
     if (hc_cuEventSynchronize (hashcat_ctx, device_param->cuda_event3) == -1) return -1;
   }
-
-  if (device_param->is_hip == true)
+  else if (device_param->is_hip == true)
   {
     if (hc_hipEventSynchronize (hashcat_ctx, device_param->hip_event3) == -1) return -1;
   }
-
-  if (device_param->is_opencl == true)
+  else /* if (device_param->is_opencl == true) */
   {
     if (hc_clWaitForEvents (hashcat_ctx, 1, &opencl_event) == -1) return -1;
 
@@ -843,6 +827,8 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
   }
 
   // check return
+  const u32 num_cracked = *(const u32 *) device_param->h_results;
+
   if (num_cracked == 0)
   {
     hc_thread_mutex_lock (status_ctx->mux_display);


### PR DESCRIPTION
Bandwidth is about double, and we avoid paging and/or memory copy overhead from staging buffer. Also we avoid allocating temporary buffers and runtime memory usage is more static. Now only gidd_to_pw_t() has couple of unpinned buffers.  

Next step is to use pinned buffers for host->device transfers which will have more impact of performance because they make up the majority. Already device_param->hooks_buf shows that it will be easy to implement.

CUDA uses hc_cuMemHostAlloc()/hc_cuMemFreeHost() and HIP uses hc_hipHostMalloc()/hc_hipHostFree() to allocate paged memory buffers. But OpenCL is different. hc_clCreateBuffer(CL_MEM_ALLOC_HOST_PTR)+hc_clEnqueueMapBuffer() to allocate and map paged memory once, and hc_clEnqueueUnmapMemObject()+hc_clReleaseMemObject() to free.