### PR TITLE
Add hashcat mode to status

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1423,8 +1423,9 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     hashcat_status->status_string);
 
   event_log_info (hashcat_ctx,
-    "Hash.Name........: %s",
-    hashcat_status->hash_name);
+    "Hash.Name........: %s (%i)",
+    hashcat_status->hash_name,
+    hashconfig->hash_mode);
 
   event_log_info (hashcat_ctx,
     "Hash.Target......: %s",


### PR DESCRIPTION
Hashcat mode displayed after the hash name.
Resolves https://github.com/hashcat/hashcat/issues/2945
