### PR TITLE
Reformat the status to include hashcat id of mode

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1423,8 +1423,9 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     hashcat_status->status_string);
 
   event_log_info (hashcat_ctx,
-    "Hash.Name........: %s",
-    hashcat_status->hash_name);
+    "Hash.Name........: %s (%i)",
+    hashcat_status->hash_name,
+    hashconfig->hash_mode);
 
   event_log_info (hashcat_ctx,
     "Hash.Target......: %s",

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1423,7 +1423,7 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     hashcat_status->status_string);
 
   event_log_info (hashcat_ctx,
-    "Hash.Name........: %i - %s",
+    "Hash.Mode........: %d (%s)",
     hashconfig->hash_mode,
     hashcat_status->hash_name);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1423,9 +1423,9 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
     hashcat_status->status_string);
 
   event_log_info (hashcat_ctx,
-    "Hash.Name........: %s (%i)",
-    hashcat_status->hash_name,
-    hashconfig->hash_mode);
+    "Hash.Name........: %i - %s",
+    hashconfig->hash_mode,
+    hashcat_status->hash_name);
 
   event_log_info (hashcat_ctx,
     "Hash.Target......: %s",


### PR DESCRIPTION
https://github.com/hashcat/hashcat/pull/2946

This matches the display format utilized in benchmarks to display both the ID and Name of the algorithm in the format of `id - name`