### PR TITLE
Align formatting

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -452,14 +452,12 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     {
       if ((hashconfig->attack_exec == ATTACK_EXEC_OUTSIDE_KERNEL) && (hashconfig->is_salted == true))
       {
-        event_log_info (hashcat_ctx, "Hashmode: %d - %s (Iterations: %d)", hashconfig->hash_mode, hashconfig->hash_name, hashes[0].salts_buf[0].salt_iter);
+        event_log_info (hashcat_ctx, "Hash.Mode........: %d (%s) (Iterations: %d)", hashconfig->hash_mode, hashconfig->hash_name, hashes[0].salts_buf[0].salt_iter);
       }
       else
       {
-        event_log_info (hashcat_ctx, "Hashmode: %d - %s", hashconfig->hash_mode, hashconfig->hash_name);
+        event_log_info (hashcat_ctx, "Hash.Mode........: %d (%s)", hashconfig->hash_mode, hashconfig->hash_name);
       }
-
-      event_log_info (hashcat_ctx, NULL);
     }
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -452,11 +452,11 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     {
       if ((hashconfig->attack_exec == ATTACK_EXEC_OUTSIDE_KERNEL) && (hashconfig->is_salted == true))
       {
-        event_log_info (hashcat_ctx, "Hash.Mode........: %d (%s) (Iterations: %d)", hashconfig->hash_mode, hashconfig->hash_name, hashes[0].salts_buf[0].salt_iter);
+        event_log_info (hashcat_ctx, "Hash.Mode: %d (%s) [Iterations: %d]", hashconfig->hash_mode, hashconfig->hash_name, hashes[0].salts_buf[0].salt_iter);
       }
       else
       {
-        event_log_info (hashcat_ctx, "Hash.Mode........: %d (%s)", hashconfig->hash_mode, hashconfig->hash_name);
+        event_log_info (hashcat_ctx, "Hash.Mode: %d (%s)", hashconfig->hash_mode, hashconfig->hash_name);
       }
     }
   }


### PR DESCRIPTION
Align formatting of the benchmark with the status changes.
Removed an extra newline which reduces clutter and groups together the mode and the result

Pre:
![image](https://user-images.githubusercontent.com/33965786/130777718-644cac07-e39d-4f2a-88b5-016a690930ab.png)

Post:
![image](https://user-images.githubusercontent.com/33965786/130777739-8c1a682d-17db-4881-9135-e19f81d8034f.png)
