### PR TITLE
Fix HAS_VPERM check in make-/undo_utf16* functions

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -2945,7 +2945,7 @@ DECLSPEC void make_utf16be (const u32x *in, u32x *out1, u32x *out2)
   out1[1] = hc_byte_perm (in[0], 0, 0x3727);
   out1[0] = hc_byte_perm (in[0], 0, 0x1707);
 
-  #elif (defined IS_AMD || defined IS_HIP) && defined HAS_VPERM == 1
+  #elif (defined IS_AMD || defined IS_HIP) && HAS_VPERM == 1
 
   out2[3] = hc_byte_perm (in[3], 0, 0x03070207);
   out2[2] = hc_byte_perm (in[3], 0, 0x01070007);
@@ -2983,7 +2983,7 @@ DECLSPEC void make_utf16beN (const u32x *in, u32x *out1, u32x *out2)
   out1[1] = hc_byte_perm (in[0], 0, 0x1707);
   out1[0] = hc_byte_perm (in[0], 0, 0x3727);
 
-  #elif (defined IS_AMD || defined IS_HIP) && defined HAS_VPERM == 1
+  #elif (defined IS_AMD || defined IS_HIP) && HAS_VPERM == 1
 
   out2[3] = hc_byte_perm (in[3], 0, 0x01070007);
   out2[2] = hc_byte_perm (in[3], 0, 0x03070207);
@@ -3021,7 +3021,7 @@ DECLSPEC void make_utf16le (const u32x *in, u32x *out1, u32x *out2)
   out1[1] = hc_byte_perm (in[0], 0, 0x7372);
   out1[0] = hc_byte_perm (in[0], 0, 0x7170);
 
-  #elif (defined IS_AMD || defined IS_HIP) && defined HAS_VPERM == 1
+  #elif (defined IS_AMD || defined IS_HIP) && HAS_VPERM == 1
 
   out2[3] = hc_byte_perm (in[3], 0, 0x07030702);
   out2[2] = hc_byte_perm (in[3], 0, 0x07010700);
@@ -3059,7 +3059,7 @@ DECLSPEC void make_utf16leN (const u32x *in, u32x *out1, u32x *out2)
   out1[1] = hc_byte_perm (in[0], 0, 0x7170);
   out1[0] = hc_byte_perm (in[0], 0, 0x7372);
 
-  #elif (defined IS_AMD || defined IS_HIP) && defined HAS_VPERM == 1
+  #elif (defined IS_AMD || defined IS_HIP) && HAS_VPERM == 1
 
   out2[3] = hc_byte_perm (in[3], 0, 0x07010700);
   out2[2] = hc_byte_perm (in[3], 0, 0x07030702);
@@ -3093,7 +3093,7 @@ DECLSPEC void undo_utf16be (const u32x *in1, const u32x *in2, u32x *out)
   out[2] = hc_byte_perm (in2[0], in2[1], 0x4602);
   out[3] = hc_byte_perm (in2[2], in2[3], 0x4602);
 
-  #elif (defined IS_AMD || defined IS_HIP) && defined HAS_VPERM == 1
+  #elif (defined IS_AMD || defined IS_HIP) && HAS_VPERM == 1
 
   out[0] = hc_byte_perm (in1[0], in1[1], 0x04060002);
   out[1] = hc_byte_perm (in1[2], in1[3], 0x04060002);
@@ -3123,7 +3123,7 @@ DECLSPEC void undo_utf16le (const u32x *in1, const u32x *in2, u32x *out)
   out[2] = hc_byte_perm (in2[0], in2[1], 0x6420);
   out[3] = hc_byte_perm (in2[2], in2[3], 0x6420);
 
-  #elif (defined IS_AMD || defined IS_HIP) && defined HAS_VPERM == 1
+  #elif (defined IS_AMD || defined IS_HIP) && HAS_VPERM == 1
 
   out[0] = hc_byte_perm (in1[0], in1[1], 0x06040200);
   out[1] = hc_byte_perm (in1[2], in1[3], 0x06040200);


### PR DESCRIPTION
Since HAS_VPERM is always defined (either set to 0 or 1) when calling the OpenCL compiler it will result in throwing a `clLinkProgram(): CL_LINK_PROGRAM_FAILURE` on AMD GPUs not supporting VPERM.