### PR TITLE
Fix compilation without brain

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -922,7 +922,10 @@ static int outer_loop (hashcat_ctx_t *hashcat_ctx)
 
   // clean up
 
+  #ifdef WITH_BRAIN
   brain_ctx_destroy       (hashcat_ctx);
+  #endif
+
   bitmap_ctx_destroy      (hashcat_ctx);
   combinator_ctx_destroy  (hashcat_ctx);
   cpt_ctx_destroy         (hashcat_ctx);
@@ -1090,13 +1093,13 @@ int hashcat_session_init (hashcat_ctx_t *hashcat_ctx, const char *install_folder
     }
   }
   #endif
-  #endif
 
   /**
    * brain
    */
 
   if (brain_ctx_init (hashcat_ctx) == -1) return -1;
+  #endif
 
   /**
    * logfile


### PR DESCRIPTION
Fixes following compile error:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: obj/combined.NATIVE.a(hashcat.NATIVE.o): in function `hashcat_session_init':
hashcat.c:(.text+0x3fd): undefined reference to `brain_ctx_init'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: obj/combined.NATIVE.a(hashcat.NATIVE.o): in function `outer_loop':
hashcat.c:(.text+0x219c): undefined reference to `brain_ctx_destroy'
collect2: error: ld returned 1 exit status
make: *** [src/Makefile:609: hashcat] Error 1
```