### PR TITLE
Set unzip internal buffer size to 256k

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -203,6 +203,7 @@ CFLAGS_ZLIB             += -Wno-implicit-fallthrough
 CFLAGS_ZLIB             += -Wno-implicit-function-declaration
 CFLAGS_ZLIB             += -Wno-unused-parameter
 CFLAGS_ZLIB             += -DIOAPI_NO_64
+CFLAGS_ZLIB             += -DUNZ_BUFSIZE=262144
 endif
 
 ## because UNRAR


### PR DESCRIPTION
Same performance improvement as with GZIP. 

And it seems that zlib unzip is buggy and it has problems with large zip files. I think we should warn hashcat users if unzip fails and file size is larger than one gigabyte, assuming wordlist compression rate to be about 70%. At the moment error message is non-informative, "Invalid argument"