### PR TITLE
tests: fixes -m 27000 verify

### DIFF
--- a/tools/test_modules/m27000.pm
+++ b/tools/test_modules/m27000.pm
@@ -146,21 +146,21 @@ sub module_verify_hash
 
   my $index1 = index ($line, "::");
 
-  return if $index1 < 1;
+  return if $index1 < 0;
 
   my $index2 = index ($line, ":", $index1 + 2);
 
-  return if $index2 < 1;
+  return if $index2 < 0;
 
   $index2 = index ($line, ":", $index2 + 1);
 
-  return if $index2 < 1;
+  return if $index2 < 0;
 
   my $salt = substr ($line, 0, $index2 - 32);
 
   $index2 = index ($line, ":", $index2 + 1);
 
-  return if $index2 < 1;
+  return if $index2 < 0;
 
   $salt .= substr ($line, $index2 + 1, 16);
 


### PR DESCRIPTION
I came accross this problem by accident by running some `verify` tests:

The test hash for
`-m 27000 = NetNTLMv1 / NetNTLMv1+ESS (NT)`

couldn't be run as `perl test.pl verify 27000 hash in out` successfully, because the code was to strict and didn't allow for empty `username` or `domain` etc.

This commit should fix the problem with failing `verify` script.

Thx