### PR TITLE
tests: fixes -m 26900 verify

### DIFF
--- a/tools/test_modules/m26900.pm
+++ b/tools/test_modules/m26900.pm
@@ -24,6 +24,8 @@ sub module_generate_hash
 
   my $pad_len = 34 - length ($engineID);
 
+  my $engineID_orig = $engineID;
+
   $engineID = join '', $engineID, "0" x $pad_len;
 
   # make salt even if needed
@@ -47,7 +49,7 @@ sub module_generate_hash
 
   $digest = substr ($digest, 0, 64);
 
-  my $hash = "\$SNMPv3\$5\$" . $pkt_num . "\$" . $salt . "\$" . $engineID . "\$" . $digest;
+  my $hash = "\$SNMPv3\$5\$" . $pkt_num . "\$" . $salt . "\$" . $engineID_orig . "\$" . $digest;
 
   return $hash;
 }


### PR DESCRIPTION
I found this problem by accident just by trying to run some `verify` tests on newly added hash types.

the problem is that the `engineID` variable is modified within the test code and therefore a mangled version of it is used within the output hash (and therefore it doesn't "verify" correctly).

With this suggested minimal fix, everything is working for me

Thank you very much.