### PR TITLE
Avoid false positives in pkzip formats

### DIFF
--- a/OpenCL/m17200_a0-pure.cl
+++ b/OpenCL/m17200_a0-pure.cl
@@ -756,7 +756,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
       ret = hc_inflate (&infstream);
     }
 
-    if (ret != MZ_STREAM_END) continue; // failed to inflate
+    if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hash.uncompressed_length) continue;
 
     const u32 r0 = ~infstream.crc32;
     const u32 r1 = 0;
@@ -982,7 +982,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
       ret = hc_inflate (&infstream);
     }
 
-    if (ret != MZ_STREAM_END) continue; // failed to inflate
+    if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hash.uncompressed_length) continue;
 
     const u32 r0 = ~infstream.crc32;
     const u32 r1 = 0;

--- a/OpenCL/m17200_a1-pure.cl
+++ b/OpenCL/m17200_a1-pure.cl
@@ -758,7 +758,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_ESALT (pkzip_t))
       ret = hc_inflate (&infstream);
     }
 
-    if (ret != MZ_STREAM_END) continue; // failed to inflate
+    if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hash.uncompressed_length) continue;
 
     const u32 r0 = ~infstream.crc32;
     const u32 r1 = 0;
@@ -988,7 +988,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_ESALT (pkzip_t))
       ret = hc_inflate (&infstream);
     }
 
-    if (ret != MZ_STREAM_END) continue; // failed to inflate
+    if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hash.uncompressed_length) continue;
 
     const u32 r0 = ~infstream.crc32;
     const u32 r1 = 0;

--- a/OpenCL/m17200_a3-pure.cl
+++ b/OpenCL/m17200_a3-pure.cl
@@ -771,7 +771,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
       ret = hc_inflate (&infstream);
     }
 
-    if (ret != MZ_STREAM_END) continue; // failed to inflate
+    if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hash.uncompressed_length) continue;
 
     const u32 r0 = ~infstream.crc32;
     const u32 r1 = 0;
@@ -1013,7 +1013,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
       ret = hc_inflate (&infstream);
     }
 
-    if (ret != MZ_STREAM_END) continue; // failed to inflate
+    if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hash.uncompressed_length) continue;
 
     const u32 r0 = ~infstream.crc32;
     const u32 r1 = 0;

--- a/OpenCL/m17220_a0-pure.cl
+++ b/OpenCL/m17220_a0-pure.cl
@@ -757,7 +757,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
         ret = hc_inflate (&infstream);
       }
 
-      if (ret != MZ_STREAM_END) break; // failed to inflate
+      if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
       // we check the crc32, but it might not necessarily be the last one (depending how strict
       if ((~infstream.crc32) == esalt_bufs[DIGESTS_OFFSET].hashes[idx].crc32)
@@ -1022,7 +1022,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
         ret = hc_inflate (&infstream);
       }
 
-      if (ret != MZ_STREAM_END) break; // failed to inflate
+      if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
       // we check the crc32, but it might not necessarily be the last one (depending how strict
       if ((~infstream.crc32) == esalt_bufs[DIGESTS_OFFSET].hashes[idx].crc32)

--- a/OpenCL/m17220_a1-pure.cl
+++ b/OpenCL/m17220_a1-pure.cl
@@ -757,7 +757,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_ESALT (pkzip_t))
         ret = hc_inflate (&infstream);
       }
 
-      if (ret != MZ_STREAM_END) break; // failed to inflate
+      if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
       // we check the crc32, but it might not necessarily be the last one (depending how strict
       if ((~infstream.crc32) == esalt_bufs[DIGESTS_OFFSET].hashes[idx].crc32)
@@ -1024,7 +1024,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_ESALT (pkzip_t))
         ret = hc_inflate (&infstream);
       }
 
-      if (ret != MZ_STREAM_END) break; // failed to inflate
+      if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
       // we check the crc32, but it might not necessarily be the last one (depending how strict
       if ((~infstream.crc32) == esalt_bufs[DIGESTS_OFFSET].hashes[idx].crc32)

--- a/OpenCL/m17220_a3-pure.cl
+++ b/OpenCL/m17220_a3-pure.cl
@@ -769,7 +769,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
         ret = hc_inflate (&infstream);
       }
 
-      if (ret != MZ_STREAM_END) break; // failed to inflate
+      if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
       // we check the crc32, but it might not necessarily be the last one (depending how strict
       if ((~infstream.crc32) == esalt_bufs[DIGESTS_OFFSET].hashes[idx].crc32)
@@ -1048,7 +1048,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
         ret = hc_inflate (&infstream);
       }
 
-      if (ret != MZ_STREAM_END) break; // failed to inflate
+      if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
       // we check the crc32, but it might not necessarily be the last one (depending how strict
       if ((~infstream.crc32) == esalt_bufs[DIGESTS_OFFSET].hashes[idx].crc32)

--- a/OpenCL/m17225_a0-pure.cl
+++ b/OpenCL/m17225_a0-pure.cl
@@ -766,7 +766,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
           ret = hc_inflate (&infstream);
         }
 
-        if (ret != MZ_STREAM_END) break; // failed to inflate
+        if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
         crc = ~infstream.crc32;
       }
@@ -1094,7 +1094,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
           ret = hc_inflate (&infstream);
         }
 
-        if (ret != MZ_STREAM_END) break; // failed to inflate
+        if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
         crc = ~infstream.crc32;
       }

--- a/OpenCL/m17225_a1-pure.cl
+++ b/OpenCL/m17225_a1-pure.cl
@@ -766,7 +766,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_ESALT (pkzip_t))
           ret = hc_inflate (&infstream);
         }
 
-        if (ret != MZ_STREAM_END) break; // failed to inflate
+        if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
         crc = ~infstream.crc32;
       }
@@ -1095,7 +1095,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_ESALT (pkzip_t))
           ret = hc_inflate (&infstream);
         }
 
-        if (ret != MZ_STREAM_END) break; // failed to inflate
+        if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
         crc = ~infstream.crc32;
       }

--- a/OpenCL/m17225_a3-pure.cl
+++ b/OpenCL/m17225_a3-pure.cl
@@ -778,7 +778,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
           ret = hc_inflate (&infstream);
         }
 
-        if (ret != MZ_STREAM_END) break; // failed to inflate
+        if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
         crc = ~infstream.crc32;
       }
@@ -1119,7 +1119,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
           ret = hc_inflate (&infstream);
         }
 
-        if (ret != MZ_STREAM_END) break; // failed to inflate
+        if (ret != MZ_STREAM_END || infstream.total_out != esalt_bufs[DIGESTS_OFFSET].hashes[idx].uncompressed_length) break;
 
         crc = ~infstream.crc32;
       }


### PR DESCRIPTION
After inflating data decrypted with an incorrect guess, you may get Z_STREAM_END (weakly indicating a correct guess) although the output length doesn't match the expected.  If the CRC-32 randomly match as well, we had a false positive before these tests were added.

Crazy yes, but I did see it happen!