### PR TITLE
Fix fgetl() logic

### DIFF
--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -982,54 +982,38 @@ void hc_fclose (HCFILE *fp)
 
 size_t fgetl (HCFILE *fp, char *line_buf, const size_t line_sz)
 {
-  size_t line_truncated = 0;
+  int c;
 
   size_t line_len = 0;
 
-  while (!hc_feof (fp))
-  {
-    const int c = hc_fgetc (fp);
+  size_t line_truncated = 0;
 
-    if (c == EOF) break;
+  while ((c = hc_fgetc (fp)) != EOF)
+  {
+    if (c == '\n') break;
 
     if (line_len == line_sz)
     {
       line_truncated++;
-
-      continue;
     }
+    else
+    {
+      line_buf[line_len] = (char) c;
 
-    line_buf[line_len] = (char) c;
-
-    line_len++;
-
-    if (c == '\n') break;
+      line_len++;
+    }
   }
 
   if (line_truncated > 0)
   {
     fprintf (stderr, "\nOversized line detected! Truncated %" PRIu64 " bytes\n", (u64) line_truncated);
   }
-
-  if (line_len == 0) return 0;
-
-  while (line_len)
+  else
   {
-    if (line_buf[line_len - 1] == '\n')
+    while (line_len > 0 && line_buf[line_len - 1] == '\r')
     {
       line_len--;
-
-      continue;
     }
-
-    if (line_buf[line_len - 1] == '\r')
-    {
-      line_len--;
-
-      continue;
-    }
-
-    break;
   }
 
   line_buf[line_len] = 0;


### PR DESCRIPTION
Second attempt, this is just a bugfix. 

Old implementation has some problems. If line is too long and it gets truncated, fgetl() reads until EOF, not until newline. If line length is zero, it's not NULL terminated. And as it's impossible to have extra newline characters in the end, trim only carriage returns. New implementation fixes all these and if line gets truncated, we don't look for any '\n' or '\r' from the end of line. We always NULL terminate. Also there is no need to check feof() as fgetc() reports EOF. And as the return value is used instead of strlen(), check for NULL terminators.

Some might argue that we should only trim single carriage return '\r', not all as extras might be part of actual line.