### PR TITLE
change default pass for LM

### DIFF
--- a/src/modules/module_03000.c
+++ b/src/modules/module_03000.c
@@ -29,7 +29,7 @@ static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_HASH_SPLIT;
 static const u32   PWDUMP_COLUMN  = PWDUMP_COLUMN_LM_HASH;
 static const u32   SALT_TYPE      = SALT_TYPE_NONE;
-static const char *ST_PASS        = "hashcat1";
+static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "299bd128c1101fd6";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }


### PR DESCRIPTION
This is a minor "problem" fix. It came to my attention that the default password for -m 3000 = LM is currently "hashcat1", see the `--hash-info` output:
```
Hash Info:
==========

Hash mode #3000
  Name................: LM
  Category............: Operating System
  Slow.Hash...........: No
  Password.Len.Min....: 0
  Password.Len.Max....: 7
  Kernel.Type(s)......: pure
  Example.Hash.Format.: plain
  Example.Hash........: 299bd128c1101fd6
  Example.Pass........: hashcat1
  Benchmark.Mask......: ?b?b?b?b?b?b?b
```

... but in my opinion it's a little bit confusing why the output says that the **max.** password length is **7** , while the default password is 8 characters long. this is kind of contradicting and confusing for a (new) user.

I suggest to change the default LM password to just "hashcat" (btw: also the example hash wiki https://hashcat.net/wiki/doku.php?id=example_hashes says that the default password is just "hashcat").

Thanks