### PR TITLE
whitespace and code style fixes

### DIFF
--- a/OpenCL/inc_ecc_secp256k1.cl
+++ b/OpenCL/inc_ecc_secp256k1.cl
@@ -2113,7 +2113,8 @@ DECLSPEC u32 parse_public (secp256k1_t *r, const u32 *k)
  * Set precomputed values of the basepoint g to a secp256k1 structure.
  * @param r out: x and y coordinates. pre-computed points: (x1,y1,-y1),(x3,y3,-y3),(x5,y5,-y5),(x7,y7,-y7)
  */
-DECLSPEC void set_precomputed_basepoint_g (secp256k1_t *r) {
+DECLSPEC void set_precomputed_basepoint_g (secp256k1_t *r)
+{
     // x1
     r->xy[ 0] = SECP256K1_G_PRE_COMPUTED_00;
     r->xy[ 1] = SECP256K1_G_PRE_COMPUTED_01;

--- a/OpenCL/m25400-pure.cl
+++ b/OpenCL/m25400-pure.cl
@@ -346,9 +346,12 @@ KERNEL_FQ void m25400_comp (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
   // the best comparison I can think of is checking each byte
   //  whether it's a padding byte or ASCII, if so we're good,
   //  if not, decryption was not successful
+
   bool correct = true;
+
   int i_padding=0;
-  for(int i=0;i<16;i++)
+
+  for (int i = 0; i < 16; i++)
   {
     // cast out buffer to byte such that we can do a byte per byte comparison
     const u32 *u32OutBufPtr = out;
@@ -363,15 +366,18 @@ KERNEL_FQ void m25400_comp (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
     // we don't use the user-password in the attack now (as we don't need it),
     //  however we could use it in the comparison of the decrypted o-value,
     //  yet it may make this attack a bit more fragile, as now we just check for ASCII
-    if((u8OutBufPtr[i] >=20 && u8OutBufPtr[i] <= 0x7e) || u8OutBufPtr[i]==u8OutPadPtr[i_padding])
+    if ((u8OutBufPtr[i] >= 20 && u8OutBufPtr[i] <= 0x7e) ||
+        (u8OutBufPtr[i] == u8OutPadPtr[i_padding]))
     {
-      if(u8OutBufPtr[i]==u8OutPadPtr[i_padding]) {
+      if (u8OutBufPtr[i] == u8OutPadPtr[i_padding])
+      {
         //printf("correct padding byte[%d]=0x%02x\n", i, u8OutBufPtr[i]);
-        i_padding=i_padding+1;
+        i_padding = i_padding + 1;
       }
       else
       {
-        if(u8OutBufPtr[i] >=20 && u8OutBufPtr[i] <= 0x7e) {
+        if (u8OutBufPtr[i] >= 20 && u8OutBufPtr[i] <= 0x7e)
+        {
           //printf("correct ASCII byte[%d]=0x%02x\n", i, u8OutBufPtr[i]);
         }
       }
@@ -400,6 +406,7 @@ KERNEL_FQ void m25400_comp (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
   if (correct)
   {
     int digest_pos = find_hash (digest, digests_cnt, &digests_buf[DIGESTS_OFFSET]);
+
     if (digest_pos != -1)
     {
       const u32 final_hash_pos = DIGESTS_OFFSET + digest_pos;

--- a/OpenCL/m27000-pure.cl
+++ b/OpenCL/m27000-pure.cl
@@ -643,7 +643,7 @@ KERNEL_FQ void m27000_comp (KERN_ATTR_TMPS_ESALT (netntlm_tmp_t, netntlm_t))
   const u32 d = tmps[gid].digest_buf[3];
 
   // I believe this matches the last 2 bytes and throws away.
-  // Taken from 5500. 
+  // Taken from 5500.
   if ((d >> 16) != s2) return;
 
   /**

--- a/OpenCL/m27200_a0-pure.cl
+++ b/OpenCL/m27200_a0-pure.cl
@@ -43,7 +43,7 @@ KERNEL_FQ void m27200_mxx (KERN_ATTR_RULES ())
   ctx0.w0[1] = dash[1];
 
   ctx0.len = 2;
-  
+
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
   sha1_update (&ctx0, dash, 2);
 
@@ -106,12 +106,12 @@ KERNEL_FQ void m27200_sxx (KERN_ATTR_RULES ())
   sha1_ctx_t ctx0;
 
   sha1_init (&ctx0);
-  
+
   ctx0.w0[0] = dash[0];
   ctx0.w0[1] = dash[1];
 
   ctx0.len = 2;
-  
+
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
   sha1_update (&ctx0, dash, 2);
 

--- a/OpenCL/m27200_a1-pure.cl
+++ b/OpenCL/m27200_a1-pure.cl
@@ -78,7 +78,7 @@ KERNEL_FQ void m27200_sxx (KERN_ATTR_BASIC ())
   if (gid >= gid_max) return;
 
   const u32 dash[16] = { 0x2d2d0000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-  
+
   /**
    * digest
    */
@@ -103,7 +103,7 @@ KERNEL_FQ void m27200_sxx (KERN_ATTR_BASIC ())
   ctx0.w0[1] = dash[1];
 
   ctx0.len = 2;
-  
+
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
   sha1_update (&ctx0, dash, 2);
 

--- a/OpenCL/m27200_a3-optimized.cl
+++ b/OpenCL/m27200_a3-optimized.cl
@@ -158,7 +158,7 @@ DECLSPEC void m27200m (u32 *w0, u32 *w1, u32 *w2, u32 *w3, const u32 pw_len, KER
     t3[1] = w3[1];
     t3[2] = w3[2];
     t3[3] = w3[3];
-    
+
     switch_buffer_by_offset_be (t0, t1, t2, t3, salt_len);
 
     t0[0] |= salt_buf0[0];

--- a/OpenCL/m27200_a3-pure.cl
+++ b/OpenCL/m27200_a3-pure.cl
@@ -98,7 +98,7 @@ KERNEL_FQ void m27200_sxx (KERN_ATTR_VECTOR ())
 
   const u32x dash_vector[16] = { 0x2d2d0000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
   const u32 dash_scalar[16] = { 0x2d2d0000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-  
+
   /**
    * digest
    */
@@ -132,7 +132,7 @@ KERNEL_FQ void m27200_sxx (KERN_ATTR_VECTOR ())
   ctx0.w0[1] = dash_scalar[1];
 
   ctx0.len = 2;
-  
+
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS].salt_buf, salt_bufs[SALT_POS].salt_len);
   sha1_update (&ctx0, dash_scalar, 2);
 

--- a/OpenCL/m27800_a0-optimized.cl
+++ b/OpenCL/m27800_a0-optimized.cl
@@ -15,42 +15,42 @@
 #include "inc_simd.cl"
 #endif
 
-inline u32 Murmur32_Scramble(u32 k) 
+inline u32 Murmur32_Scramble(u32 k)
 {
   k = (k * 0x16A88000) | ((k * 0xCC9E2D51) >> 17);
   return (k * 0x1B873593);
 }
 
-DECLSPEC u32 MurmurHash3(const u32 seed, const u32* data, const u32 size) 
+DECLSPEC u32 MurmurHash3(const u32 seed, const u32* data, const u32 size)
 {
   u32 checksum = seed;
 
   const u32 nBlocks = (size / 4);
   if (size >= 4) //Hash blocks, sizes of 4
   {
-    for (u32 i = 0; i < nBlocks; i++) 
+    for (u32 i = 0; i < nBlocks; i++)
     {
       checksum ^= Murmur32_Scramble(data[i]);
       checksum = (checksum >> 19) | (checksum << 13); //rotateRight(checksum, 19)
       checksum = (checksum * 5) + 0xE6546B64;
     }
   }
-    
-  if (size % 4) 
+
+  if (size % 4)
   {
     const u8* remainder = (u8*)(data + nBlocks);
     u32 val = 0;
 
-    switch(size & 3) //Hash remaining bytes as size isn't always aligned by 4 
-    { 
-      case 3: 
+    switch(size & 3) //Hash remaining bytes as size isn't always aligned by 4
+    {
+      case 3:
         val ^= (remainder[2] << 16);
-      case 2: 
+      case 2:
         val ^= (remainder[1] << 8);
       case 1:
         val ^= remainder[0];
         checksum ^= Murmur32_Scramble(val);
-      default: 
+      default:
         break;
     };
   }

--- a/OpenCL/m27800_a1-optimized.cl
+++ b/OpenCL/m27800_a1-optimized.cl
@@ -13,42 +13,42 @@
 #include "inc_simd.cl"
 #endif
 
-inline u32 Murmur32_Scramble(u32 k) 
+inline u32 Murmur32_Scramble(u32 k)
 {
   k = (k * 0x16A88000) | ((k * 0xCC9E2D51) >> 17);
   return (k * 0x1B873593);
 }
 
-DECLSPEC u32 MurmurHash3(const u32 seed, const u32* data, const u32 size) 
+DECLSPEC u32 MurmurHash3(const u32 seed, const u32* data, const u32 size)
 {
   u32 checksum = seed;
 
   const u32 nBlocks = (size / 4);
   if (size >= 4) //Hash blocks, sizes of 4
   {
-    for (u32 i = 0; i < nBlocks; i++) 
+    for (u32 i = 0; i < nBlocks; i++)
     {
       checksum ^= Murmur32_Scramble(data[i]);
       checksum = (checksum >> 19) | (checksum << 13); //rotateRight(checksum, 19)
       checksum = (checksum * 5) + 0xE6546B64;
     }
   }
-    
-  if (size % 4) 
+
+  if (size % 4)
   {
     const u8* remainder = (u8*)(data + nBlocks);
     u32 val = 0;
 
-    switch(size & 3) //Hash remaining bytes as size isn't always aligned by 4 
-    { 
-      case 3: 
+    switch(size & 3) //Hash remaining bytes as size isn't always aligned by 4
+    {
+      case 3:
         val ^= (remainder[2] << 16);
-      case 2: 
+      case 2:
         val ^= (remainder[1] << 8);
       case 1:
         val ^= remainder[0];
         checksum ^= Murmur32_Scramble(val);
-      default: 
+      default:
         break;
     };
   }

--- a/OpenCL/m27800_a3-optimized.cl
+++ b/OpenCL/m27800_a3-optimized.cl
@@ -13,7 +13,7 @@
 #include "inc_simd.cl"
 #endif
 
-inline u32x Murmur32_Scramble(u32x k) 
+inline u32x Murmur32_Scramble(u32x k)
 {
   k = (k * 0x16A88000) | ((k * 0xCC9E2D51) >> 17);
   return (k * 0x1B873593);
@@ -22,7 +22,7 @@ inline u32x Murmur32_Scramble(u32x k)
 DECLSPEC u32x MurmurHash3(const u32 seed, const u32x w0, const u32* data, const u32 size) {
   u32x checksum = seed;
 
-  if (size >= 4) 
+  if (size >= 4)
   {
     checksum ^= Murmur32_Scramble(w0);
     checksum = (checksum >> 19) | (checksum << 13); //rotateRight(checksum, 19)
@@ -30,52 +30,52 @@ DECLSPEC u32x MurmurHash3(const u32 seed, const u32x w0, const u32* data, const 
 
     const u32 nBlocks = (size / 4);
     if (size >= 4) //Hash blocks, sizes of 4
-    { 
-      for (u32 i = 1; i < nBlocks; i++) 
+    {
+      for (u32 i = 1; i < nBlocks; i++)
       {
         checksum ^= Murmur32_Scramble(data[i]);
         checksum = (checksum >> 19) | (checksum << 13); //rotateRight(checksum, 19)
         checksum = (checksum * 5) + 0xE6546B64;
       }
     }
-      
-    if (size % 4) 
+
+    if (size % 4)
     {
       const u8* remainder = (u8*)(data + nBlocks);
       u32x val = 0;
 
       switch(size & 3) //Hash remaining bytes as size isn't always aligned by 4
       {
-        case 3: 
-          val ^= (remainder[2] << 16);
-        case 2: 
-          val ^= (remainder[1] << 8);
-        case 1: 
-          val ^= remainder[0];
-          checksum ^= Murmur32_Scramble(val);
-        default: 
-          break;
-      };
-    }
-  }
-
-  else 
-  {
-    if (size % 4) 
-    {
-      const u8* remainder = (u8*)(&w0);
-      u32x val = 0;
-
-      switch(size & 3) 
-      {
-        case 3: 
+        case 3:
           val ^= (remainder[2] << 16);
         case 2:
           val ^= (remainder[1] << 8);
         case 1:
           val ^= remainder[0];
           checksum ^= Murmur32_Scramble(val);
-        default: 
+        default:
+          break;
+      };
+    }
+  }
+
+  else
+  {
+    if (size % 4)
+    {
+      const u8* remainder = (u8*)(&w0);
+      u32x val = 0;
+
+      switch(size & 3)
+      {
+        case 3:
+          val ^= (remainder[2] << 16);
+        case 2:
+          val ^= (remainder[1] << 8);
+        case 1:
+          val ^= remainder[0];
+          checksum ^= Murmur32_Scramble(val);
+        default:
           break;
       };
     }
@@ -165,7 +165,7 @@ DECLSPEC void m27800s (const u32 *w, const u32 pw_len, KERN_ATTR_VECTOR ())
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
-    
+
     const u32x hash = MurmurHash3 (seed, w0, w, pw_len);
 
     const u32x r0 = hash;

--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -34,7 +34,7 @@ static bool xz_initialized = false;
 static const ISzAlloc xz_alloc = { hc_lzma_alloc, hc_lzma_free };
 
 struct xzfile
-{  
+{
   CAlignOffsetAlloc  alloc;
   UInt64             inBlocks;
   Byte              *inBuf;
@@ -532,7 +532,7 @@ size_t hc_fwrite (const void *ptr, size_t size, size_t nmemb, HCFILE *fp)
   else if (fp->gfp)
   {
     n = gzfwrite (ptr, size, nmemb, fp->gfp);
-  }  
+  }
 
   return n;
 }

--- a/src/modules/module_27200.c
+++ b/src/modules/module_27200.c
@@ -174,7 +174,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) salt->salt_buf, salt->salt_len, out_buf + out_len);
-  
+
   return out_len;
 }
 

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -943,7 +943,7 @@ HC_API_CALL void *thread_selftest (void *p)
 
     if (hc_hipCtxPopCurrent (hashcat_ctx, &device_param->hip_context) == -1) return NULL;
   }
-  
+
   if (device_param->is_opencl == true)
   {
     if (hc_clFinish (hashcat_ctx, device_param->opencl_command_queue) == -1) return NULL;

--- a/tools/test_modules/m27100.pm
+++ b/tools/test_modules/m27100.pm
@@ -12,7 +12,7 @@ use Digest::HMAC qw (hmac hmac_hex);
 use Digest::MD5  qw (md5);
 use Encode       qw (encode);
 
-sub module_constraints { [[32, 32], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] } 
+sub module_constraints { [[32, 32], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
This is just a minor/small list of some code style fixes, mainly spaces at the end of a line or opening brackets not within the next line.

I've found most of them with just a couple of greps like `grep -r ' $' src/ OpenCL/`.

Thanks