### PR TITLE
Added Computer account decoding for -m 19700

### DIFF
--- a/src/modules/module_19700.c
+++ b/src/modules/module_19700.c
@@ -26,6 +26,7 @@ static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$krb5tgs$18$srv_http$synacktiv.local$16ce51f6eba20c8ee534ff8a$57d07b23643a516834795f0c010da8f549b7e65063e5a367ca9240f9b800adad1734df7e7d5dd8307e785de4f40aacf901df41aa6ce695f8619ec579c1fa57ee93661cf402aeef4e3a42e7e3477645d52c09dc72feade03512dffe0df517344f673c63532b790c242cc1d50f4b4b34976cb6e08ab325b3aefb2684262a5ee9faacb14d059754f50553be5bfa5c4c51e833ff2b6ac02c6e5d4c4eb193e27d7dde301bd1ddf480e5e282b8c27ef37b136c8f140b56de105b73adeb1de16232fa1ab5c9f6";
+//static const char *ST_HASH        = "$krb5tgs$18$CLIENT1$$VALJEAN.LOCAL$*valjean.local/CLIENT1$*$89dcdcdf385512b99b21dfd7$1f3d349af8775987651876b9714f3a1ff4f7a18f4af2f544689201ea39ac3f905b886e14a73dfa5d1d903310abb633cbb13782cd3cf9761310af993ef86b0d88e32fdf0917e73503b3ab3d9c762a2e9d3f7607434f965e2750e5157e38333056b17d854460edb351e5b0f50c0becc3ceede14448b2af649175e0f53748349793540cfa97b3f184d69f36e61c334d2e8270c86a4f0daf532290826963075e859cdf535747aabdd2cf2f340575ebc3bdc8781d80c0d7178d99273562526fbaeec4866a6a61d1a5f9b3e480ba3c2d64af9839b7a5f611c3e80bc5cbde455df4ec667869e9bf3d3443737921b56a159d70e0a17c5ab8b8f70ef8920d31bd0f56bb9948eb40a1f08d6dfcb617ba5b539ce14ef3c4b37fdcbed6d5b079999dc9b51c7ae037f4116f96feb080b15a9e713402a0dfc46d151b478111940a595b685524f461fde02482d777dae07ae7417505f1d0aa4c1a1ccda3dd083b3c959105c23b061d2995b8c5e675d261cd11b5754264d283ab2d85c5cf5e4bdfaac39c46946a42830548f7815680e7f98f6596ebc0b0539dffe5d59a63590c1b3aeebf858e2b84e9eb4027e55da2726c2b3e94916e74b58bc269fed4b3e5da5476010f92970b93424290c5311303a6d9ea8fafea02331ab195df8c6c2a8221d2a893fa3573321700b130a3a300ebfa22b5e7996bd7ec7cdcae0a47165a43bc99087bed1a1e10477259206e7c7a4a13c8625cabe2baab7f2958783c1bd7f3ca516b5c67cdb62ec0f9519d4275b908bf7aeb2773d03262a4984e1a0e31756bea8b0610ec6690565d267b1a5bed3d9c51226ec2dd2ff8dd45a7c4e41637830640947b6fc23ef463c57b58e9fe30877e179742905e5a2e2daabc8a124356de818f55ef3957fe1d2f74095c2c040d145ef7d84a0df6ddc9eb6cb7e53b00ea21b84d43583bff3c9b3828e410fa8660dfc1e597e681ea94f49f9e4274d8e8661d33da26290c153ec6d5bca60d558727c96edb6ba6d4a9837f698dd748e3a1dc088f8827b3325abdbf9080c441967a6b8fd483500025119a53ed100084a8dd9816e3067b38ac9c98a2bd730048a401aaf45aeb2fe25c9e609830739a41300ed98dc28ab5249340f4e9d8c4d48f5ca0981e022705502798f39516c889ed74b8aac8d0438924b8a3b79ad6108ea551a6f9acdd56ad56383b8c0ba6ed7e3e06f3d09f8ee636cad9696d08282d64c42632f5ba6e066032b2484de8519ea5a27c5ab5eeace286cbce46b51ed68e6df845153a8be23d614a3351471c2e6e2b11f1"
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -117,16 +118,26 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   char *spn_info_start  = strchr ((const char *) line_buf + 12 + 1, '*');
 
   int is_spn_provided = 0;
+  int is_machine_account = 0;
+
+  const char *usr_start  = line_buf + strlen(SIGNATURE_KRB5TGS);
+  char *usr_end = strchr ((const char *) usr_start, '$');
+
+  if (*(usr_end+1) == '$'){
+    is_machine_account = 1;
+    usr_end++;
+  }
+
+  int usr_len = usr_end - usr_start;
+  usr_len++; // we want the $ char included
 
   // assume $krb5tgs$17$user$realm$checksum$edata2
   if (spn_info_start == NULL)
   {
     token.token_cnt  = 5;
 
-    token.sep[1]     = '$';
-    token.len_min[1] = 1;
-    token.len_max[1] = 512;
-    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+    token.len[1]     = usr_len;
+    token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
 
     token.sep[2]     = '$';
     token.len_min[2] = 1;
@@ -160,10 +171,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     token.token_cnt  = 6;
 
-    token.sep[1]     = '$';
-    token.len_min[1] = 1;
-    token.len_max[1] = 512;
-    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+    token.len[1]     = usr_len;
+    token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
 
     token.sep[2]     = '$';
     token.len_min[2] = 1;
@@ -202,6 +211,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   int data_len;
   int account_info_len;
 
+  token.len[1]--; //Removing trailing '$' due to TOKEN_ATTR_FIXED_LENGTH
   user_pos = token.buf[1];
   user_len = token.len[1];
 
@@ -217,9 +227,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   data_pos = token.buf[4 + is_spn_provided];
   data_len = token.len[4 + is_spn_provided];
 
-  account_info_len = token.len[2] + token.len[1];
-
-  u8 *account_info_ptr = (u8 *) krb5tgs->account_info;
 
   // domain must be uppercase
 
@@ -228,8 +235,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   memcpy (domain, domain_pos, domain_len);
   uppercase (domain, domain_len);
 
-  memcpy (account_info_ptr, domain, domain_len);
-  memcpy (account_info_ptr + domain_len, user_pos, user_len);
+  if (is_machine_account){
+    //Format = uppercase(domain) + "host" + lowercase(fqdn)(without $)
+    account_info_len = snprintf ((char *)krb5tgs->account_info, 512, "%shost%.*s.%s",
+    domain,
+    user_len - 1, //remove $
+    (char*)krb5tgs->user,
+    domain);
+
+    lowercase( (u8 *)(krb5tgs->account_info) + domain_len + 4, // domain_len + "host"
+    account_info_len - domain_len + 4);
+  } else {
+    //Format = uppercase(domain) + lowercase(username)
+    account_info_len = snprintf ((char *)krb5tgs->account_info, 512, "%s%s",
+    domain,
+    (char*)krb5tgs->user);
+  }
 
   krb5tgs->account_info_len = account_info_len;
 


### PR DESCRIPTION
It is unusual to crack computer account passwords but why not ... It happens sometimes (Unix systems or static password for Windows VM/snapshots)

The format now accepts accounts with trailing `$` and generate `krb5tgs->account_info` in consequence.

An example format can be found in `ST_HASH` and a PR is opened on [impacket](https://github.com/SecureAuthCorp/impacket/pull/1196).