### PR TITLE
Increase maximum value for s2k-count

### DIFF
--- a/src/modules/module_17010.c
+++ b/src/modules/module_17010.c
@@ -280,7 +280,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u32 salt_iter = hc_strtoul ((const char *) token.buf[11], NULL, 10);
 
-  if (salt_iter < 8 || salt_iter > 1000000) return (PARSER_SALT_ITERATION);
+  if (salt_iter < 8 || salt_iter > 65011712) return (PARSER_SALT_ITERATION);
 
   salt->salt_iter = salt_iter;
 


### PR DESCRIPTION
Increases the maximum allowed value for s2k-count. The maximum s2k-count value is 65011712 according to the PGP spec. 

Increasing this value fixes a salt iteration exception for hashes with non-default value for s2k-count. (Fix successfully tested with a hash with 62914560 s2k-count.)