### PR TITLE
tests: get rid of wrong modules from -m 28100

### DIFF
--- a/tools/test_modules/m28100.pm
+++ b/tools/test_modules/m28100.pm
@@ -8,9 +8,7 @@
 use strict;
 use warnings;
 
-use Digest::MD4 qw (md4 md4_hex);
-use Digest::SHA qw (sha1 sha1_hex);
-use Digest::SHA qw (sha512 sha512_hex);
+use Digest::SHA qw (sha1 sha512);
 use Crypt::PBKDF2;
 use Encode;
 


### PR DESCRIPTION
I've discovered this by accident, but I'm sure the additional modules listed in the `-m 28100 = Windows Hello` test module can be removed (I've also tested it and it still works for me).

Thank you