### PR TITLE
Fixing HEX wordlist support in -m 3000 see #3050

### DIFF
--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -131,6 +131,25 @@ void get_next_word_lm_hex (char *buf, u64 sz, u64 *len, u64 *off)
 {
   // this one is called if --hex-wordlist is uesed
   // we need 14 hex-digits to get 7 characters
+  // but first convert 7 chars to upper case if thay are a-z
+  for (u64 i = 5; i < sz; i++)
+  {
+    if ((i & 1) == 0)
+    {
+      if (is_valid_hex_char(buf[i]))
+        if (is_valid_hex_char(buf[i+1]))
+          {
+            if (buf[i] == '6')
+              if (buf[i+1] > '0')
+                buf[i] = '4';
+            if (buf[i] == '7')
+              if (buf[i+1] < 'B')
+                buf[i] = '5';
+          }
+    }
+    if (i == 12) break;  // stop when 7 chars are converted
+  }
+  // call generic next_word
   get_next_word_lm_gen(buf, sz, len, off, 14);
 }
 
@@ -163,7 +182,8 @@ void get_next_word_lm_hex_or_text (char *buf, u64 sz, u64 *len, u64 *off)
         // upcase character if it is a letter 'a-z'
         if ((i & 1) == 1) // if first hex-char
         { 
-          if (is_valid_hex_char(buf[i+1])){
+          if (is_valid_hex_char(buf[i+1]))
+          {
             if (buf[i] == '6')
               if (buf[i+1] > '0')
                 buf[i] = '4';

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -97,7 +97,7 @@ int load_segment (hashcat_ctx_t *hashcat_ctx, HCFILE *fp)
   return 0;
 }
 
-void get_next_word_lm (char *buf, u64 sz, u64 *len, u64 *off)
+void get_next_word_lm_gen (char *buf, u64 sz, u64 *len, u64 *off, u64 cutlen)
 {
   char *ptr = buf;
 
@@ -105,12 +105,11 @@ void get_next_word_lm (char *buf, u64 sz, u64 *len, u64 *off)
   {
     if (*ptr >= 'a' && *ptr <= 'z') *ptr -= 0x20;
 
-    if (i == 7)
+    if (i == cutlen)
     {
-      *off = i;
+      if (cutlen == 20) buf[i-1]=']'; // add ] in $HEX[] format
       *len = i;
-
-      return;
+      // but continue a loop to skip rest of the line
     }
 
     if (*ptr != '\n') continue;
@@ -119,13 +118,54 @@ void get_next_word_lm (char *buf, u64 sz, u64 *len, u64 *off)
 
     if ((i > 0) && (buf[i - 1] == '\r')) i--;
 
-    *len = i;
+    if (i < cutlen + 1) *len = i;
 
     return;
   }
 
   *off = sz;
-  *len = sz;
+  if (sz<cutlen) *len = sz;
+}
+
+void get_next_word_lm_hex (char *buf, u64 sz, u64 *len, u64 *off)
+{
+  // this one is called if --hex-wordlist is uesed
+  // we need 14 hex-digits to get 7 characters
+  get_next_word_lm_gen(buf, sz, len, off, 14);
+}
+
+void get_next_word_lm_text (char *buf, u64 sz, u64 *len, u64 *off)
+{
+  // check if not $HEX[..] format
+  bool hex = true;
+  if (sz<8) hex=false;
+  if (hex && (buf[0]       != '$')) hex = false;
+  if (hex && (buf[1]       != 'H')) hex = false;
+  if (hex && (buf[2]       != 'E')) hex = false;
+  if (hex && (buf[3]       != 'X')) hex = false;
+  if (hex && (buf[4]       != '[')) hex = false;
+  if (hex){
+    char *ptr = buf;
+    for (u64 i = 0; i < sz; i++, ptr++)
+    {
+      if (*ptr == ']')
+      {
+        if ((i & 1) == 0) hex=false;  // not even number of characters
+        else
+          break;
+      }
+    }
+  }
+  if (hex)
+  {
+    //$HEX[] format so we need max 14 hex-digits + 6 chars '$HEX[]'
+    get_next_word_lm_gen(buf, sz, len, off, 20); 
+  }
+  else
+  {
+    // threat it as normal string
+    get_next_word_lm_gen(buf, sz, len, off, 7);
+  }
 }
 
 void get_next_word_uc (char *buf, u64 sz, u64 *len, u64 *off)
@@ -615,7 +655,13 @@ int wl_data_init (hashcat_ctx_t *hashcat_ctx)
 
   if (hashconfig->opts_type & OPTS_TYPE_PT_LM)
   {
-    wl_data->func = get_next_word_lm;
+    if (hashconfig->opts_type & OPTS_TYPE_PT_HEX){
+      wl_data->func = get_next_word_lm_hex;
+    }
+    else
+    {
+      wl_data->func = get_next_word_lm_text;
+    }
   }
 
   /**

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -119,7 +119,7 @@ void get_next_word_lm_gen (char *buf, u64 sz, u64 *len, u64 *off, u64 cutlen)
     if ((i > 0) && (buf[i - 1] == '\r')) i--;
 
     if (i < cutlen + 1) *len = i;
-
+ 
     return;
   }
 
@@ -145,14 +145,33 @@ void get_next_word_lm_hex_or_text (char *buf, u64 sz, u64 *len, u64 *off)
   if (hex && (buf[3]       != 'X')) hex = false;
   if (hex && (buf[4]       != '[')) hex = false;
   if (hex){
-    char *ptr = buf;
-    for (u64 i = 0; i < sz; i++, ptr++)
+    char *ptr = buf+5;
+    for (u64 i = 5; i < sz; i++, ptr++)
     {
       if (*ptr == ']')
       {
         if ((i & 1) == 0) hex=false;  // not even number of characters
-        else
+        break;
+      }
+      else
+      {
+        if (is_valid_hex_char(*ptr) == false)
+        {
+          hex = false;
           break;
+        }
+        // upcase character if it is as letter
+        if ((i & 1) == 1) // if first hex-char
+        { 
+          if (is_valid_hex_char(buf[i+1])){
+            if (buf[i] == '6')
+              if (buf[i+1] > '0')
+                buf[i] = '4';
+            if (buf[i] == '7')
+              if (buf[i+1] < 'B')
+                buf[i] = '5';
+          }
+        }
       }
     }
   }

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -119,7 +119,7 @@ void get_next_word_lm_gen (char *buf, u64 sz, u64 *len, u64 *off, u64 cutlen)
     if ((i > 0) && (buf[i - 1] == '\r')) i--;
 
     if (i < cutlen + 1) *len = i;
- 
+
     return;
   }
 
@@ -145,7 +145,7 @@ void get_next_word_lm_hex_or_text (char *buf, u64 sz, u64 *len, u64 *off)
   if (hex && (buf[3]       != 'X')) hex = false;
   if (hex && (buf[4]       != '[')) hex = false;
   if (hex){
-    char *ptr = buf+5;
+    char *ptr = buf+5;     // starting after '['
     for (u64 i = 5; i < sz; i++, ptr++)
     {
       if (*ptr == ']')
@@ -160,7 +160,7 @@ void get_next_word_lm_hex_or_text (char *buf, u64 sz, u64 *len, u64 *off)
           hex = false;
           break;
         }
-        // upcase character if it is as letter
+        // upcase character if it is a letter 'a-z'
         if ((i & 1) == 1) // if first hex-char
         { 
           if (is_valid_hex_char(buf[i+1])){

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -134,7 +134,7 @@ void get_next_word_lm_hex (char *buf, u64 sz, u64 *len, u64 *off)
   get_next_word_lm_gen(buf, sz, len, off, 14);
 }
 
-void get_next_word_lm_text (char *buf, u64 sz, u64 *len, u64 *off)
+void get_next_word_lm_hex_or_text (char *buf, u64 sz, u64 *len, u64 *off)
 {
   // check if not $HEX[..] format
   bool hex = true;
@@ -166,6 +166,11 @@ void get_next_word_lm_text (char *buf, u64 sz, u64 *len, u64 *off)
     // threat it as normal string
     get_next_word_lm_gen(buf, sz, len, off, 7);
   }
+}
+
+void get_next_word_lm_text (char *buf, u64 sz, u64 *len, u64 *off)
+{
+    get_next_word_lm_gen(buf, sz, len, off, 7);
 }
 
 void get_next_word_uc (char *buf, u64 sz, u64 *len, u64 *off)
@@ -656,11 +661,16 @@ int wl_data_init (hashcat_ctx_t *hashcat_ctx)
   if (hashconfig->opts_type & OPTS_TYPE_PT_LM)
   {
     if (hashconfig->opts_type & OPTS_TYPE_PT_HEX){
-      wl_data->func = get_next_word_lm_hex;
+      wl_data->func = get_next_word_lm_hex;           // all hex in file
     }
     else
     {
-      wl_data->func = get_next_word_lm_text;
+      if (user_options->wordlist_autohex_disable == false)
+      {
+        wl_data->func = get_next_word_lm_hex_or_text; // might be $HEX[] notation
+      }else{
+        wl_data->func = get_next_word_lm_text;        // treat as nromal text
+      }
     }
   }
 


### PR DESCRIPTION
Solving problem described in #3050 
Impacted code is only used in -m 3000 hash-type.

Additionally, this one solves an issues of splitting lines into more than one password candidate as I've described in #3050 
