### PR TITLE
Added support to use Apple Silicon compute devices

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -22,6 +22,8 @@
 - Tuning Database: Added a warning if a module implements module_extra_tuningdb_block but the installed computing device is not found
 - Usage Screen: On windows console, wait for any keypress if usage_mini_print() is used
 - User Options: Add new module function module_hash_decode_postprocess() to override hash specific configurations from command line
+- OpenCL Runtime: Added support to use Apple Silicon compute devices
+- OpenCL Runtime: Set default device-type to GPU with Apple Silicon compute devices
 
 * changes v6.2.4 -> v6.2.5
 

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -22,6 +22,7 @@ Gabriele "matrix" Gristina <matrix@hashcat.net> (@gm4tr1x)
 * Compressed wordlist feature
 * OpenCL Info feature
 * Apple macOS port
+* Apple Silicon support
 * Hardware monitor initial code base and maintenance
 * Test suite initial code base
 * Makefile initial code base

--- a/src/backend.c
+++ b/src/backend.c
@@ -341,11 +341,27 @@ static bool setup_opencl_device_types_filter (hashcat_ctx_t *hashcat_ctx, const 
   {
     #if defined (__APPLE__)
 
-    // For apple use CPU only, because GPU drivers are not reliable
-    // The user can explicitly enable GPU by setting -D2
+    #include <sys/sysctl.h>
 
-    //opencl_device_types_filter = CL_DEVICE_TYPE_ALL & ~CL_DEVICE_TYPE_GPU;
-    opencl_device_types_filter = CL_DEVICE_TYPE_CPU;
+    size_t size;
+    cpu_type_t cpu_type = 0;
+    size = sizeof (cpu_type);
+    sysctlbyname ("hw.cputype", &cpu_type, &size, NULL, 0);
+
+    if (cpu_type == 0x100000c)
+    {
+      // For apple M1* use GPU only, because CPU device it is not recognized by OpenCL
+
+      opencl_device_types_filter = CL_DEVICE_TYPE_GPU;
+    }
+    else
+    {
+      // For apple use CPU only, because GPU drivers are not reliable
+      // The user can explicitly enable GPU by setting -D2
+
+      //opencl_device_types_filter = CL_DEVICE_TYPE_ALL & ~CL_DEVICE_TYPE_GPU;
+      opencl_device_types_filter = CL_DEVICE_TYPE_CPU;
+    }
 
     #else
 


### PR DESCRIPTION
- OpenCL Runtime: Added support to use Apple Silicon compute devices
- OpenCL Runtime: Set default device-type to GPU with Apple Silicon compute devices

This patch also close the following issues: #3044 and #3022

Thanks