### PR TITLE
Updated Apple Silicon support

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -30,6 +30,7 @@
 - User Options: Add new module function module_hash_decode_postprocess() to override hash specific configurations from command line
 - OpenCL Runtime: Added support to use Apple Silicon compute devices
 - OpenCL Runtime: Set default device-type to GPU with Apple Silicon compute devices
+- Apple Silicon: clCreateKernel() never ends with optimized kernel, fallback to pure
 
 * changes v6.2.4 -> v6.2.5
 

--- a/include/shared.h
+++ b/include/shared.h
@@ -103,4 +103,8 @@ int  generic_salt_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, const u8 
 
 int input_tokenizer (const u8 *input_buf, const int input_len, token_t *token);
 
+#if defined (__APPLE__)
+bool is_apple_silicon (void);
+#endif
+
 #endif // _SHARED_H

--- a/src/backend.c
+++ b/src/backend.c
@@ -341,22 +341,15 @@ static bool setup_opencl_device_types_filter (hashcat_ctx_t *hashcat_ctx, const 
   {
     #if defined (__APPLE__)
 
-    #include <sys/sysctl.h>
-
-    size_t size;
-    cpu_type_t cpu_type = 0;
-    size = sizeof (cpu_type);
-    sysctlbyname ("hw.cputype", &cpu_type, &size, NULL, 0);
-
-    if (cpu_type == 0x100000c)
+    if (is_apple_silicon() == true)
     {
-      // For apple M1* use GPU only, because CPU device it is not recognized by OpenCL
+      // With Apple's M1* use GPU only, because CPU device it is not recognized by OpenCL
 
       opencl_device_types_filter = CL_DEVICE_TYPE_GPU;
     }
     else
     {
-      // For apple use CPU only, because GPU drivers are not reliable
+      // With Apple Intel use CPU only, because GPU drivers are not reliable
       // The user can explicitly enable GPU by setting -D2
 
       //opencl_device_types_filter = CL_DEVICE_TYPE_ALL & ~CL_DEVICE_TYPE_GPU;
@@ -469,7 +462,6 @@ static bool opencl_test_instruction (hashcat_ctx_t *hashcat_ctx, cl_context cont
   backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
 
   OCL_PTR *ocl = (OCL_PTR *) backend_ctx->ocl;
-
 
   #ifndef DEBUG
   const int fd_stderr = fileno (stderr);
@@ -14015,6 +14007,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
             snprintf (kernel_name, sizeof (kernel_name), "m%05u_s%02d", kern_type, 4);
 
+            // BUG: with Apple's M1 device the following call never ends
             if (hc_clCreateKernel (hashcat_ctx, device_param->opencl_program, kernel_name, &device_param->opencl_kernel1) == -1) return -1;
 
             if (get_opencl_kernel_wgs (hashcat_ctx, device_param, device_param->opencl_kernel1, &device_param->kernel_wgs1) == -1) return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -506,11 +506,18 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
   {
     if (hashconfig->has_optimized_kernel == true)
     {
-      event_log_advice (hashcat_ctx, "ATTENTION! Pure (unoptimized) backend kernels selected.");
-      event_log_advice (hashcat_ctx, "Pure kernels can crack longer passwords, but drastically reduce performance.");
-      event_log_advice (hashcat_ctx, "If you want to switch to optimized kernels, append -O to your commandline.");
-      event_log_advice (hashcat_ctx, "See the above message to find out about the exact limits.");
-      event_log_advice (hashcat_ctx, NULL);
+      #if defined (__APPLE__)
+      // With Apple's M1* only pure kernel works for now, then the message will not be shown
+
+      if (is_apple_silicon() == false)
+      #endif
+      {
+        event_log_advice (hashcat_ctx, "ATTENTION! Pure (unoptimized) backend kernels selected.");
+        event_log_advice (hashcat_ctx, "Pure kernels can crack longer passwords, but drastically reduce performance.");
+        event_log_advice (hashcat_ctx, "If you want to switch to optimized kernels, append -O to your commandline.");
+        event_log_advice (hashcat_ctx, "See the above message to find out about the exact limits.");
+        event_log_advice (hashcat_ctx, NULL);
+      }
     }
   }
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -15,6 +15,10 @@
 #include <sys/cygwin.h>
 #endif
 
+#if defined (__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
 static const char *const PA_000 = "OK";
 static const char *const PA_001 = "Ignored due to comment";
 static const char *const PA_002 = "Ignored due to zero length";
@@ -1369,3 +1373,17 @@ int generic_salt_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, const u8 *
 
   return tmp_len;
 }
+
+#if defined (__APPLE__)
+
+bool is_apple_silicon (void)
+{
+  size_t size;
+  cpu_type_t cpu_type = 0;
+  size = sizeof (cpu_type);
+  sysctlbyname ("hw.cputype", &cpu_type, &size, NULL, 0);
+
+  return (cpu_type == 0x100000c);
+}
+
+#endif // __APPLE__

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1780,6 +1780,29 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
+  #if defined (__APPLE__)
+
+  if (is_apple_silicon() == true)
+  {
+    if (user_options->optimized_kernel_enable == true)
+    {
+      // With Apple's M1* only pure kernel works
+      // For now we need fallback to pure to prevent infinite wait on clCreateKernel()
+
+      if (user_options->quiet == false)
+      {
+        event_log_advice (hashcat_ctx, "ATTENTION! Apple's M1 OpenCL drivers (GPU) are known not to work with optimized kernel.");
+        event_log_advice (hashcat_ctx, "Fallback to pure (unoptimized) kernel.");
+      }
+
+      user_options->optimized_kernel_enable = false;
+
+      if (user_options->quiet == false) event_log_advice (hashcat_ctx, NULL);
+    }
+  }
+
+  #endif // __APPLE__
+
   if (user_options->hash_info == true)
   {
     user_options->quiet = true;


### PR DESCRIPTION
Hi,

the following patch introduces two changes:
- with Apple M1*, optimized kernel doesn't work due to unknown OpenCL bug. Pure kernels will be forced. Using Optimized kernels, hashcat execution is blocked when the clCreateKernel () function is called at this location: https://github.com/hashcat/hashcat/blob/50e28ff3064db43eb3b10490974ec1e9c4910745/src/backend.c#L13888-L13894


- token_t has been renamed to hc_token_t, due to the following error:

<img width="714" alt="Screen Shot 2021-12-17 at 01 57 40" src="https://user-images.githubusercontent.com/15381185/146471257-26a505dc-a7f5-4e0f-b270-2b7cca610874.png">

Following the hashcat output with Apple M1 (using: ./hashcat -m 0 -t 32 -a 7 example0.hash ?a?a?a?a example.dict -O)

<img width="534" alt="Screen Shot 2021-12-17 at 02 04 16 1" src="https://user-images.githubusercontent.com/15381185/146471782-036c4aca-f618-46e9-8d06-017751aaa57a.png">

ends with

<img width="480" alt="Screen Shot 2021-12-17 at 02 06 29" src="https://user-images.githubusercontent.com/15381185/146471899-2f48ad13-77d6-470a-a8c9-962e34c0ed68.png">

Thanks :)