### PR TITLE
Backend Info: Added local memory size to output

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -30,6 +30,7 @@
 - User Options: Add new module function module_hash_decode_postprocess() to override hash specific configurations from command line
 - OpenCL Runtime: Added support to use Apple Silicon compute devices
 - OpenCL Runtime: Set default device-type to GPU with Apple Silicon compute devices
+- Backend Info: Added local memory size to output
 
 * changes v6.2.4 -> v6.2.5
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -785,6 +785,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
       char *device_name               = device_param->device_name;
       u32   device_processors         = device_param->device_processors;
       u32   device_maxclock_frequency = device_param->device_maxclock_frequency;
+      u64   device_local_mem_size     = device_param->device_local_mem_size;
       u64   device_available_mem      = device_param->device_available_mem;
       u64   device_global_mem         = device_param->device_global_mem;
       u8    pcie_domain               = device_param->pcie_domain;
@@ -806,6 +807,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
       event_log_info (hashcat_ctx, "  Clock..........: %u", device_maxclock_frequency);
       event_log_info (hashcat_ctx, "  Memory.Total...: %" PRIu64 " MB", device_global_mem / 1024 / 1024);
       event_log_info (hashcat_ctx, "  Memory.Free....: %" PRIu64 " MB", device_available_mem / 1024 / 1024);
+      event_log_info (hashcat_ctx, "  Local.Memory...: %" PRIu64 " KB", device_local_mem_size / 1024);
       event_log_info (hashcat_ctx, "  PCI.Addr.BDFe..: %04x:%02x:%02x.%d", (u16) pcie_domain, pcie_bus, pcie_device, pcie_function);
       event_log_info (hashcat_ctx, NULL);
     }
@@ -845,6 +847,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
       char *device_name               = device_param->device_name;
       u32   device_processors         = device_param->device_processors;
       u32   device_maxclock_frequency = device_param->device_maxclock_frequency;
+      u64   device_local_mem_size     = device_param->device_local_mem_size;
       u64   device_available_mem      = device_param->device_available_mem;
       u64   device_global_mem         = device_param->device_global_mem;
       u8    pcie_domain               = device_param->pcie_domain;
@@ -866,6 +869,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
       event_log_info (hashcat_ctx, "  Clock..........: %u", device_maxclock_frequency);
       event_log_info (hashcat_ctx, "  Memory.Total...: %" PRIu64 " MB", device_global_mem / 1024 / 1024);
       event_log_info (hashcat_ctx, "  Memory.Free....: %" PRIu64 " MB", device_available_mem / 1024 / 1024);
+      event_log_info (hashcat_ctx, "  Local.Memory...: %" PRIu64 " KB", device_local_mem_size / 1024);
       event_log_info (hashcat_ctx, "  PCI.Addr.BDFe..: %04x:%02x:%02x.%d", (u16) pcie_domain, pcie_bus, pcie_device, pcie_function);
       event_log_info (hashcat_ctx, NULL);
     }
@@ -907,6 +911,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
         u32            device_processors          = device_param->device_processors;
         u32            device_maxclock_frequency  = device_param->device_maxclock_frequency;
         u64            device_maxmem_alloc        = device_param->device_maxmem_alloc;
+        u64            device_local_mem_size      = device_param->device_local_mem_size;
         u64            device_available_mem       = device_param->device_available_mem;
         u64            device_global_mem          = device_param->device_global_mem;
         cl_device_type opencl_device_type         = device_param->opencl_device_type;
@@ -934,6 +939,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
         event_log_info (hashcat_ctx, "    Clock..........: %u", device_maxclock_frequency);
         event_log_info (hashcat_ctx, "    Memory.Total...: %" PRIu64 " MB (limited to %" PRIu64 " MB allocatable in one block)", device_global_mem / 1024 / 1024, device_maxmem_alloc / 1024 / 1024);
         event_log_info (hashcat_ctx, "    Memory.Free....: %" PRIu64 " MB", device_available_mem / 1024 / 1024);
+        event_log_info (hashcat_ctx, "    Local.Memory...: %" PRIu64 " KB", device_local_mem_size / 1024);
         event_log_info (hashcat_ctx, "    OpenCL.Version.: %s", opencl_device_c_version);
         event_log_info (hashcat_ctx, "    Driver.Version.: %s", opencl_driver_version);
 


### PR DESCRIPTION
Apple Intel

```
OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (May  7 2020 00:10:14)

  Backend Device ID #1
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
    Version........: OpenCL 1.2 
    Processor(s)...: 4
    Clock..........: 3000
    Memory.Total...: 8192 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 4064 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.1

  Backend Device ID #2
    Type...........: GPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Iris
    Version........: OpenCL 1.2 
    Processor(s)...: 40
    Clock..........: 1200
    Memory.Total...: 1536 MB (limited to 192 MB allocatable in one block)
    Memory.Free....: 704 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2(Oct 30 2020 14:39:13)
```

Apple Silicon

```
OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Oct  1 2021 19:40:58)

  Backend Device ID #1
    Type...........: GPU
    Vendor.ID......: 2
    Vendor.........: Apple
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 1000
    Memory.Total...: 10922 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 5408 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2 1.0
```