### PR TITLE
Fix for #3070

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -22,6 +22,7 @@
 - Fixed missing option flag OPTS_TYPE_SUGGEST_KG for hash-mode 11600 to inform the user about possible false positives in this mode
 - Fixed undefined function call to hc_byte_perm_S() in hash-mode 17010 on non-CUDA compute devices
 - Fixed HEX wordlist handling in -m 3000 
+- Fixed Platform position moved to start of line in the list of devices for having clear output
 
 ##
 ## Technical

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1101,7 +1101,7 @@ void backend_info_compact (hashcat_ctx_t *hashcat_ctx)
       char     *opencl_platform_version      = opencl_platforms_version[opencl_platforms_idx];
       cl_uint   opencl_platform_devices_cnt  = opencl_platforms_devices_cnt[opencl_platforms_idx];
 
-      const size_t len = event_log_info (hashcat_ctx, "OpenCL API (%s) - Platform #%u [%s]", opencl_platform_version, opencl_platforms_idx + 1, opencl_platform_vendor);
+      const size_t len = event_log_info (hashcat_ctx, "Platform #%u: OpenCL API (%s) -- [%s]",opencl_platforms_idx + 1, opencl_platform_version,  opencl_platform_vendor);
 
       char line[HCBUFSIZ_TINY] = { 0 };
 


### PR DESCRIPTION
Changed format of the output line in list of devices in `backend_info_compact` for OpenCL.
Platform number moved to front of the line for clarity. 
For me it makes sense to have Platform # at the beginning of the line. 