### PR TITLE
updated setup_environment_variables()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -36,6 +36,7 @@
 - OpenCL Runtime: Added support to use Apple Silicon compute devices
 - OpenCL Runtime: Set default device-type to GPU with Apple Silicon compute devices
 - Unit tests: Updated test.sh to set default device-type to CPU with Apple Intel and added -f (--force) option
+- Created environment variable to inform OpenCL/Metal runtime to not create its own kernel cache on Apple Silicon
 
 * changes v6.2.4 -> v6.2.5
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -553,7 +553,16 @@ void setup_environment_variables (const folder_config_t *folder_config)
 
   if (getenv ("POCL_KERNEL_CACHE") == NULL)
     putenv ((char *) "POCL_KERNEL_CACHE=0");
-  #endif
+  #endif // DEBUG
+
+  #if defined (__APPLE__)
+  if (is_apple_silicon() == true)
+  {
+    // disable caching with OpenCL/Metal runtime on Apple Silicon
+    if (getenv ("MTL_SHADER_CACHE_SIZE") == NULL)
+      putenv ((char *) "MTL_SHADER_CACHE_SIZE=0");
+  }
+  #endif // __APPLE__
 
   if (getenv ("TMPDIR") == NULL)
   {


### PR DESCRIPTION
Created environment variable to inform OpenCL/Metal runtime to not create its own kernel cache on Apple Silicon.