### PR TITLE
remove ioapi include

### DIFF
--- a/include/ext_lzma.h
+++ b/include/ext_lzma.h
@@ -9,7 +9,6 @@
 #include <LzmaDec.h>
 #include <Lzma2Dec.h>
 
-#include "minizip/ioapi.h"
 #include "minizip/unzip.h"
 
 int hc_lzma1_decompress (const unsigned char *in, SizeT *in_len, unsigned char *out, SizeT *out_len, const char *props);


### PR DESCRIPTION
ioapi is not available with minizip-ng, which gets used when
USE_SYSTEM_ZLIB is defined.

Signed-off-by: Rosen Penev <rosenp@gmail.com>