### PR TITLE
Fix the build for NetBSD

### DIFF
--- a/include/sort_r.h
+++ b/include/sort_r.h
@@ -25,7 +25,7 @@ Slightly modified to work with hashcat to no falsly detect _SORT_R_LINUX with mi
 */
 
 #if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
-     defined __FreeBSD__ || defined __DragonFly__)
+     defined __FreeBSD__ || defined __DragonFly__ || defined __NetBSD__)
 #  define _SORT_R_BSD
 #  define _SORT_R_INLINE inline
 #elif (defined __linux__) || defined (__CYGWIN__)
@@ -202,7 +202,12 @@ static _SORT_R_INLINE void sort_r_simple(void *base, size_t nel, size_t w,
       struct sort_r_data tmp;
       tmp.arg = arg;
       tmp.compar = compar;
-      qsort_r(base, nel, width, &tmp, sort_r_arg_swap);
+
+      #if defined __NetBSD__
+        sort_r_simple(base, nel, width, compar, arg);
+      #else
+        qsort_r(base, nel, width, &tmp, sort_r_arg_swap);
+      #endif
 
     #elif defined _SORT_R_WINDOWS
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ UNAME                   := $(patsubst MSYS_NT-%,MSYS2,$(UNAME))
 UNAME                   := $(patsubst MINGW32_NT-%,MSYS2,$(UNAME))
 UNAME                   := $(patsubst MINGW64_NT-%,MSYS2,$(UNAME))
 
-ifeq (,$(filter $(UNAME),Linux FreeBSD Darwin CYGWIN MSYS2))
+ifeq (,$(filter $(UNAME),Linux FreeBSD NetBSD Darwin CYGWIN MSYS2))
 $(error "! Your Operating System ($(UNAME)) is not supported by this Makefile")
 endif
 
@@ -59,8 +59,6 @@ MODULE_INTERFACE_VERSION := 630
 ## Native compiler paths
 ##
 
-CC                      := gcc
-CXX                     := g++
 AR                      := ar
 FIND                    := find
 INSTALL                 := install
@@ -69,20 +67,9 @@ SED                     := sed
 SED_IN_PLACE            := -i
 
 ifeq ($(UNAME),Darwin)
-CC                      := clang
-CXX                     := clang++
-# the sed -i option of macOS requires a parameter for the backup file (we just use "")
-AR                      := /usr/bin/ar
-SED                     := /usr/bin/sed
-SED_IN_PLACE            := -i ""
 DARWIN_VERSION          := $(shell uname -r | cut -d. -f1)
 endif
 
-ifeq ($(UNAME),FreeBSD)
-CC                      := cc
-CXX                     := c++
-SED                     := gsed
-endif
 
 ##
 ## Version
@@ -230,7 +217,6 @@ endif
 endif
 
 ifeq ($(DEBUG),0)
-CFLAGS                  += -O2
 ifneq ($(UNAME),Darwin)
 LFLAGS                  += -s
 endif
@@ -313,6 +299,13 @@ LFLAGS_NATIVE           += -lm
 LFLAGS_NATIVE           += -liconv
 endif
 endif # FreeBSD
+
+ifeq ($(UNAME),NetBSD)
+CFLAGS_NATIVE           := $(CFLAGS)
+CFLAGS_NATIVE           += -I$(OPENCL_HEADERS_KHRONOS)/
+LFLAGS_NATIVE           := $(LFLAGS)
+LFLAGS_NATIVE           += -lpthread
+endif # NetBSD
 
 ifeq ($(UNAME),Darwin)
 export MACOSX_DEPLOYMENT_TARGET=10.9
@@ -458,10 +451,10 @@ distclean: clean
 # allow (whitelist) "make install" only on unix-based systems (also disallow cygwin/msys)
 
 ifneq ($(findstring install,$(MAKECMDGOALS)),)
-  ifeq (,$(filter $(UNAME),Linux FreeBSD Darwin))
+  ifeq (,$(filter $(UNAME),Linux FreeBSD Darwin NetBSD))
     define ERROR_INSTALL_DISALLOWED
 ! The 'install' target is not allowed on this operating system ($(UNAME)). \
-Only Linux, FreeBSD and Darwin can use the 'install' target
+Only Linux, FreeBSD, NetBSD and Darwin can use the 'install' target
     endef
 
     $(error $(ERROR_INSTALL_DISALLOWED))
@@ -639,8 +632,13 @@ endif
 $(MODULES_DISABLE): ;
 
 ifeq ($(SHARED),1)
+  ifeq ($(UNAME),Darwin)
+modules/module_%.$(MODULE_SUFFIX): src/modules/module_%.c $(HASHCAT_LIBRARY)
+	$(CC)    $(CCFLAGS) $(CFLAGS_NATIVE) $^ -o $@ $(LFLAGS_NATIVE) -install_name $(SHARED_FOLDER)/$@ -shared -fPIC -D MODULE_INTERFACE_VERSION_CURRENT=$(MODULE_INTERFACE_VERSION)
+  else
 modules/module_%.$(MODULE_SUFFIX): src/modules/module_%.c $(HASHCAT_LIBRARY)
 	$(CC)    $(CCFLAGS) $(CFLAGS_NATIVE) $^ -o $@ $(LFLAGS_NATIVE) -shared -fPIC -D MODULE_INTERFACE_VERSION_CURRENT=$(MODULE_INTERFACE_VERSION)
+  endif
 else
 modules/module_%.$(MODULE_SUFFIX): src/modules/module_%.c obj/combined.NATIVE.a
 	$(CC)    $(CCFLAGS) $(CFLAGS_NATIVE) $^ -o $@ $(LFLAGS_NATIVE) -shared -fPIC -D MODULE_INTERFACE_VERSION_CURRENT=$(MODULE_INTERFACE_VERSION)

--- a/src/affinity.c
+++ b/src/affinity.c
@@ -45,6 +45,12 @@ static int pthread_setaffinity_np (pthread_t thread, size_t cpu_size, cpu_set_t 
 typedef cpuset_t cpu_set_t;
 #endif
 
+#if defined(__NetBSD__)
+#include <pthread.h>
+#include <sched.h>
+typedef cpuset_t cpu_set_t;
+#endif
+
 int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 {
 #if defined (__CYGWIN__)
@@ -57,6 +63,10 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
   #if defined (_WIN)
   DWORD_PTR aff_mask = 0;
   const int cpu_id_max = 8 * sizeof (aff_mask);
+  #elif defined(__NetBSD__)
+  cpuset_t * cpuset;
+  const int cpu_id_max = 8 * cpuset_size (cpuset);
+  cpuset = cpuset_create();
   #else
   cpu_set_t cpuset;
   const int cpu_id_max = 8 * sizeof (cpuset);
@@ -79,6 +89,9 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
     {
       #if defined (_WIN)
       aff_mask = 0;
+      #elif defined (__NetBSD__)
+      cpuset_destroy (cpuset);
+      cpuset = cpuset_create ();
       #else
       CPU_ZERO (&cpuset);
       #endif
@@ -90,6 +103,10 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
     {
       event_log_error (hashcat_ctx, "Invalid cpu_id %d specified.", cpu_id);
 
+      #if defined (__NetBSD__)
+      cpuset_destroy (cpuset);
+      #endif
+
       hcfree (devices);
 
       return -1;
@@ -97,11 +114,17 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 
     #if defined (_WIN)
     aff_mask |= ((DWORD_PTR) 1) << (cpu_id - 1);
+    #elif defined (__NetBSD__)
+    cpuset_set (cpu_id - 1, cpuset);
     #else
     CPU_SET ((cpu_id - 1), &cpuset);
     #endif
 
   } while ((next = strtok_r ((char *) NULL, ",", &saveptr)) != NULL);
+
+  #if defined (__NetBSD__)
+  cpuset_destroy (cpuset);
+  #endif
 
   hcfree (devices);
 
@@ -110,6 +133,19 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
   if (SetProcessAffinityMask (GetCurrentProcess (), aff_mask) == 0)
   {
     event_log_error (hashcat_ctx, "SetProcessAffinityMask() failed with error: %d", (int) GetLastError ());
+
+    return -1;
+  }
+
+  #elif defined (__NetBSD__)
+
+  pthread_t thread = pthread_self ();
+
+  const int rc = pthread_setaffinity_np (thread, cpuset_size(cpuset), cpuset);
+
+  if (rc != 0)
+  {
+    event_log_error (hashcat_ctx, "pthread_setaffinity_np() failed with error: %d", rc);
 
     return -1;
   }

--- a/src/folder.c
+++ b/src/folder.c
@@ -13,6 +13,9 @@
 
 #if defined (__APPLE__)
 #include "event.h"
+#elif defined (__FreeBSD__) || defined (__NetBSD__)
+#include <sys/param.h>
+#include <sys/sysctl.h>
 #endif
 
 static int get_exec_path (char *exec_path, const size_t exec_path_sz)
@@ -43,9 +46,7 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   const size_t len = strlen (exec_path);
 
-  #elif defined (__FreeBSD__)
-
-  #include <sys/sysctl.h>
+  #elif defined (__FreeBSD__) || defined (__NetBSD__)
 
   int mib[4];
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -439,7 +439,7 @@ void SetConsoleWindowSize (const int x)
 }
 #endif
 
-#if defined (__linux__) || defined (__CYGWIN__)
+#if defined (__FreeBSD__) || defined (__NetBSD__) || defined (__linux__) || defined (__CYGWIN__)
 static struct termios savemodes;
 static int havemodes = 0;
 


### PR DESCRIPTION
This commit lets me build hashcat on NetBSD. I believe it should not harm support for other systems.

With these changes, starting hashcat still fails with ": No such file or directory"; I haven't investigated this issue yet.