### PR TITLE
tests: update install modules

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -55,7 +55,6 @@ cpan install Authen::Passphrase::LANManager \
              Digest::SipHash                \
              Encode                         \
              JSON                           \
-             MIME::Base32                   \
              MIME::Base64                   \
              Net::DNS::RR::NSEC3            \
              Net::DNS::SEC                  \

--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -55,6 +55,7 @@ cpan install Authen::Passphrase::LANManager \
              Digest::SipHash                \
              Encode                         \
              JSON                           \
+             Math::BigInt                   \
              MIME::Base64                   \
              Net::DNS::RR::NSEC3            \
              Net::DNS::SEC                  \


### PR DESCRIPTION
For hash type -m 28000 = `CRC64Jones` we need to add `Math::BigInt` to our `tools/install_modules.sh` perl modules installation file, while `MIME::Base32` is not used at all by any unit tests.

This is just a small update of our unit test (perl modules) installation script.

thanks