### PR TITLE
remove extra spaces kerberos5

### DIFF
--- a/src/modules/module_19800.c
+++ b/src/modules/module_19800.c
@@ -130,7 +130,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.len_min[3] = 104;
   token.len_max[3] = 112;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
-                     | TOKEN_ATTR_VERIFY_HEX;
+                   | TOKEN_ATTR_VERIFY_HEX;
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
 

--- a/src/modules/module_19900.c
+++ b/src/modules/module_19900.c
@@ -130,7 +130,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.len_min[3] = 104;
   token.len_max[3] = 112;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
-                     | TOKEN_ATTR_VERIFY_HEX;
+                   | TOKEN_ATTR_VERIFY_HEX;
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
 


### PR DESCRIPTION
This is a minor style/indentation fix for -m 19800 = `Kerberos 5, etype 17, Pre-Auth` and -m 19900 = `Kerberos 5, etype 18, Pre-Auth`.

Thanks