### PR TITLE
Added exit status -2, updated Unit tests

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -44,6 +44,12 @@
 - HIP Backend: moved functions to ext_hip.c/ext_hiprtc.c and includes to ext_hip.h/ext_hiprtc.h
 - CUDA Backend: moved functions to ext_cuda.c/ext_nvrtc.c and includes to ext_cuda.h/ext_nvrtc.h
 - Makefile: updated MACOSX_DEPLOYMENT_TARGET to 10.15 and removed OpenCL framework from LFLAGS_NATIVE on MacOS
+- Added new exit status code: if the engine skips the hash due to a runtime/driver issue, hashcat will terminate with exit code -2
+- Unit tests: added -r (--runtime) option
+- Unit tests: added new status "Skip" to test.sh output
+- Unit tests: updated cryptoloop/truecrypt/veracrypt/luks test output
+- Unit tests: skip some hash-types due to some known problems with perl modules
+- Unit tests: skip deprecated hash-types
 
 * changes v6.2.4 -> v6.2.5
 

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -24,7 +24,7 @@ Gabriele "matrix" Gristina <matrix@hashcat.net> (@gm4tr1x)
 * Apple macOS port
 * Apple Silicon support
 * Hardware monitor initial code base and maintenance
-* Test suite initial code base
+* Test suite initial code base and maintenance
 * Makefile initial code base
 * Multithreading initial code base
 * MultiGPU initial code base

--- a/include/types.h
+++ b/include/types.h
@@ -214,6 +214,7 @@ typedef enum status_rc
   STATUS_ERROR              = 13,
   STATUS_ABORTED_FINISH     = 14,
   STATUS_AUTODETECT         = 16,
+  STATUS_RUNTIME_SKIP       = 17,
 
 } status_rc_t;
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -7314,6 +7314,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
   const straight_ctx_t       *straight_ctx        = hashcat_ctx->straight_ctx;
   const user_options_extra_t *user_options_extra  = hashcat_ctx->user_options_extra;
   const user_options_t       *user_options        = hashcat_ctx->user_options;
+        status_ctx_t         *status_ctx          = hashcat_ctx->status_ctx;
 
   if (backend_ctx->enabled == false) return 0;
 
@@ -7352,6 +7353,8 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
         event_log_warning (hashcat_ctx, "             You can use --force to override, but do not report related errors.");
 
         device_param->skipped_warning = true;
+
+        status_ctx->devices_status = STATUS_RUNTIME_SKIP;
 
         continue;
       }

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -291,6 +291,7 @@ static int inner2_loop (hashcat_ctx_t *hashcat_ctx)
 
   if ((status_ctx->devices_status != STATUS_CRACKED)
    && (status_ctx->devices_status != STATUS_ERROR)
+   && (status_ctx->devices_status != STATUS_RUNTIME_SKIP)
    && (status_ctx->devices_status != STATUS_ABORTED)
    && (status_ctx->devices_status != STATUS_ABORTED_CHECKPOINT)
    && (status_ctx->devices_status != STATUS_ABORTED_FINISH)
@@ -1711,6 +1712,10 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
     if (status_ctx->devices_status == STATUS_EXHAUSTED)           rc_final =  1;
     if (status_ctx->devices_status == STATUS_CRACKED)             rc_final =  0;
     if (status_ctx->devices_status == STATUS_ERROR)               rc_final = -1;
+  }
+  else if (rc_final == -1)
+  {
+    if (status_ctx->devices_status == STATUS_RUNTIME_SKIP)        rc_final = -2;
   }
 
   // special case for --stdout

--- a/src/thread.c
+++ b/src/thread.c
@@ -182,7 +182,10 @@ int myabort (hashcat_ctx_t *hashcat_ctx)
   // not sure if this is still valid, but abort is also called by gpu temp monitor
   //if (status_ctx->devices_status != STATUS_RUNNING) return;
 
-  status_ctx->devices_status = STATUS_ABORTED;
+  if (status_ctx->devices_status != STATUS_RUNTIME_SKIP)
+  {
+    status_ctx->devices_status = STATUS_ABORTED;
+  }
 
   status_ctx->run_main_level1   = false;
   status_ctx->run_main_level2   = false;

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -5,9 +5,10 @@
 ## License.....: MIT
 ##
 
-OPTS="--quiet --potfile-disable --runtime 400 --hwmon-disable"
+OPTS="--quiet --potfile-disable --hwmon-disable"
 
 FORCE=0
+RUNTIME=400
 
 TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -211,8 +212,9 @@ function init()
       echo ""
 
       # download:
+      wget -q "${luks_tests_url}"
 
-      if ! wget -q "${luks_tests_url}" >/dev/null 2>/dev/null; then
+      if [ $? -ne 0 ] || [ ! -f "${luks_tests}" ]; then
         cd - >/dev/null
         echo "ERROR: Could not fetch the luks test files from this url: ${luks_tests_url}"
         exit 1
@@ -395,6 +397,11 @@ function status()
 
   if [ "${RET}" -ne 0 ]; then
     case ${RET} in
+     254)
+        echo "skipped by runtime, cmdline : ${CMD}" >> "${OUTD}/logfull.txt" 2>> "${OUTD}/logfull.txt"
+        e_rs=$((e_rs + 1))
+
+        ;;
       1)
         if ! is_in_array "${hash_type}" ${NEVER_CRACK_ALGOS}; then
 
@@ -444,6 +451,7 @@ function attack_0()
   # single hash
   if [ "${MODE}" -ne 1 ]; then
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -536,7 +544,11 @@ function attack_0()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -546,13 +558,14 @@ function attack_0()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 0, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 0, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 
   # multihash
   if [ "${MODE}" -ne 0 ]; then
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -625,7 +638,11 @@ function attack_0()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -635,7 +652,7 @@ function attack_0()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 0, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 0, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 }
@@ -653,6 +670,7 @@ function attack_1()
   # single hash
   if [ "${MODE}" -ne 1 ]; then
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -797,7 +815,11 @@ function attack_1()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -807,7 +829,7 @@ function attack_1()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 1, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 1, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 
@@ -826,6 +848,7 @@ function attack_1()
       return
     fi
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -915,7 +938,11 @@ function attack_1()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -925,7 +952,7 @@ function attack_1()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 1, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 1, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 }
@@ -943,6 +970,7 @@ function attack_3()
   # single hash
   if [ "${MODE}" -ne 1 ]; then
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -1089,7 +1117,11 @@ function attack_3()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -1099,7 +1131,7 @@ function attack_3()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 
@@ -1118,6 +1150,7 @@ function attack_3()
       return
     fi
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -1533,7 +1566,11 @@ function attack_3()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -1543,7 +1580,7 @@ function attack_3()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 }
@@ -1561,6 +1598,7 @@ function attack_6()
   # single hash
   if [ "${MODE}" -ne 1 ]; then
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -1769,7 +1807,11 @@ function attack_6()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -1779,7 +1821,7 @@ function attack_6()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 6, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 6, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
     rm -f "${OUTD}/${hash_type}_dict1_custom"
     rm -f "${OUTD}/${hash_type}_dict2_custom"
@@ -1801,6 +1843,7 @@ function attack_6()
       return
     fi
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -1910,7 +1953,11 @@ function attack_6()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -1920,7 +1967,7 @@ function attack_6()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 6, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 6, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 }
@@ -1938,6 +1985,7 @@ function attack_7()
   # single hash
   if [ "${MODE}" -ne 1 ]; then
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -2188,7 +2236,11 @@ function attack_7()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -2198,7 +2250,7 @@ function attack_7()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 7, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 7, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
     rm -f "${OUTD}/${hash_type}_dict1_custom"
     rm -f "${OUTD}/${hash_type}_dict2_custom"
@@ -2220,6 +2272,7 @@ function attack_7()
       return
     fi
 
+    e_rs=0
     e_to=0
     e_nf=0
     e_nm=0
@@ -2364,7 +2417,11 @@ function attack_7()
 
     msg="OK"
 
-    if [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
 
       msg="Error"
 
@@ -2374,7 +2431,7 @@ function attack_7()
 
     fi
 
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 7, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout"
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 7, Mode multi,  Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
   fi
 }
@@ -2535,18 +2592,34 @@ function cryptoloop_test()
 
     echo "${output}" >> "${OUTD}/logfull.txt"
 
-    cnt=1
+    e_rs=0
+    e_to=0
     e_nf=0
-    msg="OK"
-
-    if [ ${ret} -ne 0 ]; then
-      e_nf=1
-      msg="Error"
-    fi
-
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, Key-Size ${keySize} ] > $msg : ${e_nf}/${cnt} not found"
+    e_nm=0
+    cnt=0
 
     status ${ret}
+
+    cnt=1
+
+    msg="OK"
+
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+
+      msg="Error"
+
+    elif [ "${e_to}" -ne 0 ]; then
+
+      msg="Warning"
+
+    fi
+
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, Key-Size ${keySize} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
+
   fi
 }
 
@@ -2718,18 +2791,34 @@ function truecrypt_test()
 
     echo "${output}" >> "${OUTD}/logfull.txt"
 
-    cnt=1
+    e_rs=0
+    e_to=0
     e_nf=0
-    msg="OK"
-
-    if [ ${ret} -ne 0 ]; then
-      e_nf=1
-      msg="Error"
-    fi
-
-    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, tcMode ${tcMode} ] > $msg : ${e_nf}/${cnt} not found"
+    e_nm=0
+    cnt=0
 
     status ${ret}
+
+    cnt=1
+
+    msg="OK"
+
+    if [ "${e_rs}" -ne 0 ]; then
+
+      msg="Skip"
+
+    elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+
+      msg="Error"
+
+    elif [ "${e_to}" -ne 0 ]; then
+
+      msg="Warning"
+
+    fi
+
+    echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 3, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, tcMode ${tcMode} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
+
   fi
 }
 
@@ -2795,18 +2884,33 @@ function veracrypt_test()
 
   echo "${output}" >> "${OUTD}/logfull.txt"
 
-  cnt=1
+  e_rs=0
+  e_to=0
   e_nf=0
-  msg="OK"
-
-  if [ ${ret} -ne 0 ]; then
-    e_nf=1
-    msg="Error"
-  fi
-
-  echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 0, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, Cipher ${cipher_cascade} ] > $msg : ${e_nf}/${cnt} not found"
+  e_nm=0
+  cnt=0
 
   status ${ret}
+
+  cnt=1
+
+  msg="OK"
+
+  if [ "${e_rs}" -ne 0 ]; then
+
+    msg="Skip"
+
+  elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+
+    msg="Error"
+
+  elif [ "${e_to}" -ne 0 ]; then
+
+    msg="Warning"
+
+  fi
+
+  echo "[ ${OUTD} ] [ Type ${hash_type}, Attack 0, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, Cipher ${cipher_cascade} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 }
 
 function luks_test()
@@ -2920,16 +3024,33 @@ function luks_test()
 
             echo "${output}" >> "${OUTD}/logfull.txt"
 
-            cnt=1
+            e_rs=0
+            e_to=0
             e_nf=0
+            e_nm=0
+            cnt=0
+
+            status ${ret}
+
+            cnt=1
+
             msg="OK"
 
-            if [ ${ret} -ne 0 ]; then
-              e_nf=1
+            if [ "${e_rs}" -ne 0 ]; then
+
+              msg="Skip"
+
+            elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+
               msg="Error"
+
+            elif [ "${e_to}" -ne 0 ]; then
+
+              msg="Warning"
+
             fi
 
-            echo "[ ${OUTD} ] [ Type ${hash_type}, Attack ${attackType}, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, luksMode ${luks_mode} ] > $msg : ${e_nf}/${cnt} not found"
+            echo "[ ${OUTD} ] [ Type ${hash_type}, Attack ${attackType}, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, luksMode ${luks_mode} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
 
             status ${ret}
           fi
@@ -3021,7 +3142,7 @@ HT=0
 PACKAGE=0
 OPTIMIZED=1
 
-while getopts "V:t:m:a:b:hcpd:x:o:d:D:F:POI:s:f" opt; do
+while getopts "V:t:m:a:b:hcpd:x:o:d:D:F:POI:s:fr:" opt; do
 
   case ${opt} in
     "V")
@@ -3153,6 +3274,10 @@ while getopts "V:t:m:a:b:hcpd:x:o:d:D:F:POI:s:f" opt; do
       FORCE=1
       ;;
 
+    "r")
+      RUNTIME=${OPTARG}
+      ;;
+
     \?)
       usage
       ;;
@@ -3184,6 +3309,10 @@ export IS_OPTIMIZED=${OPTIMIZED}
 if [ "${OPTIMIZED}" -eq 1 ]; then
   OPTS="${OPTS} -O"
 fi
+
+# set max-runtime
+
+OPTS="${OPTS} --runtime ${RUNTIME}"
 
 # set default device-type to CPU with Apple Intel, else GPU
 
@@ -3344,6 +3473,40 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
           fi
         fi
 
+        continue
+      fi
+    fi
+
+    # skip deprecated hash-types
+    if [ "${hash_type}" -eq 2500 ] || [ "${hash_type}" -eq 2501 ] || [ "${hash_type}" -eq 16800 ] || [ "${hash_type}" -eq 16801 ] ; then
+      continue
+    fi
+
+    # test.pl produce wrong hashes with Apple
+    # would be necessary to investigate to understand why
+    if [ "${hash_type}" -eq 1800 ]; then
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        continue
+      fi
+    fi
+
+    # Digest::BLAKE2 is broken on Apple Silicon
+    if [ "${hash_type}" -eq 600 ]; then
+      if [ "${IS_APPLE_SILICON}" -eq 1 ]; then
+        continue
+      fi
+    fi
+
+    # Digest::GOST is broken on Apple Silicon
+    if [ "${hash_type}" -eq 6900 ]; then
+      if [ "${IS_APPLE_SILICON}" -eq 1 ]; then
+        continue
+      fi
+    fi
+
+    # Crypt::GCrypt is broken on Apple and Linux
+    if [ "${hash_type}" -eq 18600 ]; then
+      if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ "$OSTYPE" == "darwin"* ]]; then
         continue
       fi
     fi


### PR DESCRIPTION
Hi,

with this patch we are going to improve the test unit (test.sh).

At the time it was not possible to easily distinguish whether cryptoloop / truecrypt / veracrypt / luks failed or not, as the output only showed "OK" or "Error".

In general it was not possible to quickly distinguish if algorithms were skipped for a known issue (module_unstable_warning).

To fix all these little issues, I added a new exit code on hashcat (-2), which will be used in case the algorithms are skipped for a known problem. As a result, I updated the test unit to handle this type of error as well, and I also avoided processing all modules marked as deprecated.

There are currently some known problems with perl modules, depending on the operating system where they are used.
For example, crypt() (used by hash mode 1800) on Apple systems produces the wrong output:

```
$ ./tools/test.pl single 1800 8
echo 25296327                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6BeOvPUZSEwg'
echo 14833964                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6oFff/iGmhY.'
echo 89654882                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6RycsJQwd6Js'
echo 27498209                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6LN/9E5CQco6'
echo 60161623                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6yUmgYN3bJdA'
echo 86013381                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6ZStvNL/8fTI'
echo 10825782                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6ar5xe2n698w'
echo 44921372                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6Ez6iEvbqugg'
```

Below is the output generated by linux:

```
$ ./tools/test.pl single 1800 8
echo 87817691                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$60210$fjO1Mj.K/O5Gm7o5Eef5LFt6W58CRNTtgy6kHhvUJQx88KUOOqW8eE1ykblyWCJOMxboU5umRU8PtL620y5oR/'
echo 99417400                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$$NcNZBcHQ.UcCUFexJLh1rZi/1MPMAByVCbmXVqm0e6w5dN6uSfSz7YQgBOCgqBgzLUqzKSx45xCIgjOnxMkIs/'
echo 90482898                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$537629594$Pj1m4USBL4fkFWRRM1pLlVWIJ4kANkaPrZfeICNQcqkDeY5GzPIUzf2Lg0KDs6eBegESu3E/hf.1YHmSywUGx.'
echo 65494099                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$17096881102543$Bi55XSDHnzLp0PYnf2CJGvwWtg1Q39DP77SboTbnT7ujI3j9owBOmlh61MJN5DBXXayB5DiCjngABukeZ1tOG1'
echo 15807146                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$6056021729099380$YmbVMNrwH88pRRCLXbpDBEqqhiBa90.JevgIcO6LyYTXWt0M8oe.XPI.3z95qsuM5sZG6slEfN.ws2zoaAKIL/'
echo 79202522                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$3289979469$0gZyD5qhUL34RaxGWPduyz1PW36WLkbueXGW.TQ/bkEQu/GdG9a85MpxbAiVHJERZwR0lfTutc/FoZzqfKrbP.'
echo 46623149                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$112925701751052$9TH5a.6GoU6nK7sb39/IJs0kz8M/zNdnTWmBKP3sjcKu9goOm6aNyggHk..MwLG97W.z6/F3QgvjGPj2tePRT.'
echo 73078613                        | ./hashcat ${OPTS} -a 0 -m 1800 '$6$3106$Z5e9erS.MtJUHJ2IUxYS2DehiJ9QaplW8sgWwZBXRvd7MVyV2IA56goEKfCNBlqEy7S47efZoyI1DNNqBRbkd/'
```

However I left comments on the code for the other issues identified.

Finally I added a new option on test.sh (-r) to allow to change the value of "--runtime" from the command line (instead of using the hardcoded one). If not specified, 400 will be used, which is the same value used up to now. 

Thanks ;)