### PR TITLE
Fixed false negative on Unit Test with hash-type 25400

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -25,6 +25,7 @@
 - Fixed missing option flag OPTS_TYPE_SUGGEST_KG for hash-mode 11600 to inform the user about possible false positives in this mode
 - Fixed undefined function call to hc_byte_perm_S() in hash-mode 17010 on non-CUDA compute devices
 - Fixed wordlist handling in -m 3000 when candidate passwords use the $HEX[...] syntax
+- Fixed false negative on Unit Test with hash-type 25400
 
 ##
 ## Technical

--- a/src/modules/module_25400.c
+++ b/src/modules/module_25400.c
@@ -541,7 +541,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   pdf_t *pdf = (pdf_t *) esalt_buf;
   if (pdf->id_len == 32)
   {
-    line_len = snprintf (line_buf, line_size, "$pdf$%d*%d*%d*%d*%d*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%s",
+    line_len = snprintf (line_buf, line_size, "$pdf$%d*%d*%d*%d*%d*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x%s",
       pdf->V,
       pdf->R,
       128,
@@ -579,7 +579,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   }
   else
   {
-    line_len = snprintf (line_buf, line_size, "$pdf$%d*%d*%d*%d*%d*%d*%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%s",
+    line_len = snprintf (line_buf, line_size, "$pdf$%d*%d*%d*%d*%d*%d*%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x%s",
       pdf->V,
       pdf->R,
       128,

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -518,6 +518,11 @@ function attack_0()
           search="${hash}:${pass}"
         fi
 
+        if [ ${hash_type} -eq 25400 ]; then
+          tmp=$(echo $output | sed -e 's/    (user password[^)].*//g')
+          output="${tmp}"
+        fi
+
         echo "${output}" | grep -F "${search}" >/dev/null 2>/dev/null
 
         if [ "${?}" -ne 0 ]; then

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -519,7 +519,7 @@ function attack_0()
         fi
 
         if [ ${hash_type} -eq 25400 ]; then
-          tmp=$(echo $output | sed -e 's/    (user password[^)].*//g')
+          tmp=$(echo $output | sed -e 's/    (user password.*//g')
           output="${tmp}"
         fi
 


### PR DESCRIPTION
```
[ test_1641775657 ] > Init test for hash type 25400.
[ test_1641775657 ] [ Type 25400, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout
[ test_1641775657 ] [ Type 25400, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout
```