### PR TITLE
Fix logic flaw in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -78,7 +78,7 @@ SED_IN_PLACE            := -i ""
 DARWIN_VERSION          := $(shell uname -r | cut -d. -f1)
 endif
 
-ifeq (,$(filter $(UNAME),FreeBSD NetBSD))
+ifneq (,$(filter $(UNAME),FreeBSD NetBSD))
 CC                      := cc
 CXX                     := c++
 SED                     := gsed


### PR DESCRIPTION
Line 81 contains inverted logic introduced by PR#3117, this should fix that logic to detect BSD and correctly select `gsed` on BSD and not on linux