### PR TITLE
Added hex format for --separator option

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@
 
 - Added support to use --debug-mode in attack-mode 9 (Association Attack)
 - Added guess data to --status-json output
+- Added hex format for --separator option
 
 ##
 ## Bugs

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -7,6 +7,7 @@
 #include "types.h"
 #include "memory.h"
 #include "event.h"
+#include "convert.h"
 #include "logfile.h"
 #include "interface.h"
 #include "shared.h"
@@ -594,9 +595,31 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->separator_chgd == true)
   {
-    if (strlen (user_options->separator) != 1)
+    bool error = false;
+    if ((strlen (user_options->separator) != 1) && (strlen (user_options->separator) != 4))
     {
-      event_log_error (hashcat_ctx, "Separator length has to be exactly 1 byte.");
+        error = true;
+    }
+    if (strlen (user_options->separator) == 4)
+    {
+      if ((user_options->separator[0] == '0') && (user_options->separator[1] == 'x'))
+      {
+        if (is_valid_hex_string((u8 * )(&(user_options->separator[2])),2)){
+          u8 sep = hex_to_u8((u8 * )(&(user_options->separator[2])));
+          user_options->separator[0] = sep;
+          user_options->separator[1] = 0;
+        }
+        else
+        {
+          error = true;
+        }
+      }
+      else{
+        error = true;
+      }
+    }
+    if (error){
+      event_log_error (hashcat_ctx, "Separator length has to be exactly 1 byte (single char or hex format e.g. 0x09 for TAB)");
 
       return -1;
     }


### PR DESCRIPTION
As in #3084 I've added this small feature so you can now specify separator special characters like CR or TAB.

Now `-p` and `--separator` options accepts single character or value in hex format (like: `0x09` for `TAB`)

