### PR TITLE
Fixed Unit Test salt-max in case of optimized kernel, with hash-type 22 and 23

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -29,6 +29,7 @@
 - Fixed bug on benchmark engine, from now it will not stop at the first error detected
 - Fixed false negative on Unit Test in case of out-of-memory with grep in single mode
 - Fixed Unit Test early exit on luks test file download/extract failure
+- Fixed Unit Test salt-max in case of optimized kernel, with hash-type 22 and 23
 
 ##
 ## Technical

--- a/tools/test_modules/m00022.pm
+++ b/tools/test_modules/m00022.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::MD5 qw (md5);
 
-sub module_constraints { [[0, 232], [0, 232], [0, 32], [0, 32], [0, 32]] }
+sub module_constraints { [[0, 232], [0, 232], [0, 32], [0, 28], [0, 32]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m00023.pm
+++ b/tools/test_modules/m00023.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::MD5 qw (md5_hex);
 
-sub module_constraints { [[0, 247], [0, 247], [0, 47], [0, 47], [0, 47]] }
+sub module_constraints { [[0, 247], [0, 247], [0, 47], [0, 43], [0, 47]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
Hi,

for hash-type 22 and 23, salt-max is wrong and produces false positives on test.sh engine

Example:

```
hash:plains not matched in output, cmdline : cat test_1642256184/23_passwords.txt | ./hashcat --quiet --potfile-disable --hwmon-disable -O --runtime 20 -D 2 --backend-vector-width 1 -a 0 -m 23 test_1642256184/23_hashes.txt
```

```
$ cat test_1642256184/23_passwords.txt

3716
8265132
20016756104
430613063437891884614
209102555350329809517444
2745377512866937925528548
7091650330496076093870813270248
```

```
$ cat test_1642256184/23_hashes.txt
f253bee97ba5cfd462847a2c85a60621:90034361870199904778329239762624740925060575418
41100299de432d72473d47ac944c95dc:81546567741958778041244880219503085478
5592e6a070ffd7dadfb4f014c64d851e:0157508983
1968a562b5f5975e9613dc093f790182:78369133130150297520624
52c5e5f2018f4a57455b6a8b41ada2a5:6865022362
548f8637cc929f81910c5397550a21bd:
f597884dedda7030405e2039b4adf8b9:11087236861274801408
fe4be159a6bcef763cf2a784b5c24651:
```

```
$ cat test_1642256184/23_passwords.txt | ./hashcat --potfile-disable --hwmon-disable -O --runtime 20 -D 1 --backend-vector-width 1 -a 0 -m 23 test_1642256184/23_hashes.txt
hashcat (v6.2.5-121-gb6138ac36+) starting

OpenCL API (OpenCL 1.2 (May  7 2020 00:10:14)) - Platform #1 [Apple]
====================================================================
* Device #1: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, 4064/8192 MB (1024 MB allocatable), 4MCU
* Device #2: Iris, skipped

Minimum password length supported by kernel: 0
Maximum password length supported by kernel: 31
Minimim salt length supported by kernel: 0
Maximum salt length supported by kernel: 51

Hashfile 'test_1642256184/23_hashes.txt' on line 1 (f253be...04778329239762624740925060575418): Salt-length exception
Hashes: 7 digests; 7 unique digests, 6 unique salts
Bitmaps: 16 bits, 65536 entries, 0x0000ffff mask, 262144 bytes, 5/13 rotates
Rules: 1

Optimizers applied:
* Optimized-Kernel
* Zero-Byte
* Precompute-Init
* Early-Skip
* Not-Iterated
* Prepended-Salt
* Raw-Hash

Watchdog: Hardware monitoring interface not found on your system.
Watchdog: Temperature abort trigger disabled.

Host memory required for this attack: 1 MB

Starting attack in stdin mode

548f8637cc929f81910c5397550a21bd::209102555350329809517444
fe4be159a6bcef763cf2a784b5c24651::7091650330496076093870813270248
52c5e5f2018f4a57455b6a8b41ada2a5:6865022362:430613063437891884614
5592e6a070ffd7dadfb4f014c64d851e:0157508983:8265132
f597884dedda7030405e2039b4adf8b9:11087236861274801408:2745377512866937925528548
1968a562b5f5975e9613dc093f790182:78369133130150297520624:20016756104
41100299de432d72473d47ac944c95dc:81546567741958778041244880219503085478:3716
Session..........: hashcat
Status...........: Cracked
Hash.Mode........: 23 (Skype)
Hash.Target......: test_1642256184/23_hashes.txt
Time.Started.....: Sat Jan 15 16:11:44 2022 (0 secs)
Time.Estimated...: Sat Jan 15 16:11:44 2022 (0 secs; Runtime limited: 20 secs)
Kernel.Feature...: Optimized Kernel
Guess.Base.......: Pipe
Speed.#1.........:    52402 H/s (0.01ms) @ Accel:512 Loops:1 Thr:1 Vec:1
Recovered........: 7/7 (100.00%) Digests, 6/6 (100.00%) Salts
Progress.........: 48
Rejected.........: 0
Restore.Point....: 0
Restore.Sub.#1...: Salt:5 Amplifier:0-1 Iteration:0-1
Candidate.Engine.: Device Generator
Candidates.#1....:  -> 7091650330496076093870813270248
Started: Sat Jan 15 16:11:39 2022
Stopped: Sat Jan 15 16:11:45 2022
```

In case of optimized kernel, in case the default value is used, salt_max is set to SALT_MAX_OLD.

```
$ grep SALT_MAX_OLD include/common.h 
#define SALT_MAX_OLD        51
```

```
u32 default_salt_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
{
  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);

  // salt_max : this limit is only interessting for generic hash types that support a salt

  u32 salt_max = SALT_MAX;

  if (optimized_kernel == true)
  {
    salt_max = SALT_MAX_OLD;

    if ((hashconfig->opts_type & OPTS_TYPE_ST_UTF16LE) || (hashconfig->opts_type & OPTS_TYPE_ST_UTF16BE))
    {
      salt_max /= 2;
    }
  }

  if (hashconfig->salt_type == SALT_TYPE_GENERIC)
  {
    if (hashconfig->opts_type & OPTS_TYPE_ST_HEX)
    {
      salt_max *= 2;
    }
  }

  return salt_max;
}
```

For hash-type 22 and 23, in their respective test modules there're these sentences:

```
  # we need to reduce the maximum password and salt buffer size by 23 since we
  # add it here statically
[...]
  # we need to reduce the maximum password and salt buffer size by 8 since we
  # add it here statically
```

This patch fix the module_constraints for both.
I still have no idea if there are any others wrong, but if they happen they will be fixed, always if I have not misunderstood something :)

Thanks