### PR TITLE
Fixed --hash-info example password output: force uppercase if OPTS_TYPE_PT_UPPER is set

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -29,6 +29,7 @@
 - Fixed bug on benchmark engine, from now it will not stop at the first error detected
 - Fixed false negative on Unit Test in case of out-of-memory with grep in single mode
 - Fixed Unit Test early exit on luks test file download/extract failure
+- Fixed --hash-info example password output: force uppercase if OPTS_TYPE_PT_UPPER is set
 
 ##
 ## Technical

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -699,6 +699,20 @@ void hash_info_single (hashcat_ctx_t *hashcat_ctx, user_options_extra_t *user_op
 
         hcfree (tmp_buf);
       }
+      else if (hashconfig->opts_type & OPTS_TYPE_PT_UPPER)
+      {
+        size_t st_pass_len = strlen (hashconfig->st_pass);
+
+        char *tmp_buf = (char *) hcmalloc (st_pass_len + 1);
+
+        strncpy (tmp_buf, hashconfig->st_pass, st_pass_len);
+
+        uppercase ((u8 *) tmp_buf, st_pass_len);
+
+        event_log_info (hashcat_ctx, "  Example.Pass........: %s", tmp_buf);
+
+        hcfree (tmp_buf);
+      }
       else
       {
         event_log_info (hashcat_ctx, "  Example.Pass........: %s", hashconfig->st_pass);


### PR DESCRIPTION
Hi,

for the following hash types, --hash-info / -- example may show an incorrect example password, due to not being converted to uppercase:

```
   3000 | LM                                                  | Operating System
    131 | MSSQL (2000)                                        | Database Server
   3100 | Oracle H: Type (Oracle 7+)                          | Database Server
   7700 | SAP CODVN B (BCODE)                                 | Enterprise Application Software (EAS)
   7701 | SAP CODVN B (BCODE) from RFC_READ_TABLE             | Enterprise Application Software (EAS)
```

Thanks :)