### PR TITLE
Fixed bug on benchmark engine, add some unstable warnings, updated negative status code

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -48,6 +48,7 @@
 - Hash-Mode 7500: set native_threads to 32 with Apple GPU's
 - Hash-Mode 10500: set native_threads to 32 with Apple GPU's
 - Hash-Mode 13100: set native_threads to 32 with Apple GPU's
+- Fixed bug on benchmark engine, avoid skipping all devices in case of "kernel create error" in one of them
 
 ##
 ## Technical
@@ -72,6 +73,13 @@
 - Unit tests: added -r (--runtime) option
 - Unit tests: handle negative status code, skip deprecated hash-types, skip hash-types with known perl modules issues, updated output
 - Hash Info: show more information (Updated Hash-Format. Added Autodetect, Self-Test, Potfile and Plaintext encoding)
+- Status code: updated negative status code (added kernel create failure and resync)
+
+##
+## Improvements
+##
+
+- OpenCL Runtime: Add some unstable warnings detected on macOS
 
 * changes v6.2.4 -> v6.2.5
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -48,7 +48,6 @@
 - Hash-Mode 7500: set native_threads to 32 with Apple GPU's
 - Hash-Mode 10500: set native_threads to 32 with Apple GPU's
 - Hash-Mode 13100: set native_threads to 32 with Apple GPU's
-- Fixed bug on benchmark engine, avoid skipping all devices in case of "kernel create error" in one of them
 
 ##
 ## Technical
@@ -72,13 +71,6 @@
 - Unit tests: added -r (--runtime) option
 - Unit tests: handle negative status code, skip deprecated hash-types, skip hash-types with known perl modules issues, updated output
 - Hash Info: show more information (Updated Hash-Format. Added Autodetect, Self-Test, Potfile and Plaintext encoding)
-- Status code: updated negative status code (added kernel create failure and resync)
-
-##
-## Improvements
-##
-
-- OpenCL Runtime: Add some unstable warnings detected on macOS
 
 * changes v6.2.4 -> v6.2.5
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -34,6 +34,7 @@
 - Fixed Unit Test salt-max in case of optimized kernel, with hash-type 22 and 23
 - Fixed Unit Test false negative if there are spaces in the filesystem path to hashcat
 - Fixed --hash-info example password output: force uppercase if OPTS_TYPE_PT_UPPER is set
+- Fixed bug on benchmark engine, avoid skipping all devices in case of "kernel create error" in one of them
 
 ##
 ## Technical
@@ -57,6 +58,13 @@
 - Unit tests: added -r (--runtime) option
 - Unit tests: handle negative status code, skip deprecated hash-types, skip hash-types with known perl modules issues, updated output
 - Hash Info: show more information (Updated Hash-Format. Added Autodetect, Self-Test, Potfile and Plaintext encoding)
+- Status code: updated negative status code (added kernel create failure and resync)
+
+##
+## Improvements
+##
+
+- OpenCL Runtime: Add some unstable warnings detected on macOS
 
 * changes v6.2.4 -> v6.2.5
 

--- a/docs/status_codes.txt
+++ b/docs/status_codes.txt
@@ -2,9 +2,10 @@ status codes on exit:
 =====================
 
 -10 = autotune failure
- -8 = mixed backend errors (combo of -3, -4, -5, -6, -7 errors type)
- -7 = backend error: Invalid module_extra_buffer_size
- -6 = backend error: Too many compute units to keep minimum kernel accel limit
+ -9 = mixed backend errors (combo of -3, -4, -5, -6, -7 errors type)
+ -8 = backend error: Invalid module_extra_buffer_size
+ -7 = backend error: Too many compute units to keep minimum kernel accel limit
+ -6 = backend error: kernel create error
  -5 = backend error: main kernel build error
  -4 = backend error: memory hit
  -3 = backend error: skipping hash-type due to module_unstable_warning settings

--- a/docs/status_codes.txt
+++ b/docs/status_codes.txt
@@ -1,9 +1,10 @@
 status codes on exit:
 =====================
 
--8 = mixed backend errors (combo of -3, -4, -5, -6, -7 errors type)
--7 = backend error: Invalid module_extra_buffer_size
--6 = backend error: Too many compute units to keep minimum kernel accel limit
+-9 = mixed backend errors (combo of -3, -4, -5, -6, -7 errors type)
+-8 = backend error: Invalid module_extra_buffer_size
+-7 = backend error: Too many compute units to keep minimum kernel accel limit
+-6 = backend error: kernel create error
 -5 = backend error: main kernel build error
 -4 = backend error: memory hit
 -3 = backend error: skipping hash-type due to module_unstable_warning settings

--- a/docs/status_codes.txt
+++ b/docs/status_codes.txt
@@ -1,10 +1,9 @@
 status codes on exit:
 =====================
 
--9 = mixed backend errors (combo of -3, -4, -5, -6, -7 errors type)
--8 = backend error: Invalid module_extra_buffer_size
--7 = backend error: Too many compute units to keep minimum kernel accel limit
--6 = backend error: kernel create error
+-8 = mixed backend errors (combo of -3, -4, -5, -6, -7 errors type)
+-7 = backend error: Invalid module_extra_buffer_size
+-6 = backend error: Too many compute units to keep minimum kernel accel limit
 -5 = backend error: main kernel build error
 -4 = backend error: memory hit
 -3 = backend error: skipping hash-type due to module_unstable_warning settings

--- a/include/types.h
+++ b/include/types.h
@@ -1688,6 +1688,7 @@ typedef struct backend_ctx
   bool                memory_hit_warning;
   bool                runtime_skip_warning;
   bool                kernel_build_warning;
+  bool                kernel_create_warning;
   bool                kernel_accel_warnings;
   bool                extra_size_warning;
   bool                mixed_warnings;

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -1751,9 +1751,10 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
     if (backend_ctx->runtime_skip_warning  == true)               rc_final = -3;
     if (backend_ctx->memory_hit_warning    == true)               rc_final = -4;
     if (backend_ctx->kernel_build_warning  == true)               rc_final = -5;
-    if (backend_ctx->kernel_accel_warnings == true)               rc_final = -6;
-    if (backend_ctx->extra_size_warning    == true)               rc_final = -7;
-    if (backend_ctx->mixed_warnings        == true)               rc_final = -8;
+    if (backend_ctx->kernel_create_warning == true)               rc_final = -6;
+    if (backend_ctx->kernel_accel_warnings == true)               rc_final = -7;
+    if (backend_ctx->extra_size_warning    == true)               rc_final = -8;
+    if (backend_ctx->mixed_warnings        == true)               rc_final = -9;
   }
 
   // special case for --stdout

--- a/src/modules/module_10700.c
+++ b/src/modules/module_10700.c
@@ -81,6 +81,17 @@ typedef struct pdf17l8_tmp
 static const char *SIGNATURE_PDF  = "$pdf$";
 static const int   ROUNDS_PDF17L8 = 64;
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (or never-end with pure kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
   const u64 esalt_size = (const u64) sizeof (pdf_t);
@@ -390,6 +401,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = module_tmp_size;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_11700.c
+++ b/src/modules/module_11700.c
@@ -43,6 +43,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
   char *jit_build_options = NULL;
@@ -203,6 +214,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = MODULE_DEFAULT;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_11750.c
+++ b/src/modules/module_11750.c
@@ -43,6 +43,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
   char *jit_build_options = NULL;
@@ -230,6 +241,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = MODULE_DEFAULT;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_11760.c
+++ b/src/modules/module_11760.c
@@ -43,6 +43,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
   char *jit_build_options = NULL;
@@ -230,6 +241,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = MODULE_DEFAULT;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_11800.c
+++ b/src/modules/module_11800.c
@@ -43,6 +43,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
   char *jit_build_options = NULL;
@@ -227,6 +238,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = MODULE_DEFAULT;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_11850.c
+++ b/src/modules/module_11850.c
@@ -43,6 +43,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
   char *jit_build_options = NULL;
@@ -254,6 +265,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = MODULE_DEFAULT;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_11860.c
+++ b/src/modules/module_11860.c
@@ -43,6 +43,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
   char *jit_build_options = NULL;
@@ -254,6 +265,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = MODULE_DEFAULT;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_13733.c
+++ b/src/modules/module_13733.c
@@ -84,6 +84,17 @@ typedef struct vc
 static const int   ROUNDS_VERACRYPT_500000     = 500000;
 static const float MIN_SUFFICIENT_ENTROPY_FILE = 7.0f;
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService never-end (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 int module_build_plain_postprocess (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const void *tmps, const u32 *src_buf, MAYBE_UNUSED const size_t src_sz, MAYBE_UNUSED const int src_len, u32 *dst_buf, MAYBE_UNUSED const size_t dst_sz)
 {
   const vc_tmp_t *vc_tmp = (const vc_tmp_t *) tmps;
@@ -352,6 +363,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = module_tmp_size;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_13773.c
+++ b/src/modules/module_13773.c
@@ -105,6 +105,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
     }
   }
 
+  // AppleM1, OpenCL, MTLCompilerService never-end
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
   return false;
 }
 

--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -180,6 +180,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
     return true;
   }
 
+  // AppleM1, OpenCL, MTLCompilerService never-end
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
   return false;
 }
 

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -180,6 +180,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
     return true;
   }
 
+  // AppleM1, OpenCL, MTLCompilerService never-end
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
   return false;
 }
 

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -180,6 +180,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
     return true;
   }
 
+  // AppleM1, OpenCL, MTLCompilerService never-end
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
   return false;
 }
 

--- a/src/modules/module_19200.c
+++ b/src/modules/module_19200.c
@@ -62,6 +62,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
     {
       return true;
     }
+
+    // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+    if ((device_param->opencl_device_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_21600.c
+++ b/src/modules/module_21600.c
@@ -55,6 +55,17 @@ typedef struct web2py_sha512_tmp
 
 } web2py_sha512_tmp_t;
 
+bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (pure/optimized kernel)
+  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+  {
+    return true;
+  }
+
+  return false;
+}
+
 u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
   const u64 tmp_size = (const u64) sizeof (web2py_sha512_tmp_t);
@@ -228,6 +239,6 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_st_hash                  = module_st_hash;
   module_ctx->module_st_pass                  = module_st_pass;
   module_ctx->module_tmp_size                 = module_tmp_size;
-  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = module_unstable_warning;
   module_ctx->module_warmup_disable           = MODULE_DEFAULT;
 }

--- a/src/modules/module_21800.c
+++ b/src/modules/module_21800.c
@@ -95,6 +95,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
     {
       return true;
     }
+
+    // AppleM1, OpenCL, MTLCompilerService never-end (pure/optimized kernel)
+    if ((device_param->opencl_device_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
+    {
+      return true;
+    }
   }
 
   // amdgpu-pro-20.50-1234664-ubuntu-20.04 (legacy)


### PR DESCRIPTION
Hi,

while doing a full benchmark, i identified issues on some modules in case they run on macOS.
I solved these by updating "module_unstable_warning" function where necessary, and also continuing to implement the logic inserted from my last commits: handling backend errors by deactivating only the single device instead of all active devices (no early exit when possible).

Although in the title I talk about benchmarks, these issues related to errors catched during the execution of the "backend_session_begin" function, also occur during the "standard" execution of hashcat (cracking hashes), but to get them out you need to use devices with different configurations or characteristics (in my case CPU + GPU).

Finally I have updated and re-synchronized the negative status codes.

By applying the recently updated PR #3113 and by generating an x86_64 binary on the Apple Silicon (mini-mac M1), I was able to complete the full benchmark.

More details here: https://gist.github.com/matrix/ae6b64a6e44392355a5467d129fd8bee

Thanks :)

