### PR TITLE
Added support to building Universal macOS binary on Apple Silicon

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -16,6 +16,7 @@
 - Added support to use --debug-mode in attack-mode 9 (Association Attack)
 - Added guess data to --status-json output
 - Added hex format for --separator option
+- Added support to building Universal macOS binary on Apple Silicon
 
 ##
 ## Bugs

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -23,6 +23,7 @@ Gabriele "matrix" Gristina <matrix@hashcat.net> (@gm4tr1x)
 * OpenCL Info feature
 * Apple macOS port
 * Apple Silicon support
+* Universal binary on Apple Silicon
 * Hardware monitor initial code base and maintenance
 * Test suite initial code base and maintenance
 * Makefile initial code base

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,7 @@ $(error "! Your Operating System ($(UNAME)) is not supported by this Makefile")
 endif
 
 ifeq ($(DEBUG),1)
-$(warning "## Detected Operating System : $(UNAME)")
+$(info "## Detected Operating System : $(UNAME)")
 endif
 
 ##
@@ -76,6 +76,7 @@ AR                      := /usr/bin/ar
 SED                     := /usr/bin/sed
 SED_IN_PLACE            := -i ""
 DARWIN_VERSION          := $(shell uname -r | cut -d. -f1)
+IS_APPLE_SILICON        := $(shell lipo /bin/zsh -verify_arch arm64e && echo 1 || echo 0)
 endif
 
 ifneq (,$(filter $(UNAME),FreeBSD NetBSD))
@@ -333,6 +334,16 @@ LFLAGS_NATIVE           := $(LFLAGS)
 LFLAGS_NATIVE           += -framework IOKit
 LFLAGS_NATIVE           += -lpthread
 LFLAGS_NATIVE           += -liconv
+
+ifeq ($(IS_APPLE_SILICON),1)
+CFLAGS_NATIVE           += -arch arm64
+CFLAGS_NATIVE           += -arch x86_64
+ifeq ($(SHARED),1)
+LFLAGS_NATIVE           += -arch arm64
+LFLAGS_NATIVE           += -arch x86_64
+endif
+endif
+
 endif # Darwin
 
 ifeq ($(UNAME),CYGWIN)


### PR DESCRIPTION
Hi,

I found a simple way to do this (Universal macOS binary) on Apple Silicon.
By using _lipo -archs_ it was possible to "Display only the architecture names present in a single input file" (man lipo).

On Apple Intel the output is:
```
$ lipo -archs /bin/zsh 
x86_64 
```
while on Apple Silicon we have the following:

```
bash-3.2$ lipo -archs /bin/zsh
x86_64 arm64e
```

Based on this, I modified the Makefile to determine if we are on Apple Silicon, using /bin/zsh as target file (present by default on Apple). Then I added the supported architectures in the CFLAGS and LFLAGS, in order to successfully generate the binary, the modules and the shared library. So on Apple Silicon we will have this:

```
bash-3.2$ file hashcat
hashcat: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]
hashcat (for architecture x86_64):	Mach-O 64-bit executable x86_64
hashcat (for architecture arm64):	Mach-O 64-bit executable arm64
bash-3.2$ file libhashcat.6.2.5.dylib 
libhashcat.6.2.5.dylib: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64]
libhashcat.6.2.5.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
libhashcat.6.2.5.dylib (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64
bash-3.2$ file modules/module_00000.so 
modules/module_00000.so: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64:Mach-O 64-bit dynamically linked shared library arm64]
modules/module_00000.so (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
modules/module_00000.so (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64
```

and on Apple Intel the same as before the patch (because nothing change in this case):

```
$ file hashcat
hashcat: Mach-O 64-bit executable x86_64
$ file libhashcat.6.2.5.dylib 
libhashcat.6.2.5.dylib: Mach-O 64-bit dynamically linked shared library x86_64
$ file modules/module_00000.so
modules/module_00000.so: Mach-O 64-bit dynamically linked shared library x86_64
```

In my Apple M1 environment, by default the arm64 architecture will be used:

```
bash-3.2$ ./hashcat -I
hashcat (v6.2.5-155-gd85f86373+) starting in backend information mode

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Nov 13 2021 00:45:09)

  Backend Device ID #1
    Type...........: GPU
    Vendor.ID......: 2
    Vendor.........: Apple
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 1000
    Memory.Total...: 10922 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 5408 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2 1.0
```

but if I can run hashcat also with x86_64 emulation (through Rosetta) in two way and without rebuild all.

1. by spawning a shell with x86_64 emulation

```
bash-3.2$ arch -arch x86_64 /bin/bash
The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.

bash-3.2$ ./hashcat -I
hashcat (v6.2.5-155-gd85f86373+) starting in backend information mode

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Nov 13 2021 00:45:09)

  Backend Device ID #1
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 2400
    Memory.Total...: 16384 MB (limited to 2048 MB allocatable in one block)
    Memory.Free....: 8160 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.1

  Backend Device ID #2
    Type...........: GPU
    Vendor.ID......: 2
    Vendor.........: Apple
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 1000
    Memory.Total...: 10922 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 5408 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2 1.0

bash-3.2$ ./hashcat -b -m 0 -D1,2
hashcat (v6.2.5-155-gd85f86373+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (Nov 13 2021 00:45:09)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, 8160/16384 MB (2048 MB allocatable), 8MCU
* Device #2: Apple M1, 5408/10922 MB (1024 MB allocatable), 8MCU

Benchmark relevant options:
===========================
* --opencl-device-types=1,2
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#1.........:   185.8 MH/s (45.07ms) @ Accel:1024 Loops:1024 Thr:1 Vec:4
Speed.#2.........:  2594.6 MH/s (93.64ms) @ Accel:1024 Loops:512 Thr:64 Vec:1
Speed.#*.........:  2780.4 MH/s

Started: Sat Jan 22 23:31:39 2022
Stopped: Sat Jan 22 23:31:59 2022
```

2. using arch (specifying the architecture: x86_64 or arm64)

```
bash-3.2$ arch -arch arm64 ./hashcat -b -m 0 -D1,2
hashcat (v6.2.5-155-gd85f86373+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #1: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (Nov 13 2021 00:45:09)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, 5408/10922 MB (1024 MB allocatable), 8MCU

Benchmark relevant options:
===========================
* --opencl-device-types=1,2
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#1.........:  2843.7 MH/s (4.49ms) @ Accel:1024 Loops:1024 Thr:64 Vec:1

Started: Sat Jan 22 23:34:24 2022
Stopped: Sat Jan 22 23:34:42 2022

bash-3.2$ arch -arch arm64 ./hashcat -b -D1,2
hashcat (v6.2.5-155-gd85f86373+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #1: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (Nov 13 2021 00:45:09)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, 5408/10922 MB (1024 MB allocatable), 8MCU

Benchmark relevant options:
===========================
* --opencl-device-types=1,2
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#1.........:  2844.0 MH/s (4.49ms) @ Accel:2048 Loops:1024 Thr:32 Vec:1

----------------------
* Hash-Mode 100 (SHA1)
----------------------

Speed.#1.........:  1023.8 MH/s (12.53ms) @ Accel:512 Loops:1024 Thr:128 Vec:1

---------------------------
* Hash-Mode 1400 (SHA2-256)
---------------------------

Speed.#1.........:   307.7 MH/s (41.68ms) @ Accel:1024 Loops:1024 Thr:64 Vec:1

---------------------------
* Hash-Mode 1700 (SHA2-512)
---------------------------

Speed.#1.........:   101.0 MH/s (63.60ms) @ Accel:1024 Loops:512 Thr:64 Vec:1

-------------------------------------------------------------
* Hash-Mode 22000 (WPA-PBKDF2-PMKID+EAPOL) [Iterations: 4095]
-------------------------------------------------------------

Speed.#1.........:    49770 H/s (62.96ms) @ Accel:1024 Loops:1024 Thr:64 Vec:1

-----------------------
* Hash-Mode 1000 (NTLM)
-----------------------

Speed.#1.........:  4862.8 MH/s (2.62ms) @ Accel:2048 Loops:1024 Thr:32 Vec:1

---------------------
* Hash-Mode 3000 (LM)
---------------------

Speed.#1.........:   413.4 MH/s (31.02ms) @ Accel:1024 Loops:1024 Thr:64 Vec:1

--------------------------------------------
* Hash-Mode 5500 (NetNTLMv1 / NetNTLMv1+ESS)
--------------------------------------------

Speed.#1.........:  2983.6 MH/s (4.28ms) @ Accel:1024 Loops:1024 Thr:64 Vec:1

[...]

bash-3.2$ arch -arch x86_64 ./hashcat -b -D1,2
hashcat (v6.2.5-155-gd85f86373+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (Nov 13 2021 00:45:09)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, 8160/16384 MB (2048 MB allocatable), 8MCU
* Device #2: Apple M1, 5408/10922 MB (1024 MB allocatable), 8MCU

Benchmark relevant options:
===========================
* --opencl-device-types=1,2
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#1.........:   185.6 MH/s (45.10ms) @ Accel:1024 Loops:1024 Thr:1 Vec:4
Speed.#2.........:  2598.5 MH/s (93.64ms) @ Accel:2048 Loops:512 Thr:32 Vec:1
Speed.#*.........:  2784.2 MH/s

----------------------
* Hash-Mode 100 (SHA1)
----------------------

Speed.#1.........:   141.1 MH/s (29.39ms) @ Accel:1024 Loops:512 Thr:1 Vec:4
Speed.#2.........:   918.2 MH/s (65.39ms) @ Accel:256 Loops:256 Thr:128 Vec:1
Speed.#*.........:  1059.2 MH/s

---------------------------
* Hash-Mode 1400 (SHA2-256)
---------------------------

Speed.#1.........: 61088.8 kH/s (68.57ms) @ Accel:512 Loops:1024 Thr:1 Vec:4
Speed.#2.........:   274.5 MH/s (54.71ms) @ Accel:512 Loops:128 Thr:32 Vec:1
Speed.#*.........:   335.6 MH/s

[...]
```

Thanks :)
