### PR TITLE
tests: cleanup and module dependencies fix

### DIFF
--- a/tools/test_modules/m00050.pm
+++ b/tools/test_modules/m00050.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Digest::MD5  qw (md5);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [-1, -1]] }
 

--- a/tools/test_modules/m00060.pm
+++ b/tools/test_modules/m00060.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Digest::MD5  qw (md5);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [-1, -1]] }
 

--- a/tools/test_modules/m00150.pm
+++ b/tools/test_modules/m00150.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Digest::SHA1 qw (sha1);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [-1, -1]] }
 

--- a/tools/test_modules/m00160.pm
+++ b/tools/test_modules/m00160.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Digest::SHA1 qw (sha1);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [-1, -1]] }
 

--- a/tools/test_modules/m00900.pm
+++ b/tools/test_modules/m00900.pm
@@ -9,7 +9,6 @@ use strict;
 use warnings;
 
 use Digest::MD4 qw (md4_hex);
-use Encode;
 
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m01711.pm
+++ b/tools/test_modules/m01711.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Digest::SHA  qw (sha512_hex);
-use MIME::Base64 qw (encode_base64);
+use MIME::Base64 qw (encode_base64 decode_base64);
 
 sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [0, 55]] }
 

--- a/tools/test_modules/m02100.pm
+++ b/tools/test_modules/m02100.pm
@@ -8,7 +8,7 @@
 use strict;
 use warnings;
 
-use Digest::MD4 qw (md4 md4_hex);
+use Digest::MD4 qw (md4);
 use Crypt::PBKDF2;
 use Encode;
 

--- a/tools/test_modules/m02400.pm
+++ b/tools/test_modules/m02400.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Digest::MD5 qw (md5);
-use POSIX qw (strftime ceil);
+use POSIX qw (ceil);
 
 sub module_constraints { [[-1, -1], [-1, -1], [1, 55], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m05500.pm
+++ b/tools/test_modules/m05500.pm
@@ -9,10 +9,8 @@ use strict;
 use warnings;
 
 use Authen::Passphrase::NTHash;
-use Digest::HMAC qw (hmac hmac_hex);
-use Digest::MD5  qw (md5);
-use Encode       qw (encode);
-use Crypt::ECB   qw (encrypt);
+use Digest::MD5 qw (md5);
+use Crypt::ECB;
 
 sub setup_des_key
 {

--- a/tools/test_modules/m07500.pm
+++ b/tools/test_modules/m07500.pm
@@ -12,7 +12,6 @@ use Encode;
 use Crypt::RC4;
 use Digest::HMAC_MD5 qw (hmac_md5);
 use Digest::MD4      qw (md4);
-use Digest::MD5      qw (md5_hex);
 use POSIX            qw (strftime);
 
 sub get_random_kerberos5_salt

--- a/tools/test_modules/m08900.pm
+++ b/tools/test_modules/m08900.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Crypt::ScryptKDF qw (scrypt_hash);
-use MIME::Base64 qw (decode_base64);
+use MIME::Base64     qw (decode_base64);
 
 sub module_constraints { [[0, 256], [1, 15], [-1, -1], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m10901.pm
+++ b/tools/test_modules/m10901.pm
@@ -7,8 +7,9 @@
 
 use strict;
 use warnings;
+
 use Crypt::PBKDF2;
-use MIME::Base64;
+use MIME::Base64 qw (encode_base64 decode_base64);
 
 sub module_constraints { [[0, 256], [64, 64], [-1, -1], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m11200.pm
+++ b/tools/test_modules/m11200.pm
@@ -8,7 +8,6 @@
 use strict;
 use warnings;
 
-use Digest::MD5 qw (md5_hex);
 use Digest::SHA qw (sha1);
 
 sub module_constraints { [[0, 256], [40, 40], [0, 55], [40, 40], [-1, -1]] }

--- a/tools/test_modules/m13100.pm
+++ b/tools/test_modules/m13100.pm
@@ -12,8 +12,6 @@ use Encode;
 use Crypt::RC4;
 use Digest::HMAC_MD5 qw (hmac_md5);
 use Digest::MD4      qw (md4);
-use Digest::MD5      qw (md5_hex);
-use POSIX            qw (strftime);
 
 sub module_constraints { [[0, 256], [16, 16], [0, 27], [16, 16], [-1, -1]] }
 

--- a/tools/test_modules/m13900.pm
+++ b/tools/test_modules/m13900.pm
@@ -9,7 +9,6 @@ use strict;
 use warnings;
 
 use Digest::SHA qw (sha1_hex);
-use Encode;
 
 sub module_constraints { [[0, 256], [9, 9], [0, 46], [9, 9], [-1, -1]] }
 

--- a/tools/test_modules/m15300.pm
+++ b/tools/test_modules/m15300.pm
@@ -8,9 +8,9 @@
 use strict;
 use warnings;
 
-use Crypt::ECB  qw (encrypt);
 use Digest::MD4 qw (md4);
 use Digest::SHA qw (sha1 hmac_sha1);
+use Crypt::ECB;
 use Encode;
 
 sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m15900.pm
+++ b/tools/test_modules/m15900.pm
@@ -8,10 +8,10 @@
 use strict;
 use warnings;
 
-use Crypt::CBC;
-use Crypt::ECB  qw (encrypt);
 use Digest::MD4 qw (md4);
 use Digest::SHA qw (sha1 hmac_sha1 hmac_sha512);
+use Crypt::CBC;
+use Crypt::ECB;
 use Encode;
 
 sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m16900.pm
+++ b/tools/test_modules/m16900.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Crypt::PBKDF2;
 use Digest::HMAC qw (hmac_hex);
-use Digest::SHA qw (sha256);
+use Digest::SHA  qw (sha256);
 
 sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m18200.pm
+++ b/tools/test_modules/m18200.pm
@@ -12,8 +12,6 @@ use Encode;
 use Crypt::RC4;
 use Digest::HMAC_MD5 qw (hmac_md5);
 use Digest::MD4      qw (md4);
-use Digest::MD5      qw (md5_hex);
-use POSIX            qw (strftime);
 
 sub module_constraints { [[0, 256], [16, 16], [0, 27], [16, 16], [-1, -1]] }
 

--- a/tools/test_modules/m19600.pm
+++ b/tools/test_modules/m19600.pm
@@ -11,8 +11,6 @@ use warnings;
 use Digest::SHA qw (hmac_sha1);
 use Crypt::Mode::CBC;
 use Crypt::PBKDF2;
-use Encode;
-use POSIX            qw (strftime);
 
 sub byte2hex
 {

--- a/tools/test_modules/m19700.pm
+++ b/tools/test_modules/m19700.pm
@@ -11,8 +11,6 @@ use warnings;
 use Digest::SHA qw (hmac_sha1);
 use Crypt::Mode::CBC;
 use Crypt::PBKDF2;
-use Encode;
-use POSIX            qw (strftime);
 
 sub byte2hex
 {

--- a/tools/test_modules/m19800.pm
+++ b/tools/test_modules/m19800.pm
@@ -11,8 +11,6 @@ use warnings;
 use Digest::SHA qw (hmac_sha1);
 use Crypt::Mode::CBC;
 use Crypt::PBKDF2;
-use Encode;
-use POSIX            qw (strftime);
 
 sub byte2hex
 {

--- a/tools/test_modules/m19900.pm
+++ b/tools/test_modules/m19900.pm
@@ -11,8 +11,6 @@ use warnings;
 use Digest::SHA qw (hmac_sha1);
 use Crypt::Mode::CBC;
 use Crypt::PBKDF2;
-use Encode;
-use POSIX            qw (strftime);
 
 sub byte2hex
 {

--- a/tools/test_modules/m20011.pm
+++ b/tools/test_modules/m20011.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Crypt::PBKDF2;
-use MIME::Base64 qw (encode_base64 decode_base64);
+use MIME::Base64 qw (encode_base64);
 use Encode;
 
 sub module_constraints { [[0, 256], [128, 128], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m20012.pm
+++ b/tools/test_modules/m20012.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Crypt::PBKDF2;
-use MIME::Base64 qw (encode_base64 decode_base64);
+use MIME::Base64 qw (encode_base64);
 use Encode;
 
 sub module_constraints { [[0, 256], [128, 128], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m20013.pm
+++ b/tools/test_modules/m20013.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 
 use Crypt::PBKDF2;
-use MIME::Base64 qw (encode_base64 decode_base64);
+use MIME::Base64 qw (encode_base64);
 use Encode;
 
 sub module_constraints { [[0, 256], [128, 128], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m20600.pm
+++ b/tools/test_modules/m20600.pm
@@ -8,8 +8,8 @@
 use strict;
 use warnings;
 
-use Digest::SHA qw (sha256);
-use MIME::Base64;
+use Digest::SHA  qw (sha256);
+use MIME::Base64 qw (encode_base64);
 
 sub module_constraints { [[0, 256], [0, 16], [-1, -1], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m21500.pm
+++ b/tools/test_modules/m21500.pm
@@ -8,9 +8,9 @@
 use strict;
 use warnings;
 
-use MIME::Base64 qw (encode_base64 decode_base64);
+use MIME::Base64 qw (encode_base64);
+use Digest::SHA  qw (sha512);
 use Crypt::PBKDF2;
-use Digest::SHA qw (sha512);
 use Encode;
 
 sub module_constraints { [[0, 256], [0, 256], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m21501.pm
+++ b/tools/test_modules/m21501.pm
@@ -8,9 +8,9 @@
 use strict;
 use warnings;
 
-use MIME::Base64 qw (encode_base64 decode_base64);
+use MIME::Base64 qw (encode_base64);
+use Digest::SHA  qw (sha512);
 use Crypt::PBKDF2;
-use Digest::SHA qw (sha512);
 use Encode;
 
 sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m21600.pm
+++ b/tools/test_modules/m21600.pm
@@ -8,12 +8,9 @@
 use strict;
 use warnings;
 
-use MIME::Base64 qw (encode_base64 decode_base64);
 use Crypt::PBKDF2;
 
 sub module_constraints { [[0, 256], [1, 15], [-1, -1], [-1, -1], [-1, -1]] }
-
-#pbkdf2(1000,20,sha512)$a2a2ca127df6bc19$77bb5a3d129e2ce710daaefeefef8356c4c827ff";
 
 sub module_generate_hash
 {
@@ -36,8 +33,6 @@ sub module_generate_hash
 
   return $hash;
 }
-
-#pbkdf2(1000,20,sha512)$a2a2ca127df6bc19$77bb5a3d129e2ce710daaefeefef8356c4c827ff";
 
 sub module_verify_hash
 {

--- a/tools/test_modules/m24700.pm
+++ b/tools/test_modules/m24700.pm
@@ -8,7 +8,6 @@
 use strict;
 use warnings;
 
-use Digest::MD5 qw (md5_hex);
 use Digest::MD5 qw (md5);
 
 sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m24800.pm
+++ b/tools/test_modules/m24800.pm
@@ -9,9 +9,9 @@ use strict;
 use warnings;
 
 use Digest::SHA1 qw (sha1);
-use Digest::HMAC qw (hmac hmac_hex);
-use Encode qw (encode decode);
-use MIME::Base64;
+use Digest::HMAC qw (hmac);
+use Encode       qw (encode);
+use MIME::Base64 qw (encode_base64);
 
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 

--- a/tools/test_modules/m24900.pm
+++ b/tools/test_modules/m24900.pm
@@ -7,7 +7,6 @@
 
 use strict;
 use warnings;
-use MIME::Base64 qw (encode_base64 decode_base64);
 
 use Digest::MD5 qw (md5);
 

--- a/tools/test_modules/m25000.pm
+++ b/tools/test_modules/m25000.pm
@@ -8,9 +8,9 @@
 use strict;
 use warnings;
 
-use Digest::MD5 qw (md5 md5_hex);
-use Digest::SHA qw (sha1 sha1_hex);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::MD5  qw (md5 md5_hex);
+use Digest::SHA  qw (sha1 sha1_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[8, 256], [24, 3000], [-1, -1], [-1, -1], [-1, -1]] }
 
@@ -18,13 +18,13 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $pkt_num = shift // int(rand(100000000));
-  my $engineID = shift // random_hex_string(26, 34);
-  my $mode = shift // int(rand(1)) + 1;
+  my $pkt_num = shift // int (rand (100000000));
+  my $engineID = shift // random_hex_string (26, 34);
+  my $mode = shift // int (rand (1)) + 1;
 
   # make even if needed
 
-  if (length($salt) %2 == 1)
+  if (length ($salt) % 2 == 1)
   {
     $salt = $salt . "8";
   }
@@ -50,15 +50,15 @@ sub module_generate_hash
 
   if ($mode eq 2)
   {
-    my $digest2 = sha1(pack("H*", $buf));
+    my $digest2 = sha1 (pack ("H*", $buf));
 
-    $digest = hmac_hex (pack("H*", $salt), $digest2, \&sha1);
+    $digest = hmac_hex (pack ("H*", $salt), $digest2, \&sha1);
   }
   elsif ($mode eq 1)
   {
-    my $digest2 = md5(pack("H*", $buf));
+    my $digest2 = md5 (pack ("H*", $buf));
 
-    $digest = hmac_hex (pack("H*", $salt), $digest2, \&md5);
+    $digest = hmac_hex (pack ("H*", $salt), $digest2, \&md5);
   }
 
   $digest = substr ($digest, 0, 24);

--- a/tools/test_modules/m25100.pm
+++ b/tools/test_modules/m25100.pm
@@ -8,8 +8,8 @@
 use strict;
 use warnings;
 
-use Digest::MD5 qw (md5 md5_hex);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::MD5  qw (md5 md5_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[8, 256], [24, 3000], [-1, -1], [-1, -1], [-1, -1]] }
 
@@ -17,12 +17,12 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $pkt_num = shift // int(rand(100000000));
-  my $engineID = shift // random_hex_string(26, 34);
+  my $pkt_num = shift // int (rand (100000000));
+  my $engineID = shift // random_hex_string (26, 34);
 
   # make even if needed
 
-  if (length($salt) %2 == 1)
+  if (length ($salt) % 2 == 1)
   {
     $salt = $salt . "8";
   }
@@ -35,9 +35,9 @@ sub module_generate_hash
 
   my $buf = join '', $md5_digest1, $engineID, $md5_digest1;
 
-  my $md5_digest2 = md5(pack("H*", $buf));
+  my $md5_digest2 = md5 (pack ("H*", $buf));
 
-  my $digest = hmac_hex (pack("H*", $salt), $md5_digest2, \&md5);
+  my $digest = hmac_hex (pack ("H*", $salt), $md5_digest2, \&md5);
 
   $digest = substr ($digest, 0, 24);
 

--- a/tools/test_modules/m25200.pm
+++ b/tools/test_modules/m25200.pm
@@ -8,8 +8,8 @@
 use strict;
 use warnings;
 
-use Digest::SHA qw (sha1 sha1_hex);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::SHA  qw (sha1 sha1_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[8, 256], [24, 3000], [-1, -1], [-1, -1], [-1, -1]] }
 
@@ -17,12 +17,12 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $pkt_num = shift // int(rand(100000000));
-  my $engineID = shift // random_hex_string(26, 34);
+  my $pkt_num = shift // int (rand (100000000));
+  my $engineID = shift // random_hex_string (26, 34);
 
   # make even if needed
 
-  if (length($salt) %2 == 1)
+  if (length ($salt) % 2 == 1)
   {
     $salt = $salt . "8";
   }
@@ -35,9 +35,9 @@ sub module_generate_hash
 
   my $buf = join '', $sha1_digest1, $engineID, $sha1_digest1;
 
-  my $sha1_digest2 = sha1(pack("H*", $buf));
+  my $sha1_digest2 = sha1 (pack ("H*", $buf));
 
-  my $digest = hmac_hex (pack("H*", $salt), $sha1_digest2, \&sha1);
+  my $digest = hmac_hex (pack ("H*", $salt), $sha1_digest2, \&sha1);
 
   $digest = substr ($digest, 0, 24);
 

--- a/tools/test_modules/m25300.pm
+++ b/tools/test_modules/m25300.pm
@@ -8,8 +8,8 @@
 use strict;
 use warnings;
 
-use MIME::Base64 qw (encode_base64 decode_base64);
-use Digest::SHA qw (sha512);
+use MIME::Base64 qw (encode_base64);
+use Digest::SHA  qw (sha512);
 use Encode;
 
 sub module_constraints { [[0, 64], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }

--- a/tools/test_modules/m25400.pm
+++ b/tools/test_modules/m25400.pm
@@ -99,11 +99,11 @@ sub pdf_compute_encryption_key_owner
   my $o_key;
   if ($R == 2)
   {
-    $o_key = substr($o_digest, 0, 8);  # rc4 key is always 5 for revision 2, but for 3 or greather is dependent on the value of the encryption dictionaries length entry
+    $o_key = substr ($o_digest, 0, 8);  # rc4 key is always 5 for revision 2, but for 3 or greather is dependent on the value of the encryption dictionaries length entry
   }
   else
   {
-    $o_key = substr($o_digest, 0, 16); #length is always 128 bits or 16 bytes
+    $o_key = substr ($o_digest, 0, 16); # length is always 128 bits or 16 bytes
   }
 
   return $o_key;
@@ -175,15 +175,15 @@ sub module_generate_hash
   if ($u eq "0000000000000000000000000000000000000000000000000000000000000000")
   {
     my $res;
-    if($u_pass eq "")
+    if ($u_pass eq "")
     {
       # we don't know the user-password so calculate $u based on the owner-password
-    $res = pdf_compute_encryption_key_user($word, $padding, $id, $u, $o, $P, $V, $R, $enc);
+      $res = pdf_compute_encryption_key_user ($word, $padding, $id, $u, $o, $P, $V, $R, $enc);
     }
     else
     {
-    #we do know the user-password, so we can generate $u
-    $res = pdf_compute_encryption_key_user($u_pass, $padding, $id, $u, $o, $P, $V, $R, $enc);
+      # we do know the user-password, so we can generate $u
+      $res = pdf_compute_encryption_key_user ($u_pass, $padding, $id, $u, $o, $P, $V, $R, $enc);
     }
 
     my $digest = md5 ($padding . pack ("H*", $id));
@@ -193,7 +193,7 @@ sub module_generate_hash
 
     my @ress = split "", $res;
 
-    #do xor of rc4 19 times
+    # do xor of rc4 19 times
     for (my $x = 1; $x <= 19; $x++)
     {
     my @xor;
@@ -213,28 +213,28 @@ sub module_generate_hash
   }
   else
   {
-    $u = pack("H*", $u)
+    $u = pack ("H*", $u)
   }
 
   ################ OWNER PASSWORD #################
-  my $o_key = pdf_compute_encryption_key_owner($word, $padding, $id, $u, $o, $P, $V, $R, $enc);
+  my $o_key = pdf_compute_encryption_key_owner ($word, $padding, $id, $u, $o, $P, $V, $R, $enc);
 
   my $n = Crypt::RC4->new ($o_key);
-  if($u_pass eq "")
+  if ($u_pass eq "")
   {
-     $o = $n->RC4(substr ($padding, 0, 32 - length ""));
+     $o = $n->RC4 (substr ($padding, 0, 32 - length ""));
   }
   else
   {
-    #dynamically add user password including padding to the RC4 input for the computation of the pdf o-value
-    $o = $n->RC4($u_pass.substr ($padding, 0, 32 - length $u_pass));
+    # dynamically add user password including padding to the RC4 input for the computation of the pdf o-value
+    $o = $n->RC4 ($u_pass . substr ($padding, 0, 32 - length $u_pass));
   }
 
   my @ress2 = split "", $o_key;
 
   if ($R >= 3)
   {
-    #do xor of rc4 19 times
+    # do xor of rc4 19 times
     for (my $x = 1; $x <= 19; $x++)
     {
       my @xor;
@@ -245,14 +245,14 @@ sub module_generate_hash
       }
 
       my $s = join ("", @xor);
-    my $n2 = Crypt::RC4->new ($s);
+      my $n2 = Crypt::RC4->new ($s);
 
       $o = $n2->RC4 ($o);
     }
   }
 
   my $hash;
-  if($u_pass eq "")
+  if ($u_pass eq "")
   {
     $hash = sprintf ('$pdf$%d*%d*128*%d*%d*16*%s*32*%s*32*%s', $V, $R, $P, $enc, $id, unpack ("H*", $u), unpack ("H*", $o));
   }
@@ -275,7 +275,7 @@ sub module_verify_hash
   my @data = split /\*/, $hash_in;
 
   my $i_data = scalar @data;
-  return unless ($i_data == 11) || ($i_data == 12); #or 12 if user-password is included
+  return unless ($i_data == 11) || ($i_data == 12); # or 12 if user-password is included
 
   my $V        = shift @data; $V = substr ($V, 5, 1);
   my $R        = shift @data;
@@ -290,7 +290,8 @@ sub module_verify_hash
   my $o        = shift @data;
 
   my $u_pass = "";
-  if($i_data == 12) {
+  if ($i_data == 12)
+  {
     $u_pass = shift @data;
   }
 

--- a/tools/test_modules/m25700.pm
+++ b/tools/test_modules/m25700.pm
@@ -145,4 +145,3 @@ sub module_verify_hash
 }
 
 1;
-

--- a/tools/test_modules/m26600.pm
+++ b/tools/test_modules/m26600.pm
@@ -58,12 +58,12 @@ sub module_generate_hash
     }
     else
     {
-      $pt = "\xff" x ($ct_min_len + int(rand($ct_max_len - $ct_min_len)) + 1);
+      $pt = "\xff" x ($ct_min_len + int (rand ($ct_max_len - $ct_min_len)) + 1);
     }
   }
   else
   {
-    $pt = "\xff" x ($ct_min_len + int(rand($ct_max_len - $ct_min_len)) + 1);
+    $pt = "\xff" x ($ct_min_len + int (rand ($ct_max_len - $ct_min_len)) + 1);
   }
 
   my $aes = Crypt::AuthEnc::GCM->new ("AES", $key, $iv_bin);

--- a/tools/test_modules/m26700.pm
+++ b/tools/test_modules/m26700.pm
@@ -8,8 +8,8 @@
 use strict;
 use warnings;
 
-use Digest::SHA qw (sha224 sha224_hex);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::SHA  qw (sha224 sha224_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[8, 256], [32, 3000], [-1, -1], [-1, -1], [-1, -1]] }
 
@@ -17,12 +17,12 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $pkt_num = shift // int(rand(100000000));
-  my $engineID = shift // random_hex_string(26, 34);
+  my $pkt_num = shift // int (rand (100000000));
+  my $engineID = shift // random_hex_string (26, 34);
 
   # make even if needed
 
-  if (length($salt) %2 == 1)
+  if (length ($salt) % 2 == 1)
   {
     $salt = $salt . "8";
   }
@@ -35,9 +35,9 @@ sub module_generate_hash
 
   my $buf = join '', $sha224_digest1, $engineID, $sha224_digest1;
 
-  my $sha224_digest2 = sha224(pack("H*", $buf));
+  my $sha224_digest2 = sha224 (pack ("H*", $buf));
 
-  my $digest = hmac_hex (pack("H*", $salt), $sha224_digest2, \&sha224);
+  my $digest = hmac_hex (pack ("H*", $salt), $sha224_digest2, \&sha224);
 
   $digest = substr ($digest, 0, 32);
 

--- a/tools/test_modules/m26800.pm
+++ b/tools/test_modules/m26800.pm
@@ -8,8 +8,8 @@
 use strict;
 use warnings;
 
-use Digest::SHA qw (sha256 sha256_hex);
-use Digest::HMAC qw (hmac hmac_hex);
+use Digest::SHA  qw (sha256 sha256_hex);
+use Digest::HMAC qw (hmac_hex);
 
 sub module_constraints { [[8, 256], [48, 3000], [-1, -1], [-1, -1], [-1, -1]] }
 
@@ -17,12 +17,12 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $pkt_num = shift // int(rand(100000000));
-  my $engineID = shift // random_hex_string(26, 34);
+  my $pkt_num = shift // int (rand (100000000));
+  my $engineID = shift // random_hex_string (26, 34);
 
   # make even if needed
 
-  if (length($salt) %2 == 1)
+  if (length ($salt) % 2 == 1)
   {
     $salt = $salt . "8";
   }
@@ -35,9 +35,9 @@ sub module_generate_hash
 
   my $buf = join '', $sha256_digest1, $engineID, $sha256_digest1;
 
-  my $sha256_digest2 = sha256(pack("H*", $buf));
+  my $sha256_digest2 = sha256 (pack ("H*", $buf));
 
-  my $digest = hmac_hex (pack("H*", $salt), $sha256_digest2, \&sha256);
+  my $digest = hmac_hex (pack ("H*", $salt), $sha256_digest2, \&sha256);
 
   $digest = substr ($digest, 0, 48);
 

--- a/tools/test_modules/m26900.pm
+++ b/tools/test_modules/m26900.pm
@@ -9,7 +9,6 @@ use strict;
 use warnings;
 
 use Digest::SHA qw (sha384 sha384_hex hmac_sha384_hex);
-#use Digest::HMAC qw (hmac hmac_hex);
 
 sub module_constraints { [[8, 256], [64, 3000], [-1, -1], [-1, -1], [-1, -1]] }
 
@@ -17,8 +16,8 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $pkt_num = shift // int(rand(100000000));
-  my $engineID = shift // random_hex_string(26, 34);
+  my $pkt_num = shift // int (rand (100000000));
+  my $engineID = shift // random_hex_string (26, 34);
 
   # padding engineID: fill with zero
 
@@ -30,7 +29,7 @@ sub module_generate_hash
 
   # make salt even if needed
 
-  if (length($salt) %2 == 1)
+  if (length ($salt) % 2 == 1)
   {
     $salt = $salt . "8";
   }
@@ -43,9 +42,9 @@ sub module_generate_hash
 
   my $buf = join '', $sha384_digest1, $engineID, $sha384_digest1;
 
-  my $sha384_digest2 = sha384(pack("H*", $buf));
+  my $sha384_digest2 = sha384 (pack ("H*", $buf));
 
-  my $digest = hmac_sha384_hex (pack("H*", $salt), $sha384_digest2);
+  my $digest = hmac_sha384_hex (pack ("H*", $salt), $sha384_digest2);
 
   $digest = substr ($digest, 0, 64);
 

--- a/tools/test_modules/m27000.pm
+++ b/tools/test_modules/m27000.pm
@@ -8,10 +8,8 @@
 use strict;
 use warnings;
 
-use Digest::HMAC qw (hmac hmac_hex);
-use Digest::MD5  qw (md5);
-use Encode       qw (encode);
-use Crypt::ECB   qw (encrypt);
+use Digest::MD5 qw (md5);
+use Crypt::ECB;
 
 sub setup_des_key
 {

--- a/tools/test_modules/m27100.pm
+++ b/tools/test_modules/m27100.pm
@@ -87,4 +87,3 @@ sub random_client_challenge
 }
 
 1;
-

--- a/tools/test_modules/m27300.pm
+++ b/tools/test_modules/m27300.pm
@@ -16,8 +16,8 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $pkt_num = shift // int(rand(100000000));
-  my $engineID = shift // random_hex_string(26, 34);
+  my $pkt_num = shift // int (rand (100000000));
+  my $engineID = shift // random_hex_string (26, 34);
 
   # padding engineID: fill with zero
 
@@ -27,7 +27,7 @@ sub module_generate_hash
 
   # make salt even if needed
 
-  if (length($salt) %2 == 1)
+  if (length ($salt) % 2 == 1)
   {
     $salt = $salt . "8";
   }
@@ -40,9 +40,9 @@ sub module_generate_hash
 
   my $buf = join '', $sha512_digest1, $engineID, $sha512_digest1;
 
-  my $sha512_digest2 = sha512(pack("H*", $buf));
+  my $sha512_digest2 = sha512 (pack ("H*", $buf));
 
-  my $digest = hmac_sha512_hex (pack("H*", $salt), $sha512_digest2);
+  my $digest = hmac_sha512_hex (pack ("H*", $salt), $sha512_digest2);
 
   $digest = substr ($digest, 0, 96);
 

--- a/tools/test_modules/m27500.pm
+++ b/tools/test_modules/m27500.pm
@@ -9,8 +9,7 @@ use strict;
 use warnings;
 
 use Crypt::PBKDF2;
-use MIME::Base64 qw (encode_base64 decode_base64);
-use Encode;
+use MIME::Base64 qw (encode_base64);
 
 sub module_constraints { [[0, 256], [64, 64], [-1, -1], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m27600.pm
+++ b/tools/test_modules/m27600.pm
@@ -9,8 +9,7 @@ use strict;
 use warnings;
 
 use Crypt::PBKDF2;
-use MIME::Base64 qw (encode_base64 decode_base64);
-use Encode;
+use MIME::Base64 qw (encode_base64);
 
 sub module_constraints { [[0, 256], [64, 64], [-1, -1], [-1, -1], [-1, -1]] }
 

--- a/tools/test_modules/m28300.pm
+++ b/tools/test_modules/m28300.pm
@@ -8,9 +8,8 @@
 use strict;
 use warnings;
 
-use Digest::SHA1 qw (sha1 sha1_hex);
-use Encode qw (encode decode);
-use MIME::Base64;
+use Digest::SHA1 qw (sha1);
+use MIME::Base64 qw (encode_base64 decode_base64);
 
 sub module_constraints { [[0, 256], [224, 224], [-1, -1], [-1, -1], [-1, -1]] }
 


### PR DESCRIPTION
This is just a minor test module cleanup/fix... It removes and fixes some `perl` module dependencies and adds some minor changes to the code readabilty in a few other modules.

I've carefully checked all the changed modules to see if they still work and everything is fine after these changes.

The main problem was that some of our `unit tests` just seem to "use" some hashing/encryption algorithm, that were included completely incorrectly, and it gave the wrong impression that this algorithm or hash type is using such code/module (while it was not, confusion because of the wrong perl modules).

I think this way it's much better/cleaner.

Thanks