### PR TITLE
Backends: added Metal host-code

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -13,10 +13,11 @@
 ## Features
 ##
 
-- Added support to building Universal macOS binary on Apple Silicon
-- Added support to use --debug-mode in attack-mode 9 (Association Attack)
 - Added guess data to --status-json output
 - Added hex format for --separator option
+- Added new backend support for Metal, the OpenCL replacement API on Apple
+- Added support to building Universal macOS binary on Apple Silicon
+- Added support to use --debug-mode in attack-mode 9 (Association Attack)
 
 ##
 ## Bugs

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -21,6 +21,7 @@ Gabriele "matrix" Gristina <matrix@hashcat.net> (@gm4tr1x)
 * Multiple kernel modules
 * Compressed wordlist feature
 * OpenCL Info feature
+* Apple Metal Runtime API feature
 * Apple macOS port
 * Apple Silicon support
 * Universal binary on Apple Silicon

--- a/include/backend.h
+++ b/include/backend.h
@@ -40,43 +40,51 @@ int  backend_session_update_mp              (hashcat_ctx_t *hashcat_ctx);
 int  backend_session_update_mp_rl           (hashcat_ctx_t *hashcat_ctx, const u32 css_cnt_l, const u32 css_cnt_r);
 
 void generate_source_kernel_filename        (const bool slow_candidates, const u32 attack_exec, const u32 attack_kern, const u32 kern_type, const u32 opti_type, char *shared_dir, char *source_file);
-void generate_cached_kernel_filename        (const bool slow_candidates, const u32 attack_exec, const u32 attack_kern, const u32 kern_type, const u32 opti_type, char *cache_dir, const char *device_name_chksum, char *cached_file);
+void generate_cached_kernel_filename        (const bool slow_candidates, const u32 attack_exec, const u32 attack_kern, const u32 kern_type, const u32 opti_type, char *cache_dir, const char *device_name_chksum, char *cached_file, bool is_metal);
 void generate_source_kernel_shared_filename (char *shared_dir, char *source_file);
-void generate_cached_kernel_shared_filename (char *cache_dir, const char *device_name_chksum, char *cached_file);
+void generate_cached_kernel_shared_filename (char *cache_dir, const char *device_name_chksum, char *cached_file, bool is_metal);
 void generate_source_kernel_mp_filename     (const u32 opti_type, const u64 opts_type, char *shared_dir, char *source_file);
-void generate_cached_kernel_mp_filename     (const u32 opti_type, const u64 opts_type, char *cache_dir, const char *device_name_chksum, char *cached_file);
+void generate_cached_kernel_mp_filename     (const u32 opti_type, const u64 opts_type, char *cache_dir, const char *device_name_chksum, char *cached_file, bool is_metal);
 void generate_source_kernel_amp_filename    (const u32 attack_kern, char *shared_dir, char *source_file);
-void generate_cached_kernel_amp_filename    (const u32 attack_kern, char *cache_dir, const char *device_name_chksum, char *cached_file);
+void generate_cached_kernel_amp_filename    (const u32 attack_kern, char *cache_dir, const char *device_name_chksum, char *cached_file, bool is_metal);
 
-int gidd_to_pw_t                    (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 gidd, pw_t *pw);
+int gidd_to_pw_t                            (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 gidd, pw_t *pw);
 
-int choose_kernel                   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u32 highest_pw_len, const u64 pws_pos, const u64 pws_cnt, const u32 fast_iteration, const u32 salt_pos);
+int choose_kernel                           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u32 highest_pw_len, const u64 pws_pos, const u64 pws_cnt, const u32 fast_iteration, const u32 salt_pos);
 
-int run_cuda_kernel_atinit          (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 num);
-int run_cuda_kernel_utf8toutf16le   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 num);
-int run_cuda_kernel_memset          (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 offset, const u8  value, const u64 size);
-int run_cuda_kernel_memset32        (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 offset, const u32 value, const u64 size);
-int run_cuda_kernel_bzero           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 size);
+int run_cuda_kernel_atinit                  (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 num);
+int run_cuda_kernel_utf8toutf16le           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 num);
+int run_cuda_kernel_memset                  (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 offset, const u8  value, const u64 size);
+int run_cuda_kernel_memset32                (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 offset, const u32 value, const u64 size);
+int run_cuda_kernel_bzero                   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, CUdeviceptr buf, const u64 size);
 
-int run_hip_kernel_atinit           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 num);
-int run_hip_kernel_utf8toutf16le    (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 num);
-int run_hip_kernel_memset           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 offset, const u8  value, const u64 size);
-int run_hip_kernel_memset32         (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 offset, const u32 value, const u64 size);
-int run_hip_kernel_bzero            (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 size);
+int run_hip_kernel_atinit                   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 num);
+int run_hip_kernel_utf8toutf16le            (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 num);
+int run_hip_kernel_memset                   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 offset, const u8  value, const u64 size);
+int run_hip_kernel_memset32                 (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 offset, const u32 value, const u64 size);
+int run_hip_kernel_bzero                    (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, hipDeviceptr_t buf, const u64 size);
 
-int run_opencl_kernel_atinit        (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 num);
-int run_opencl_kernel_utf8toutf16le (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 num);
-int run_opencl_kernel_memset        (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 offset, const u8  value, const u64 size);
-int run_opencl_kernel_memset32      (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 offset, const u32 value, const u64 size);
-int run_opencl_kernel_bzero         (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 size);
+#if defined (__APPLE__)
+int run_metal_kernel_atinit                 (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, mtl_mem buf, const u64 num);
+int run_metal_kernel_utf8toutf16le          (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, mtl_mem buf, const u64 num);
+int run_metal_kernel_memset                 (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, mtl_mem buf, const u64 offset, const u8  value, const u64 size);
+int run_metal_kernel_memset32               (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, mtl_mem buf, const u64 offset, const u32 value, const u64 size);
+int run_metal_kernel_bzero                  (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, mtl_mem buf, const u64 size);
+#endif
 
-int run_kernel                      (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u32 kern_run, const u64 pws_pos, const u64 num, const u32 event_update, const u32 iteration);
-int run_kernel_mp                   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u32 kern_run, const u64 num);
-int run_kernel_tm                   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param);
-int run_kernel_amp                  (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 num);
-int run_kernel_decompress           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 num);
-int run_copy                        (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 pws_cnt);
-int run_cracker                     (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 pws_pos, const u64 pws_cnt);
+int run_opencl_kernel_atinit                (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 num);
+int run_opencl_kernel_utf8toutf16le         (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 num);
+int run_opencl_kernel_memset                (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 offset, const u8  value, const u64 size);
+int run_opencl_kernel_memset32              (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 offset, const u32 value, const u64 size);
+int run_opencl_kernel_bzero                 (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_mem buf, const u64 size);
+
+int run_kernel                              (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u32 kern_run, const u64 pws_pos, const u64 num, const u32 event_update, const u32 iteration);
+int run_kernel_mp                           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u32 kern_run, const u64 num);
+int run_kernel_tm                           (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param);
+int run_kernel_amp                          (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 num);
+int run_kernel_decompress                   (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 num);
+int run_copy                                (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 pws_cnt);
+int run_cracker                             (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 pws_pos, const u64 pws_cnt);
 
 void *hook12_thread (void *p);
 void *hook23_thread (void *p);

--- a/include/ext_metal.h
+++ b/include/ext_metal.h
@@ -1,0 +1,118 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifndef _EXT_METAL_H
+#define _EXT_METAL_H
+
+#if defined (__APPLE__)
+
+#include <objc/runtime.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#define mtl_device_id id
+#define mtl_command_queue id
+#define mtl_function id
+#define mtl_pipeline id
+#define mtl_mem id
+#define mtl_library id
+#define mtl_command_buffer id
+#define mtl_command_encoder id
+#define mtl_blit_command_encoder id
+#define mtl_compute_command_encoder id
+
+typedef enum metalDeviceAttribute
+{
+  MTL_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 1,
+  MTL_DEVICE_ATTRIBUTE_UNIFIED_MEMORY,
+  MTL_DEVICE_ATTRIBUTE_WARP_SIZE,
+  MTL_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+  MTL_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+  MTL_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+  MTL_DEVICE_ATTRIBUTE_CLOCK_RATE,
+  MTL_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
+  MTL_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY,
+  MTL_DEVICE_ATTRIBUTE_MAX_TRANSFER_RATE,
+  MTL_DEVICE_ATTRIBUTE_HEADLESS,
+  MTL_DEVICE_ATTRIBUTE_LOW_POWER,
+  MTL_DEVICE_ATTRIBUTE_REMOVABLE,
+  MTL_DEVICE_ATTRIBUTE_REGISTRY_ID,
+  MTL_DEVICE_ATTRIBUTE_PHYSICAL_LOCATION,
+  MTL_DEVICE_ATTRIBUTE_LOCATION_NUMBER,
+
+} metalDeviceAttribute_t;
+
+typedef enum metalDeviceLocation
+{
+  // MTLDeviceLocationBuiltIn
+  // The GPU is built into the device
+  MTL_DEVICE_LOCATION_BUILTIN = 0,
+
+  // MTLDeviceLocationSlot
+  // The GPU is connected to a slot inside the computer
+  MTL_DEVICE_LOCATION_SLOT = 1,
+
+  // MTLDeviceLocationExternal
+  // The GPU is connected via an external interface, such as Thunderbolt
+  MTL_DEVICE_LOCATION_EXTERNAL = 2,
+
+  // MTLDeviceLocationUnspecified
+  // The GPU's location is not specified or cannot be determined
+  MTL_DEVICE_LOCATION_UNSPECIFIED = 4294967295,
+
+} metalDeviceLocation_t;
+
+typedef struct hc_metal
+{
+  CFArrayRef devices;
+
+} hc_metal_t;
+
+typedef hc_metal_t MTL_PTR;
+
+int  mtl_init                       (void *hashcat_ctx);
+void mtl_close                      (void *hashcat_ctx);
+
+int  hc_mtlRuntimeGetVersionString  (void *hashcat_ctx, char *runtimeVersion_str, size_t *size);
+
+int  hc_mtlDeviceGetCount           (void *hashcat_ctx, int *count);
+int  hc_mtlDeviceGet                (void *hashcat_ctx, mtl_device_id *metal_device, int ordinal);
+int  hc_mtlDeviceGetName            (void *hashcat_ctx, char *name, size_t len, mtl_device_id metal_device);
+int  hc_mtlDeviceGetAttribute       (void *hashcat_ctx, int *pi, metalDeviceAttribute_t attrib, mtl_device_id metal_device);
+int  hc_mtlDeviceTotalMem           (void *hashcat_ctx, size_t *bytes, mtl_device_id metal_device);
+int  hc_mtlDeviceMaxMemAlloc        (void *hashcat_ctx, size_t *bytes, mtl_device_id metal_device);
+int  hc_mtlMemGetInfo               (void *hashcat_ctx, size_t *mem_free, size_t *mem_total);
+
+int  hc_mtlCreateCommandQueue       (void *hashcat_ctx, mtl_device_id metal_device, mtl_command_queue *command_queue);
+int  hc_mtlCreateBuffer             (void *hashcat_ctx, mtl_device_id metal_device, size_t size, void *ptr, mtl_mem *metal_buffer);
+
+int  hc_mtlCreateKernel             (void *hashcat_ctx, mtl_device_id metal_device, mtl_library metal_library, const char *func_name, mtl_function *metal_function, mtl_pipeline *metal_pipeline);
+
+int  hc_mtlGetMaxTotalThreadsPerThreadgroup (void *hashcat_ctx, mtl_pipeline metal_pipeline, unsigned int *maxTotalThreadsPerThreadgroup);
+int  hc_mtlGetThreadExecutionWidth  (void *hashcat_ctx, mtl_pipeline metal_pipeline, unsigned int *threadExecutionWidth);
+
+// copy buffer
+int  hc_mtlMemcpyDtoD               (void *hashcat_ctx, mtl_command_queue command_queue, mtl_mem buf_dst, size_t buf_dst_off, mtl_mem buf_src, size_t buf_src_off, size_t buf_size);
+// write
+int  hc_mtlMemcpyHtoD               (void *hashcat_ctx, mtl_command_queue command_queue, mtl_mem buf_dst, size_t buf_dst_off, const void *buf_src, size_t buf_size);
+// read
+int  hc_mtlMemcpyDtoH               (void *hashcat_ctx, mtl_command_queue command_queue, void *buf_dst, mtl_mem buf_src, size_t buf_src_off, size_t buf_size);
+
+int  hc_mtlReleaseMemObject         (void *hashcat_ctx, mtl_mem metal_buffer);
+int  hc_mtlReleaseFunction          (void *hashcat_ctx, mtl_function metal_function);
+int  hc_mtlReleaseLibrary           (void *hashcat_ctx, mtl_function metal_library);
+int  hc_mtlReleaseCommandQueue      (void *hashcat_ctx, mtl_command_queue command_queue);
+int  hc_mtlReleaseDevice            (void *hashcat_ctx, mtl_device_id metal_device);
+
+int  hc_mtlCreateLibraryWithSource  (void *hashcat_ctx, mtl_device_id metal_device, const char *kernel_sources, const char *build_options_buf, const char *include_path, mtl_library *metal_library);
+int  hc_mtlCreateLibraryWithFile    (void *hashcat_ctx, mtl_device_id metal_device, const char *cached_file, mtl_library *metal_library);
+
+int  hc_mtlEncodeComputeCommand_pre (void *hashcat_ctx, mtl_pipeline metal_pipeline, mtl_command_queue metal_command_queue, mtl_command_buffer *metal_command_buffer, mtl_command_encoder *metal_command_encoder);
+int  hc_mtlSetCommandEncoderArg     (void *hashcat_ctx, mtl_command_encoder metal_command_encoder, size_t off, size_t idx, mtl_mem buf, void *host_data, size_t host_data_size);
+
+int  hc_mtlEncodeComputeCommand     (void *hashcat_ctx, mtl_command_encoder metal_command_encoder, mtl_command_buffer metal_command_buffer, size_t global_work_size, size_t local_work_size, double *ms);
+
+#endif // __APPLE__
+
+#endif // _EXT_METAL_H

--- a/include/types.h
+++ b/include/types.h
@@ -660,6 +660,9 @@ typedef enum user_options_defaults
   NONCE_ERROR_CORRECTIONS  = 8,
   BACKEND_IGNORE_CUDA      = false,
   BACKEND_IGNORE_HIP       = false,
+  #if defined (__APPLE__)
+  BACKEND_IGNORE_METAL     = false,
+  #endif
   BACKEND_IGNORE_OPENCL    = false,
   BACKEND_INFO             = false,
   BACKEND_VECTOR_WIDTH     = 0,
@@ -711,116 +714,117 @@ typedef enum user_options_map
   IDX_BACKEND_DEVICES           = 'd',
   IDX_BACKEND_IGNORE_CUDA       = 0xff01,
   IDX_BACKEND_IGNORE_HIP        = 0xff02,
-  IDX_BACKEND_IGNORE_OPENCL     = 0xff03,
+  IDX_BACKEND_IGNORE_METAL      = 0xff03,
+  IDX_BACKEND_IGNORE_OPENCL     = 0xff04,
   IDX_BACKEND_INFO              = 'I',
-  IDX_BACKEND_VECTOR_WIDTH      = 0xff04,
-  IDX_BENCHMARK_ALL             = 0xff05,
+  IDX_BACKEND_VECTOR_WIDTH      = 0xff05,
+  IDX_BENCHMARK_ALL             = 0xff06,
   IDX_BENCHMARK                 = 'b',
-  IDX_BITMAP_MAX                = 0xff06,
-  IDX_BITMAP_MIN                = 0xff07,
+  IDX_BITMAP_MAX                = 0xff07,
+  IDX_BITMAP_MIN                = 0xff08,
   #ifdef WITH_BRAIN
   IDX_BRAIN_CLIENT              = 'z',
-  IDX_BRAIN_CLIENT_FEATURES     = 0xff08,
-  IDX_BRAIN_HOST                = 0xff09,
-  IDX_BRAIN_PASSWORD            = 0xff0a,
-  IDX_BRAIN_PORT                = 0xff0b,
-  IDX_BRAIN_SERVER              = 0xff0c,
-  IDX_BRAIN_SERVER_TIMER        = 0xff0d,
-  IDX_BRAIN_SESSION             = 0xff0e,
-  IDX_BRAIN_SESSION_WHITELIST   = 0xff0f,
+  IDX_BRAIN_CLIENT_FEATURES     = 0xff09,
+  IDX_BRAIN_HOST                = 0xff0a,
+  IDX_BRAIN_PASSWORD            = 0xff0b,
+  IDX_BRAIN_PORT                = 0xff0c,
+  IDX_BRAIN_SERVER              = 0xff0d,
+  IDX_BRAIN_SERVER_TIMER        = 0xff0e,
+  IDX_BRAIN_SESSION             = 0xff0f,
+  IDX_BRAIN_SESSION_WHITELIST   = 0xff10,
   #endif
-  IDX_CPU_AFFINITY              = 0xff10,
+  IDX_CPU_AFFINITY              = 0xff11,
   IDX_CUSTOM_CHARSET_1          = '1',
   IDX_CUSTOM_CHARSET_2          = '2',
   IDX_CUSTOM_CHARSET_3          = '3',
   IDX_CUSTOM_CHARSET_4          = '4',
-  IDX_DEBUG_FILE                = 0xff11,
-  IDX_DEBUG_MODE                = 0xff12,
-  IDX_DEPRECATED_CHECK_DISABLE  = 0xff13,
-  IDX_ENCODING_FROM             = 0xff14,
-  IDX_ENCODING_TO               = 0xff15,
-  IDX_HASH_INFO                 = 0xff16,
-  IDX_FORCE                     = 0xff17,
-  IDX_HWMON_DISABLE             = 0xff18,
-  IDX_HWMON_TEMP_ABORT          = 0xff19,
+  IDX_DEBUG_FILE                = 0xff12,
+  IDX_DEBUG_MODE                = 0xff13,
+  IDX_DEPRECATED_CHECK_DISABLE  = 0xff14,
+  IDX_ENCODING_FROM             = 0xff15,
+  IDX_ENCODING_TO               = 0xff16,
+  IDX_HASH_INFO                 = 0xff17,
+  IDX_FORCE                     = 0xff18,
+  IDX_HWMON_DISABLE             = 0xff19,
+  IDX_HWMON_TEMP_ABORT          = 0xff1a,
   IDX_HASH_MODE                 = 'm',
-  IDX_HCCAPX_MESSAGE_PAIR       = 0xff1a,
+  IDX_HCCAPX_MESSAGE_PAIR       = 0xff1b,
   IDX_HELP                      = 'h',
-  IDX_HEX_CHARSET               = 0xff1b,
-  IDX_HEX_SALT                  = 0xff1c,
-  IDX_HEX_WORDLIST              = 0xff1d,
-  IDX_HOOK_THREADS              = 0xff1e,
-  IDX_IDENTIFY                  = 0xff1f,
+  IDX_HEX_CHARSET               = 0xff1c,
+  IDX_HEX_SALT                  = 0xff1d,
+  IDX_HEX_WORDLIST              = 0xff1e,
+  IDX_HOOK_THREADS              = 0xff1f,
+  IDX_IDENTIFY                  = 0xff20,
   IDX_INCREMENT                 = 'i',
-  IDX_INCREMENT_MAX             = 0xff20,
-  IDX_INCREMENT_MIN             = 0xff21,
-  IDX_INDUCTION_DIR             = 0xff22,
-  IDX_KEEP_GUESSING             = 0xff23,
+  IDX_INCREMENT_MAX             = 0xff21,
+  IDX_INCREMENT_MIN             = 0xff22,
+  IDX_INDUCTION_DIR             = 0xff23,
+  IDX_KEEP_GUESSING             = 0xff24,
   IDX_KERNEL_ACCEL              = 'n',
   IDX_KERNEL_LOOPS              = 'u',
   IDX_KERNEL_THREADS            = 'T',
-  IDX_KEYBOARD_LAYOUT_MAPPING   = 0xff24,
-  IDX_KEYSPACE                  = 0xff25,
-  IDX_LEFT                      = 0xff26,
+  IDX_KEYBOARD_LAYOUT_MAPPING   = 0xff25,
+  IDX_KEYSPACE                  = 0xff26,
+  IDX_LEFT                      = 0xff27,
   IDX_LIMIT                     = 'l',
-  IDX_LOGFILE_DISABLE           = 0xff27,
-  IDX_LOOPBACK                  = 0xff28,
-  IDX_MACHINE_READABLE          = 0xff29,
-  IDX_MARKOV_CLASSIC            = 0xff2a,
-  IDX_MARKOV_DISABLE            = 0xff2b,
-  IDX_MARKOV_HCSTAT2            = 0xff2c,
-  IDX_MARKOV_INVERSE            = 0xff2d,
+  IDX_LOGFILE_DISABLE           = 0xff28,
+  IDX_LOOPBACK                  = 0xff29,
+  IDX_MACHINE_READABLE          = 0xff2a,
+  IDX_MARKOV_CLASSIC            = 0xff2b,
+  IDX_MARKOV_DISABLE            = 0xff2c,
+  IDX_MARKOV_HCSTAT2            = 0xff2d,
+  IDX_MARKOV_INVERSE            = 0xff2e,
   IDX_MARKOV_THRESHOLD          = 't',
-  IDX_NONCE_ERROR_CORRECTIONS   = 0xff2e,
+  IDX_NONCE_ERROR_CORRECTIONS   = 0xff2f,
   IDX_OPENCL_DEVICE_TYPES       = 'D',
   IDX_OPTIMIZED_KERNEL_ENABLE   = 'O',
   IDX_MULTIPLY_ACCEL_DISABLE    = 'M',
-  IDX_OUTFILE_AUTOHEX_DISABLE   = 0xff2f,
-  IDX_OUTFILE_CHECK_DIR         = 0xff30,
-  IDX_OUTFILE_CHECK_TIMER       = 0xff31,
-  IDX_OUTFILE_FORMAT            = 0xff32,
+  IDX_OUTFILE_AUTOHEX_DISABLE   = 0xff30,
+  IDX_OUTFILE_CHECK_DIR         = 0xff31,
+  IDX_OUTFILE_CHECK_TIMER       = 0xff32,
+  IDX_OUTFILE_FORMAT            = 0xff33,
   IDX_OUTFILE                   = 'o',
-  IDX_POTFILE_DISABLE           = 0xff33,
-  IDX_POTFILE_PATH              = 0xff34,
-  IDX_PROGRESS_ONLY             = 0xff35,
-  IDX_QUIET                     = 0xff36,
-  IDX_REMOVE                    = 0xff37,
-  IDX_REMOVE_TIMER              = 0xff38,
-  IDX_RESTORE                   = 0xff39,
-  IDX_RESTORE_DISABLE           = 0xff3a,
-  IDX_RESTORE_FILE_PATH         = 0xff3b,
+  IDX_POTFILE_DISABLE           = 0xff34,
+  IDX_POTFILE_PATH              = 0xff35,
+  IDX_PROGRESS_ONLY             = 0xff36,
+  IDX_QUIET                     = 0xff37,
+  IDX_REMOVE                    = 0xff38,
+  IDX_REMOVE_TIMER              = 0xff39,
+  IDX_RESTORE                   = 0xff3a,
+  IDX_RESTORE_DISABLE           = 0xff3b,
+  IDX_RESTORE_FILE_PATH         = 0xff3c,
   IDX_RP_FILE                   = 'r',
-  IDX_RP_GEN_FUNC_MAX           = 0xff3c,
-  IDX_RP_GEN_FUNC_MIN           = 0xff3d,
-  IDX_RP_GEN_FUNC_SEL           = 0xff3e,
+  IDX_RP_GEN_FUNC_MAX           = 0xff3d,
+  IDX_RP_GEN_FUNC_MIN           = 0xff3e,
+  IDX_RP_GEN_FUNC_SEL           = 0xff3f,
   IDX_RP_GEN                    = 'g',
-  IDX_RP_GEN_SEED               = 0xff3f,
+  IDX_RP_GEN_SEED               = 0xff40,
   IDX_RULE_BUF_L                = 'j',
   IDX_RULE_BUF_R                = 'k',
-  IDX_RUNTIME                   = 0xff40,
-  IDX_SCRYPT_TMTO               = 0xff41,
+  IDX_RUNTIME                   = 0xff41,
+  IDX_SCRYPT_TMTO               = 0xff42,
   IDX_SEGMENT_SIZE              = 'c',
-  IDX_SELF_TEST_DISABLE         = 0xff42,
+  IDX_SELF_TEST_DISABLE         = 0xff43,
   IDX_SEPARATOR                 = 'p',
-  IDX_SESSION                   = 0xff43,
-  IDX_SHOW                      = 0xff44,
+  IDX_SESSION                   = 0xff44,
+  IDX_SHOW                      = 0xff45,
   IDX_SKIP                      = 's',
   IDX_SLOW_CANDIDATES           = 'S',
-  IDX_SPEED_ONLY                = 0xff45,
-  IDX_SPIN_DAMP                 = 0xff46,
-  IDX_STATUS                    = 0xff47,
-  IDX_STATUS_JSON               = 0xff48,
-  IDX_STATUS_TIMER              = 0xff49,
-  IDX_STDOUT_FLAG               = 0xff4a,
-  IDX_STDIN_TIMEOUT_ABORT       = 0xff4b,
-  IDX_TRUECRYPT_KEYFILES        = 0xff4c,
-  IDX_USERNAME                  = 0xff4d,
-  IDX_VERACRYPT_KEYFILES        = 0xff4e,
-  IDX_VERACRYPT_PIM_START       = 0xff4f,
-  IDX_VERACRYPT_PIM_STOP        = 0xff50,
+  IDX_SPEED_ONLY                = 0xff46,
+  IDX_SPIN_DAMP                 = 0xff47,
+  IDX_STATUS                    = 0xff48,
+  IDX_STATUS_JSON               = 0xff49,
+  IDX_STATUS_TIMER              = 0xff4a,
+  IDX_STDOUT_FLAG               = 0xff4b,
+  IDX_STDIN_TIMEOUT_ABORT       = 0xff4c,
+  IDX_TRUECRYPT_KEYFILES        = 0xff4d,
+  IDX_USERNAME                  = 0xff4e,
+  IDX_VERACRYPT_KEYFILES        = 0xff4f,
+  IDX_VERACRYPT_PIM_START       = 0xff50,
+  IDX_VERACRYPT_PIM_STOP        = 0xff51,
   IDX_VERSION_LOWER             = 'v',
   IDX_VERSION                   = 'V',
-  IDX_WORDLIST_AUTOHEX_DISABLE  = 0xff51,
+  IDX_WORDLIST_AUTOHEX_DISABLE  = 0xff52,
   IDX_WORKLOAD_PROFILE          = 'w',
 
 } user_options_map_t;
@@ -1100,6 +1104,7 @@ typedef struct hc_fp
 #include "ext_cuda.h"
 #include "ext_hip.h"
 #include "ext_OpenCL.h"
+#include "ext_metal.h"
 
 typedef struct hc_device_param
 {
@@ -1601,6 +1606,129 @@ typedef struct hc_device_param
   hipDeviceptr_t    hip_d_st_esalts_buf;
   hipDeviceptr_t    hip_d_kernel_param;
 
+  // API: opencl and metal
+
+  bool              is_apple_silicon;
+
+  // API: metal
+
+  bool              is_metal;
+
+  #if defined (__APPLE__)
+
+  int               mtl_major;
+  int               mtl_minor;
+
+  int               device_physical_location;
+  int               device_location_number;
+  int               device_registryID;
+  int               device_max_transfer_rate;
+  int               device_is_headless;
+  int               device_is_low_power;
+  int               device_is_removable;
+
+  int               metal_warp_size;
+
+  mtl_device_id     metal_device;
+  mtl_command_queue metal_command_queue;
+
+  mtl_library       metal_library;
+  mtl_library       metal_library_shared;
+  mtl_library       metal_library_mp;
+  mtl_library       metal_library_amp;
+
+  mtl_function      metal_function1;
+  mtl_function      metal_function12;
+  mtl_function      metal_function2p;
+  mtl_function      metal_function2;
+  mtl_function      metal_function2e;
+  mtl_function      metal_function23;
+  mtl_function      metal_function3;
+  mtl_function      metal_function4;
+  mtl_function      metal_function_init2;
+  mtl_function      metal_function_loop2p;
+  mtl_function      metal_function_loop2;
+  mtl_function      metal_function_mp;
+  mtl_function      metal_function_mp_l;
+  mtl_function      metal_function_mp_r;
+  mtl_function      metal_function_amp;
+  mtl_function      metal_function_tm;
+  mtl_function      metal_function_memset;
+  mtl_function      metal_function_bzero;
+  mtl_function      metal_function_atinit;
+  mtl_function      metal_function_utf8toutf16le;
+  mtl_function      metal_function_decompress;
+  mtl_function      metal_function_aux1;
+  mtl_function      metal_function_aux2;
+  mtl_function      metal_function_aux3;
+  mtl_function      metal_function_aux4;
+
+  mtl_pipeline      metal_pipeline1;
+  mtl_pipeline      metal_pipeline12;
+  mtl_pipeline      metal_pipeline2p;
+  mtl_pipeline      metal_pipeline2;
+  mtl_pipeline      metal_pipeline2e;
+  mtl_pipeline      metal_pipeline23;
+  mtl_pipeline      metal_pipeline3;
+  mtl_pipeline      metal_pipeline4;
+  mtl_pipeline      metal_pipeline_init2;
+  mtl_pipeline      metal_pipeline_loop2p;
+  mtl_pipeline      metal_pipeline_loop2;
+  mtl_pipeline      metal_pipeline_mp;
+  mtl_pipeline      metal_pipeline_mp_l;
+  mtl_pipeline      metal_pipeline_mp_r;
+  mtl_pipeline      metal_pipeline_amp;
+  mtl_pipeline      metal_pipeline_tm;
+  mtl_pipeline      metal_pipeline_memset;
+  mtl_pipeline      metal_pipeline_bzero;
+  mtl_pipeline      metal_pipeline_atinit;
+  mtl_pipeline      metal_pipeline_utf8toutf16le;
+  mtl_pipeline      metal_pipeline_decompress;
+  mtl_pipeline      metal_pipeline_aux1;
+  mtl_pipeline      metal_pipeline_aux2;
+  mtl_pipeline      metal_pipeline_aux3;
+  mtl_pipeline      metal_pipeline_aux4;
+
+  mtl_mem           metal_d_pws_buf;
+  mtl_mem           metal_d_pws_amp_buf;
+  mtl_mem           metal_d_pws_comp_buf;
+  mtl_mem           metal_d_pws_idx;
+  mtl_mem           metal_d_rules;
+  mtl_mem           metal_d_rules_c;
+  mtl_mem           metal_d_combs;
+  mtl_mem           metal_d_combs_c;
+  mtl_mem           metal_d_bfs;
+  mtl_mem           metal_d_bfs_c;
+  mtl_mem           metal_d_tm_c;
+  mtl_mem           metal_d_bitmap_s1_a;
+  mtl_mem           metal_d_bitmap_s1_b;
+  mtl_mem           metal_d_bitmap_s1_c;
+  mtl_mem           metal_d_bitmap_s1_d;
+  mtl_mem           metal_d_bitmap_s2_a;
+  mtl_mem           metal_d_bitmap_s2_b;
+  mtl_mem           metal_d_bitmap_s2_c;
+  mtl_mem           metal_d_bitmap_s2_d;
+  mtl_mem           metal_d_plain_bufs;
+  mtl_mem           metal_d_digests_buf;
+  mtl_mem           metal_d_digests_shown;
+  mtl_mem           metal_d_salt_bufs;
+  mtl_mem           metal_d_esalt_bufs;
+  mtl_mem           metal_d_tmps;
+  mtl_mem           metal_d_hooks;
+  mtl_mem           metal_d_result;
+  mtl_mem           metal_d_extra0_buf;
+  mtl_mem           metal_d_extra1_buf;
+  mtl_mem           metal_d_extra2_buf;
+  mtl_mem           metal_d_extra3_buf;
+  mtl_mem           metal_d_root_css_buf;
+  mtl_mem           metal_d_markov_css_buf;
+  mtl_mem           metal_d_st_digests_buf;
+  mtl_mem           metal_d_st_salts_buf;
+  mtl_mem           metal_d_st_esalts_buf;
+  mtl_mem           metal_d_kernel_param;
+
+  #endif // __APPLE__
+
   // API: opencl
 
   bool              is_opencl;
@@ -1708,6 +1836,7 @@ typedef struct backend_ctx
 
   void               *cuda;
   void               *hip;
+  void               *mtl;
   void               *ocl;
 
   void               *nvrtc;
@@ -1715,6 +1844,7 @@ typedef struct backend_ctx
 
   int                 backend_device_from_cuda[DEVICES_MAX];                              // from cuda device index to backend device index
   int                 backend_device_from_hip[DEVICES_MAX];                               // from hip device index to backend device index
+  int                 backend_device_from_metal[DEVICES_MAX];                             // from metal device index to backend device index
   int                 backend_device_from_opencl[DEVICES_MAX];                            // from opencl device index to backend device index
   int                 backend_device_from_opencl_platform[CL_PLATFORMS_MAX][DEVICES_MAX]; // from opencl device index to backend device index (by platform)
 
@@ -1725,6 +1855,8 @@ typedef struct backend_ctx
   int                 cuda_devices_active;
   int                 hip_devices_cnt;
   int                 hip_devices_active;
+  int                 metal_devices_cnt;
+  int                 metal_devices_active;
   int                 opencl_devices_cnt;
   int                 opencl_devices_active;
 
@@ -1765,6 +1897,13 @@ typedef struct backend_ctx
 
   int                 hip_runtimeVersion;
   int                 hip_driverVersion;
+
+  // metal
+
+  int                 rc_metal_init;
+
+  unsigned int        metal_runtimeVersion;
+  char               *metal_runtimeVersionStr;
 
   // opencl
 
@@ -2169,6 +2308,7 @@ typedef struct user_options
   bool         markov_inverse;
   bool         backend_ignore_cuda;
   bool         backend_ignore_hip;
+  bool         backend_ignore_metal;
   bool         backend_ignore_opencl;
   bool         backend_info;
   bool         optimized_kernel_enable;

--- a/src/Makefile
+++ b/src/Makefile
@@ -331,7 +331,11 @@ CFLAGS_NATIVE           += -DMISSING_CLOCK_GETTIME
 endif
 
 LFLAGS_NATIVE           := $(LFLAGS)
+LFLAGS_NATIVE           += -framework CoreFoundation
+LFLAGS_NATIVE           += -framework CoreGraphics
+LFLAGS_NATIVE           += -framework Foundation
 LFLAGS_NATIVE           += -framework IOKit
+LFLAGS_NATIVE           += -framework Metal
 LFLAGS_NATIVE           += -lpthread
 LFLAGS_NATIVE           += -liconv
 
@@ -384,6 +388,10 @@ EMU_OBJS_ALL            += emu_inc_hash_md4 emu_inc_hash_md5 emu_inc_hash_ripemd
 EMU_OBJS_ALL            += emu_inc_cipher_aes emu_inc_cipher_camellia emu_inc_cipher_des emu_inc_cipher_kuznyechik emu_inc_cipher_serpent emu_inc_cipher_twofish
 
 OBJS_ALL                := affinity autotune backend benchmark bitmap bitops combinator common convert cpt cpu_crc32 debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_cpu ext_iokit ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
+
+ifeq ($(UNAME),Darwin)
+OBJS_ALL                += ext_metal
+endif
 
 ifeq ($(ENABLE_BRAIN),1)
 OBJS_ALL                += brain
@@ -583,6 +591,9 @@ uninstall:
 ##
 
 obj/%.NATIVE.o: src/%.c
+	$(CC) -c $(CCFLAGS) $(CFLAGS_NATIVE) $< -o $@ -fpic
+
+obj/%.NATIVE.o: src/%.m
 	$(CC) -c $(CCFLAGS) $(CFLAGS_NATIVE) $< -o $@ -fpic
 
 ifeq ($(USE_SYSTEM_LZMA),0)

--- a/src/backend.c
+++ b/src/backend.c
@@ -7918,8 +7918,11 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 #endif
 {
   const hashconfig_t    *hashconfig    = hashcat_ctx->hashconfig;
-  const folder_config_t *folder_config = hashcat_ctx->folder_config;
   const user_options_t  *user_options  = hashcat_ctx->user_options;
+
+  #if !defined (_WIN) && !defined (__CYGWIN__) && !defined (__MSYS__)
+  const folder_config_t *folder_config = hashcat_ctx->folder_config;
+  #endif
 
   bool cached = true;
 

--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -1,0 +1,1433 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "memory.h"
+#include "event.h"
+#include "timer.h"
+#include "ext_metal.h"
+
+#include <sys/sysctl.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
+
+typedef NS_ENUM(NSUInteger, hc_mtlFeatureSet)
+{
+  MTL_FEATURESET_MACOS_GPUFAMILY_1_V1 = 10000,
+  MTL_FEATURESET_MACOS_GPUFAMILY_1_V2 = 10001,
+  MTL_FEATURESET_MACOS_GPUFAMILY_1_V3 = 10003,
+  MTL_FEATURESET_MACOS_GPUFAMILY_1_V4 = 10004,
+  MTL_FEATURESET_MACOS_GPUFAMILY_2_V1 = 10005,
+
+} metalDeviceFeatureSet_macOS_t;
+
+typedef NS_ENUM(NSUInteger, hc_mtlLanguageVersion)
+{
+  MTL_LANGUAGEVERSION_1_0 = (1 << 16),
+  MTL_LANGUAGEVERSION_1_1 = (1 << 16) + 1,
+  MTL_LANGUAGEVERSION_1_2 = (1 << 16) + 2,
+  MTL_LANGUAGEVERSION_2_0 = (2 << 16),
+  MTL_LANGUAGEVERSION_2_1 = (2 << 16) + 1,
+  MTL_LANGUAGEVERSION_2_2 = (2 << 16) + 2,
+  MTL_LANGUAGEVERSION_2_3 = (2 << 16) + 3,
+  MTL_LANGUAGEVERSION_2_4 = (2 << 16) + 4,
+
+} metalLanguageVersion_t;
+
+static bool iokit_getGPUCore (void *hashcat_ctx, int *gpu_core)
+{
+  bool rc = false;
+
+  CFMutableDictionaryRef matching = IOServiceMatching ("IOAccelerator");
+
+  io_service_t service = IOServiceGetMatchingService (kIOMasterPortDefault, matching);
+
+  if (!service)
+  {
+    event_log_error (hashcat_ctx, "IOServiceGetMatchingService(): %08x", service);
+
+    return rc;
+  }
+
+  // "gpu-core-count" is present only on Apple Silicon
+
+  CFNumberRef num = IORegistryEntryCreateCFProperty(service, CFSTR("gpu-core-count"), kCFAllocatorDefault, 0);
+
+  int gc = 0;
+
+  if (num == nil || CFNumberGetValue (num, kCFNumberIntType, &gc) == false)
+  {
+    //event_log_error (hashcat_ctx, "IORegistryEntryCreateCFProperty(): 'gpu-core-count' entry not found");
+  }
+  else
+  {
+    *gpu_core = gc;
+
+    rc = true;
+  }
+
+  IOObjectRelease (service);
+
+  return rc;
+}
+
+static int hc_mtlInvocationHelper (id target, SEL selector, void *returnValue)
+{
+  if (target == nil) return -1;
+  if (selector == nil) return -1;
+
+  if ([target respondsToSelector: selector])
+  {
+    NSMethodSignature *signature = [object_getClass (target) instanceMethodSignatureForSelector: selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature: signature];
+    [invocation setTarget: target];
+    [invocation setSelector: selector];
+    [invocation invoke];
+    [invocation getReturnValue: returnValue];
+
+    return 0;
+  }
+
+  return -1;
+}
+
+static int hc_mtlBuildOptionsToDict (void *hashcat_ctx, const char *build_options_buf, const char *include_path, NSMutableDictionary *build_options_dict)
+{
+  if (build_options_buf == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): build_options_buf is NULL", __func__);
+    return -1;
+  }
+
+  if (build_options_dict == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): build_options_dict is NULL", __func__);
+    return -1;
+  }
+
+  // NSString from build_options_buf
+
+  NSString *options = [NSString stringWithCString: build_options_buf encoding: NSUTF8StringEncoding];
+
+  if (options == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): stringWithCString failed", __func__);
+    return -1;
+  }
+
+  // replace '-D ' to ''
+
+  options = [options stringByReplacingOccurrencesOfString:@"-D " withString:@""];
+
+  if (options == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): stringByReplacingOccurrencesOfString(-D) failed", __func__);
+    return -1;
+  }
+
+  // replace '-I OpenCL ' to ''
+
+  options = [options stringByReplacingOccurrencesOfString:@"-I OpenCL " withString:@""];
+
+  if (options == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): stringByReplacingOccurrencesOfString(-I OpenCL) failed", __func__);
+    return -1;
+  }
+
+  //NSLog(@"options: '%@'", options);
+
+  // creating NSDictionary from options
+
+  NSArray *lines = [options componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+  for (NSString *aKeyValue in lines)
+  {
+    NSArray *components = [aKeyValue componentsSeparatedByString:@"="];
+
+    NSString *key = [components[0] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    NSString *value = nil;
+
+    if ([components count] != 2)
+    {
+      if ([key isEqualToString:[NSString stringWithUTF8String:"KERNEL_STATIC"]] ||
+          [key isEqualToString:[NSString stringWithUTF8String:"IS_APPLE_SILICON"]] ||
+          [key isEqualToString:[NSString stringWithUTF8String:"DYNAMIC_LOCAL"]] ||
+          [key isEqualToString:[NSString stringWithUTF8String:"_unroll"]] ||
+          [key isEqualToString:[NSString stringWithUTF8String:"NO_UNROLL"]] ||
+          [key isEqualToString:[NSString stringWithUTF8String:"FORCE_DISABLE_SHM"]])
+      {
+        value = @"1";
+      }
+      else
+      {
+        //event_log_warning (hashcat_ctx, "%s(): skipping malformed build option: %s", __func__, [key UTF8String]);
+
+        continue;
+      }
+    }
+    else
+    {
+      value = [components[1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    }
+
+    [build_options_dict setObject:value forKey:key];
+  }
+
+  // if set, add INCLUDE_PATH to hack Apple kernel build from source limitation on -I usage
+  if (include_path != nil)
+  {
+    NSString *path_key = @"INCLUDE_PATH";
+    NSString *path_value = [NSString stringWithCString: include_path encoding: NSUTF8StringEncoding];
+
+    [build_options_dict setObject:path_value forKey:path_key];
+  }
+
+  //NSLog(@"Dict:\n%@", build_options_dict);
+
+  return 0;
+}
+
+int mtl_init (void *hashcat_ctx)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  memset (mtl, 0, sizeof (MTL_PTR));
+
+  mtl->devices = nil;
+
+  if (MTLCreateSystemDefaultDevice() == nil)
+  {
+    event_log_error (hashcat_ctx, "Metal is not supported on this computer");
+
+    return -1;
+  }
+
+  return 0;
+}
+
+void mtl_close (void *hashcat_ctx)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl)
+  {
+    if (mtl->devices)
+    {
+      int count = (int) CFArrayGetCount (mtl->devices);
+      for (int i = 0; i < count; i++)
+      {
+        mtl_device_id device = (mtl_device_id) CFArrayGetValueAtIndex (mtl->devices, i);
+        if (device != nil)
+        {
+          hc_mtlReleaseDevice (hashcat_ctx, device);
+        }
+      }
+      mtl->devices = nil;
+    }
+
+    hcfree (backend_ctx->mtl);
+
+    backend_ctx->mtl = NULL;
+  }
+}
+
+int hc_mtlDeviceGetCount (void *hashcat_ctx, int *count)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == nil) return -1;
+
+  CFArrayRef devices = (CFArrayRef) MTLCopyAllDevices();
+
+  if (devices == nil)
+  {
+    event_log_error (hashcat_ctx, "metalDeviceGetCount(): empty device objects");
+
+    return -1;
+  }
+
+  mtl->devices = devices;
+
+  *count = CFArrayGetCount (devices);
+
+  return 0;
+}
+
+int hc_mtlDeviceGet (void *hashcat_ctx, mtl_device_id *metal_device, int ordinal)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == nil) return -1;
+
+  if (mtl->devices == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid devices pointer", __func__);
+
+    return -1;
+  }
+
+  mtl_device_id device = (mtl_device_id) CFArrayGetValueAtIndex (mtl->devices, ordinal);
+
+  if (device == nil)
+  {
+    event_log_error (hashcat_ctx, "metalDeviceGet(): invalid index");
+
+    return -1;
+  }
+
+  *metal_device = device;
+
+  return 0;
+}
+
+int hc_mtlDeviceGetName (void *hashcat_ctx, char *name, size_t len, mtl_device_id metal_device)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device", __func__);
+
+    return -1;
+  }
+
+  if (len <= 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): buffer length", __func__);
+
+    return -1;
+  }
+
+  id device_name_ptr = [metal_device name];
+
+  if (device_name_ptr == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to get device name", __func__);
+
+    return -1;
+  }
+
+  const char *device_name_str = [device_name_ptr UTF8String];
+
+  if (device_name_str == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to get UTF8String from device name", __func__);
+
+    return -1;
+  }
+
+  const size_t device_name_len = strlen (device_name_str);
+
+  if (device_name_len <= 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device name length", __func__);
+
+    return -1;
+  }
+
+  if (strncpy (name, device_name_str, (device_name_len > len) ? len : device_name_len) != name)
+  {
+    event_log_error (hashcat_ctx, "%s(): strncpy failed", __func__);
+
+    return -1;
+  }
+
+  return 0;
+}
+
+int hc_mtlDeviceGetAttribute (void *hashcat_ctx, int *pi, metalDeviceAttribute_t attrib, mtl_device_id metal_device)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device", __func__);
+
+    return -1;
+  }
+
+  uint64_t val64 = 0;
+  bool valBool = false;
+  int valInt = 0;
+
+  switch (attrib)
+  {
+    case MTL_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT:
+      // works only with Apple Silicon
+      if (iokit_getGPUCore (hashcat_ctx, pi) == false) *pi = 1;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_UNIFIED_MEMORY:
+      *pi = 0;
+
+      SEL hasUnifiedMemorySelector = NSSelectorFromString(@"hasUnifiedMemory");
+
+      hc_mtlInvocationHelper (metal_device, hasUnifiedMemorySelector, &valBool);
+
+      *pi = (valBool == true) ? 1 : 0;
+
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_WARP_SIZE:
+      // return a fake size of 32, it will be updated later
+      *pi = 32;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR:
+      *pi = 0;
+
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_2_V1] == true) *pi = 2;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V4] == true) *pi = 1;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V3] == true) *pi = 1;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V2] == true) *pi = 1;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V1] == true) *pi = 1;
+
+      if (*pi == 0)
+      {
+        //event_log_error (hashcat_ctx, "%s(): no feature sets supported", __func__);
+        return -1;
+      }
+
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR:
+      *pi = 0;
+
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_2_V1] == true) *pi = 1;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V4] == true) *pi = 4;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V3] == true) *pi = 3;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V2] == true) *pi = 2;
+      if (*pi == 0 && [metal_device supportsFeatureSet:MTL_FEATURESET_MACOS_GPUFAMILY_1_V1] == true) *pi = 1;
+
+      if (*pi == 0)
+      {
+        //event_log_error (hashcat_ctx, "%s(): no feature sets supported", __func__);
+        return -1;
+      }
+
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK:
+      // M1 max is 1024
+      // [MTLComputePipelineState maxTotalThreadsPerThreadgroup]
+      *pi = 1024;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_CLOCK_RATE:
+      // unknown
+      *pi = 1000000;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK:
+      // 32k
+      *pi = 32768;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY:
+      // Maximum function memory allocation for a buffer in the constant address space
+      // 64k
+      *pi = 64 * 1024;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_MAX_TRANSFER_RATE:
+      val64 = 0;
+
+      SEL maxTransferRateSelector = NSSelectorFromString(@"maxTransferRate");
+
+      hc_mtlInvocationHelper (metal_device, maxTransferRateSelector, &val64);
+
+      *pi = (val64 == 0) ? 0 : val64 / 125; // kb/s
+
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_HEADLESS:
+      valBool = [metal_device isHeadless];
+      *pi = (valBool == true) ? 1 : 0;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_LOW_POWER:
+      valBool = [metal_device isLowPower];
+      *pi = (valBool == true) ? 1 : 0;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_REMOVABLE:
+      valBool = [metal_device isRemovable];
+      *pi = (valBool == true) ? 1 : 0;
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_REGISTRY_ID:
+      *pi = (int) [metal_device registryID];
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_PHYSICAL_LOCATION:
+      *pi = 0;
+
+      SEL locationSelector = NSSelectorFromString(@"location");
+      valInt = 0;
+
+      hc_mtlInvocationHelper (metal_device, locationSelector, &valInt);
+
+      *pi = valInt;
+
+      break;
+
+    case MTL_DEVICE_ATTRIBUTE_LOCATION_NUMBER:
+      *pi = 0;
+
+      SEL locationNumberSelector = NSSelectorFromString(@"locationNumber");
+
+      valInt = 0;
+      hc_mtlInvocationHelper (metal_device, locationNumberSelector, &valInt);
+
+      *pi = valInt;
+
+      break;
+
+    default:
+      event_log_error (hashcat_ctx, "%s(): unknown attribute (%d)", __func__, attrib);
+      return -1;
+  }
+
+  return 0;
+}
+
+int hc_mtlMemGetInfo (void *hashcat_ctx, size_t *mem_free, size_t *mem_total)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  struct vm_statistics64 vm_stats;
+  vm_size_t page_size = 0;
+  unsigned int count = HOST_VM_INFO64_COUNT;
+
+  mach_port_t port = mach_host_self();
+
+  if (host_page_size (port, &page_size) != KERN_SUCCESS)
+  {
+    event_log_error (hashcat_ctx, "metalMemGetInfo(): cannot get page_size");
+
+    return -1;
+  }
+
+  if (host_statistics64 (port, HOST_VM_INFO64, (host_info64_t) &vm_stats, &count) != KERN_SUCCESS)
+  {
+    event_log_error (hashcat_ctx, "metalMemGetInfo(): cannot get vm_stats");
+
+    return -1;
+  }
+
+  uint64_t mem_free_tmp = (uint64_t) (vm_stats.free_count - vm_stats.speculative_count) * page_size;
+  uint64_t mem_used_tmp = (uint64_t) (vm_stats.active_count + vm_stats.inactive_count + vm_stats.wire_count) * page_size;
+
+  *mem_free = (size_t) mem_free_tmp;
+  *mem_total = (size_t) (mem_free_tmp + mem_used_tmp);
+
+  return 0;
+}
+
+int hc_mtlDeviceMaxMemAlloc (void *hashcat_ctx, size_t *bytes, mtl_device_id metal_device)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device", __func__);
+
+    return -1;
+  }
+
+  uint64_t memsize = 0;
+
+  SEL maxBufferLengthSelector = NSSelectorFromString(@"maxBufferLength");
+
+  if (hc_mtlInvocationHelper (metal_device, maxBufferLengthSelector, &memsize) == -1) return -1;
+
+  if (memsize == 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid maxBufferLength", __func__);
+
+    return -1;
+  }
+
+  *bytes = (size_t) memsize;
+
+  return 0;
+}
+
+int hc_mtlDeviceTotalMem (void *hashcat_ctx, size_t *bytes, mtl_device_id metal_device)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device", __func__);
+
+    return -1;
+  }
+
+  uint64_t memsize = 0;
+
+  if (true)
+  {
+    memsize = [metal_device recommendedMaxWorkingSetSize];
+  }
+  else
+  {
+    size_t len = sizeof (memsize);
+
+    if (sysctlbyname ("hw.memsize", &memsize, &len, NULL, 0) != 0)
+    {
+      event_log_error (hashcat_ctx, "%s(): sysctlbyname(hw.memsize) failed", __func__);
+
+      return -1;
+    }
+  }
+
+  if (memsize == 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid memory size", __func__);
+
+    return -1;
+  }
+
+  *bytes = (size_t) memsize;
+
+  return 0;
+}
+
+int hc_mtlCreateCommandQueue (void *hashcat_ctx, mtl_device_id metal_device, mtl_command_queue *command_queue)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device", __func__);
+
+    return -1;
+  }
+
+  mtl_command_queue queue = [metal_device newCommandQueue];
+
+  if (queue == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to create newCommandQueue", __func__);
+
+    return -1;
+  }
+
+  *command_queue = queue;
+
+  return 0;
+
+}
+
+int hc_mtlCreateKernel (void *hashcat_ctx, mtl_device_id metal_device, mtl_library metal_library, const char *func_name, mtl_function *metal_function, mtl_pipeline *metal_pipeline)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device", __func__);
+
+    return -1;
+  }
+
+  if (metal_library == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid library", __func__);
+
+    return -1;
+  }
+
+  if (func_name == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid function name", __func__);
+
+    return -1;
+  }
+
+  NSError *error = nil;
+
+  NSString *f_name = [NSString stringWithCString: func_name encoding: NSUTF8StringEncoding];
+
+  mtl_function mtl_func = [metal_library newFunctionWithName: f_name];
+
+  if (mtl_func == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to create '%s' function", __func__, func_name);
+
+    return -1;
+  }
+
+  mtl_pipeline mtl_pipe = [metal_device newComputePipelineStateWithFunction: mtl_func error: &error];
+
+  if (error != nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to create '%s' pipeline, %s", __func__, func_name, [[error localizedDescription] UTF8String]);
+
+    return -1;
+  }
+
+  if (mtl_pipe == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to create '%s' pipeline", __func__, func_name);
+
+    return -1;
+  }
+
+  *metal_function = mtl_func;
+  *metal_pipeline = mtl_pipe;
+
+  return 0;
+}
+
+int hc_mtlGetMaxTotalThreadsPerThreadgroup (void *hashcat_ctx, mtl_pipeline metal_pipeline, unsigned int *maxTotalThreadsPerThreadgroup)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_pipeline == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid pipeline", __func__);
+
+    return -1;
+  }
+
+  *maxTotalThreadsPerThreadgroup = [metal_pipeline maxTotalThreadsPerThreadgroup];
+
+  return 0;
+}
+
+int hc_mtlGetThreadExecutionWidth (void *hashcat_ctx, mtl_pipeline metal_pipeline, unsigned int *threadExecutionWidth)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_pipeline == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid pipeline", __func__);
+
+    return -1;
+  }
+
+  *threadExecutionWidth = [metal_pipeline threadExecutionWidth];
+
+  return 0;
+}
+
+int hc_mtlCreateBuffer (void *hashcat_ctx, mtl_device_id metal_device, size_t size, void *ptr, mtl_mem *metal_buffer)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid device", __func__);
+
+    return -1;
+  }
+
+  mtl_mem buf = NULL;
+
+  MTLResourceOptions bufferOptions = MTLResourceStorageModeShared;
+
+  if (ptr == NULL)
+  {
+    buf = [metal_device newBufferWithLength:size options:bufferOptions];
+  }
+  else
+  {
+    buf = [metal_device newBufferWithBytes:ptr length:size options:bufferOptions];
+  }
+
+  if (buf == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): %s failed (size: %zu)", __func__, (ptr == NULL) ? "newBufferWithLength" : "newBufferWithBytes", size);
+
+    return -1;
+  }
+
+  *metal_buffer = buf;
+
+  return 0;
+}
+
+int hc_mtlReleaseMemObject (void *hashcat_ctx, mtl_mem metal_buffer)
+{
+  backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+  MTL_PTR *mtl = (MTL_PTR *) backend_ctx->mtl;
+
+  if (mtl == NULL) return -1;
+
+  if (metal_buffer == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal buffer", __func__);
+
+    return -1;
+  }
+
+  [metal_buffer setPurgeableState:MTLPurgeableStateEmpty];
+  [metal_buffer release];
+
+  return 0;
+}
+
+int hc_mtlReleaseFunction (void *hashcat_ctx, mtl_function metal_function)
+{
+  if (metal_function == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal function", __func__);
+
+    return -1;
+  }
+
+  [metal_function release];
+
+  return 0;
+}
+
+int hc_mtlReleaseLibrary (void *hashcat_ctx, mtl_library metal_library)
+{
+  if (metal_library == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal library", __func__);
+
+    return -1;
+  }
+
+  [metal_library release];
+  metal_library = nil;
+
+  return 0;
+}
+
+int hc_mtlReleaseCommandQueue (void *hashcat_ctx, mtl_command_queue command_queue)
+{
+  if (command_queue == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal command queue", __func__);
+
+    return -1;
+  }
+
+  [command_queue release];
+  command_queue = nil;
+
+  return 0;
+}
+
+int hc_mtlReleaseDevice (void *hashcat_ctx, mtl_device_id metal_device)
+{
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal device", __func__);
+
+    return -1;
+  }
+
+  [metal_device release];
+  metal_device = nil;
+
+  return 0;
+}
+
+// device to device
+
+int hc_mtlMemcpyDtoD (void *hashcat_ctx, mtl_command_queue command_queue, mtl_mem buf_dst, size_t buf_dst_off, mtl_mem buf_src, size_t buf_src_off, size_t buf_size)
+{
+  if (command_queue == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): metal command queue is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_src == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): metal src buffer is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_src_off < 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): src buffer offset is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_dst == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): metal dst buffer is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_dst_off < 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): dst buffer offset is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_size <= 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): buffer size is invalid", __func__);
+    return -1;
+  }
+
+  id<MTLCommandBuffer> command_buffer = [command_queue commandBuffer];
+
+  if (command_buffer == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to create a new command buffer", __func__);
+    return -1;
+  }
+
+  id<MTLBlitCommandEncoder> blit_encoder = [command_buffer blitCommandEncoder];
+
+  if (blit_encoder == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to create a blit command encoder", __func__);
+    return -1;
+  }
+
+  // copy
+
+  [blit_encoder copyFromBuffer: buf_src sourceOffset: buf_src_off toBuffer: buf_dst destinationOffset: buf_dst_off size: buf_size];
+
+  // finish encoding and start the data transfer
+
+  [blit_encoder endEncoding];
+  [command_buffer commit];
+
+  // Wait for complete
+
+  [command_buffer waitUntilCompleted];
+
+  return 0;
+}
+
+// host to device
+
+int hc_mtlMemcpyHtoD (void *hashcat_ctx, mtl_command_queue command_queue, mtl_mem buf_dst, size_t buf_dst_off, const void *buf_src, size_t buf_size)
+{
+  if (command_queue == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): metal command queue is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_src == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): metal src buffer is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_dst == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): host dst buffer is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_size <= 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): buffer size is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_dst_off < 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): buffer dst offset is invalid", __func__);
+    return -1;
+  }
+
+  void *buf_dst_ptr = [buf_dst contents];
+
+  if (buf_dst_ptr == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to get metal buffer data pointer", __func__);
+
+    return -1;
+  }
+
+  if (memcpy (buf_dst_ptr + buf_dst_off, buf_src, buf_size) != buf_dst_ptr + buf_dst_off)
+  {
+    event_log_error (hashcat_ctx, "%s(): memcpy failed", __func__);
+
+    return -1;
+  }
+
+  [buf_dst didModifyRange: NSMakeRange (buf_dst_off, buf_size)];
+
+  return 0;
+}
+
+// device to host
+
+int hc_mtlMemcpyDtoH (void *hashcat_ctx, mtl_command_queue command_queue, void *buf_dst, mtl_mem buf_src, size_t buf_src_off, size_t buf_size)
+{
+  if (command_queue == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): metal command queue is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_src == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): metal src buffer is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_dst == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): host dst buffer is invalid", __func__);
+    return -1;
+  }
+
+  if (buf_size <= 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): buffer size is invalid", __func__);
+    return -1;
+  }
+
+  id<MTLCommandBuffer> command_buffer = [command_queue commandBuffer];
+
+  if (command_buffer == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to create a new command buffer", __func__);
+    return -1;
+  }
+
+  id<MTLBlitCommandEncoder> blit_encoder = [command_buffer blitCommandEncoder];
+
+  [blit_encoder synchronizeResource: buf_src];
+
+  // Finish encoding and start the data transfer to the CPU
+
+  [blit_encoder endEncoding];
+  [command_buffer commit];
+
+  // Wait for complete
+
+  [command_buffer waitUntilCompleted];
+
+  // get src buf ptr
+
+  void *buf_src_ptr = [buf_src contents];
+
+  if (buf_src_ptr == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): failed to get metal buffer data pointer", __func__);
+
+    return -1;
+  }
+
+  if (memcpy (buf_dst, buf_src_ptr + buf_src_off, buf_size) != buf_dst)
+  {
+    event_log_error (hashcat_ctx, "%s(): memcpy failed", __func__);
+
+    return -1;
+  }
+
+  return 0;
+}
+
+int hc_mtlRuntimeGetVersionString (void *hashcat_ctx, char *runtimeVersion_str, size_t *size)
+{
+  CFURLRef plist_url = CFURLCreateWithFileSystemPath (kCFAllocatorDefault, CFSTR("/System/Library/Frameworks/Metal.framework/Versions/Current/Resources/version.plist"), kCFURLPOSIXPathStyle, false);
+
+  if (plist_url == NULL)
+  {
+    event_log_error (hashcat_ctx, "%s(): CFURLCreateWithFileSystemPath() failed\n", __func__);
+
+    return -1;
+  }
+
+  CFReadStreamRef plist_stream = CFReadStreamCreateWithFile (NULL, plist_url);
+
+  if (plist_stream == NULL)
+  {
+    event_log_error (hashcat_ctx, "%s(): CFReadStreamCreateWithFile() failed\n", __func__);
+
+    CFRelease (plist_url);
+
+    return -1;
+  }
+
+  if (CFReadStreamOpen (plist_stream) == false)
+  {
+    event_log_error (hashcat_ctx, "%s(): CFReadStreamOpen() failed\n", __func__);
+
+    CFRelease (plist_stream);
+    CFRelease (plist_url);
+
+    return -1;
+  }
+
+  CFPropertyListRef plist_prop = CFPropertyListCreateWithStream (NULL, plist_stream, 0, kCFPropertyListImmutable, NULL, NULL);
+
+  if (plist_prop == NULL)
+  {
+    event_log_error (hashcat_ctx, "%s(): CFPropertyListCreateWithStream() failed\n", __func__);
+
+    CFReadStreamClose (plist_stream);
+
+    CFRelease (plist_stream);
+    CFRelease (plist_url);
+    return -1;
+  }
+
+  CFStringRef runtime_version_str = CFRetain (CFDictionaryGetValue (plist_prop, CFSTR("CFBundleVersion")));
+
+  if (runtime_version_str != NULL)
+  {
+    if (runtimeVersion_str == NULL)
+    {
+      CFIndex len = CFStringGetLength (runtime_version_str);
+      CFIndex maxSize = CFStringGetMaximumSizeForEncoding (len, kCFStringEncodingUTF8) + 1;
+      *size = maxSize;
+      return 0;
+    }
+
+    CFIndex maxSize = *size;
+
+    if (CFStringGetCString (runtime_version_str, runtimeVersion_str, maxSize, kCFStringEncodingUTF8) == false)
+    {
+      event_log_error (hashcat_ctx, "%s(): CFStringGetCString() failed\n", __func__);
+
+      hcfree (runtimeVersion_str);
+
+      return -1;
+    }
+
+    return 0;
+  }
+
+  return -1;
+}
+
+int hc_mtlEncodeComputeCommand_pre (void *hashcat_ctx, mtl_pipeline metal_pipeline, mtl_command_queue metal_command_queue, mtl_command_buffer *metal_command_buffer, mtl_command_encoder *metal_command_encoder)
+{
+  if (metal_pipeline == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal_pipeline", __func__);
+
+    return -1;
+  }
+
+  if (metal_command_queue == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal_command_queue", __func__);
+
+    return -1;
+  }
+
+  id<MTLCommandBuffer> metal_commandBuffer = [metal_command_queue commandBuffer];
+
+  if (metal_commandBuffer == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal_commandBuffer", __func__);
+
+    return -1;
+  }
+
+  id<MTLComputeCommandEncoder> metal_commandEncoder = [metal_commandBuffer computeCommandEncoder];
+
+  if (metal_commandEncoder == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal_commandBuffer", __func__);
+
+    return -1;
+  }
+
+  [metal_commandEncoder setComputePipelineState: metal_pipeline];
+
+  *metal_command_buffer = metal_commandBuffer;
+  *metal_command_encoder = metal_commandEncoder;
+
+  return 0;
+}
+
+int hc_mtlSetCommandEncoderArg (void *hashcat_ctx, mtl_command_encoder metal_command_encoder, size_t off, size_t idx, mtl_mem buf, void *host_data, size_t host_data_size)
+{
+  if (metal_command_encoder == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal_command_encoder", __func__);
+
+    return -1;
+  }
+
+  if (buf == nil && host_data == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid buf/host_data", __func__);
+
+    return -1;
+  }
+
+  if (buf == nil)
+  {
+    if (host_data_size <= 0)
+    {
+      event_log_error (hashcat_ctx, "%s(): invalid host_data size", __func__);
+
+      return -1;
+    }
+  }
+  else
+  {
+    if (off < 0)
+    {
+      event_log_error (hashcat_ctx, "%s(): invalid buf off", __func__);
+
+      return -1;
+    }
+  }
+
+  if (idx < 0)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid buf/host_data idx", __func__);
+
+    return -1;
+  }
+
+  if (host_data == nil)
+  {
+    [metal_command_encoder setBuffer: buf offset: off atIndex: idx];
+  }
+  else
+  {
+    [metal_command_encoder setBytes: host_data length: host_data_size atIndex: idx];
+  }
+
+  return 0;
+}
+
+int hc_mtlEncodeComputeCommand (void *hashcat_ctx, mtl_command_encoder metal_command_encoder, mtl_command_buffer metal_command_buffer, size_t global_work_size, size_t local_work_size, double *ms)
+{
+/*
+  #define MTL_OPTS 3
+
+  #if MTL_OPTS == 0
+  local_work_size = 1;
+  MTLSize threadsGroup = {global_work_size, 1, 1};
+  MTLSize numThreadgroups = {local_work_size, 1, 1};
+  #elif MTL_OPTS == 1
+  MTLSize numThreadgroups = {local_work_size, 1, 1};
+  MTLSize threadsGroup = { (global_work_size + local_work_size)/local_work_size, 1, 1};
+  #else
+*/
+  MTLSize numThreadgroups = {local_work_size, 1, 1};
+  MTLSize threadsGroup = {global_work_size, 1, 1};
+//  #endif
+
+  if (metal_command_encoder == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal_command_encoder", __func__);
+
+    return -1;
+  }
+
+  if (metal_command_buffer == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal_command_buffer", __func__);
+
+    return -1;
+  }
+
+//  #if MTL_OPTS == 0
+//  [metal_command_encoder dispatchThreads: threadsGroup threadsPerThreadgroup: numThreadgroups];
+//  #else
+  [metal_command_encoder dispatchThreadgroups: threadsGroup threadsPerThreadgroup: numThreadgroups];
+//  #endif
+
+  [metal_command_encoder endEncoding];
+  [metal_command_buffer commit];
+  [metal_command_buffer waitUntilCompleted];
+
+  CFTimeInterval myGPUStartTime = 0;
+  CFTimeInterval myGPUEndTime = 0;
+
+  SEL myGPUStartTimeSelector = NSSelectorFromString(@"GPUStartTime");
+  SEL myGPUEndTimeSelector   = NSSelectorFromString(@"GPUEndTime");
+
+  if (hc_mtlInvocationHelper (metal_command_buffer, myGPUStartTimeSelector, &myGPUStartTime) == -1) return -1;
+  if (hc_mtlInvocationHelper (metal_command_buffer, myGPUEndTimeSelector, &myGPUEndTime) == -1) return -1;
+
+  CFTimeInterval elapsed = myGPUEndTime - myGPUStartTime;
+
+  *ms = (1000.0 * elapsed);
+
+  return 0;
+}
+
+int hc_mtlCreateLibraryWithFile (void *hashcat_ctx, mtl_device_id metal_device, const char *cached_file, mtl_library *metal_library)
+{
+  NSError *error = nil;
+
+  if (metal_device == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metal device", __func__);
+
+    return -1;
+  }
+
+  if (cached_file == nil)
+  {
+    event_log_error (hashcat_ctx, "%s(): invalid metallib", __func__);
+
+    return -1;
+  }
+
+  NSString *k_string = [NSString stringWithCString: cached_file encoding: NSUTF8StringEncoding];
+
+  if (k_string != nil)
+  {
+    id <MTLLibrary> r = [metal_device newLibraryWithFile: k_string error: &error];
+
+    if (error != nil)
+    {
+      event_log_error (hashcat_ctx, "%s(): failed to create metal library from metallib, %s", __func__, [[error localizedDescription] UTF8String]);
+      return -1;
+    }
+
+    *metal_library = r;
+
+    return 0;
+  }
+
+  return -1;
+}
+
+int hc_mtlCreateLibraryWithSource (void *hashcat_ctx, mtl_device_id metal_device, const char *kernel_sources, const char *build_options_buf, const char *cpath, mtl_library *metal_library)
+{
+  NSError *error = nil;
+
+  NSString *k_string = [NSString stringWithCString: kernel_sources encoding: NSUTF8StringEncoding];
+
+  if (k_string != nil)
+  {
+    MTLCompileOptions *compileOptions = [MTLCompileOptions new];
+
+    NSMutableDictionary *build_options_dict = nil;
+
+    if (build_options_buf != nil)
+    {
+      //printf("using build_opts from arg:\n%s\n", build_options_buf);
+
+      build_options_dict = [NSMutableDictionary dictionary]; //[[NSMutableDictionary alloc] init];
+
+      if (hc_mtlBuildOptionsToDict (hashcat_ctx, build_options_buf, cpath, build_options_dict) == -1)
+      {
+        event_log_error (hashcat_ctx, "%s(): failed to build options dictionary", __func__);
+
+        [build_options_dict release];
+        return -1;
+      }
+
+      compileOptions.preprocessorMacros = build_options_dict;
+    }
+
+    // todo: detect current os version and choose the right
+//    compileOptions.languageVersion = MTL_LANGUAGEVERSION_2_3;
+/*
+    if (@available(macOS 12.0, *))
+    {
+      compileOptions.languageVersion = MTL_LANGUAGEVERSION_2_4;
+    }
+    else if (@available(macOS 11.0, *))
+    {
+      compileOptions.languageVersion = MTL_LANGUAGEVERSION_2_3;
+    }
+    else if (@available(macOS 10.15, *))
+    {
+      compileOptions.languageVersion = MTL_LANGUAGEVERSION_2_2;
+    }
+    else if (@available(macOS 10.14, *))
+    {
+      compileOptions.languageVersion = MTL_LANGUAGEVERSION_2_1;
+    }
+    else if (@available(macOS 10.13, *))
+    {
+      compileOptions.languageVersion = MTL_LANGUAGEVERSION_2_0;
+    }
+    else if (@available(macOS 10.12, *))
+    {
+      compileOptions.languageVersion = MTL_LANGUAGEVERSION_1_2;
+    }
+    else if (@available(macOS 10.11, *))
+    {
+      compileOptions.languageVersion = MTL_LANGUAGEVERSION_1_1;
+    }
+*/
+    id<MTLLibrary> r = [metal_device newLibraryWithSource: k_string options: compileOptions error: &error];
+
+    [compileOptions release];
+    compileOptions = nil;
+
+    if (build_options_dict != nil)
+    {
+      [build_options_dict release];
+      build_options_dict = nil;
+    }
+
+    if (error != nil)
+    {
+      event_log_error (hashcat_ctx, "%s(): failed to create metal library, %s", __func__, [[error localizedDescription] UTF8String]);
+
+      return -1;
+    }
+
+    *metal_library = r;
+
+    return 0;
+  }
+
+  return -1;
+}

--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -1251,21 +1251,8 @@ int hc_mtlSetCommandEncoderArg (void *hashcat_ctx, mtl_command_encoder metal_com
 
 int hc_mtlEncodeComputeCommand (void *hashcat_ctx, mtl_command_encoder metal_command_encoder, mtl_command_buffer metal_command_buffer, size_t global_work_size, size_t local_work_size, double *ms)
 {
-/*
-  #define MTL_OPTS 3
-
-  #if MTL_OPTS == 0
-  local_work_size = 1;
-  MTLSize threadsGroup = {global_work_size, 1, 1};
-  MTLSize numThreadgroups = {local_work_size, 1, 1};
-  #elif MTL_OPTS == 1
-  MTLSize numThreadgroups = {local_work_size, 1, 1};
-  MTLSize threadsGroup = { (global_work_size + local_work_size)/local_work_size, 1, 1};
-  #else
-*/
   MTLSize numThreadgroups = {local_work_size, 1, 1};
   MTLSize threadsGroup = {global_work_size, 1, 1};
-//  #endif
 
   if (metal_command_encoder == nil)
   {
@@ -1281,11 +1268,7 @@ int hc_mtlEncodeComputeCommand (void *hashcat_ctx, mtl_command_encoder metal_com
     return -1;
   }
 
-//  #if MTL_OPTS == 0
-//  [metal_command_encoder dispatchThreads: threadsGroup threadsPerThreadgroup: numThreadgroups];
-//  #else
   [metal_command_encoder dispatchThreadgroups: threadsGroup threadsPerThreadgroup: numThreadgroups];
-//  #endif
 
   [metal_command_encoder endEncoding];
   [metal_command_buffer commit];

--- a/src/modules/module_01500.c
+++ b/src/modules/module_01500.c
@@ -151,7 +151,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
   {
     if ((user_options->attack_mode == ATTACK_MODE_BF) && (hashes->salts_cnt == 1) && (user_options->slow_candidates == false))
     {
-      hc_asprintf (&jit_build_options, "-DDESCRYPT_SALT=%u", hashes->salts_buf[0].salt_buf[0] & 0xfff);
+      hc_asprintf (&jit_build_options, "-D DESCRYPT_SALT=%u", hashes->salts_buf[0].salt_buf[0] & 0xfff);
     }
 
     return jit_build_options;
@@ -161,7 +161,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
   {
     if ((user_options->attack_mode == ATTACK_MODE_BF) && (hashes->salts_cnt == 1) && (user_options->slow_candidates == false))
     {
-      hc_asprintf (&jit_build_options, "-DDESCRYPT_SALT=%u -D _unroll", hashes->salts_buf[0].salt_buf[0] & 0xfff);
+      hc_asprintf (&jit_build_options, "-D DESCRYPT_SALT=%u -D _unroll", hashes->salts_buf[0].salt_buf[0] & 0xfff);
     }
   }
   // ROCM
@@ -169,7 +169,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
   {
     if ((user_options->attack_mode == ATTACK_MODE_BF) && (hashes->salts_cnt == 1) && (user_options->slow_candidates == false))
     {
-      hc_asprintf (&jit_build_options, "-DDESCRYPT_SALT=%u -D _unroll", hashes->salts_buf[0].salt_buf[0] & 0xfff);
+      hc_asprintf (&jit_build_options, "-D DESCRYPT_SALT=%u -D _unroll", hashes->salts_buf[0].salt_buf[0] & 0xfff);
     }
   }
   // ROCM
@@ -177,7 +177,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
   {
     if ((user_options->attack_mode == ATTACK_MODE_BF) && (hashes->salts_cnt == 1) && (user_options->slow_candidates == false))
     {
-      hc_asprintf (&jit_build_options, "-DDESCRYPT_SALT=%u -D _unroll -fno-experimental-new-pass-manager", hashes->salts_buf[0].salt_buf[0] & 0xfff);
+      hc_asprintf (&jit_build_options, "-D DESCRYPT_SALT=%u -D _unroll -fno-experimental-new-pass-manager", hashes->salts_buf[0].salt_buf[0] & 0xfff);
     }
     else
     {
@@ -188,7 +188,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
   {
     if ((user_options->attack_mode == ATTACK_MODE_BF) && (hashes->salts_cnt == 1) && (user_options->slow_candidates == false))
     {
-      hc_asprintf (&jit_build_options, "-DDESCRYPT_SALT=%u", hashes->salts_buf[0].salt_buf[0] & 0xfff);
+      hc_asprintf (&jit_build_options, "-D DESCRYPT_SALT=%u", hashes->salts_buf[0].salt_buf[0] & 0xfff);
     }
   }
 

--- a/src/modules/module_06211.c
+++ b/src/modules/module_06211.c
@@ -77,7 +77,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_06212.c
+++ b/src/modules/module_06212.c
@@ -77,7 +77,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_06213.c
+++ b/src/modules/module_06213.c
@@ -77,7 +77,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_06241.c
+++ b/src/modules/module_06241.c
@@ -78,7 +78,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_06242.c
+++ b/src/modules/module_06242.c
@@ -78,7 +78,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_06243.c
+++ b/src/modules/module_06243.c
@@ -78,7 +78,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_06800.c
+++ b/src/modules/module_06800.c
@@ -56,7 +56,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_08900.c
+++ b/src/modules/module_08900.c
@@ -56,7 +56,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   // amdgpu-pro-20.50-1234664-ubuntu-20.04 (legacy)
@@ -266,7 +269,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
 
   char *jit_build_options = NULL;
 
-  hc_asprintf (&jit_build_options, "-DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%" PRIu64 " -DSCRYPT_TMP_ELEM=%" PRIu64,
+  hc_asprintf (&jit_build_options, "-D SCRYPT_N=%u -D SCRYPT_R=%u -D SCRYPT_P=%u -D SCRYPT_TMTO=%" PRIu64 " -D SCRYPT_TMP_ELEM=%" PRIu64,
     hashes->salts_buf[0].scrypt_N,
     hashes->salts_buf[0].scrypt_r,
     hashes->salts_buf[0].scrypt_p,

--- a/src/modules/module_09300.c
+++ b/src/modules/module_09300.c
@@ -56,7 +56,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;
@@ -258,7 +261,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
 
   char *jit_build_options = NULL;
 
-  hc_asprintf (&jit_build_options, "-DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%" PRIu64 " -DSCRYPT_TMP_ELEM=%" PRIu64,
+  hc_asprintf (&jit_build_options, "-D SCRYPT_N=%u -D SCRYPT_R=%u -D SCRYPT_P=%u -D SCRYPT_TMTO=%" PRIu64 " -D SCRYPT_TMP_ELEM=%" PRIu64,
     hashes->salts_buf[0].scrypt_N,
     hashes->salts_buf[0].scrypt_r,
     hashes->salts_buf[0].scrypt_p,

--- a/src/modules/module_09500.c
+++ b/src/modules/module_09500.c
@@ -62,7 +62,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_09600.c
+++ b/src/modules/module_09600.c
@@ -65,7 +65,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_12700.c
+++ b/src/modules/module_12700.c
@@ -60,7 +60,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13711.c
+++ b/src/modules/module_13711.c
@@ -88,7 +88,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13712.c
+++ b/src/modules/module_13712.c
@@ -88,7 +88,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13713.c
+++ b/src/modules/module_13713.c
@@ -88,7 +88,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13721.c
+++ b/src/modules/module_13721.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)

--- a/src/modules/module_13722.c
+++ b/src/modules/module_13722.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)

--- a/src/modules/module_13723.c
+++ b/src/modules/module_13723.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)

--- a/src/modules/module_13733.c
+++ b/src/modules/module_13733.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AppleM1, OpenCL, MTLCompilerService never-end (pure/optimized kernel)
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13741.c
+++ b/src/modules/module_13741.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13742.c
+++ b/src/modules/module_13742.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13743.c
+++ b/src/modules/module_13743.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13751.c
+++ b/src/modules/module_13751.c
@@ -88,7 +88,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13752.c
+++ b/src/modules/module_13752.c
@@ -88,7 +88,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13753.c
+++ b/src/modules/module_13753.c
@@ -88,7 +88,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13761.c
+++ b/src/modules/module_13761.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13762.c
+++ b/src/modules/module_13762.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_13763.c
+++ b/src/modules/module_13763.c
@@ -89,7 +89,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_14700.c
+++ b/src/modules/module_14700.c
@@ -66,7 +66,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_15200.c
+++ b/src/modules/module_15200.c
@@ -56,7 +56,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_15700.c
+++ b/src/modules/module_15700.c
@@ -279,7 +279,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
 
   char *jit_build_options = NULL;
 
-  hc_asprintf (&jit_build_options, "-DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%" PRIu64 " -DSCRYPT_TMP_ELEM=%" PRIu64,
+  hc_asprintf (&jit_build_options, "-D SCRYPT_N=%u -D SCRYPT_R=%u -D SCRYPT_P=%u -D SCRYPT_TMTO=%" PRIu64 " -D SCRYPT_TMP_ELEM=%" PRIu64,
     hashes->salts_buf[0].scrypt_N,
     hashes->salts_buf[0].scrypt_r,
     hashes->salts_buf[0].scrypt_p,

--- a/src/modules/module_18900.c
+++ b/src/modules/module_18900.c
@@ -71,7 +71,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_19600.c
+++ b/src/modules/module_19600.c
@@ -71,7 +71,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_19700.c
+++ b/src/modules/module_19700.c
@@ -71,7 +71,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_19800.c
+++ b/src/modules/module_19800.c
@@ -71,7 +71,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_19900.c
+++ b/src/modules/module_19900.c
@@ -71,7 +71,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_20011.c
+++ b/src/modules/module_20011.c
@@ -68,7 +68,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_20012.c
+++ b/src/modules/module_20012.c
@@ -68,7 +68,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_20013.c
+++ b/src/modules/module_20013.c
@@ -68,7 +68,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_22700.c
+++ b/src/modules/module_22700.c
@@ -266,7 +266,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
 
   char *jit_build_options = NULL;
 
-  hc_asprintf (&jit_build_options, "-DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%" PRIu64 " -DSCRYPT_TMP_ELEM=%" PRIu64,
+  hc_asprintf (&jit_build_options, "-D SCRYPT_N=%u -D SCRYPT_R=%u -D SCRYPT_P=%u -D SCRYPT_TMTO=%" PRIu64 " -D SCRYPT_TMP_ELEM=%" PRIu64,
     hashes->salts_buf[0].scrypt_N,
     hashes->salts_buf[0].scrypt_r,
     hashes->salts_buf[0].scrypt_p,

--- a/src/modules/module_23100.c
+++ b/src/modules/module_23100.c
@@ -67,7 +67,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_24500.c
+++ b/src/modules/module_24500.c
@@ -68,7 +68,10 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // AMD Radeon Pro W5700X Compute Engine; 1.2 (Apr 22 2021 21:54:44); 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if (device_param->is_metal == false)
+    {
+      return true;
+    }
   }
 
   return false;

--- a/src/modules/module_27700.c
+++ b/src/modules/module_27700.c
@@ -264,7 +264,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
 
   char *jit_build_options = NULL;
 
-  hc_asprintf (&jit_build_options, "-DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%" PRIu64 " -DSCRYPT_TMP_ELEM=%" PRIu64,
+  hc_asprintf (&jit_build_options, "-D SCRYPT_N=%u -D SCRYPT_R=%u -D SCRYPT_P=%u -D SCRYPT_TMTO=%" PRIu64 " -D SCRYPT_TMP_ELEM=%" PRIu64,
     hashes->salts_buf[0].scrypt_N,
     hashes->salts_buf[0].scrypt_r,
     hashes->salts_buf[0].scrypt_p,

--- a/src/modules/module_28200.c
+++ b/src/modules/module_28200.c
@@ -258,7 +258,7 @@ char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAY
 
   char *jit_build_options = NULL;
 
-  hc_asprintf (&jit_build_options, "-DSCRYPT_N=%u -DSCRYPT_R=%u -DSCRYPT_P=%u -DSCRYPT_TMTO=%" PRIu64 " -DSCRYPT_TMP_ELEM=%" PRIu64,
+  hc_asprintf (&jit_build_options, "-D SCRYPT_N=%u -D SCRYPT_R=%u -D SCRYPT_P=%u -D SCRYPT_TMTO=%" PRIu64 " -D SCRYPT_TMP_ELEM=%" PRIu64,
     hashes->salts_buf[0].scrypt_N,
     hashes->salts_buf[0].scrypt_r,
     hashes->salts_buf[0].scrypt_p,

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -39,6 +39,15 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     device_param->kernel_params[18] = &device_param->hip_d_st_esalts_buf;
   }
 
+  #if defined (__APPLE__)
+  if (device_param->is_metal == true)
+  {
+    device_param->kernel_params[15] = device_param->metal_d_st_digests_buf;
+    device_param->kernel_params[17] = device_param->metal_d_st_salts_buf;
+    device_param->kernel_params[18] = device_param->metal_d_st_esalts_buf;
+  }
+  #endif
+
   if (device_param->is_opencl == true)
   {
     device_param->kernel_params[15] = &device_param->opencl_d_st_digests_buf;
@@ -105,6 +114,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_pws_buf, &pw, 1 * sizeof (pw_t), device_param->hip_stream) == -1) return -1;
     }
 
+    #if defined (__APPLE__)
+    if (device_param->is_metal == true)
+    {
+      if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_pws_buf, 0, &pw, 1 * sizeof (pw_t)) == -1) return -1;
+    }
+    #endif
+
     if (device_param->is_opencl == true)
     {
       if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_pws_buf, CL_FALSE, 0, 1 * sizeof (pw_t), &pw, 0, NULL, NULL) == -1) return -1;
@@ -142,6 +158,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
         {
           if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_pws_buf, &pw, 1 * sizeof (pw_t), device_param->hip_stream) == -1) return -1;
         }
+
+        #if defined (__APPLE__)
+        if (device_param->is_metal == true)
+        {
+          if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_pws_buf, 0, &pw, 1 * sizeof (pw_t)) == -1) return -1;
+        }
+        #endif
 
         if (device_param->is_opencl == true)
         {
@@ -210,6 +233,15 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
           if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_pws_buf, &pw, 1 * sizeof (pw_t), device_param->hip_stream) == -1) return -1;
         }
 
+        #if defined (__APPLE__)
+        if (device_param->is_metal == true)
+        {
+          if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_combs_c, 0, &comb, 1 * sizeof (pw_t)) == -1) return -1;
+
+          if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_pws_buf, 0, &pw, 1 * sizeof (pw_t)) == -1) return -1;
+        }
+        #endif
+
         if (device_param->is_opencl == true)
         {
           if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_combs_c, CL_FALSE, 0, 1 * sizeof (pw_t), &comb, 0, NULL, NULL) == -1) return -1;
@@ -247,6 +279,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
           {
             if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_pws_buf, &pw, 1 * sizeof (pw_t), device_param->hip_stream) == -1) return -1;
           }
+
+          #if defined (__APPLE__)
+          if (device_param->is_metal == true)
+          {
+            if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_pws_buf, 0, &pw, 1 * sizeof (pw_t)) == -1) return -1;
+          }
+          #endif
 
           if (device_param->is_opencl == true)
           {
@@ -301,6 +340,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
           {
             if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_bfs_c, &bf, 1 * sizeof (bf_t), device_param->hip_stream) == -1) return -1;
           }
+
+          #if defined (__APPLE__)
+          if (device_param->is_metal == true)
+          {
+            if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_bfs_c, 0, &bf, 1 * sizeof (bf_t)) == -1) return -1;
+          }
+          #endif
 
           if (device_param->is_opencl == true)
           {
@@ -401,6 +447,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
             if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_pws_buf, &pw, 1 * sizeof (pw_t), device_param->hip_stream) == -1) return -1;
           }
 
+          #if defined (__APPLE__)
+          if (device_param->is_metal == true)
+          {
+            if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_pws_buf, 0, &pw, 1 * sizeof (pw_t)) == -1) return -1;
+          }
+          #endif
+
           if (device_param->is_opencl == true)
           {
             if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_pws_buf, CL_FALSE, 0, 1 * sizeof (pw_t), &pw, 0, NULL, NULL) == -1) return -1;
@@ -431,6 +484,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       {
         if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_pws_buf, &pw, 1 * sizeof (pw_t), device_param->hip_stream) == -1) return -1;
       }
+
+      #if defined (__APPLE__)
+      if (device_param->is_metal == true)
+      {
+        if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_pws_buf, 0, &pw, 1 * sizeof (pw_t)) == -1) return -1;
+      }
+      #endif
 
       if (device_param->is_opencl == true)
       {
@@ -487,6 +547,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
         if (run_hip_kernel_utf8toutf16le (hashcat_ctx, device_param, device_param->hip_d_pws_buf, 1) == -1) return -1;
       }
 
+      #if defined (__APPLE__)
+      if (device_param->is_metal == true)
+      {
+        if (run_metal_kernel_utf8toutf16le (hashcat_ctx, device_param, device_param->metal_d_pws_buf, 1) == -1) return -1;
+      }
+      #endif
+
       if (device_param->is_opencl == true)
       {
         if (run_opencl_kernel_utf8toutf16le (hashcat_ctx, device_param, device_param->opencl_d_pws_buf, 1) == -1) return -1;
@@ -513,6 +580,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
         if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
       }
 
+      #if defined (__APPLE__)
+      if (device_param->is_metal == true)
+      {
+        if (hc_mtlMemcpyDtoH (hashcat_ctx, device_param->metal_command_queue, device_param->hooks_buf, device_param->metal_d_hooks, 0, device_param->size_hooks) == -1) return -1;
+      }
+      #endif
+
       if (device_param->is_opencl == true)
       {
         /* blocking */
@@ -530,6 +604,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       {
         if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_hooks, device_param->hooks_buf, device_param->size_hooks, device_param->hip_stream) == -1) return -1;
       }
+
+      #if defined (__APPLE__)
+      if (device_param->is_metal == true)
+      {
+        if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_hooks, 0, device_param->hooks_buf, device_param->size_hooks) == -1) return -1;
+      }
+      #endif
 
       if (device_param->is_opencl == true)
       {
@@ -591,6 +672,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
           if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return -1;
         }
 
+        #if defined (__APPLE__)
+        if (device_param->is_metal == true)
+        {
+          if (hc_mtlMemcpyDtoH (hashcat_ctx, device_param->metal_command_queue, device_param->hooks_buf, device_param->metal_d_hooks, 0, device_param->size_hooks) == -1) return -1;
+        }
+        #endif
+
         if (device_param->is_opencl == true)
         {
           /* blocking */
@@ -608,6 +696,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
         {
           if (hc_hipMemcpyHtoDAsync (hashcat_ctx, device_param->hip_d_hooks, device_param->hooks_buf, device_param->size_hooks, device_param->hip_stream) == -1) return -1;
         }
+
+        #if defined (__APPLE__)
+        if (device_param->is_metal == true)
+        {
+          if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_hooks, 0, device_param->hooks_buf, device_param->size_hooks) == -1) return -1;
+        }
+        #endif
 
         if (device_param->is_opencl == true)
         {
@@ -701,6 +796,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     if (hc_hipEventRecord (hashcat_ctx, device_param->hip_event3, device_param->hip_stream) == -1) return -1;
   }
 
+  #if defined (__APPLE__)
+  if (device_param->is_metal == true)
+  {
+    if (hc_mtlMemcpyDtoH (hashcat_ctx, device_param->metal_command_queue, &num_cracked, device_param->metal_d_result, 0, sizeof (u32)) == -1) return -1;
+  }
+  #endif
+
   if (device_param->is_opencl == true)
   {
     if (hc_clEnqueueReadBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_result, CL_FALSE, 0, sizeof (u32), &num_cracked, 0, NULL, &opencl_event) == -1) return -1;
@@ -747,6 +849,22 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_result,        device_param->size_results) == -1) return -1;
   }
 
+  #if defined (__APPLE__)
+  if (device_param->is_metal == true)
+  {
+    device_param->kernel_params[15] = device_param->metal_d_digests_buf;
+    device_param->kernel_params[17] = device_param->metal_d_salt_bufs;
+    device_param->kernel_params[18] = device_param->metal_d_esalt_bufs;
+
+    if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_pws_buf,       device_param->size_pws)     == -1) return -1;
+    if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_tmps,          device_param->size_tmps)    == -1) return -1;
+    if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_hooks,         device_param->size_hooks)   == -1) return -1;
+    if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_plain_bufs,    device_param->size_plains)  == -1) return -1;
+    if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_digests_shown, device_param->size_shown)   == -1) return -1;
+    if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_result,        device_param->size_results) == -1) return -1;
+  }
+  #endif
+
   if (device_param->is_opencl == true)
   {
     device_param->kernel_params[15] = &device_param->opencl_d_digests_buf;
@@ -773,6 +891,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_rules_c, device_param->size_rules_c) == -1) return -1;
     }
 
+    #if defined (__APPLE__)
+    if (device_param->is_metal == true)
+    {
+      if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_rules_c, device_param->size_rules_c) == -1) return -1;
+    }
+    #endif
+
     if (device_param->is_opencl == true)
     {
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_rules_c, device_param->size_rules_c) == -1) return -1;
@@ -792,6 +917,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
         if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_rules_c, device_param->size_rules_c) == -1) return -1;
       }
 
+      #if defined (__APPLE__)
+      if (device_param->is_metal == true)
+      {
+        if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_rules_c, device_param->size_rules_c) == -1) return -1;
+      }
+      #endif
+
       if (device_param->is_opencl == true)
       {
         if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_rules_c, device_param->size_rules_c) == -1) return -1;
@@ -809,6 +941,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
         if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_combs_c, device_param->size_combs) == -1) return -1;
       }
 
+      #if defined (__APPLE__)
+      if (device_param->is_metal == true)
+      {
+        if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_combs_c, device_param->size_combs) == -1) return -1;
+      }
+      #endif
+
       if (device_param->is_opencl == true)
       {
         if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_combs_c, device_param->size_combs) == -1) return -1;
@@ -825,6 +964,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
       {
         if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_bfs_c, device_param->size_bfs) == -1) return -1;
       }
+
+      #if defined (__APPLE__)
+      if (device_param->is_metal == true)
+      {
+        if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_bfs_c, device_param->size_bfs) == -1) return -1;
+      }
+      #endif
 
       if (device_param->is_opencl == true)
       {
@@ -865,6 +1011,13 @@ static int selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
     {
       event_log_error (hashcat_ctx, "* Device #%u: ATTENTION! HIP kernel self-test failed.", device_param->device_id + 1);
     }
+
+    #if defined (__APPLE__)
+    if (device_param->is_metal == true)
+    {
+      event_log_error (hashcat_ctx, "* Device #%u: ATTENTION! Metal kernel self-test failed.", device_param->device_id + 1);
+    }
+    #endif
 
     if (device_param->is_opencl == true)
     {

--- a/src/usage.c
+++ b/src/usage.c
@@ -95,6 +95,7 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   "     --example-hashes           |      | Alias of --hash-info                                 |",
   "     --backend-ignore-cuda      |      | Do not try to open CUDA interface on startup         |",
   "     --backend-ignore-hip       |      | Do not try to open HIP interface on startup          |",
+  "     --backend-ignore-metal     |      | Do not try to open Metal interface on startup        |",
   "     --backend-ignore-opencl    |      | Do not try to open OpenCL interface on startup       |",
   " -I, --backend-info             |      | Show info about detected backend API devices         | -I",
   " -d, --backend-devices          | Str  | Backend devices to use, separated with commas        | -d 1",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -35,6 +35,9 @@ static const struct option long_options[] =
   {"backend-devices",           required_argument, NULL, IDX_BACKEND_DEVICES},
   {"backend-ignore-cuda",       no_argument,       NULL, IDX_BACKEND_IGNORE_CUDA},
   {"backend-ignore-hip",        no_argument,       NULL, IDX_BACKEND_IGNORE_HIP},
+  #if defined (__APPLE__)
+  {"backend-ignore-metal",      no_argument,       NULL, IDX_BACKEND_IGNORE_METAL},
+  #endif
   {"backend-ignore-opencl",     no_argument,       NULL, IDX_BACKEND_IGNORE_OPENCL},
   {"backend-info",              no_argument,       NULL, IDX_BACKEND_INFO},
   {"backend-vector-width",      required_argument, NULL, IDX_BACKEND_VECTOR_WIDTH},
@@ -170,6 +173,9 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->backend_devices           = NULL;
   user_options->backend_ignore_cuda       = BACKEND_IGNORE_CUDA;
   user_options->backend_ignore_hip        = BACKEND_IGNORE_HIP;
+  #if defined (__APPLE__)
+  user_options->backend_ignore_metal      = BACKEND_IGNORE_METAL;
+  #endif
   user_options->backend_ignore_opencl     = BACKEND_IGNORE_OPENCL;
   user_options->backend_info              = BACKEND_INFO;
   user_options->backend_vector_width      = BACKEND_VECTOR_WIDTH;
@@ -455,6 +461,9 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_CPU_AFFINITY:              user_options->cpu_affinity              = optarg;                          break;
       case IDX_BACKEND_IGNORE_CUDA:       user_options->backend_ignore_cuda       = true;                            break;
       case IDX_BACKEND_IGNORE_HIP:        user_options->backend_ignore_hip        = true;                            break;
+      #if defined (__APPLE__)
+      case IDX_BACKEND_IGNORE_METAL:      user_options->backend_ignore_metal      = true;                            break;
+      #endif
       case IDX_BACKEND_IGNORE_OPENCL:     user_options->backend_ignore_opencl     = true;                            break;
       case IDX_BACKEND_INFO:              user_options->backend_info              = true;                            break;
       case IDX_BACKEND_DEVICES:           user_options->backend_devices           = optarg;                          break;


### PR DESCRIPTION
Hi,

with this PR the host code for Metal is added and also resolves issue #3154 

Currently it is not possible to use hashcat with Metal on Apple Intel (tested only on macOS 10.13.6 / macbookpro 2014) due to limitations set by Apple (it will only be possible to list GPU info). **It will only work on Apple Silicon.**

In order to be able to handle Metal's functionality, a piece of code has been developed in objective-c, which is present in its entirety in the file "src/ext_metal.m", as it was not possible to use C and at the same time obtain an easy-to-read source code.

A new option, --backend-ignore-metal, will be available for end users.

Thanks :)