### PR TITLE
Fixed building error on Raspberry Pi

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -22,6 +22,7 @@
 ## Bugs
 ##
 
+- Fixed building error on Raspberry Pi
 - Fixed false negative on Unit Test in case of out-of-memory with grep in single mode
 - Fixed false negative on Unit Test with hash-type 25400
 - Fixed functional error when nonce-error-corrections that were set on the command line in hash-mode 22000/22001 were not accepted

--- a/src/Makefile
+++ b/src/Makefile
@@ -254,6 +254,14 @@ endif
 endif
 endif
 
+ifeq ($(UNAME),Linux)
+IS_RPI                  := $(shell grep -q Raspberry /proc/cpuinfo && echo 1 || echo 0)
+
+ifeq ($(IS_RPI),1)
+CFLAGS                  += -mcpu=cortex-a72
+endif
+endif
+
 CFLAGS                  += -pipe -Iinclude/ -IOpenCL/
 
 # LZMA


### PR DESCRIPTION
Fix #3155 

Tested on RPI4, Raspbian GNU/Linux 11 (bullseye):
- hashcat: builded from github with this changes and also #3156  applied
- POCL: builded from github with https://github.com/pocl/pocl/pull/1028 applied

```
$ ./hashcat -I
hashcat (v6.2.5-201-g7ac879f1e+) starting in backend information mode

System Info:
============

OS.Name......: Linux
OS.Release...: 5.15.18-v7l+
HW.Model.....: N/A
HW.Platform..: armv7l

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: The pocl project
  Name....: Portable Computing Language
  Version.: OpenCL 2.0 pocl 1.9-pre master-0-gdffab17f  Linux, Debug+Asserts, RELOC, LLVM 11.0.1, SLEEF, FP16, LTTNG, POCL_DEBUG

  Backend Device ID #1
    Type...........: CPU
    Vendor.ID......: 2147483648
    Vendor.........: ARM
    Name...........: pthread-cortex-a72
    Version........: OpenCL 1.2 pocl HSTR: pthread-armv6k-unknown-linux-gnueabihf-cortex-a72
    Processor(s)...: 4
    Clock..........: 1500
    Memory.Total...: 2840 MB (limited to 512 MB allocatable in one block)
    Memory.Free....: 1388 MB
    Local.Memory...: 512 KB
    OpenCL.Version.: OpenCL C 1.2 pocl
    Driver.Version.: 1.9-pre master-0-gdffab17f

$ ./hashcat -m 0 -b
hashcat (v6.2.5-201-g7ac879f1e+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

OpenCL API (OpenCL 2.0 pocl 1.9-pre master-0-gdffab17f  Linux, Debug+Asserts, RELOC, LLVM 11.0.1, SLEEF, FP16, LTTNG, POCL_DEBUG) - Platform #1 [The pocl project]
==================================================================================================================================================================
* Device #1: pthread-cortex-a72, 1388/2840 MB (512 MB allocatable), 4MCU

Benchmark relevant options:
===========================
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#1.........: 22419.3 kH/s (38.00ms) @ Accel:256 Loops:1024 Thr:1 Vec:4

Started: Sun Feb  6 08:52:17 2022
Stopped: Sun Feb  6 08:54:53 2022
```