### PR TITLE
fixes #3029: cracking long salts in -m 4510/4710

### DIFF
--- a/OpenCL/m04510_a0-optimized.cl
+++ b/OpenCL/m04510_a0-optimized.cl
@@ -1015,6 +1015,11 @@ KERNEL_FQ void m04510_m04 (KERN_ATTR_RULES ())
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u);
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
 
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
+
     COMPARE_M_SIMD (d, e, c, b);
   }
 }
@@ -1112,12 +1117,6 @@ KERNEL_FQ void m04510_s04 (KERN_ATTR_RULES ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
-
-  /**
-   * reverse
-   */
-
-  const u32 e_rev = hc_rotl32_S (search[1], 2u);
 
   /**
    * loop
@@ -2024,18 +2023,23 @@ KERNEL_FQ void m04510_s04 (KERN_ATTR_RULES ())
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
     wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u);
     SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
-
-    if (MATCHES_NONE_VS (e, e_rev))
-      continue;
-
     wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u);
     SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
     wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u);
     SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+
+    if (MATCHES_NONE_VS (e + digest[4] - SHA1M_E, search[1]))
+      continue;
+
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u);
     SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u);
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
 
     COMPARE_S_SIMD (d, e, c, b);
   }

--- a/OpenCL/m04510_a1-optimized.cl
+++ b/OpenCL/m04510_a1-optimized.cl
@@ -1070,6 +1070,11 @@ KERNEL_FQ void m04510_m04 (KERN_ATTR_BASIC ())
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u);
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
 
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
+
     COMPARE_M_SIMD (d, e, c, b);
   }
 }
@@ -1167,12 +1172,6 @@ KERNEL_FQ void m04510_s04 (KERN_ATTR_BASIC ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
-
-  /**
-   * reverse
-   */
-
-  const u32 e_rev = hc_rotl32_S (search[1], 2u);
 
   /**
    * loop
@@ -2136,18 +2135,23 @@ KERNEL_FQ void m04510_s04 (KERN_ATTR_BASIC ())
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
     wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u);
     SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
-
-    if (MATCHES_NONE_VS (e, e_rev))
-      continue;
-
     wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u);
     SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
     wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u);
     SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+
+    if (MATCHES_NONE_VS (e + digest[4] - SHA1M_E, search[1]))
+      continue;
+
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u);
     SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u);
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
 
     COMPARE_S_SIMD (d, e, c, b);
   }

--- a/OpenCL/m04510_a3-optimized.cl
+++ b/OpenCL/m04510_a3-optimized.cl
@@ -969,6 +969,11 @@ DECLSPEC void m04510m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u);
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
 
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
+
     COMPARE_M_SIMD (d, e, c, b);
   }
 }
@@ -1017,12 +1022,6 @@ DECLSPEC void m04510s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
-
-  /**
-   * reverse
-   */
-
-  const u32 e_rev = hc_rotl32_S (search[1], 2u);
 
   /**
    * loop
@@ -1926,18 +1925,23 @@ DECLSPEC void m04510s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
     wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u);
     SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
-
-    if (MATCHES_NONE_VS (e, e_rev))
-      continue;
-
     wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u);
     SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
     wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u);
     SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+
+    if (MATCHES_NONE_VS (e + digest[4] - SHA1M_E, search[1]))
+      continue;
+
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u);
     SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u);
     SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
 
     COMPARE_S_SIMD (d, e, c, b);
   }

--- a/OpenCL/m04710_a0-optimized.cl
+++ b/OpenCL/m04710_a0-optimized.cl
@@ -715,6 +715,11 @@ KERNEL_FQ void m04710_m04 (KERN_ATTR_RULES ())
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
 
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
+
     COMPARE_M_SIMD (d, e, c, b);
   }
 }
@@ -813,12 +818,6 @@ KERNEL_FQ void m04710_s04 (KERN_ATTR_RULES ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
-
-  /**
-   * reverse
-   */
-
-  const u32 e_rev = hc_rotl32_S (search[1], 2u);
 
   /**
    * loop
@@ -1426,13 +1425,19 @@ KERNEL_FQ void m04710_s04 (KERN_ATTR_RULES ())
     w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
     wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
     wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
-
-    if (MATCHES_NONE_VS (e, e_rev)) continue;
-
     wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
     wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+
+    if (MATCHES_NONE_VS (e + digest[4] - SHA1M_E, search[1]))
+      continue;
+
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
 
     COMPARE_S_SIMD (d, e, c, b);
   }

--- a/OpenCL/m04710_a1-optimized.cl
+++ b/OpenCL/m04710_a1-optimized.cl
@@ -768,6 +768,11 @@ KERNEL_FQ void m04710_m04 (KERN_ATTR_BASIC ())
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
 
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
+
     COMPARE_M_SIMD (d, e, c, b);
   }
 }
@@ -866,12 +871,6 @@ KERNEL_FQ void m04710_s04 (KERN_ATTR_BASIC ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
-
-  /**
-   * reverse
-   */
-
-  const u32 e_rev = hc_rotl32_S (search[1], 2u);
 
   /**
    * loop
@@ -1534,13 +1533,19 @@ KERNEL_FQ void m04710_s04 (KERN_ATTR_BASIC ())
     w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
     wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
     wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
-
-    if (MATCHES_NONE_VS (e, e_rev)) continue;
-
     wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
     wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+
+    if (MATCHES_NONE_VS (e + digest[4] - SHA1M_E, search[1]))
+      continue;
+
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
 
     COMPARE_S_SIMD (d, e, c, b);
   }

--- a/OpenCL/m04710_a3-optimized.cl
+++ b/OpenCL/m04710_a3-optimized.cl
@@ -683,6 +683,11 @@ DECLSPEC void m04710m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
 
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
+
     COMPARE_M_SIMD (d, e, c, b);
   }
 }
@@ -732,12 +737,6 @@ DECLSPEC void m04710s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
-
-  /**
-   * reverse
-   */
-
-  const u32 e_rev = hc_rotl32_S (search[1], 2u);
 
   /**
    * loop
@@ -1356,13 +1355,19 @@ DECLSPEC void m04710s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
     wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
     wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
-
-    if (MATCHES_NONE_VS (e, e_rev)) continue;
-
     wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
     wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+
+    if (MATCHES_NONE_VS (e + digest[4] - SHA1M_E, search[1]))
+      continue;
+
     we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
     wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    b += digest[1] - SHA1M_B;
+    c += digest[2] - SHA1M_C;
+    d += digest[3] - SHA1M_D;
+    e += digest[4] - SHA1M_E;
 
     COMPARE_S_SIMD (d, e, c, b);
   }

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -26,6 +26,7 @@
 - Fixed building error on Raspberry Pi
 - Fixed false negative on Unit Test in case of out-of-memory with grep in single mode
 - Fixed false negative on Unit Test with hash-type 25400
+- Fixed false negative on hash-types 4510 and 4710 for hashes with long salts
 - Fixed functional error when nonce-error-corrections that were set on the command line in hash-mode 22000/22001 were not accepted
 - Fixed handling of devices in benchmark mode for "kernel build error". Instead of canceling, skip the device and move on to the next
 - Fixed handling of password candidates that are shorter than the minimum password length in Association Attack

--- a/src/modules/module_04510.c
+++ b/src/modules/module_04510.c
@@ -46,6 +46,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+u32 module_salt_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  // allow 64 bytes salts instead of 51 (default salt max for optimized: SALT_MAX_OLD)
+
+  const u32 salt_max = (optimized_kernel == true) ? 64 : hashconfig->salt_max;
+
+  return salt_max;
+}
+
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
   u32 *digest = (u32 *) digest_buf;
@@ -226,7 +237,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_pwdump_column            = MODULE_DEFAULT;
   module_ctx->module_pw_max                   = MODULE_DEFAULT;
   module_ctx->module_pw_min                   = MODULE_DEFAULT;
-  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = module_salt_max;
   module_ctx->module_salt_min                 = MODULE_DEFAULT;
   module_ctx->module_salt_type                = module_salt_type;
   module_ctx->module_separator                = MODULE_DEFAULT;

--- a/src/modules/module_04710.c
+++ b/src/modules/module_04710.c
@@ -46,6 +46,17 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+u32 module_salt_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  // allow 64 bytes salts instead of 51 (default salt max for optimized: SALT_MAX_OLD)
+
+  const u32 salt_max = (optimized_kernel == true) ? 64 : hashconfig->salt_max;
+
+  return salt_max;
+}
+
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
   u32 *digest = (u32 *) digest_buf;
@@ -226,7 +237,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_pwdump_column            = MODULE_DEFAULT;
   module_ctx->module_pw_max                   = MODULE_DEFAULT;
   module_ctx->module_pw_min                   = MODULE_DEFAULT;
-  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = module_salt_max;
   module_ctx->module_salt_min                 = MODULE_DEFAULT;
   module_ctx->module_salt_type                = module_salt_type;
   module_ctx->module_separator                = MODULE_DEFAULT;

--- a/tools/test_modules/m04510.pm
+++ b/tools/test_modules/m04510.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::SHA qw (sha1_hex);
 
-sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 15], [-1, -1]] }
+sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 64], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m04710.pm
+++ b/tools/test_modules/m04710.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::MD5 qw (md5_hex);
 use Digest::SHA qw (sha1_hex);
 
-sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 15], [-1, -1]] }
+sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 64], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
As mentioned in #3029 the problem with modes 4510 (`sha1(sha1($pass).$salt)`) and 4710 (`sha1(md5($pass).$salt)`) was that it didn't support long salts for **optimized** kernels even if the startup/init message of `hashcat` told the user that at least 51 byte long salts are supported.

The problem was with the combination of `sha1+salt` (in 4510) and `md5+salt` (in 4710) that whenever one block (64) was full, this wasn't taken into account when computing the `b`,`c`,`d` and `e` values and therefore `false negatives` were possible (only with hashes with longer salts that would trigger the extra if branch (see `pos >= 56`) and only with the `-O` command line option).

Thanks