### PR TITLE
Added folder_config info to --backend-info/-I output, changed --backend-info/-I option handling 

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -45,6 +45,7 @@
 
 - Association Attack: Enable module specific pw_min and pw_max settings to avoid false positives in -a 9 attack-mode
 - Autotune: Added error handling. By default skipping device on error, with --force using accel/loops/threads min values instead
+- Backend Info: Added folder_config info to output
 - Backend Info: Added generic system info to output (must be completed on Windows side)
 - Backend Info: Added local memory size to output
 - Backend: with kernel build options, switch from -I to -D INCLUDE_PATH, in order to support Apple Metal runtime

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -71,6 +71,7 @@
 - Unit tests: Updated test.sh to set default device-type to CPU with Apple Intel and added -f (--force) option
 - Usage Screen: On windows console, wait for any keypress if usage_mini_print() is used
 - User Options: Add new module function module_hash_decode_postprocess() to override hash specific configurations from command line
+- User Options: Change --backend-info/-I option type, from bool to int
 
 * changes v6.2.4 -> v6.2.5
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -71,7 +71,7 @@
 - Unit tests: Updated test.sh to set default device-type to CPU with Apple Intel and added -f (--force) option
 - Usage Screen: On windows console, wait for any keypress if usage_mini_print() is used
 - User Options: Add new module function module_hash_decode_postprocess() to override hash specific configurations from command line
-- User Options: Change --backend-info/-I option type, from bool to int
+- User Options: Change --backend-info/-I option type, from bool to uint
 
 * changes v6.2.4 -> v6.2.5
 

--- a/include/types.h
+++ b/include/types.h
@@ -664,7 +664,7 @@ typedef enum user_options_defaults
   BACKEND_IGNORE_METAL     = false,
   #endif
   BACKEND_IGNORE_OPENCL    = false,
-  BACKEND_INFO             = false,
+  BACKEND_INFO             = 0,
   BACKEND_VECTOR_WIDTH     = 0,
   OPTIMIZED_KERNEL_ENABLE  = false,
   MULTIPLY_ACCEL_DISABLE   = false,
@@ -2310,7 +2310,7 @@ typedef struct user_options
   bool         backend_ignore_hip;
   bool         backend_ignore_metal;
   bool         backend_ignore_opencl;
-  bool         backend_info;
+  uint         backend_info;
   bool         optimized_kernel_enable;
   bool         multiply_accel_disable;
   bool         outfile_autohex;

--- a/src/backend.c
+++ b/src/backend.c
@@ -5144,7 +5144,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
       if (device_param->skipped == false)
       {
-        if ((user_options->force == false) && (user_options->backend_info == false))
+        if ((user_options->force == false) && (user_options->backend_info == 0))
         {
           // CUDA does not support query nvidia driver version, therefore no driver checks here
           // IF needed, could be retrieved using nvmlSystemGetDriverVersion()
@@ -5535,7 +5535,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
       if (device_param->skipped == false)
       {
-        if ((user_options->force == false) && (user_options->backend_info == false))
+        if ((user_options->force == false) && (user_options->backend_info == 0))
         {
           // CUDA does not support query nvidia driver version, therefore no driver checks here
           // IF needed, could be retrieved using nvmlSystemGetDriverVersion()
@@ -5968,7 +5968,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
       /*
       if (device_param->skipped == false)
       {
-        if ((user_options->force == false) && (user_options->backend_info == false))
+        if ((user_options->force == false) && (user_options->backend_info == 0))
         {
         }
 
@@ -6963,7 +6963,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
         if (device_param->skipped == false)
         {
-          if ((user_options->force == false) && (user_options->backend_info == false))
+          if ((user_options->force == false) && (user_options->backend_info == 0))
           {
             if (opencl_device_type & CL_DEVICE_TYPE_CPU)
             {
@@ -7280,7 +7280,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
       if (device_param->is_metal == false) continue;
 
-      if (user_options->backend_info == false)
+      if (user_options->backend_info == 0)
       {
         // do not ignore in case -I because user expects a value also for skipped devices
 
@@ -7381,7 +7381,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
       if (device_param->is_opencl == false) continue;
 
-      if (user_options->backend_info == false)
+      if (user_options->backend_info == 0)
       {
         // do not ignore in case -I because user expects a value also for skipped devices
 

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -72,21 +72,21 @@ static bool generate_bitmaps (const u32 digests_cnt, const u32 dgst_size, const 
 
 int bitmap_ctx_init (hashcat_ctx_t *hashcat_ctx)
 {
+  hashes_t       *hashes       = hashcat_ctx->hashes;
   bitmap_ctx_t   *bitmap_ctx   = hashcat_ctx->bitmap_ctx;
   hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
-  hashes_t       *hashes       = hashcat_ctx->hashes;
   user_options_t *user_options = hashcat_ctx->user_options;
 
   bitmap_ctx->enabled = false;
 
-  if (user_options->hash_info     == true) return 0;
-  if (user_options->keyspace      == true) return 0;
-  if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
-  if (user_options->show          == true) return 0;
-  if (user_options->usage         == true) return 0;
-  if (user_options->version       == true) return 0;
-  if (user_options->identify      == true) return 0;
+  if (user_options->hash_info    == true) return 0;
+  if (user_options->keyspace     == true) return 0;
+  if (user_options->left         == true) return 0;
+  if (user_options->show         == true) return 0;
+  if (user_options->usage        == true) return 0;
+  if (user_options->version      == true) return 0;
+  if (user_options->identify     == true) return 0;
+  if (user_options->backend_info  > 0)    return 0;
 
   bitmap_ctx->enabled = true;
 
@@ -117,9 +117,7 @@ int bitmap_ctx_init (hashcat_ctx_t *hashcat_ctx)
   for (bitmap_bits = bitmap_min; bitmap_bits < bitmap_max; bitmap_bits++)
   {
     bitmap_nums = 1U << bitmap_bits;
-
     bitmap_mask = bitmap_nums - 1;
-
     bitmap_size = bitmap_nums * sizeof (u32);
 
     if ((hashes->digests_cnt & bitmap_mask) == hashes->digests_cnt) break;
@@ -136,9 +134,7 @@ int bitmap_ctx_init (hashcat_ctx_t *hashcat_ctx)
   }
 
   bitmap_nums = 1U << bitmap_bits;
-
   bitmap_mask = bitmap_nums - 1;
-
   bitmap_size = bitmap_nums * sizeof (u32);
 
   generate_bitmaps (hashes->digests_cnt, hashconfig->dgst_size, bitmap_shift1, (char *) hashes->digests_buf, hashconfig->dgst_pos0, hashconfig->dgst_pos1, hashconfig->dgst_pos2, hashconfig->dgst_pos3, bitmap_mask, bitmap_size, bitmap_s1_a, bitmap_s1_b, bitmap_s1_c, bitmap_s1_d, -1);

--- a/src/combinator.c
+++ b/src/combinator.c
@@ -14,17 +14,17 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
 {
   combinator_ctx_t     *combinator_ctx      = hashcat_ctx->combinator_ctx;
   hashconfig_t         *hashconfig          = hashcat_ctx->hashconfig;
-  user_options_extra_t *user_options_extra  = hashcat_ctx->user_options_extra;
   user_options_t       *user_options        = hashcat_ctx->user_options;
+  user_options_extra_t *user_options_extra  = hashcat_ctx->user_options_extra;
 
   combinator_ctx->enabled = false;
 
-  if (user_options->hash_info      == true) return 0;
-  if (user_options->left           == true) return 0;
-  if (user_options->backend_info   == true) return 0;
-  if (user_options->show           == true) return 0;
-  if (user_options->usage          == true) return 0;
-  if (user_options->version        == true) return 0;
+  if (user_options->hash_info    == true) return 0;
+  if (user_options->left         == true) return 0;
+  if (user_options->show         == true) return 0;
+  if (user_options->usage        == true) return 0;
+  if (user_options->version      == true) return 0;
+  if (user_options->backend_info  > 0)    return 0;
 
   if ((user_options->attack_mode != ATTACK_MODE_COMBI)
    && (user_options->attack_mode != ATTACK_MODE_HYBRID1)

--- a/src/cpt.c
+++ b/src/cpt.c
@@ -15,14 +15,14 @@ int cpt_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
   cpt_ctx->enabled = false;
 
-  if (user_options->hash_info     == true) return 0;
-  if (user_options->keyspace      == true) return 0;
-  if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
-  if (user_options->show          == true) return 0;
-  if (user_options->usage         == true) return 0;
-  if (user_options->version       == true) return 0;
-  if (user_options->identify      == true) return 0;
+  if (user_options->hash_info    == true) return 0;
+  if (user_options->keyspace     == true) return 0;
+  if (user_options->left         == true) return 0;
+  if (user_options->show         == true) return 0;
+  if (user_options->usage        == true) return 0;
+  if (user_options->version      == true) return 0;
+  if (user_options->identify     == true) return 0;
+  if (user_options->backend_info  > 0)    return 0;
 
   cpt_ctx->enabled = true;
 

--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -97,7 +97,6 @@ int debugfile_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->hash_info     == true) return 0;
   if (user_options->keyspace      == true) return 0;
   if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
   if (user_options->show          == true) return 0;
   if (user_options->stdout_flag   == true) return 0;
   if (user_options->speed_only    == true) return 0;
@@ -106,11 +105,11 @@ int debugfile_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->version       == true) return 0;
   if (user_options->identify      == true) return 0;
   if (user_options->debug_mode    == 0)    return 0;
+  if (user_options->backend_info   > 0)    return 0;
 
   debugfile_ctx->enabled = true;
 
-  debugfile_ctx->mode = user_options->debug_mode;
-
+  debugfile_ctx->mode     = user_options->debug_mode;
   debugfile_ctx->filename = user_options->debug_file;
 
   if (debugfile_ctx->filename)

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -60,11 +60,11 @@ int dictstat_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->hash_info     == true) return 0;
   if (user_options->keyspace      == true) return 0;
   if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
   if (user_options->show          == true) return 0;
   if (user_options->usage         == true) return 0;
   if (user_options->version       == true) return 0;
   if (user_options->identify      == true) return 0;
+  if (user_options->backend_info   > 0)    return 0;
 
   if (user_options->attack_mode == ATTACK_MODE_BF) return 0;
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -22,7 +22,7 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 {
   #if defined (__linux__) || defined (__CYGWIN__)
 
-  char *tmp;
+  char *tmp = NULL;
 
   hc_asprintf (&tmp, "/proc/%d/exe", getpid ());
 
@@ -147,7 +147,7 @@ static void get_session_dir (char *session_dir, const char *profile_dir)
 {
   snprintf (session_dir, HCBUFSIZ_TINY, "%s/%s", profile_dir, SESSIONS_FOLDER);
 }
-#endif
+#endif // _POSIX
 
 int count_dictionaries (char **dictionary_files)
 {
@@ -160,12 +160,12 @@ int count_dictionaries (char **dictionary_files)
     cnt++;
   }
 
-  return (cnt);
+  return cnt;
 }
 
 char *first_file_in_directory (const char *path)
 {
-  DIR *d;
+  DIR *d = NULL;
 
   if ((d = opendir (path)) != NULL)
   {
@@ -187,7 +187,7 @@ char *first_file_in_directory (const char *path)
 
     #else
 
-    struct dirent *de;
+    struct dirent *de = NULL;
 
     while ((de = readdir (d)) != NULL)
     {
@@ -246,7 +246,7 @@ char **scan_directory (const char *path)
 
     #else
 
-    struct dirent *de;
+    struct dirent *de = NULL;
 
     while ((de = readdir (d)) != NULL)
     {
@@ -255,11 +255,11 @@ char **scan_directory (const char *path)
 
       if (de->d_name[0] == '.') continue;
 
-      char *path_file;
+      char *path_file = NULL;
 
       hc_asprintf (&path_file, "%s/%s", tmp_path, de->d_name);
 
-      DIR *d_test;
+      DIR *d_test = NULL;
 
       if ((d_test = opendir (path_file)) != NULL)
       {
@@ -294,7 +294,7 @@ char **scan_directory (const char *path)
 
   hcfree (tmp_path);
 
-  return (files);
+  return files;
 }
 
 int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *install_folder, MAYBE_UNUSED const char *shared_folder)
@@ -393,9 +393,12 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
   if (strcmp (install_dir, resolved_install_folder) == 0)
   {
     struct passwd pw;
-    struct passwd *pwp;
+    struct passwd *pwp = NULL;
 
     char buf[HCBUFSIZ_TINY];
+
+    memset (buf, 0, sizeof (buf));
+    memset (&pw, 0, sizeof (pw));
 
     getpwuid_r (getuid (), &pw, buf, HCBUFSIZ_TINY, &pwp);
 
@@ -448,13 +451,13 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
    * The best workaround found so far is to modify the TMP variable (only inside hashcat process) before the runtime is loaded.
    */
 
-  char *cpath;
+  char *cpath = NULL;
 
   #if defined (_WIN)
 
   hc_asprintf (&cpath, "%s\\OpenCL\\", shared_dir);
 
-  char *cpath_real;
+  char *cpath_real = NULL;
 
   hc_asprintf (&cpath_real, "%s\\OpenCL\\", shared_dir);
 
@@ -481,14 +484,12 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
     shared_dir = NULL;
 
-
     hcfree (profile_dir);
 
     if (session_dir == profile_dir) session_dir = NULL;
     if (cache_dir   == profile_dir) cache_dir   = NULL;
 
     profile_dir = NULL;
-
 
     hcfree (cache_dir);
 
@@ -536,7 +537,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
    * kernel cache, we need to make sure folder exist
    */
 
-  char *kernels_folder;
+  char *kernels_folder = NULL;
 
   hc_asprintf (&kernels_folder, "%s/kernels", cache_dir);
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1122,7 +1122,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
   else if (user_options->stdout_flag == true)
   {
   }
-  else if (user_options->backend_info == true)
+  else if (user_options->backend_info > 0)
   {
   }
   else

--- a/src/hwmon.c
+++ b/src/hwmon.c
@@ -1204,13 +1204,13 @@ int hwmon_ctx_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->hash_info     == true) return 0;
   if (user_options->keyspace      == true) return 0;
   if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
   if (user_options->show          == true) return 0;
   if (user_options->stdout_flag   == true) return 0;
   if (user_options->usage         == true) return 0;
   if (user_options->version       == true) return 0;
   if (user_options->identify      == true) return 0;
   if (user_options->hwmon_disable == true) return 0;
+  if (user_options->backend_info   > 0)    return 0;
 
   hwmon_ctx->hm_device = (hm_attrs_t *) hccalloc (DEVICES_MAX, sizeof (hm_attrs_t));
 

--- a/src/induct.c
+++ b/src/induct.c
@@ -43,7 +43,6 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->hash_info     == true) return 0;
   if (user_options->keyspace      == true) return 0;
   if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
   if (user_options->show          == true) return 0;
   if (user_options->stdout_flag   == true) return 0;
   if (user_options->speed_only    == true) return 0;
@@ -51,6 +50,7 @@ int induct_ctx_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->usage         == true) return 0;
   if (user_options->version       == true) return 0;
   if (user_options->identify      == true) return 0;
+  if (user_options->backend_info   > 0)    return 0;
 
   if ((user_options->attack_mode != ATTACK_MODE_STRAIGHT)
    && (user_options->attack_mode != ATTACK_MODE_ASSOCIATION)) return 0;

--- a/src/loopback.c
+++ b/src/loopback.c
@@ -64,7 +64,6 @@ int loopback_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->hash_info     == true) return 0;
   if (user_options->keyspace      == true) return 0;
   if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
   if (user_options->show          == true) return 0;
   if (user_options->stdout_flag   == true) return 0;
   if (user_options->speed_only    == true) return 0;
@@ -72,6 +71,7 @@ int loopback_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->usage         == true) return 0;
   if (user_options->version       == true) return 0;
   if (user_options->identify      == true) return 0;
+  if (user_options->backend_info   > 0)    return 0;
 
   loopback_ctx->enabled  = true;
   loopback_ctx->fp.pfp   = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -184,12 +184,12 @@ static void main_outerloop_starting (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MA
 
   status_ctx->shutdown_outer = false;
 
-  if (user_options->hash_info      == true) return;
-  if (user_options->keyspace       == true) return;
-  if (user_options->stdout_flag    == true) return;
-  if (user_options->backend_info   == true) return;
-  if (user_options->speed_only     == true) return;
-  if (user_options->identify       == true) return;
+  if (user_options->hash_info    == true) return;
+  if (user_options->keyspace     == true) return;
+  if (user_options->stdout_flag  == true) return;
+  if (user_options->speed_only   == true) return;
+  if (user_options->identify     == true) return;
+  if (user_options->backend_info  > 0)    return;
 
   if ((user_options_extra->wordlist_mode == WL_MODE_FILE) || (user_options_extra->wordlist_mode == WL_MODE_MASK))
   {
@@ -261,10 +261,10 @@ static void main_cracker_finished (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYB
   const user_options_t       *user_options       = hashcat_ctx->user_options;
   const user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
 
-  if (user_options->hash_info       == true) return;
-  if (user_options->keyspace        == true) return;
-  if (user_options->backend_info    == true) return;
-  if (user_options->stdout_flag     == true) return;
+  if (user_options->hash_info    == true) return;
+  if (user_options->keyspace     == true) return;
+  if (user_options->stdout_flag  == true) return;
+  if (user_options->backend_info  > 0)    return;
 
   // if we had a prompt, clear it
 
@@ -1265,7 +1265,7 @@ int main (int argc, char **argv)
 
       rc_final = 0;
     }
-    else if (user_options->backend_info == true)
+    else if (user_options->backend_info > 0)
     {
       // if this is just backend_info, no need to execute some real cracking session
 

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -1394,23 +1394,23 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
 int mask_ctx_init (hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t         *hashconfig          = hashcat_ctx->hashconfig;
-  const user_options_extra_t *user_options_extra  = hashcat_ctx->user_options_extra;
-  const user_options_t       *user_options        = hashcat_ctx->user_options;
-  mask_ctx_t                 *mask_ctx            = hashcat_ctx->mask_ctx;
+  const hashconfig_t         *hashconfig         = hashcat_ctx->hashconfig;
+  const user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
+  const user_options_t       *user_options       = hashcat_ctx->user_options;
+  mask_ctx_t                 *mask_ctx           = hashcat_ctx->mask_ctx;
 
   mask_ctx->enabled = false;
 
-  if (user_options->hash_info      == true) return 0;
-  if (user_options->left           == true) return 0;
-  if (user_options->backend_info   == true) return 0;
-  if (user_options->show           == true) return 0;
-  if (user_options->usage          == true) return 0;
-  if (user_options->version        == true) return 0;
+  if (user_options->hash_info    == true) return 0;
+  if (user_options->left         == true) return 0;
+  if (user_options->show         == true) return 0;
+  if (user_options->usage        == true) return 0;
+  if (user_options->version      == true) return 0;
+  if (user_options->backend_info  > 0)    return 0;
 
-  if (user_options->attack_mode == ATTACK_MODE_STRAIGHT) return 0;
-  if (user_options->attack_mode == ATTACK_MODE_COMBI)    return 0;
-  if (user_options->attack_mode == ATTACK_MODE_ASSOCIATION)  return 0;
+  if (user_options->attack_mode  == ATTACK_MODE_ASSOCIATION) return 0;
+  if (user_options->attack_mode  == ATTACK_MODE_STRAIGHT)    return 0;
+  if (user_options->attack_mode  == ATTACK_MODE_COMBI)       return 0;
 
   mask_ctx->enabled = true;
 

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -348,12 +348,11 @@ int outcheck_ctx_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->hash_info     == true) return 0;
   if (user_options->speed_only    == true) return 0;
   if (user_options->progress_only == true) return 0;
-  if (user_options->backend_info  == true) return 0;
   if (user_options->identify      == true) return 0;
+  if (user_options->backend_info   > 0)    return 0;
 
   if (hashconfig->outfile_check_disable == true) return 0;
-
-  if (user_options->outfile_check_timer == 0) return 0;
+  if (user_options->outfile_check_timer == 0)    return 0;
 
   if (user_options->outfile_check_dir == NULL)
   {
@@ -385,8 +384,7 @@ void outcheck_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
   outcheck_ctx_t *outcheck_ctx = hashcat_ctx->outcheck_ctx;
   user_options_t *user_options = hashcat_ctx->user_options;
 
-  if (outcheck_ctx->enabled == false) return;
-
+  if (outcheck_ctx->enabled == false)            return;
   if (hashconfig->outfile_check_disable == true) return;
 
   if (rmdir (outcheck_ctx->root_directory) == -1)

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -104,16 +104,15 @@ void pot_tree_destroy (pot_tree_entry_t *tree)
 int potfile_init (hashcat_ctx_t *hashcat_ctx)
 {
   const folder_config_t *folder_config = hashcat_ctx->folder_config;
+  const user_options_t  *user_options  = hashcat_ctx->user_options;
   const hashconfig_t    *hashconfig    = hashcat_ctx->hashconfig;
         potfile_ctx_t   *potfile_ctx   = hashcat_ctx->potfile_ctx;
-  const user_options_t  *user_options  = hashcat_ctx->user_options;
 
   potfile_ctx->enabled = false;
 
   if (user_options->benchmark       == true) return 0;
   if (user_options->hash_info       == true) return 0;
   if (user_options->keyspace        == true) return 0;
-  if (user_options->backend_info    == true) return 0;
   if (user_options->stdout_flag     == true) return 0;
   if (user_options->speed_only      == true) return 0;
   if (user_options->progress_only   == true) return 0;
@@ -121,8 +120,9 @@ int potfile_init (hashcat_ctx_t *hashcat_ctx)
   if (user_options->version         == true) return 0;
   if (user_options->identify        == true) return 0;
   if (user_options->potfile_disable == true) return 0;
+  if (user_options->backend_info     > 0)    return 0;
 
-  if (hashconfig->potfile_disable == true) return 0;
+  if (hashconfig->potfile_disable   == true) return 0;
 
   potfile_ctx->enabled = true;
 
@@ -186,7 +186,7 @@ void potfile_destroy (hashcat_ctx_t *hashcat_ctx)
 int potfile_read_open (hashcat_ctx_t *hashcat_ctx)
 {
   const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
-  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
+        potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return 0;
 
@@ -205,7 +205,7 @@ int potfile_read_open (hashcat_ctx_t *hashcat_ctx)
 void potfile_read_close (hashcat_ctx_t *hashcat_ctx)
 {
   const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
-  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
+        potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return;
 
@@ -217,7 +217,7 @@ void potfile_read_close (hashcat_ctx_t *hashcat_ctx)
 int potfile_write_open (hashcat_ctx_t *hashcat_ctx)
 {
   const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
-  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
+        potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return 0;
 
@@ -236,7 +236,7 @@ int potfile_write_open (hashcat_ctx_t *hashcat_ctx)
 void potfile_write_close (hashcat_ctx_t *hashcat_ctx)
 {
   const hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
-  potfile_ctx_t       *potfile_ctx = hashcat_ctx->potfile_ctx;
+        potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return;
 
@@ -249,7 +249,7 @@ void potfile_write_append (hashcat_ctx_t *hashcat_ctx, const char *out_buf, cons
 {
   const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const user_options_t *user_options = hashcat_ctx->user_options;
-  potfile_ctx_t        *potfile_ctx  = hashcat_ctx->potfile_ctx;
+        potfile_ctx_t  *potfile_ctx  = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return;
 
@@ -378,10 +378,10 @@ void potfile_update_hashes (hashcat_ctx_t *hashcat_ctx, hash_t *hash_buf, char *
 
 int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
-  const hashes_t       *hashes       = hashcat_ctx->hashes;
-  const module_ctx_t   *module_ctx   = hashcat_ctx->module_ctx;
-  potfile_ctx_t        *potfile_ctx  = hashcat_ctx->potfile_ctx;
+  const hashconfig_t  *hashconfig   = hashcat_ctx->hashconfig;
+  const hashes_t      *hashes       = hashcat_ctx->hashes;
+  const module_ctx_t  *module_ctx   = hashcat_ctx->module_ctx;
+        potfile_ctx_t *potfile_ctx  = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return 0;
 
@@ -637,10 +637,10 @@ int potfile_handle_show (hashcat_ctx_t *hashcat_ctx)
   hashes_t      *hashes      = hashcat_ctx->hashes;
   potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
 
-  hash_t *hashes_buf  = hashes->hashes_buf;
+  u32     salts_cnt  = hashes->salts_cnt;
+  salt_t *salts_buf  = hashes->salts_buf;
 
-  u32     salts_cnt = hashes->salts_cnt;
-  salt_t *salts_buf = hashes->salts_buf;
+  hash_t *hashes_buf = hashes->hashes_buf;
 
   pot_orig_line_entry_t *final_buf = (pot_orig_line_entry_t *) hccalloc (hashes->hashes_cnt, sizeof (pot_orig_line_entry_t));
   u32                    final_cnt = 0;
@@ -879,10 +879,10 @@ int potfile_handle_left (hashcat_ctx_t *hashcat_ctx)
   module_ctx_t  *module_ctx  = hashcat_ctx->module_ctx;
   potfile_ctx_t *potfile_ctx = hashcat_ctx->potfile_ctx;
 
-  hash_t *hashes_buf = hashes->hashes_buf;
+  u32     salts_cnt  = hashes->salts_cnt;
+  salt_t *salts_buf  = hashes->salts_buf;
 
-  u32     salts_cnt = hashes->salts_cnt;
-  salt_t *salts_buf = hashes->salts_buf;
+  hash_t *hashes_buf = hashes->hashes_buf;
 
   pot_orig_line_entry_t *final_buf = (pot_orig_line_entry_t *) hccalloc (hashes->hashes_cnt, sizeof (pot_orig_line_entry_t));
   u32                    final_cnt = 0;

--- a/src/restore.c
+++ b/src/restore.c
@@ -293,7 +293,6 @@ int restore_ctx_init (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
   if (user_options->hash_info       == true) return 0;
   if (user_options->keyspace        == true) return 0;
   if (user_options->left            == true) return 0;
-  if (user_options->backend_info    == true) return 0;
   if (user_options->show            == true) return 0;
   if (user_options->stdout_flag     == true) return 0;
   if (user_options->speed_only      == true) return 0;
@@ -302,6 +301,7 @@ int restore_ctx_init (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
   if (user_options->version         == true) return 0;
   if (user_options->identify        == true) return 0;
   if (user_options->restore_disable == true) return 0;
+  if (user_options->backend_info     > 0)    return 0;
 
   if (argc ==    0) return 0;
   if (argv == NULL) return 0;

--- a/src/straight.c
+++ b/src/straight.c
@@ -48,8 +48,8 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
   mask_ctx_t           *mask_ctx           = hashcat_ctx->mask_ctx;
   status_ctx_t         *status_ctx         = hashcat_ctx->status_ctx;
   straight_ctx_t       *straight_ctx       = hashcat_ctx->straight_ctx;
-  user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
   user_options_t       *user_options       = hashcat_ctx->user_options;
+  user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
 
   if (user_options->attack_mode == ATTACK_MODE_STRAIGHT)
   {
@@ -256,20 +256,20 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
 int straight_ctx_init (hashcat_ctx_t *hashcat_ctx)
 {
-  straight_ctx_t       *straight_ctx        = hashcat_ctx->straight_ctx;
-  user_options_extra_t *user_options_extra  = hashcat_ctx->user_options_extra;
-  user_options_t       *user_options        = hashcat_ctx->user_options;
+  straight_ctx_t       *straight_ctx       = hashcat_ctx->straight_ctx;
+  user_options_t       *user_options       = hashcat_ctx->user_options;
+  user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
 
   straight_ctx->enabled = false;
 
-  if (user_options->hash_info      == true) return 0;
-  if (user_options->left           == true) return 0;
-  if (user_options->backend_info   == true) return 0;
-  if (user_options->show           == true) return 0;
-  if (user_options->usage          == true) return 0;
-  if (user_options->version        == true) return 0;
+  if (user_options->left         == true) return 0;
+  if (user_options->show         == true) return 0;
+  if (user_options->usage        == true) return 0;
+  if (user_options->version      == true) return 0;
+  if (user_options->hash_info    == true) return 0;
+  if (user_options->backend_info  > 0)    return 0;
 
-  if (user_options->attack_mode == ATTACK_MODE_BF) return 0;
+  if (user_options->attack_mode  == ATTACK_MODE_BF) return 0;
 
   straight_ctx->enabled = true;
 
@@ -502,7 +502,6 @@ void straight_ctx_destroy (hashcat_ctx_t *hashcat_ctx)
   }
 
   hcfree (straight_ctx->dicts);
-
   hcfree (straight_ctx->kernel_rules_buf);
 
   memset (straight_ctx, 0, sizeof (straight_ctx_t));

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -75,7 +75,7 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
     event_log_info (hashcat_ctx, "%s (%s) starting in progress-only mode", PROGNAME, version_tag);
     event_log_info (hashcat_ctx, NULL);
   }
-  else if (user_options->backend_info == true)
+  else if (user_options->backend_info > 0)
   {
     event_log_info (hashcat_ctx, "%s (%s) starting in backend information mode", PROGNAME, version_tag);
     event_log_info (hashcat_ctx, NULL);
@@ -800,80 +800,84 @@ void hash_info (hashcat_ctx_t *hashcat_ctx)
 void backend_info (hashcat_ctx_t *hashcat_ctx)
 {
   const backend_ctx_t   *backend_ctx   = hashcat_ctx->backend_ctx;
+  const user_options_t  *user_options  = hashcat_ctx->user_options;
   const folder_config_t *folder_config = hashcat_ctx->folder_config;
 
-  event_log_info (hashcat_ctx, "System Info:");
-  event_log_info (hashcat_ctx, "============");
-  event_log_info (hashcat_ctx, NULL);
-
-  #if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
-  // TODO
-  event_log_info (hashcat_ctx, "OS.Name......: Windows");
-  event_log_info (hashcat_ctx, "OS.Release...: N/A");
-  event_log_info (hashcat_ctx, "HW.Platform..: N/A");
-  event_log_info (hashcat_ctx, "HW.Model.....: N/A");
-  #else
-
-  struct utsname utsbuf;
-
-  bool rc_uname  = false;
-  bool rc_sysctl = false;
-
-  char *hw_model_buf = NULL;
-
-  #if !defined (__linux__)
-
-  size_t hw_model_len = 0;
-
-  if (sysctlbyname ("hw.model", NULL, &hw_model_len, NULL, 0) == 0 && hw_model_len > 0)
+  if (user_options->backend_info > 1)
   {
-    hw_model_buf = (char *) hcmalloc (hw_model_len);
+    event_log_info (hashcat_ctx, "System Info:");
+    event_log_info (hashcat_ctx, "============");
+    event_log_info (hashcat_ctx, NULL);
 
-    if (sysctlbyname ("hw.model", hw_model_buf, &hw_model_len, NULL, 0) != 0)
+    #if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
+    // TODO
+    event_log_info (hashcat_ctx, "OS.Name......: Windows");
+    event_log_info (hashcat_ctx, "OS.Release...: N/A");
+    event_log_info (hashcat_ctx, "HW.Platform..: N/A");
+    event_log_info (hashcat_ctx, "HW.Model.....: N/A");
+    #else
+
+    struct utsname utsbuf;
+
+    bool rc_uname  = false;
+    bool rc_sysctl = false;
+
+    char *hw_model_buf = NULL;
+
+    #if !defined (__linux__)
+
+    size_t hw_model_len = 0;
+
+    if (sysctlbyname ("hw.model", NULL, &hw_model_len, NULL, 0) == 0 && hw_model_len > 0)
     {
-      hw_model_buf = NULL;
-      hw_model_len = 0;
+      hw_model_buf = (char *) hcmalloc (hw_model_len);
 
+      if (sysctlbyname ("hw.model", hw_model_buf, &hw_model_len, NULL, 0) != 0)
+      {
+        hw_model_buf = NULL;
+        hw_model_len = 0;
+
+        hcfree (hw_model_buf);
+      }
+      else
+      {
+        rc_sysctl = true;
+      }
+    }
+    #endif // ! __linux__
+
+    if (uname (&utsbuf) == 0)
+    {
+      rc_uname = true;
+    }
+
+    event_log_info (hashcat_ctx, "OS.Name......: %s", (rc_uname  == true) ? utsbuf.sysname : "N/A");
+    event_log_info (hashcat_ctx, "OS.Release...: %s", (rc_uname  == true) ? utsbuf.release : "N/A");
+    event_log_info (hashcat_ctx, "HW.Model.....: %s", (rc_sysctl == true) ? hw_model_buf   : "N/A");
+    event_log_info (hashcat_ctx, "HW.Platform..: %s", (rc_uname  == true) ? utsbuf.machine : "N/A");
+
+    if (rc_sysctl == true)
+    {
       hcfree (hw_model_buf);
     }
-    else
-    {
-      rc_sysctl = true;
-    }
+    #endif // _WIN || __CYGWIN__ || __MSYS__
+
+    event_log_info (hashcat_ctx, NULL);
+
+    event_log_info (hashcat_ctx, "Environment Info:");
+    event_log_info (hashcat_ctx, "=================");
+    event_log_info (hashcat_ctx, NULL);
+
+    event_log_info (hashcat_ctx, "Cur.Work.Dir.: %s", folder_config->cwd);
+    event_log_info (hashcat_ctx, "Install.Dir..: %s", folder_config->install_dir);
+    event_log_info (hashcat_ctx, "Profile.Dir..: %s", folder_config->profile_dir);
+    event_log_info (hashcat_ctx, "Cache.Dir....: %s", folder_config->cache_dir);
+    event_log_info (hashcat_ctx, "Session.Dir..: %s", folder_config->session_dir);
+    event_log_info (hashcat_ctx, "Shared.Dir...: %s", folder_config->shared_dir);
+    event_log_info (hashcat_ctx, "CL.Inc.Path..: %s", folder_config->cpath_real);
+
+    event_log_info (hashcat_ctx, NULL);
   }
-  #endif // ! __linux__
-
-  if (uname (&utsbuf) == 0)
-  {
-    rc_uname = true;
-  }
-
-  event_log_info (hashcat_ctx, "OS.Name......: %s", (rc_uname  == true) ? utsbuf.sysname : "N/A");
-  event_log_info (hashcat_ctx, "OS.Release...: %s", (rc_uname  == true) ? utsbuf.release : "N/A");
-  event_log_info (hashcat_ctx, "HW.Model.....: %s", (rc_sysctl == true) ? hw_model_buf   : "N/A");
-  event_log_info (hashcat_ctx, "HW.Platform..: %s", (rc_uname  == true) ? utsbuf.machine : "N/A");
-
-  if (rc_sysctl == true)
-  {
-    hcfree (hw_model_buf);
-  }
-  #endif // _WIN || __CYGWIN__ || __MSYS__
-
-  event_log_info (hashcat_ctx, NULL);
-
-  event_log_info (hashcat_ctx, "Environment Info:");
-  event_log_info (hashcat_ctx, "=================");
-  event_log_info (hashcat_ctx, NULL);
-
-  event_log_info (hashcat_ctx, "Cur.Work.Dir.: %s", folder_config->cwd);
-  event_log_info (hashcat_ctx, "Install.Dir..: %s", folder_config->install_dir);
-  event_log_info (hashcat_ctx, "Profile.Dir..: %s", folder_config->profile_dir);
-  event_log_info (hashcat_ctx, "Cache.Dir....: %s", folder_config->cache_dir);
-  event_log_info (hashcat_ctx, "Session.Dir..: %s", folder_config->session_dir);
-  event_log_info (hashcat_ctx, "Shared.Dir...: %s", folder_config->shared_dir);
-  event_log_info (hashcat_ctx, "CL.Inc.Path..: %s", folder_config->cpath_real);
-
-  event_log_info (hashcat_ctx, NULL);
 
   if (backend_ctx->cuda)
   {

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -799,7 +799,8 @@ void hash_info (hashcat_ctx_t *hashcat_ctx)
 
 void backend_info (hashcat_ctx_t *hashcat_ctx)
 {
-  const backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
+  const backend_ctx_t   *backend_ctx   = hashcat_ctx->backend_ctx;
+  const folder_config_t *folder_config = hashcat_ctx->folder_config;
 
   event_log_info (hashcat_ctx, "System Info:");
   event_log_info (hashcat_ctx, "============");
@@ -857,6 +858,20 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
     hcfree (hw_model_buf);
   }
   #endif // _WIN || __CYGWIN__ || __MSYS__
+
+  event_log_info (hashcat_ctx, NULL);
+
+  event_log_info (hashcat_ctx, "Environment Info:");
+  event_log_info (hashcat_ctx, "=================");
+  event_log_info (hashcat_ctx, NULL);
+
+  event_log_info (hashcat_ctx, "Cur.Work.Dir.: %s", folder_config->cwd);
+  event_log_info (hashcat_ctx, "Install.Dir..: %s", folder_config->install_dir);
+  event_log_info (hashcat_ctx, "Profile.Dir..: %s", folder_config->profile_dir);
+  event_log_info (hashcat_ctx, "Cache.Dir....: %s", folder_config->cache_dir);
+  event_log_info (hashcat_ctx, "Session.Dir..: %s", folder_config->session_dir);
+  event_log_info (hashcat_ctx, "Shared.Dir...: %s", folder_config->shared_dir);
+  event_log_info (hashcat_ctx, "CL.Inc.Path..: %s", folder_config->cpath_real);
 
   event_log_info (hashcat_ctx, NULL);
 

--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -47,24 +47,24 @@ int sort_by_tuning_db_entry (const void *v1, const void *v2)
 
 int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 {
-  folder_config_t *folder_config  = hashcat_ctx->folder_config;
   tuning_db_t     *tuning_db      = hashcat_ctx->tuning_db;
   user_options_t  *user_options   = hashcat_ctx->user_options;
+  folder_config_t *folder_config  = hashcat_ctx->folder_config;
 
   tuning_db->enabled = false;
 
-  if (user_options->hash_info     == true) return 0;
-  if (user_options->keyspace      == true) return 0;
-  if (user_options->left          == true) return 0;
-  if (user_options->backend_info  == true) return 0;
-  if (user_options->show          == true) return 0;
-  if (user_options->usage         == true) return 0;
-  if (user_options->version       == true) return 0;
-  if (user_options->identify      == true) return 0;
+  if (user_options->hash_info    == true) return 0;
+  if (user_options->keyspace     == true) return 0;
+  if (user_options->left         == true) return 0;
+  if (user_options->show         == true) return 0;
+  if (user_options->usage        == true) return 0;
+  if (user_options->version      == true) return 0;
+  if (user_options->identify     == true) return 0;
+  if (user_options->backend_info  > 0)    return 0;
 
   tuning_db->enabled = true;
 
-  char *tuning_db_file;
+  char *tuning_db_file = NULL;
 
   hc_asprintf (&tuning_db_file, "%s/%s", folder_config->shared_dir, TUNING_DB_FILE);
 
@@ -225,11 +225,11 @@ bool tuning_db_process_line (hashcat_ctx_t *hashcat_ctx, const char *line_buf, c
 
     char *device_name = token_ptr[0];
 
-    int attack_mode      = -1;
-    int hash_mode        = -1;
-    int vector_width     = -1;
-    int kernel_accel     = -1;
-    int kernel_loops     = -1;
+    int hash_mode     = -1;
+    int attack_mode   = -1;
+    int vector_width  = -1;
+    int kernel_accel  = -1;
+    int kernel_loops  = -1;
 
     if (token_ptr[1][0] != '*') attack_mode   = (int) strtol (token_ptr[1], NULL, 10);
     if (token_ptr[2][0] != '*') hash_mode     = (int) strtol (token_ptr[2], NULL, 10);
@@ -460,7 +460,7 @@ tuning_db_entry_t *tuning_db_search_real (hashcat_ctx_t *hashcat_ctx, const char
 
 tuning_db_entry_t *tuning_db_search (hashcat_ctx_t *hashcat_ctx, const char *device_name, const cl_device_type device_type, int attack_mode, const int hash_mode)
 {
-  tuning_db_entry_t *entry;
+  tuning_db_entry_t *entry = NULL;
 
   const char *NV_prefix = (const char *) "NVIDIA ";
 

--- a/src/usage.c
+++ b/src/usage.c
@@ -97,7 +97,7 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   "     --backend-ignore-hip       |      | Do not try to open HIP interface on startup          |",
   "     --backend-ignore-metal     |      | Do not try to open Metal interface on startup        |",
   "     --backend-ignore-opencl    |      | Do not try to open OpenCL interface on startup       |",
-  " -I, --backend-info             |      | Show info about detected backend API devices         | -I",
+  " -I, --backend-info             |      | Show system/evironment/backend API info              | -I or -II",
   " -d, --backend-devices          | Str  | Backend devices to use, separated with commas        | -d 1",
   " -D, --opencl-device-types      | Str  | OpenCL device-types to use, separated with commas    | -D 1",
   " -O, --optimized-kernel-enable  |      | Enable optimized kernels (limits password length)    |",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1382,7 +1382,7 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->backend_info > 2)
   {
-    event_log_error (hashcat_ctx, "Invalid --backend-info/-I value, must have a value greater than or equal to 0 and lower than 3.");
+    event_log_error (hashcat_ctx, "Invalid --backend-info/-I value, must have a value greater or equal to 0 and lower than 3.");
 
     return -1;
   }

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -465,7 +465,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_BACKEND_IGNORE_METAL:      user_options->backend_ignore_metal      = true;                            break;
       #endif
       case IDX_BACKEND_IGNORE_OPENCL:     user_options->backend_ignore_opencl     = true;                            break;
-      case IDX_BACKEND_INFO:              user_options->backend_info              = true;                            break;
+      case IDX_BACKEND_INFO:              user_options->backend_info++;                                              break;
       case IDX_BACKEND_DEVICES:           user_options->backend_devices           = optarg;                          break;
       case IDX_BACKEND_VECTOR_WIDTH:      user_options->backend_vector_width      = hc_strtoul (optarg, NULL, 10);
                                           user_options->backend_vector_width_chgd = true;                            break;
@@ -1380,6 +1380,13 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
+  if (user_options->backend_info > 2)
+  {
+    event_log_error (hashcat_ctx, "Invalid --backend-info/-I value, must have a value greater than or equal to 0 and lower than 3.");
+
+    return -1;
+  }
+
   #ifdef WITH_BRAIN
   if ((user_options->brain_client == true) && (user_options->remove == true))
   {
@@ -1481,7 +1488,7 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
       show_error = false;
     }
   }
-  else if (user_options->backend_info == true)
+  else if (user_options->backend_info > 0)
   {
     if (user_options->hc_argc == 0)
     {
@@ -1702,7 +1709,7 @@ void user_options_session_auto (hashcat_ctx_t *hashcat_ctx)
       user_options->session = "stdout";
     }
 
-    if (user_options->backend_info == true)
+    if (user_options->backend_info > 0)
     {
       user_options->session = "backend_info";
     }
@@ -1755,13 +1762,13 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     user_options->bitmap_max          = 1;
   }
 
-  if (user_options->hash_info       == true
-   || user_options->backend_info    == true
-   || user_options->keyspace        == true
-   || user_options->speed_only      == true
-   || user_options->progress_only   == true
-   || user_options->identify        == true
-   || user_options->usage           == true)
+  if (user_options->hash_info        == true
+   || user_options->keyspace         == true
+   || user_options->speed_only       == true
+   || user_options->progress_only    == true
+   || user_options->identify         == true
+   || user_options->usage            == true
+   || user_options->backend_info      > 0)
   {
     user_options->hwmon_disable       = true;
     user_options->left                = false;
@@ -1872,7 +1879,7 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
-  if (user_options->backend_info == true)
+  if (user_options->backend_info > 0)
   {
     user_options->backend_devices     = NULL;
     user_options->opencl_device_types = hcstrdup ("1,2,3");
@@ -1930,7 +1937,7 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     {
 
     }
-    else if (user_options->backend_info == true)
+    else if (user_options->backend_info > 0)
     {
 
     }
@@ -2176,7 +2183,7 @@ void user_options_extra_init (hashcat_ctx_t *hashcat_ctx)
   {
 
   }
-  else if (user_options->backend_info == true)
+  else if (user_options->backend_info > 0)
   {
 
   }

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -665,18 +665,18 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
 
 int wl_data_init (hashcat_ctx_t *hashcat_ctx)
 {
+  wl_data_t      *wl_data      = hashcat_ctx->wl_data;
   hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   user_options_t *user_options = hashcat_ctx->user_options;
-  wl_data_t      *wl_data      = hashcat_ctx->wl_data;
 
   wl_data->enabled = false;
 
-  if (user_options->benchmark      == true) return 0;
-  if (user_options->hash_info      == true) return 0;
-  if (user_options->left           == true) return 0;
-  if (user_options->backend_info   == true) return 0;
-  if (user_options->usage          == true) return 0;
-  if (user_options->version        == true) return 0;
+  if (user_options->benchmark    == true) return 0;
+  if (user_options->hash_info    == true) return 0;
+  if (user_options->left         == true) return 0;
+  if (user_options->usage        == true) return 0;
+  if (user_options->version      == true) return 0;
+  if (user_options->backend_info  > 0)    return 0;
 
   wl_data->enabled = true;
 


### PR DESCRIPTION
It is not beautiful, but it could be useful to debug potential issues and enabling it only for debug builds doesn't make sense.

Reference: https://github.com/hashcat/hashcat/issues/2827#issuecomment-1030776353

Sample output 

```
matrixs-MacBook-Pro:hashcat matrix$ ./hashcat -I
hashcat (v6.2.5-213-gae3eeb171+) starting in backend information mode

System Info:
============

OS.Name......: Darwin
OS.Release...: 17.7.0
HW.Model.....: MacBookPro11,1
HW.Platform..: x86_64

Environment Info:
=================

Cur.Work.Dir.: /Users/matrix/works/github/hashcat
Install.Dir..: /Users/matrix/works/github/hashcat
Profile.Dir..: /Users/matrix/works/github/hashcat
Cache.Dir....: /Users/matrix/works/github/hashcat
Session.Dir..: /Users/matrix/works/github/hashcat
Shared.Dir...: /Users/matrix/works/github/hashcat
CL.Inc.Path..: /Users/matrix/works/github/hashcat/OpenCL

Metal Info:
===========

Metal.Version.: 125.30

Backend Device ID #1
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Intel Iris Graphics
  Processor(s)...: 1
  Clock..........: N/A
  Memory.Total...: 1536 MB (limited to 1024 MB allocatable in one block)
  Memory.Free....: 1408 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Feature.Set....: macOS GPU Family 1 v3
  Registry.ID....: 968
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 1, removable 0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (May  7 2020 00:10:14)

  Backend Device ID #2
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
    Version........: OpenCL 1.2 
    Processor(s)...: 4
    Clock..........: 3000
    Memory.Total...: 8192 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 4064 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.1

  Backend Device ID #3
    Type...........: GPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Iris
    Version........: OpenCL 1.2 
    Processor(s)...: 40
    Clock..........: 1200
    Memory.Total...: 1536 MB (limited to 192 MB allocatable in one block)
    Memory.Free....: 704 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2(Oct 30 2020 14:39:13)

```