### PR TITLE
OpenCL Backend: show device_type in device list info on Apple Silicon

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -58,6 +58,7 @@
 - Metal Runtime: added support for vectors up to 4
 - OpenCL Backend: added workaround to make optimized kernels work on Apple Silicon
 - OpenCL Backend: moved functions to ext_OpenCL.c and includes to ext_OpenCL.h
+- OpenCL Backend: show device_type in device list info on Apple Silicon
 - OpenCL Kernel: Set native_threads to 32 on Apple GPU's for various hash-modes
 - OpenCL Runtime: Added support to use Apple Silicon compute devices
 - OpenCL Runtime: Add some unstable warnings detected on macOS

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1388,13 +1388,31 @@ void backend_info_compact (hashcat_ctx_t *hashcat_ctx)
 
         if ((device_param->skipped == false) && (device_param->skipped_warning == false))
         {
-          event_log_info (hashcat_ctx, "* Device #%u: %s, %" PRIu64 "/%" PRIu64 " MB (%" PRIu64 " MB allocatable), %uMCU",
-                    device_id + 1,
-                    device_name,
-                    device_available_mem / 1024 / 1024,
-                    device_global_mem    / 1024 / 1024,
-                    device_maxmem_alloc  / 1024 / 1024,
-                    device_processors);
+          if (strncmp (device_name, "Apple M", 7) == 0)
+          {
+            cl_device_type opencl_device_type = device_param->opencl_device_type;
+
+            const char *device_type_desc = ((opencl_device_type & CL_DEVICE_TYPE_CPU) ? "CPU" : ((opencl_device_type & CL_DEVICE_TYPE_GPU) ? "GPU" : "Accelerator"));
+
+            event_log_info (hashcat_ctx, "* Device #%u: %s, %s, %" PRIu64 "/%" PRIu64 " MB (%" PRIu64 " MB allocatable), %uMCU",
+                      device_id + 1,
+                      device_name,
+                      device_type_desc,
+                      device_available_mem / 1024 / 1024,
+                      device_global_mem    / 1024 / 1024,
+                      device_maxmem_alloc  / 1024 / 1024,
+                      device_processors);
+          }
+          else
+          {
+            event_log_info (hashcat_ctx, "* Device #%u: %s, %" PRIu64 "/%" PRIu64 " MB (%" PRIu64 " MB allocatable), %uMCU",
+                      device_id + 1,
+                      device_name,
+                      device_available_mem / 1024 / 1024,
+                      device_global_mem    / 1024 / 1024,
+                      device_maxmem_alloc  / 1024 / 1024,
+                      device_processors);
+          }
         }
         else
         {


### PR DESCRIPTION
Using OpenCL on Apple Silicon with an x86_64 binary, it is not possible to distinguish the device_type from the description printed in the output. Following two example:

1.  select all devices

```
bash-3.2$ arch -arch x86_64 ./hashcat -b -m 0 -D1,2 -d1,2 --backend-ignore-metal
hashcat (v6.2.5-213-gae3eeb171+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (Dec 17 2021 16:38:42)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, 8160/16384 MB (2048 MB allocatable), 8MCU
* Device #2: Apple M1, 5408/10922 MB (1024 MB allocatable), 8MCU

[...]
```

2.  select only device 1

```
bash-3.2$ arch -arch x86_64 ./hashcat -b -m 0 -D1,2 -d1 --backend-ignore-metal
hashcat (v6.2.5-213-gae3eeb171+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

OpenCL API (OpenCL 1.2 (Dec 17 2021 16:38:42)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, 8160/16384 MB (2048 MB allocatable), 8MCU
* Device #2: Apple M1, skipped

[...]
```


Consequently, it is necessary to specify it in order to give users a way to quickly recognize which device type (CPU or GPU) is currently used. Following the new output:

1.

```
bash-3.2$ arch -arch x86_64 ./hashcat -b -m 0 -D1,2 -d1,2 --backend-ignore-metal
hashcat (v6.2.5-213-gae3eeb171+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Apple's OpenCL drivers (GPU) are known to be unreliable.
             You have been warned.

OpenCL API (OpenCL 1.2 (Dec 17 2021 16:38:42)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, CPU, 8160/16384 MB (2048 MB allocatable), 8MCU
* Device #2: Apple M1, GPU, 5408/10922 MB (1024 MB allocatable), 8MCU

[...]
```

2. 

```
bash-3.2$ arch -arch x86_64 ./hashcat -b -m 0 -D1,2 -d1 --backend-ignore-metal
hashcat (v6.2.5-213-gae3eeb171+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

OpenCL API (OpenCL 1.2 (Dec 17 2021 16:38:42)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, CPU, 8160/16384 MB (2048 MB allocatable), 8MCU
* Device #2: Apple M1, skipped

[...]

```
Thanks :)