### PR TITLE
Fixed segfault on hc_mtlInvocationHelper() with valInt

### DIFF
--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -84,7 +84,13 @@ static int hc_mtlInvocationHelper (id target, SEL selector, void *returnValue)
   if ([target respondsToSelector: selector])
   {
     NSMethodSignature *signature = [object_getClass (target) instanceMethodSignatureForSelector: selector];
+
+    if (signature == nil) return -1;
+
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature: signature];
+
+    if (invocation == nil) return -1;
+
     [invocation setTarget: target];
     [invocation setSelector: selector];
     [invocation invoke];
@@ -377,7 +383,7 @@ int hc_mtlDeviceGetAttribute (void *hashcat_ctx, int *pi, metalDeviceAttribute_t
 
   uint64_t val64 = 0;
   bool valBool = false;
-  int valInt = 0;
+  unsigned long valULong = 0;
 
   switch (attrib)
   {
@@ -492,11 +498,11 @@ int hc_mtlDeviceGetAttribute (void *hashcat_ctx, int *pi, metalDeviceAttribute_t
       *pi = 0;
 
       SEL locationSelector = NSSelectorFromString(@"location");
-      valInt = 0;
+      valULong = 0;
 
-      hc_mtlInvocationHelper (metal_device, locationSelector, &valInt);
+      hc_mtlInvocationHelper (metal_device, locationSelector, &valULong);
 
-      *pi = valInt;
+      *pi = valULong;
 
       break;
 
@@ -505,10 +511,10 @@ int hc_mtlDeviceGetAttribute (void *hashcat_ctx, int *pi, metalDeviceAttribute_t
 
       SEL locationNumberSelector = NSSelectorFromString(@"locationNumber");
 
-      valInt = 0;
-      hc_mtlInvocationHelper (metal_device, locationNumberSelector, &valInt);
+      valULong = 0;
+      hc_mtlInvocationHelper (metal_device, locationNumberSelector, &valULong);
 
-      *pi = valInt;
+      *pi = valULong;
 
       break;
 


### PR DESCRIPTION
Fixed stack-buffer overflow when retrieving "location" and "locationNumber" due to wrong type.

<img width="837" alt="Screen Shot 2022-02-13 at 21 18 03" src="https://user-images.githubusercontent.com/15381185/153773237-dc19e314-3038-49ab-8ed9-2a6ad9ab2b35.png">

References:
https://developer.apple.com/documentation/metal/mtldevice/3114005-location?language=objc
https://developer.apple.com/documentation/metal/mtldevice/3114006-locationnumber?language=objc
https://developer.apple.com/documentation/objectivec/nsuinteger?language=objc