### PR TITLE
Hardware Monitor: Add support for GPU device utilization readings using iokit on Apple Silicon (OpenCL and Metal)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -50,6 +50,7 @@
 - Backend Info: Added local memory size to output
 - Backend: with kernel build options, switch from -I to -D INCLUDE_PATH, in order to support Apple Metal runtime
 - CUDA Backend: moved functions to ext_cuda.c/ext_nvrtc.c and includes to ext_cuda.h/ext_nvrtc.h
+- Hardware Monitor: Add support for GPU device utilization readings using iokit on Apple Silicon (OpenCL and Metal)
 - Hash Info: show more information (Updated Hash-Format. Added Autodetect, Self-Test, Potfile and Plaintext encoding)
 - HIP Backend: moved functions to ext_hip.c/ext_hiprtc.c and includes to ext_hip.h/ext_hiprtc.h
 - Kernels: Refactored standard kernel declaration to use a structure holding u32/u64 attributes to reduce the number of attributes

--- a/include/ext_iokit.h
+++ b/include/ext_iokit.h
@@ -111,7 +111,7 @@ typedef struct hm_iokit_lib
 typedef hm_iokit_lib_t IOKIT_PTR;
 
 #if defined(__APPLE__)
-UInt32 hm_IOKIT_strtoul (char *str, int size, int base);
+UInt32 hm_IOKIT_strtoul (const char *str, int size, int base);
 void hm_IOKIT_ultostr (char *str, UInt32 val);
 kern_return_t hm_IOKIT_SMCOpen (void *hashcat_ctx, io_connect_t *conn);
 kern_return_t hm_IOKIT_SMCClose (io_connect_t conn);
@@ -121,6 +121,7 @@ int hm_IOKIT_SMCGetSensorGraphicHot (void *hashcat_ctx);
 int hm_IOKIT_SMCGetTemperature (void *hashcat_ctx, char *key, double *temp);
 bool hm_IOKIT_SMCGetFanRPM (char *key, io_connect_t conn, float *ret);
 int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf);
+int hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization);
 bool iokit_init (void *hashcat_ctx);
 bool iokit_close (void *hashcat_ctx);
 #endif // __APPLE__

--- a/src/backend.c
+++ b/src/backend.c
@@ -6746,10 +6746,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
           #if defined (__APPLE__)
           if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
           {
-            if (device_param->skipped == false)
-            {
-              need_iokit = true;
-            }
+            need_iokit = true;
           }
           #endif
 
@@ -6778,16 +6775,15 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
             #endif
           }
 
+          #if defined (__APPLE__)
           if (strncmp (device_param->device_name, "Apple M", 7) == 0)
           {
             if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
             {
-              if (device_param->skipped == false)
-              {
-                need_iokit = true;
-              }
+              need_iokit = true;
             }
           }
+          #endif
         }
 
         if (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU)

--- a/src/backend.c
+++ b/src/backend.c
@@ -6777,6 +6777,17 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
             need_nvapi = true;
             #endif
           }
+
+          if (strncmp (device_param->device_name, "Apple M", 7) == 0)
+          {
+            if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
+            {
+              if (device_param->skipped == false)
+              {
+                need_iokit = true;
+              }
+            }
+          }
         }
 
         if (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU)

--- a/src/ext_iokit.c
+++ b/src/ext_iokit.c
@@ -249,29 +249,36 @@ int hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization)
     {
       // Service dictionary creation failed.
       IOObjectRelease (regEntry);
+
       continue;
     }
 
-    CFMutableDictionaryRef perf_properties = (CFMutableDictionaryRef) CFDictionaryGetValue( serviceDictionary, CFSTR("PerformanceStatistics"));
+    CFMutableDictionaryRef perf_properties = (CFMutableDictionaryRef) CFDictionaryGetValue (serviceDictionary, CFSTR ("PerformanceStatistics"));
+
     if (perf_properties)
     {
-      static ssize_t gpuCoreUtil=0;
-      const void* gpuCoreUtilization = CFDictionaryGetValue(perf_properties, CFSTR("Device Utilization %"));
-      if (gpuCoreUtilization)
+      static ssize_t gpuCoreUtil = 0;
+
+      const void *gpuCoreUtilization = CFDictionaryGetValue (perf_properties, CFSTR ("Device Utilization %"));
+
+      if (gpuCoreUtilization != NULL)
       {
-        CFNumberGetValue( gpuCoreUtilization, kCFNumberSInt64Type, &gpuCoreUtil);
+        CFNumberGetValue (gpuCoreUtilization, kCFNumberSInt64Type, &gpuCoreUtil);
+
         *utilization = gpuCoreUtil;
 
         rc = true;
       }
     }
 
-    CFRelease(serviceDictionary);
+    CFRelease (serviceDictionary);
+
     IOObjectRelease (regEntry);
-    IOObjectRelease(iterator);
 
     if (rc == true) break;
   }
+
+  IOObjectRelease (iterator);
 
   return rc;
 }

--- a/src/ext_iokit.c
+++ b/src/ext_iokit.c
@@ -13,7 +13,7 @@
 #if defined (__APPLE__)
 #include <IOKit/IOKitLib.h>
 
-UInt32 hm_IOKIT_strtoul (char *str, int size, int base)
+UInt32 hm_IOKIT_strtoul (const char *str, int size, int base)
 {
   int i;
 
@@ -221,6 +221,59 @@ bool hm_IOKIT_SMCGetFanRPM (char *key, io_connect_t conn, float *ret)
   *ret = -1.f;
 
   return false;
+}
+
+int hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization)
+{
+  bool rc = false;
+
+  io_iterator_t iterator;
+
+  CFMutableDictionaryRef matching = IOServiceMatching ("IOAccelerator");
+
+  if (IOServiceGetMatchingServices (kIOMasterPortDefault, matching, &iterator) != kIOReturnSuccess)
+  {
+    event_log_error (hashcat_ctx, "IOServiceGetMatchingServices(): failure");
+
+    return rc;
+  }
+
+  io_registry_entry_t regEntry;
+
+  while ((regEntry = IOIteratorNext (iterator)))
+  {
+    // Put this services object into a dictionary object.
+    CFMutableDictionaryRef serviceDictionary;
+
+    if (IORegistryEntryCreateCFProperties (regEntry, &serviceDictionary, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess)
+    {
+      // Service dictionary creation failed.
+      IOObjectRelease (regEntry);
+      continue;
+    }
+
+    CFMutableDictionaryRef perf_properties = (CFMutableDictionaryRef) CFDictionaryGetValue( serviceDictionary, CFSTR("PerformanceStatistics"));
+    if (perf_properties)
+    {
+      static ssize_t gpuCoreUtil=0;
+      const void* gpuCoreUtilization = CFDictionaryGetValue(perf_properties, CFSTR("Device Utilization %"));
+      if (gpuCoreUtilization)
+      {
+        CFNumberGetValue( gpuCoreUtilization, kCFNumberSInt64Type, &gpuCoreUtil);
+        *utilization = gpuCoreUtil;
+
+        rc = true;
+      }
+    }
+
+    CFRelease(serviceDictionary);
+    IOObjectRelease (regEntry);
+    IOObjectRelease(iterator);
+
+    if (rc == true) break;
+  }
+
+  return rc;
 }
 
 int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf)


### PR DESCRIPTION
Examples:

1. **Metal GPU**

```
% arch -arch x86_64 ./hashcat -m 0 '8743b52063cd84097a65d1633f5c74f5' -a 3 '?a?b?h?l?d' --potfile-disable --backend-ignore-opencl -D 2
[...]
METAL API (Metal 258.18)
========================
* Device #1: Apple M1, 5408/10922 MB, 8MCU
[...]
Session..........: hashcat                                
Status...........: Exhausted
Hash.Mode........: 0 (MD5)
Hash.Target......: 8743b52063cd84097a65d1633f5c74f5
Time.Started.....: Tue Feb 15 22:17:04 2022 (0 secs)
Time.Estimated...: Tue Feb 15 22:17:04 2022 (0 secs)
Kernel.Feature...: Pure Kernel
Guess.Mask.......: ?a?b?h?l?d [5]
Guess.Queue......: 1/1 (100.00%)
Speed.#1.........:   854.8 MH/s (5.14ms) @ Accel:512 Loops:95 Thr:32 Vec:1
Recovered........: 0/1 (0.00%) Digests
Progress.........: 101171200/101171200 (100.00%)
Rejected.........: 0/101171200 (0.00%)
Restore.Point....: 1064960/1064960 (100.00%)
Restore.Sub.#1...: Salt:0 Amplifier:0-95 Iteration:0-95
Candidate.Engine.: Device Generator
Candidates.#1....: $HEX[7361627136] -> $HEX[2000667136]
Hardware.Mon.SMC.: Fan0: 37%
Hardware.Mon.#1..: Util: 89%
```

2. **OpenCL CPU** 

```
% arch -arch x86_64 ./hashcat -m 0 '8743b52063cd84097a65d1633f5c74f5' -a 3 '?a?b?h?l?d' --potfile-disable --backend-ignore-metal -D 1 
[...]
OpenCL API (OpenCL 1.2 (Dec 17 2021 16:38:42)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, CPU, 8160/16384 MB (2048 MB allocatable), 8MCU
* Device #2: Apple M1, skipped
[...]
Session..........: hashcat                                
Status...........: Exhausted
Hash.Mode........: 0 (MD5)
Hash.Target......: 8743b52063cd84097a65d1633f5c74f5
Time.Started.....: Tue Feb 15 22:24:36 2022 (1 sec)
Time.Estimated...: Tue Feb 15 22:24:37 2022 (0 secs)
Kernel.Feature...: Pure Kernel
Guess.Mask.......: ?a?b?h?l?d [5]
Guess.Queue......: 1/1 (100.00%)
Speed.#1.........: 81081.2 kH/s (9.36ms) @ Accel:1024 Loops:95 Thr:1 Vec:4
Recovered........: 0/1 (0.00%) Digests
Progress.........: 101171200/101171200 (100.00%)
Rejected.........: 0/101171200 (0.00%)
Restore.Point....: 1064960/1064960 (100.00%)
Restore.Sub.#1...: Salt:0 Amplifier:0-95 Iteration:0-95
Candidate.Engine.: Device Generator
Candidates.#1....: $HEX[7361627835] -> $HEX[2000667136]
[...]
```

3. **OpenCL GPU**

```
% arch -arch x86_64 ./hashcat -m 0 '8743b52063cd84097a65d1633f5c74f5' -a 3 '?a?b?h?l?d' --potfile-disable --backend-ignore-metal -D 2 
[...]
OpenCL API (OpenCL 1.2 (Dec 17 2021 16:38:42)) - Platform #1 [Apple]
====================================================================
* Device #1: Apple M1, skipped
* Device #2: Apple M1, GPU, 5408/10922 MB (1024 MB allocatable), 8MCU
[...]
Session..........: hashcat                                
Status...........: Exhausted
Hash.Mode........: 0 (MD5)
Hash.Target......: 8743b52063cd84097a65d1633f5c74f5
Time.Started.....: Tue Feb 15 22:21:11 2022 (0 secs)
Time.Estimated...: Tue Feb 15 22:21:11 2022 (0 secs)
Kernel.Feature...: Pure Kernel
Guess.Mask.......: ?a?b?h?l?d [5]
Guess.Queue......: 1/1 (100.00%)
Speed.#2.........:  1007.5 MH/s (2.67ms) @ Accel:128 Loops:47 Thr:256 Vec:1
Recovered........: 0/1 (0.00%) Digests
Progress.........: 101171200/101171200 (100.00%)
Rejected.........: 0/101171200 (0.00%)
Restore.Point....: 1064960/1064960 (100.00%)
Restore.Sub.#2...: Salt:0 Amplifier:94-95 Iteration:0-47
Candidate.Engine.: Device Generator
Candidates.#2....: $HEX[2061627136] -> $HEX[2000667136]
Hardware.Mon.SMC.: Fan0: 37%
Hardware.Mon.#2..: Util: 91%
```