### PR TITLE
Fixed backend active devices checks

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -24,6 +24,7 @@
 ##
 
 - Fixed building error on Raspberry Pi
+- Fixed backend active devices checks
 - Fixed false negative on Unit Test in case of out-of-memory with grep in single mode
 - Fixed false negative on Unit Test with hash-type 25400
 - Fixed false negative on hash-types 4510 and 4710 for hashes with long salts


### PR DESCRIPTION
Hi,

I found this bug on windows with Intel OneApi drivers installed.
In the first round hashcat enum all the active devices and set the initial backend_devices_active counter. 
Later:

- if the backend is Metal, try to create the command queue
- if the backend is OpenCL, try to create both the context and the command queue

If one of these initializations fails, the counter of the active devices is not updated.

For example in the case of a benchmark, the hash-mode was printed but not the speed, since in reality there was no device on which to perform it.

Thanks :)