### PR TITLE
Improved management of systems with multiple OpenCL platforms and show empty OpenCL platforms only in backend information mode

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -50,6 +50,7 @@
 - Backend Info: Added generic system info to output (must be completed on Windows side)
 - Backend Info: Added local memory size to output
 - Backend: with kernel build options, switch from -I to -D INCLUDE_PATH, in order to support Apple Metal runtime
+- Backend: improved management of systems with multiple OpenCL platforms
 - CUDA Backend: moved functions to ext_cuda.c/ext_nvrtc.c and includes to ext_cuda.h/ext_nvrtc.h
 - Hardware Monitor: Add support for GPU device utilization readings using iokit on Apple Silicon (OpenCL and Metal)
 - Hash Info: show more information (Updated Hash-Format. Added Autodetect, Self-Test, Potfile and Plaintext encoding)
@@ -68,6 +69,7 @@
 - OpenCL Runtime: Set default device-type to GPU with Apple Silicon compute devices
 - Status code: updated negative status code (added kernel create failure and resync)
 - Status code: updated negative status code, usefull in Unit tests engine (test.sh)
+- Terminal: show empty OpenCL platforms only in backend information mode
 - Tuning Database: Added a warning if a module implements module_extra_tuningdb_block but the installed computing device is not found
 - Unit tests: added -r (--runtime) option
 - Unit tests: handle negative status code, skip deprecated hash-types, skip hash-types with known perl modules issues, updated output

--- a/src/ext_OpenCL.c
+++ b/src/ext_OpenCL.c
@@ -456,7 +456,12 @@ int hc_clGetDeviceIDs (void *hashcat_ctx, cl_platform_id platform, cl_device_typ
 
   if (CL_err != CL_SUCCESS)
   {
-    event_log_error (hashcat_ctx, "clGetDeviceIDs(): %s", val2cstr_cl (CL_err));
+    #ifndef DEBUG
+    if (CL_err != CL_DEVICE_NOT_FOUND)
+    #endif
+    {
+      event_log_error (hashcat_ctx, "clGetDeviceIDs(): %s", val2cstr_cl (CL_err));
+    }
 
     return -1;
   }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1382,6 +1382,9 @@ void backend_info_compact (hashcat_ctx_t *hashcat_ctx)
       char     *opencl_platform_version      = opencl_platforms_version[opencl_platforms_idx];
       cl_uint   opencl_platform_devices_cnt  = opencl_platforms_devices_cnt[opencl_platforms_idx];
 
+      // hide empty OpenCL platforms
+      if (opencl_platform_devices_cnt == 0) continue;
+
       const size_t len = event_log_info (hashcat_ctx, "OpenCL API (%s) - Platform #%u [%s]", opencl_platform_version, opencl_platforms_idx + 1, opencl_platform_vendor);
 
       char line[HCBUFSIZ_TINY] = { 0 };


### PR DESCRIPTION
Hi,

other minor issues found on Windows with OneApi drivers.

Changes:
- remove duplicated and not useful errors in case of system with crap OpenCL platforms
- prevent potential early exit in case of system with multiple OpenCL platforms
- hide empty (without devices) OpenCL platforms from standard output (keep it in backend information mode)

Following some example (focus on errors and OpenCL Platform ID 3).

Output before this PR:

```
PS C:\Users\matrix\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\rootfs\home\matrix\hash cat> .\hashcat.exe -I
hashcat (v6.2.5-245-g24de156ce) starting in backend information mode

clGetDeviceIDs(): CL_DEVICE_NOT_FOUND

clGetDeviceIDs(): CL_DEVICE_NOT_FOUND

clCreateContext(): CL_OUT_OF_HOST_MEMORY

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) OpenCL HD Graphics
  Version.: OpenCL 2.1

  Backend Device ID #1
    Type...........: GPU
    Vendor.ID......: 8
    Vendor.........: Intel(R) Corporation
    Name...........: Intel(R) UHD Graphics
    Version........: OpenCL 2.1 NEO
    Processor(s)...: 24
    Clock..........: 1150
    Memory.Total...: 26135 MB (limited to 2047 MB allocatable in one block)
    Memory.Free....: 13024 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 2.0
    Driver.Version.: 27.20.100.8681

OpenCL Platform ID #2
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) FPGA Emulation Platform for OpenCL(TM)
  Version.: OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3

  Backend Device ID #2
    Type...........: Accelerator
    Vendor.ID......: 8
    Vendor.........: Intel(R) Corporation
    Name...........: Intel(R) FPGA Emulation Device
    Version........: OpenCL 1.2
    Processor(s)...: 12
    Clock..........: 1100
    Memory.Total...: 65339 MB (limited to 8167 MB allocatable in one block)
    Memory.Free....: 0 MB
    Local.Memory...: 256 KB
    OpenCL.Version.: OpenCL C 1.2
    Driver.Version.: 2021.13.11.0.23_160000

OpenCL Platform ID #3
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) FPGA SDK for OpenCL(TM)
  Version.: OpenCL 1.0 Intel(R) FPGA SDK for OpenCL(TM), Version 2022.1

OpenCL Platform ID #4
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) OpenCL
  Version.: OpenCL 3.0 WINDOWS

  Backend Device ID #3
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel(R) Corporation
    Name...........: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
    Version........: OpenCL 3.0 (Build 0)
    Processor(s)...: 12
    Clock..........: 1100
    Memory.Total...: 65339 MB (limited to 8167 MB allocatable in one block)
    Memory.Free....: 32637 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 3.0
    Driver.Version.: 2021.13.11.0.23_160000

PS C:\Users\matrix\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\rootfs\home\matrix\hash cat> .\hashcat.exe -m 0 -b -D 1
hashcat (v6.2.5-245-g24de156ce) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

clGetDeviceIDs(): CL_DEVICE_NOT_FOUND

clGetDeviceIDs(): CL_DEVICE_NOT_FOUND

OpenCL API (OpenCL 2.1 ) - Platform #1 [Intel(R) Corporation]
=============================================================
* Device #1: Intel(R) UHD Graphics, skipped

OpenCL API (OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3) - Platform #2 [Intel(R) Corporation]
===========================================================================================================
* Device #2: Intel(R) FPGA Emulation Device, skipped

OpenCL API (OpenCL 1.0 Intel(R) FPGA SDK for OpenCL(TM), Version 2022.1) - Platform #3 [Intel(R) Corporation]
=============================================================================================================

OpenCL API (OpenCL 3.0 WINDOWS) - Platform #4 [Intel(R) Corporation]
====================================================================
* Device #3: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz, 32637/65339 MB (8167 MB allocatable), 12MCU

Benchmark relevant options:
===========================
* --opencl-device-types=1
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#3.........:   708.3 MH/s (17.92ms) @ Accel:1024 Loops:1024 Thr:1 Vec:8

Started: Sat Feb 19 21:01:03 2022
Stopped: Sat Feb 19 21:01:28 2022

PS C:\Users\matrix\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\rootfs\home\matrix\hash cat> .\hashcat.exe -m 0 -b -D 3
hashcat (v6.2.5-245-g24de156ce) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

clGetDeviceIDs(): CL_DEVICE_NOT_FOUND

clGetDeviceIDs(): CL_DEVICE_NOT_FOUND

clCreateContext(): CL_OUT_OF_HOST_MEMORY

No devices found/left.

Started: Sat Feb 19 21:01:30 2022
Stopped: Sat Feb 19 21:01:31 2022
```

Output after this PR:

```
PS C:\Users\matrix\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\rootfs\home\matrix\hash cat> .\hashcat.exe -I
hashcat (v6.2.5-245-g24de156ce+) starting in backend information mode

clCreateContext(): CL_OUT_OF_HOST_MEMORY

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) OpenCL HD Graphics
  Version.: OpenCL 2.1

  Backend Device ID #1
    Type...........: GPU
    Vendor.ID......: 8
    Vendor.........: Intel(R) Corporation
    Name...........: Intel(R) UHD Graphics
    Version........: OpenCL 2.1 NEO
    Processor(s)...: 24
    Clock..........: 1150
    Memory.Total...: 26135 MB (limited to 2047 MB allocatable in one block)
    Memory.Free....: 13024 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 2.0
    Driver.Version.: 27.20.100.8681

OpenCL Platform ID #2
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) FPGA Emulation Platform for OpenCL(TM)
  Version.: OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3

  Backend Device ID #2
    Type...........: Accelerator
    Vendor.ID......: 8
    Vendor.........: Intel(R) Corporation
    Name...........: Intel(R) FPGA Emulation Device
    Version........: OpenCL 1.2
    Processor(s)...: 12
    Clock..........: 1100
    Memory.Total...: 65339 MB (limited to 8167 MB allocatable in one block)
    Memory.Free....: 0 MB
    Local.Memory...: 256 KB
    OpenCL.Version.: OpenCL C 1.2
    Driver.Version.: 2021.13.11.0.23_160000

OpenCL Platform ID #3
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) FPGA SDK for OpenCL(TM)
  Version.: OpenCL 1.0 Intel(R) FPGA SDK for OpenCL(TM), Version 2022.1

OpenCL Platform ID #4
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) OpenCL
  Version.: OpenCL 3.0 WINDOWS

  Backend Device ID #3
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel(R) Corporation
    Name...........: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
    Version........: OpenCL 3.0 (Build 0)
    Processor(s)...: 12
    Clock..........: 1100
    Memory.Total...: 65339 MB (limited to 8167 MB allocatable in one block)
    Memory.Free....: 32637 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 3.0
    Driver.Version.: 2021.13.11.0.23_160000

PS C:\Users\matrix\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\rootfs\home\matrix\hash cat> .\hashcat.exe -m 0 -b -D 1
hashcat (v6.2.5-245-g24de156ce+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

OpenCL API (OpenCL 2.1 ) - Platform #1 [Intel(R) Corporation]
=============================================================
* Device #1: Intel(R) UHD Graphics, skipped

OpenCL API (OpenCL 1.2 Intel(R) FPGA SDK for OpenCL(TM), Version 20.3) - Platform #2 [Intel(R) Corporation]
===========================================================================================================
* Device #2: Intel(R) FPGA Emulation Device, skipped

OpenCL API (OpenCL 3.0 WINDOWS) - Platform #4 [Intel(R) Corporation]
====================================================================
* Device #3: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz, 32637/65339 MB (8167 MB allocatable), 12MCU

Benchmark relevant options:
===========================
* --opencl-device-types=1
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#3.........:   839.8 MH/s (15.19ms) @ Accel:1024 Loops:1024 Thr:1 Vec:8

Started: Sat Feb 19 20:56:34 2022
Stopped: Sat Feb 19 20:56:57 2022

PS C:\Users\matrix\AppData\Local\Packages\CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc\LocalState\rootfs\home\matrix\hash cat> .\hashcat.exe -m 0 -b -D 3
hashcat (v6.2.5-245-g24de156ce+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

clCreateContext(): CL_OUT_OF_HOST_MEMORY

No devices found/left.

Started: Sat Feb 19 20:57:11 2022
Stopped: Sat Feb 19 20:57:11 2022
```

Thanks :)