### PR TITLE
Added hash-mode: Amazon AWS4-HMAC-SHA256

### DIFF
--- a/OpenCL/m28700_a0-optimized.cl
+++ b/OpenCL/m28700_a0-optimized.cl
@@ -1,0 +1,752 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.h)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct aws4_sig_v4
+{
+  u32 date[3];
+  u32 date_len;
+
+  u32 longdate[4];
+  u32 longdate_len;
+
+  u32 region[4];
+  u32 region_len;
+
+  u32 service[4];
+  u32 service_len;
+
+  u32 canonical[8];
+  u32 canonical_len;
+
+  u32 stringtosign[64];
+  u32 stringtosign_len;
+
+} aws4_sig_v4_t;
+
+DECLSPEC void hmac_sha256_pad (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad)
+{
+  w0[0] = w0[0] ^ 0x36363636;
+  w0[1] = w0[1] ^ 0x36363636;
+  w0[2] = w0[2] ^ 0x36363636;
+  w0[3] = w0[3] ^ 0x36363636;
+  w1[0] = w1[0] ^ 0x36363636;
+  w1[1] = w1[1] ^ 0x36363636;
+  w1[2] = w1[2] ^ 0x36363636;
+  w1[3] = w1[3] ^ 0x36363636;
+  w2[0] = w2[0] ^ 0x36363636;
+  w2[1] = w2[1] ^ 0x36363636;
+  w2[2] = w2[2] ^ 0x36363636;
+  w2[3] = w2[3] ^ 0x36363636;
+  w3[0] = w3[0] ^ 0x36363636;
+  w3[1] = w3[1] ^ 0x36363636;
+  w3[2] = w3[2] ^ 0x36363636;
+  w3[3] = w3[3] ^ 0x36363636;
+
+  ipad[0] = SHA256M_A;
+  ipad[1] = SHA256M_B;
+  ipad[2] = SHA256M_C;
+  ipad[3] = SHA256M_D;
+  ipad[4] = SHA256M_E;
+  ipad[5] = SHA256M_F;
+  ipad[6] = SHA256M_G;
+  ipad[7] = SHA256M_H;
+
+  sha256_transform_vector (w0, w1, w2, w3, ipad);
+
+  w0[0] = w0[0] ^ 0x6a6a6a6a;
+  w0[1] = w0[1] ^ 0x6a6a6a6a;
+  w0[2] = w0[2] ^ 0x6a6a6a6a;
+  w0[3] = w0[3] ^ 0x6a6a6a6a;
+  w1[0] = w1[0] ^ 0x6a6a6a6a;
+  w1[1] = w1[1] ^ 0x6a6a6a6a;
+  w1[2] = w1[2] ^ 0x6a6a6a6a;
+  w1[3] = w1[3] ^ 0x6a6a6a6a;
+  w2[0] = w2[0] ^ 0x6a6a6a6a;
+  w2[1] = w2[1] ^ 0x6a6a6a6a;
+  w2[2] = w2[2] ^ 0x6a6a6a6a;
+  w2[3] = w2[3] ^ 0x6a6a6a6a;
+  w3[0] = w3[0] ^ 0x6a6a6a6a;
+  w3[1] = w3[1] ^ 0x6a6a6a6a;
+  w3[2] = w3[2] ^ 0x6a6a6a6a;
+  w3[3] = w3[3] ^ 0x6a6a6a6a;
+
+  opad[0] = SHA256M_A;
+  opad[1] = SHA256M_B;
+  opad[2] = SHA256M_C;
+  opad[3] = SHA256M_D;
+  opad[4] = SHA256M_E;
+  opad[5] = SHA256M_F;
+  opad[6] = SHA256M_G;
+  opad[7] = SHA256M_H;
+
+  sha256_transform_vector (w0, w1, w2, w3, opad);
+}
+
+DECLSPEC void hmac_sha256_run (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad, PRIVATE_AS u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+  digest[5] = ipad[5];
+  digest[6] = ipad[6];
+  digest[7] = ipad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = digest[5];
+  w1[2] = digest[6];
+  w1[3] = digest[7];
+  w2[0] = 0x80000000;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 32) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+  digest[5] = opad[5];
+  digest[6] = opad[6];
+  digest[7] = opad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+}
+
+KERNEL_FQ void m28700_m04 (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4] = { 0 };
+  u32 pw_buf1[4] = { 0 };
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * date
+   */
+
+  u32x date_buf0[4] = { 0 };
+
+  date_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 0]);
+  date_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 1]);
+  date_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 2]);
+  date_buf0[3] = 0;
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  /**
+   * region
+   */
+
+  u32x region_buf0[4] = { 0 };
+
+  region_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 0]);
+  region_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 1]);
+  region_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 2]);
+  region_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 3]);
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  /**
+   * service
+   */
+
+  u32x service_buf0[4] = { 0 };
+
+  service_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 0]);
+  service_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 1]);
+  service_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 2]);
+  service_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 3]);
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  /**
+   * stringtosign
+   */
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0_t[4] = { 0 };
+    u32x w1_t[4] = { 0 };
+
+    u32x ipad[8];
+    u32x opad[8];
+
+    u32x digest[8];
+
+    apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0_t, w1_t);
+
+    // kdate
+
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    w0[0] = 0x41575334;
+    w0[1] = hc_swap32 (w0_t[0]);
+    w0[2] = hc_swap32 (w0_t[1]);
+    w0[3] = hc_swap32 (w0_t[2]);
+    w1[0] = hc_swap32 (w0_t[3]);
+    w1[1] = hc_swap32 (w1_t[0]);
+    w1[2] = hc_swap32 (w1_t[1]);
+    w1[3] = hc_swap32 (w1_t[2]);
+    w2[0] = hc_swap32 (w1_t[3]);
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = date_buf0[0];
+    w0[1] = date_buf0[1];
+    w0[2] = date_buf0[2];
+    w0[3] = date_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + date_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kregion
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = region_buf0[0];
+    w0[1] = region_buf0[1];
+    w0[2] = region_buf0[2];
+    w0[3] = region_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + region_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kservice
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = service_buf0[0];
+    w0[1] = service_buf0[1];
+    w0[2] = service_buf0[2];
+    w0[3] = service_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + service_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signingkey
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0x80000000;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + 12) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signature
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_m08 (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+}
+
+KERNEL_FQ void m28700_m16 (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+}
+
+KERNEL_FQ void m28700_s04 (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * base
+   */
+
+  if (gid >= GID_CNT) return;
+
+  u32 pw_buf0[4] = { 0 };
+  u32 pw_buf1[4] = { 0 };
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * date
+   */
+
+  u32x date_buf0[4] = { 0 };
+
+  date_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 0]);
+  date_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 1]);
+  date_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 2]);
+  date_buf0[3] = 0;
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  /**
+   * region
+   */
+
+  u32x region_buf0[4] = { 0 };
+
+  region_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 0]);
+  region_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 1]);
+  region_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 2]);
+  region_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 3]);
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  /**
+   * service
+   */
+
+  u32x service_buf0[4] = { 0 };
+
+  service_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 0]);
+  service_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 1]);
+  service_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 2]);
+  service_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 3]);
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  /**
+   * stringtosign
+   */
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0_t[4] = { 0 };
+    u32x w1_t[4] = { 0 };
+
+    u32x ipad[8];
+    u32x opad[8];
+
+    u32x digest[8];
+
+    apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0_t, w1_t);
+
+    // kdate
+
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    w0[0] = 0x41575334;
+    w0[1] = hc_swap32 (w0_t[0]);
+    w0[2] = hc_swap32 (w0_t[1]);
+    w0[3] = hc_swap32 (w0_t[2]);
+    w1[0] = hc_swap32 (w0_t[3]);
+    w1[1] = hc_swap32 (w1_t[0]);
+    w1[2] = hc_swap32 (w1_t[1]);
+    w1[3] = hc_swap32 (w1_t[2]);
+    w2[0] = hc_swap32 (w1_t[3]);
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = date_buf0[0];
+    w0[1] = date_buf0[1];
+    w0[2] = date_buf0[2];
+    w0[3] = date_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + date_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kregion
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = region_buf0[0];
+    w0[1] = region_buf0[1];
+    w0[2] = region_buf0[2];
+    w0[3] = region_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + region_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kservice
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = service_buf0[0];
+    w0[1] = service_buf0[1];
+    w0[2] = service_buf0[2];
+    w0[3] = service_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + service_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signingkey
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0x80000000;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + 12) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signature
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_s08 (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+}
+
+KERNEL_FQ void m28700_s16 (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+}

--- a/OpenCL/m28700_a0-pure.cl
+++ b/OpenCL/m28700_a0-pure.cl
@@ -1,0 +1,503 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct aws4_sig_v4
+{
+  u32 date[3];
+  u32 date_len;
+
+  u32 longdate[4];
+  u32 longdate_len;
+
+  u32 region[4];
+  u32 region_len;
+
+  u32 service[4];
+  u32 service_len;
+
+  u32 canonical[8];
+  u32 canonical_len;
+
+  u32 stringtosign[64];
+  u32 stringtosign_len;
+
+} aws4_sig_v4_t;
+
+KERNEL_FQ void m28700_mxx (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  u32 date_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < date_len; i += 4, idx += 1)
+  {
+    date_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[idx]);
+  }
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  u32 region_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < region_len; i += 4, idx += 1)
+  {
+    region_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[idx]);
+  }
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  u32 service_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < service_len; i += 4, idx += 1)
+  {
+    service_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[idx]);
+  }
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  u32 stringtosign_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    // set AWS4 + pass
+
+    u32 w[64] = { 0 };
+
+    w[0] = 0x41575334;
+
+    for (u32 i = 4, idx = 1; i < tmp.pw_len + 4; i += 4, idx += 1)
+    {
+      w[idx] = hc_swap32_S (tmp.i[idx - 1]);
+    }
+
+    // kdate
+
+    sha256_hmac_ctx_t ctx_kdate;
+
+    sha256_hmac_init (&ctx_kdate, w, tmp.pw_len + 4);
+
+    sha256_hmac_update (&ctx_kdate, date_buf, date_len);
+
+    sha256_hmac_final (&ctx_kdate);
+
+    // kregion
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = ctx_kdate.opad.h[0];
+    w0[1] = ctx_kdate.opad.h[1];
+    w0[2] = ctx_kdate.opad.h[2];
+    w0[3] = ctx_kdate.opad.h[3];
+    w1[0] = ctx_kdate.opad.h[4];
+    w1[1] = ctx_kdate.opad.h[5];
+    w1[2] = ctx_kdate.opad.h[6];
+    w1[3] = ctx_kdate.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kregion;
+
+    sha256_hmac_init_64 (&ctx_kregion, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kregion, region_buf, region_len);
+
+    sha256_hmac_final (&ctx_kregion);
+
+    // kservice
+
+    w0[0] = ctx_kregion.opad.h[0];
+    w0[1] = ctx_kregion.opad.h[1];
+    w0[2] = ctx_kregion.opad.h[2];
+    w0[3] = ctx_kregion.opad.h[3];
+    w1[0] = ctx_kregion.opad.h[4];
+    w1[1] = ctx_kregion.opad.h[5];
+    w1[2] = ctx_kregion.opad.h[6];
+    w1[3] = ctx_kregion.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kservice;
+
+    sha256_hmac_init_64 (&ctx_kservice, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kservice, service_buf, service_len);
+
+    sha256_hmac_final (&ctx_kservice);
+
+    // signingkey
+
+    w0[0] = ctx_kservice.opad.h[0];
+    w0[1] = ctx_kservice.opad.h[1];
+    w0[2] = ctx_kservice.opad.h[2];
+    w0[3] = ctx_kservice.opad.h[3];
+    w1[0] = ctx_kservice.opad.h[4];
+    w1[1] = ctx_kservice.opad.h[5];
+    w1[2] = ctx_kservice.opad.h[6];
+    w1[3] = ctx_kservice.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signingkey;
+
+    sha256_hmac_init_64 (&ctx_signingkey, w0, w1, w2, w3);
+
+    // aws4_request
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_update_64 (&ctx_signingkey, w0, w1, w2, w3, 12);
+
+    sha256_hmac_final (&ctx_signingkey);
+
+    // signature
+
+    w0[0] = ctx_signingkey.opad.h[0];
+    w0[1] = ctx_signingkey.opad.h[1];
+    w0[2] = ctx_signingkey.opad.h[2];
+    w0[3] = ctx_signingkey.opad.h[3];
+    w1[0] = ctx_signingkey.opad.h[4];
+    w1[1] = ctx_signingkey.opad.h[5];
+    w1[2] = ctx_signingkey.opad.h[6];
+    w1[3] = ctx_signingkey.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signature;
+
+    sha256_hmac_init_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final (&ctx_signature);
+
+    const u32 r0 = ctx_signature.opad.h[DGST_R0];
+    const u32 r1 = ctx_signature.opad.h[DGST_R1];
+    const u32 r2 = ctx_signature.opad.h[DGST_R2];
+    const u32 r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_sxx (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  u32 date_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < date_len; i += 4, idx += 1)
+  {
+    date_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[idx]);
+  }
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  u32 region_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < region_len; i += 4, idx += 1)
+  {
+    region_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[idx]);
+  }
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  u32 service_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < service_len; i += 4, idx += 1)
+  {
+    service_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[idx]);
+  }
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  u32 stringtosign_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    // set AWS4 + pass
+
+    u32 w[64] = { 0 };
+
+    w[0] = 0x41575334;
+
+    for (u32 i = 4, idx = 1; i < tmp.pw_len + 4; i += 4, idx += 1)
+    {
+      w[idx] = hc_swap32_S (tmp.i[idx - 1]);
+    }
+
+    // kdate
+
+    sha256_hmac_ctx_t ctx_kdate;
+
+    sha256_hmac_init (&ctx_kdate, w, tmp.pw_len + 4);
+
+    sha256_hmac_update (&ctx_kdate, date_buf, date_len);
+
+    sha256_hmac_final (&ctx_kdate);
+
+    // kregion
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = ctx_kdate.opad.h[0];
+    w0[1] = ctx_kdate.opad.h[1];
+    w0[2] = ctx_kdate.opad.h[2];
+    w0[3] = ctx_kdate.opad.h[3];
+    w1[0] = ctx_kdate.opad.h[4];
+    w1[1] = ctx_kdate.opad.h[5];
+    w1[2] = ctx_kdate.opad.h[6];
+    w1[3] = ctx_kdate.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kregion;
+
+    sha256_hmac_init_64 (&ctx_kregion, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kregion, region_buf, region_len);
+
+    sha256_hmac_final (&ctx_kregion);
+
+    // kservice
+
+    w0[0] = ctx_kregion.opad.h[0];
+    w0[1] = ctx_kregion.opad.h[1];
+    w0[2] = ctx_kregion.opad.h[2];
+    w0[3] = ctx_kregion.opad.h[3];
+    w1[0] = ctx_kregion.opad.h[4];
+    w1[1] = ctx_kregion.opad.h[5];
+    w1[2] = ctx_kregion.opad.h[6];
+    w1[3] = ctx_kregion.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kservice;
+
+    sha256_hmac_init_64 (&ctx_kservice, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kservice, service_buf, service_len);
+
+    sha256_hmac_final (&ctx_kservice);
+
+    // signingkey
+
+    w0[0] = ctx_kservice.opad.h[0];
+    w0[1] = ctx_kservice.opad.h[1];
+    w0[2] = ctx_kservice.opad.h[2];
+    w0[3] = ctx_kservice.opad.h[3];
+    w1[0] = ctx_kservice.opad.h[4];
+    w1[1] = ctx_kservice.opad.h[5];
+    w1[2] = ctx_kservice.opad.h[6];
+    w1[3] = ctx_kservice.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signingkey;
+
+    sha256_hmac_init_64 (&ctx_signingkey, w0, w1, w2, w3);
+
+    // aws4_request
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_update_64 (&ctx_signingkey, w0, w1, w2, w3, 12);
+
+    sha256_hmac_final (&ctx_signingkey);
+
+    // signature
+
+    w0[0] = ctx_signingkey.opad.h[0];
+    w0[1] = ctx_signingkey.opad.h[1];
+    w0[2] = ctx_signingkey.opad.h[2];
+    w0[3] = ctx_signingkey.opad.h[3];
+    w1[0] = ctx_signingkey.opad.h[4];
+    w1[1] = ctx_signingkey.opad.h[5];
+    w1[2] = ctx_signingkey.opad.h[6];
+    w1[3] = ctx_signingkey.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signature;
+
+    sha256_hmac_init_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final (&ctx_signature);
+
+    const u32 r0 = ctx_signature.opad.h[DGST_R0];
+    const u32 r1 = ctx_signature.opad.h[DGST_R1];
+    const u32 r2 = ctx_signature.opad.h[DGST_R2];
+    const u32 r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m28700_a1-optimized.cl
+++ b/OpenCL/m28700_a1-optimized.cl
@@ -1,0 +1,888 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct aws4_sig_v4
+{
+  u32 date[3];
+  u32 date_len;
+
+  u32 longdate[4];
+  u32 longdate_len;
+
+  u32 region[4];
+  u32 region_len;
+
+  u32 service[4];
+  u32 service_len;
+
+  u32 canonical[8];
+  u32 canonical_len;
+
+  u32 stringtosign[64];
+  u32 stringtosign_len;
+
+} aws4_sig_v4_t;
+
+DECLSPEC void hmac_sha256_pad (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad)
+{
+  w0[0] = w0[0] ^ 0x36363636;
+  w0[1] = w0[1] ^ 0x36363636;
+  w0[2] = w0[2] ^ 0x36363636;
+  w0[3] = w0[3] ^ 0x36363636;
+  w1[0] = w1[0] ^ 0x36363636;
+  w1[1] = w1[1] ^ 0x36363636;
+  w1[2] = w1[2] ^ 0x36363636;
+  w1[3] = w1[3] ^ 0x36363636;
+  w2[0] = w2[0] ^ 0x36363636;
+  w2[1] = w2[1] ^ 0x36363636;
+  w2[2] = w2[2] ^ 0x36363636;
+  w2[3] = w2[3] ^ 0x36363636;
+  w3[0] = w3[0] ^ 0x36363636;
+  w3[1] = w3[1] ^ 0x36363636;
+  w3[2] = w3[2] ^ 0x36363636;
+  w3[3] = w3[3] ^ 0x36363636;
+
+  ipad[0] = SHA256M_A;
+  ipad[1] = SHA256M_B;
+  ipad[2] = SHA256M_C;
+  ipad[3] = SHA256M_D;
+  ipad[4] = SHA256M_E;
+  ipad[5] = SHA256M_F;
+  ipad[6] = SHA256M_G;
+  ipad[7] = SHA256M_H;
+
+  sha256_transform_vector (w0, w1, w2, w3, ipad);
+
+  w0[0] = w0[0] ^ 0x6a6a6a6a;
+  w0[1] = w0[1] ^ 0x6a6a6a6a;
+  w0[2] = w0[2] ^ 0x6a6a6a6a;
+  w0[3] = w0[3] ^ 0x6a6a6a6a;
+  w1[0] = w1[0] ^ 0x6a6a6a6a;
+  w1[1] = w1[1] ^ 0x6a6a6a6a;
+  w1[2] = w1[2] ^ 0x6a6a6a6a;
+  w1[3] = w1[3] ^ 0x6a6a6a6a;
+  w2[0] = w2[0] ^ 0x6a6a6a6a;
+  w2[1] = w2[1] ^ 0x6a6a6a6a;
+  w2[2] = w2[2] ^ 0x6a6a6a6a;
+  w2[3] = w2[3] ^ 0x6a6a6a6a;
+  w3[0] = w3[0] ^ 0x6a6a6a6a;
+  w3[1] = w3[1] ^ 0x6a6a6a6a;
+  w3[2] = w3[2] ^ 0x6a6a6a6a;
+  w3[3] = w3[3] ^ 0x6a6a6a6a;
+
+  opad[0] = SHA256M_A;
+  opad[1] = SHA256M_B;
+  opad[2] = SHA256M_C;
+  opad[3] = SHA256M_D;
+  opad[4] = SHA256M_E;
+  opad[5] = SHA256M_F;
+  opad[6] = SHA256M_G;
+  opad[7] = SHA256M_H;
+
+  sha256_transform_vector (w0, w1, w2, w3, opad);
+}
+
+DECLSPEC void hmac_sha256_run (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad, PRIVATE_AS u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+  digest[5] = ipad[5];
+  digest[6] = ipad[6];
+  digest[7] = ipad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = digest[5];
+  w1[2] = digest[6];
+  w1[3] = digest[7];
+  w2[0] = 0x80000000;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 32) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+  digest[5] = opad[5];
+  digest[6] = opad[6];
+  digest[7] = opad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+}
+
+KERNEL_FQ void m28700_m04 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4] = { 0 };
+  u32 pw_buf1[4] = { 0 };
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * date
+   */
+
+  u32x date_buf0[4] = { 0 };
+
+  date_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 0]);
+  date_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 1]);
+  date_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 2]);
+  date_buf0[3] = 0;
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  /**
+   * region
+   */
+
+  u32x region_buf0[4] = { 0 };
+
+  region_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 0]);
+  region_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 1]);
+  region_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 2]);
+  region_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 3]);
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  /**
+   * service
+   */
+
+  u32x service_buf0[4] = { 0 };
+
+  service_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 0]);
+  service_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 1]);
+  service_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 2]);
+  service_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 3]);
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  /**
+   * stringtosign
+   */
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0_t[4];
+    u32x w1_t[4];
+    u32x w2_t[4];
+    u32x w3_t[4];
+
+    w0_t[0] = wordl0[0] | wordr0[0];
+    w0_t[1] = wordl0[1] | wordr0[1];
+    w0_t[2] = wordl0[2] | wordr0[2];
+    w0_t[3] = wordl0[3] | wordr0[3];
+    w1_t[0] = wordl1[0] | wordr1[0];
+    w1_t[1] = wordl1[1] | wordr1[1];
+    w1_t[2] = wordl1[2] | wordr1[2];
+    w1_t[3] = wordl1[3] | wordr1[3];
+    w2_t[0] = wordl2[0] | wordr2[0];
+    w2_t[1] = wordl2[1] | wordr2[1];
+    w2_t[2] = wordl2[2] | wordr2[2];
+    w2_t[3] = wordl2[3] | wordr2[3];
+    w3_t[0] = wordl3[0] | wordr3[0];
+    w3_t[1] = wordl3[1] | wordr3[1];
+    w3_t[2] = wordl3[2] | wordr3[2];
+    w3_t[3] = wordl3[3] | wordr3[3];
+
+    u32x ipad[8];
+    u32x opad[8];
+
+    u32x digest[8];
+
+    // kdate
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = 0x41575334;
+    w0[1] = hc_swap32 (w0_t[0]);
+    w0[2] = hc_swap32 (w0_t[1]);
+    w0[3] = hc_swap32 (w0_t[2]);
+    w1[0] = hc_swap32 (w0_t[3]);
+    w1[1] = hc_swap32 (w1_t[0]);
+    w1[2] = hc_swap32 (w1_t[1]);
+    w1[3] = hc_swap32 (w1_t[2]);
+    w2[0] = hc_swap32 (w1_t[3]);
+    w2[1] = hc_swap32 (w2_t[0]);
+    w2[2] = hc_swap32 (w2_t[1]);
+    w2[3] = hc_swap32 (w2_t[2]);
+    w3[0] = hc_swap32 (w2_t[3]);
+    w3[1] = hc_swap32 (w3_t[0]);
+    w3[2] = hc_swap32 (w3_t[1]);
+    w3[3] = hc_swap32 (w3_t[2]);
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = date_buf0[0];
+    w0[1] = date_buf0[1];
+    w0[2] = date_buf0[2];
+    w0[3] = date_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + date_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kregion
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = region_buf0[0];
+    w0[1] = region_buf0[1];
+    w0[2] = region_buf0[2];
+    w0[3] = region_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + region_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kservice
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = service_buf0[0];
+    w0[1] = service_buf0[1];
+    w0[2] = service_buf0[2];
+    w0[3] = service_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + service_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signingkey
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0x80000000;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + 12) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signature
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_m08 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+}
+
+KERNEL_FQ void m28700_m16 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+}
+
+KERNEL_FQ void m28700_s04 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * date
+   */
+
+  u32x date_buf0[4] = { 0 };
+
+  date_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 0]);
+  date_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 1]);
+  date_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 2]);
+  date_buf0[3] = 0;
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  /**
+   * region
+   */
+
+  u32x region_buf0[4] = { 0 };
+
+  region_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 0]);
+  region_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 1]);
+  region_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 2]);
+  region_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 3]);
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  /**
+   * service
+   */
+
+  u32x service_buf0[4] = { 0 };
+
+  service_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 0]);
+  service_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 1]);
+  service_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 2]);
+  service_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 3]);
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  /**
+   * stringtosign
+   */
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0_t[4];
+    u32x w1_t[4];
+    u32x w2_t[4];
+    u32x w3_t[4];
+
+    w0_t[0] = wordl0[0] | wordr0[0];
+    w0_t[1] = wordl0[1] | wordr0[1];
+    w0_t[2] = wordl0[2] | wordr0[2];
+    w0_t[3] = wordl0[3] | wordr0[3];
+    w1_t[0] = wordl1[0] | wordr1[0];
+    w1_t[1] = wordl1[1] | wordr1[1];
+    w1_t[2] = wordl1[2] | wordr1[2];
+    w1_t[3] = wordl1[3] | wordr1[3];
+    w2_t[0] = wordl2[0] | wordr2[0];
+    w2_t[1] = wordl2[1] | wordr2[1];
+    w2_t[2] = wordl2[2] | wordr2[2];
+    w2_t[3] = wordl2[3] | wordr2[3];
+    w3_t[0] = wordl3[0] | wordr3[0];
+    w3_t[1] = wordl3[1] | wordr3[1];
+    w3_t[2] = wordl3[2] | wordr3[2];
+    w3_t[3] = wordl3[3] | wordr3[3];
+
+    u32x ipad[8];
+    u32x opad[8];
+
+    u32x digest[8];
+
+    // kdate
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = 0x41575334;
+    w0[1] = hc_swap32 (w0_t[0]);
+    w0[2] = hc_swap32 (w0_t[1]);
+    w0[3] = hc_swap32 (w0_t[2]);
+    w1[0] = hc_swap32 (w0_t[3]);
+    w1[1] = hc_swap32 (w1_t[0]);
+    w1[2] = hc_swap32 (w1_t[1]);
+    w1[3] = hc_swap32 (w1_t[2]);
+    w2[0] = hc_swap32 (w1_t[3]);
+    w2[1] = hc_swap32 (w2_t[0]);
+    w2[2] = hc_swap32 (w2_t[1]);
+    w2[3] = hc_swap32 (w2_t[2]);
+    w3[0] = hc_swap32 (w2_t[3]);
+    w3[1] = hc_swap32 (w3_t[0]);
+    w3[2] = hc_swap32 (w3_t[1]);
+    w3[3] = hc_swap32 (w3_t[2]);
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = date_buf0[0];
+    w0[1] = date_buf0[1];
+    w0[2] = date_buf0[2];
+    w0[3] = date_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + date_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kregion
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = region_buf0[0];
+    w0[1] = region_buf0[1];
+    w0[2] = region_buf0[2];
+    w0[3] = region_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + region_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // kservice
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = service_buf0[0];
+    w0[1] = service_buf0[1];
+    w0[2] = service_buf0[2];
+    w0[3] = service_buf0[3];
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + service_len) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signingkey
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    hmac_sha256_pad (w0, w1, w2, w3, ipad, opad);
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0x80000000;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + 12) * 8;
+
+    hmac_sha256_run (w0, w1, w2, w3, ipad, opad, digest);
+
+    // signature
+
+    w0[0] = digest[0];
+    w0[1] = digest[1];
+    w0[2] = digest[2];
+    w0[3] = digest[3];
+    w1[0] = digest[4];
+    w1[1] = digest[5];
+    w1[2] = digest[6];
+    w1[3] = digest[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_s08 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+}
+
+KERNEL_FQ void m28700_s16 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+}

--- a/OpenCL/m28700_a1-pure.cl
+++ b/OpenCL/m28700_a1-pure.cl
@@ -1,0 +1,547 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct aws4_sig_v4
+{
+  u32 date[3];
+  u32 date_len;
+
+  u32 longdate[4];
+  u32 longdate_len;
+
+  u32 region[4];
+  u32 region_len;
+
+  u32 service[4];
+  u32 service_len;
+
+  u32 canonical[8];
+  u32 canonical_len;
+
+  u32 stringtosign[64];
+  u32 stringtosign_len;
+
+} aws4_sig_v4_t;
+
+KERNEL_FQ void m28700_mxx (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  u32 date_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < date_len; i += 4, idx += 1)
+  {
+    date_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[idx]);
+  }
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  u32 region_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < region_len; i += 4, idx += 1)
+  {
+    region_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[idx]);
+  }
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  u32 service_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < service_len; i += 4, idx += 1)
+  {
+    service_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[idx]);
+  }
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  u32 stringtosign_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    u32 w_t[64];
+
+    w_t[0] = 0x41575334;
+
+    for (u32 i = 1; i < 64; i++)
+    {
+      w_t[i] = c[i - 1];
+    }
+
+    // kdate
+
+    sha256_hmac_ctx_t ctx_kdate;
+
+    sha256_hmac_init (&ctx_kdate, w_t, pw_len + comb_len + 4);
+
+    sha256_hmac_update (&ctx_kdate, date_buf, date_len);
+
+    sha256_hmac_final (&ctx_kdate);
+
+    // kregion
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = ctx_kdate.opad.h[0];
+    w0[1] = ctx_kdate.opad.h[1];
+    w0[2] = ctx_kdate.opad.h[2];
+    w0[3] = ctx_kdate.opad.h[3];
+    w1[0] = ctx_kdate.opad.h[4];
+    w1[1] = ctx_kdate.opad.h[5];
+    w1[2] = ctx_kdate.opad.h[6];
+    w1[3] = ctx_kdate.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kregion;
+
+    sha256_hmac_init_64 (&ctx_kregion, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kregion, region_buf, region_len);
+
+    sha256_hmac_final (&ctx_kregion);
+
+    // kservice
+
+    w0[0] = ctx_kregion.opad.h[0];
+    w0[1] = ctx_kregion.opad.h[1];
+    w0[2] = ctx_kregion.opad.h[2];
+    w0[3] = ctx_kregion.opad.h[3];
+    w1[0] = ctx_kregion.opad.h[4];
+    w1[1] = ctx_kregion.opad.h[5];
+    w1[2] = ctx_kregion.opad.h[6];
+    w1[3] = ctx_kregion.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kservice;
+
+    sha256_hmac_init_64 (&ctx_kservice, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kservice, service_buf, service_len);
+
+    sha256_hmac_final (&ctx_kservice);
+
+    // signingkey
+
+    w0[0] = ctx_kservice.opad.h[0];
+    w0[1] = ctx_kservice.opad.h[1];
+    w0[2] = ctx_kservice.opad.h[2];
+    w0[3] = ctx_kservice.opad.h[3];
+    w1[0] = ctx_kservice.opad.h[4];
+    w1[1] = ctx_kservice.opad.h[5];
+    w1[2] = ctx_kservice.opad.h[6];
+    w1[3] = ctx_kservice.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signingkey;
+
+    sha256_hmac_init_64 (&ctx_signingkey, w0, w1, w2, w3);
+
+    // aws4_request
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_update_64 (&ctx_signingkey, w0, w1, w2, w3, 12);
+
+    sha256_hmac_final (&ctx_signingkey);
+
+    // signature
+
+    w0[0] = ctx_signingkey.opad.h[0];
+    w0[1] = ctx_signingkey.opad.h[1];
+    w0[2] = ctx_signingkey.opad.h[2];
+    w0[3] = ctx_signingkey.opad.h[3];
+    w1[0] = ctx_signingkey.opad.h[4];
+    w1[1] = ctx_signingkey.opad.h[5];
+    w1[2] = ctx_signingkey.opad.h[6];
+    w1[3] = ctx_signingkey.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signature;
+
+    sha256_hmac_init_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final (&ctx_signature);
+
+    const u32 r0 = ctx_signature.opad.h[DGST_R0];
+    const u32 r1 = ctx_signature.opad.h[DGST_R1];
+    const u32 r2 = ctx_signature.opad.h[DGST_R2];
+    const u32 r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_sxx (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  u32 date_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < date_len; i += 4, idx += 1)
+  {
+    date_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[idx]);
+  }
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  u32 region_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < region_len; i += 4, idx += 1)
+  {
+    region_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[idx]);
+  }
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  u32 service_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < service_len; i += 4, idx += 1)
+  {
+    service_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[idx]);
+  }
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  u32 stringtosign_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    u32 w_t[64];
+
+    w_t[0] = 0x41575334;
+
+    for (u32 i = 1; i < 64; i++)
+    {
+      w_t[i] = c[i - 1];
+    }
+
+    // kdate
+
+    sha256_hmac_ctx_t ctx_kdate;
+
+    sha256_hmac_init (&ctx_kdate, w_t, pw_len + comb_len + 4);
+
+    sha256_hmac_update (&ctx_kdate, date_buf, date_len);
+
+    sha256_hmac_final (&ctx_kdate);
+
+    // kregion
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = ctx_kdate.opad.h[0];
+    w0[1] = ctx_kdate.opad.h[1];
+    w0[2] = ctx_kdate.opad.h[2];
+    w0[3] = ctx_kdate.opad.h[3];
+    w1[0] = ctx_kdate.opad.h[4];
+    w1[1] = ctx_kdate.opad.h[5];
+    w1[2] = ctx_kdate.opad.h[6];
+    w1[3] = ctx_kdate.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kregion;
+
+    sha256_hmac_init_64 (&ctx_kregion, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kregion, region_buf, region_len);
+
+    sha256_hmac_final (&ctx_kregion);
+
+    // kservice
+
+    w0[0] = ctx_kregion.opad.h[0];
+    w0[1] = ctx_kregion.opad.h[1];
+    w0[2] = ctx_kregion.opad.h[2];
+    w0[3] = ctx_kregion.opad.h[3];
+    w1[0] = ctx_kregion.opad.h[4];
+    w1[1] = ctx_kregion.opad.h[5];
+    w1[2] = ctx_kregion.opad.h[6];
+    w1[3] = ctx_kregion.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_kservice;
+
+    sha256_hmac_init_64 (&ctx_kservice, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_kservice, service_buf, service_len);
+
+    sha256_hmac_final (&ctx_kservice);
+
+    // signingkey
+
+    w0[0] = ctx_kservice.opad.h[0];
+    w0[1] = ctx_kservice.opad.h[1];
+    w0[2] = ctx_kservice.opad.h[2];
+    w0[3] = ctx_kservice.opad.h[3];
+    w1[0] = ctx_kservice.opad.h[4];
+    w1[1] = ctx_kservice.opad.h[5];
+    w1[2] = ctx_kservice.opad.h[6];
+    w1[3] = ctx_kservice.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signingkey;
+
+    sha256_hmac_init_64 (&ctx_signingkey, w0, w1, w2, w3);
+
+    // aws4_request
+
+    w0[0] = 0x61777334;
+    w0[1] = 0x5f726571;
+    w0[2] = 0x75657374;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_update_64 (&ctx_signingkey, w0, w1, w2, w3, 12);
+
+    sha256_hmac_final (&ctx_signingkey);
+
+    // signature
+
+    w0[0] = ctx_signingkey.opad.h[0];
+    w0[1] = ctx_signingkey.opad.h[1];
+    w0[2] = ctx_signingkey.opad.h[2];
+    w0[3] = ctx_signingkey.opad.h[3];
+    w1[0] = ctx_signingkey.opad.h[4];
+    w1[1] = ctx_signingkey.opad.h[5];
+    w1[2] = ctx_signingkey.opad.h[6];
+    w1[3] = ctx_signingkey.opad.h[7];
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_ctx_t ctx_signature;
+
+    sha256_hmac_init_64 (&ctx_signature, w0, w1, w2, w3);
+
+    sha256_hmac_update (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final (&ctx_signature);
+
+    const u32 r0 = ctx_signature.opad.h[DGST_R0];
+    const u32 r1 = ctx_signature.opad.h[DGST_R1];
+    const u32 r2 = ctx_signature.opad.h[DGST_R2];
+    const u32 r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m28700_a3-optimized.cl
+++ b/OpenCL/m28700_a3-optimized.cl
@@ -1,0 +1,996 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct aws4_sig_v4
+{
+  u32 date[3];
+  u32 date_len;
+
+  u32 longdate[4];
+  u32 longdate_len;
+
+  u32 region[4];
+  u32 region_len;
+
+  u32 service[4];
+  u32 service_len;
+
+  u32 canonical[8];
+  u32 canonical_len;
+
+  u32 stringtosign[64];
+  u32 stringtosign_len;
+
+} aws4_sig_v4_t;
+
+DECLSPEC void hmac_sha256_pad (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad)
+{
+  w0[0] = w0[0] ^ 0x36363636;
+  w0[1] = w0[1] ^ 0x36363636;
+  w0[2] = w0[2] ^ 0x36363636;
+  w0[3] = w0[3] ^ 0x36363636;
+  w1[0] = w1[0] ^ 0x36363636;
+  w1[1] = w1[1] ^ 0x36363636;
+  w1[2] = w1[2] ^ 0x36363636;
+  w1[3] = w1[3] ^ 0x36363636;
+  w2[0] = w2[0] ^ 0x36363636;
+  w2[1] = w2[1] ^ 0x36363636;
+  w2[2] = w2[2] ^ 0x36363636;
+  w2[3] = w2[3] ^ 0x36363636;
+  w3[0] = w3[0] ^ 0x36363636;
+  w3[1] = w3[1] ^ 0x36363636;
+  w3[2] = w3[2] ^ 0x36363636;
+  w3[3] = w3[3] ^ 0x36363636;
+
+  ipad[0] = SHA256M_A;
+  ipad[1] = SHA256M_B;
+  ipad[2] = SHA256M_C;
+  ipad[3] = SHA256M_D;
+  ipad[4] = SHA256M_E;
+  ipad[5] = SHA256M_F;
+  ipad[6] = SHA256M_G;
+  ipad[7] = SHA256M_H;
+
+  sha256_transform_vector (w0, w1, w2, w3, ipad);
+
+  w0[0] = w0[0] ^ 0x6a6a6a6a;
+  w0[1] = w0[1] ^ 0x6a6a6a6a;
+  w0[2] = w0[2] ^ 0x6a6a6a6a;
+  w0[3] = w0[3] ^ 0x6a6a6a6a;
+  w1[0] = w1[0] ^ 0x6a6a6a6a;
+  w1[1] = w1[1] ^ 0x6a6a6a6a;
+  w1[2] = w1[2] ^ 0x6a6a6a6a;
+  w1[3] = w1[3] ^ 0x6a6a6a6a;
+  w2[0] = w2[0] ^ 0x6a6a6a6a;
+  w2[1] = w2[1] ^ 0x6a6a6a6a;
+  w2[2] = w2[2] ^ 0x6a6a6a6a;
+  w2[3] = w2[3] ^ 0x6a6a6a6a;
+  w3[0] = w3[0] ^ 0x6a6a6a6a;
+  w3[1] = w3[1] ^ 0x6a6a6a6a;
+  w3[2] = w3[2] ^ 0x6a6a6a6a;
+  w3[3] = w3[3] ^ 0x6a6a6a6a;
+
+  opad[0] = SHA256M_A;
+  opad[1] = SHA256M_B;
+  opad[2] = SHA256M_C;
+  opad[3] = SHA256M_D;
+  opad[4] = SHA256M_E;
+  opad[5] = SHA256M_F;
+  opad[6] = SHA256M_G;
+  opad[7] = SHA256M_H;
+
+  sha256_transform_vector (w0, w1, w2, w3, opad);
+}
+
+DECLSPEC void hmac_sha256_run (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad, PRIVATE_AS u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+  digest[5] = ipad[5];
+  digest[6] = ipad[6];
+  digest[7] = ipad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = digest[5];
+  w1[2] = digest[6];
+  w1[3] = digest[7];
+  w2[0] = 0x80000000;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 32) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+  digest[5] = opad[5];
+  digest[6] = opad[6];
+  digest[7] = opad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+}
+
+DECLSPEC void m28700m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifiers are taken from args
+   */
+
+  /**
+   * date
+   */
+
+  u32x date_buf0[4] = { 0 };
+
+  date_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 0]);
+  date_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 1]);
+  date_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 2]);
+  date_buf0[3] = 0;
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  /**
+   * region
+   */
+
+  u32x region_buf0[4] = { 0 };
+
+  region_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 0]);
+  region_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 1]);
+  region_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 2]);
+  region_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 3]);
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  /**
+   * service
+   */
+
+  u32x service_buf0[4] = { 0 };
+
+  service_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 0]);
+  service_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 1]);
+  service_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 2]);
+  service_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 3]);
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  /**
+   * stringtosign
+   */
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x ipad[8];
+    u32x opad[8];
+
+    u32x digest[8];
+
+    // kdate
+
+    u32x w0_t[4];
+    u32x w1_t[4];
+    u32x w2_t[4];
+    u32x w3_t[4];
+
+    w0_t[0] = 0x41575334;
+    w0_t[1] = w0lr;
+    w0_t[2] = w0[1];
+    w0_t[3] = w0[2];
+    w1_t[0] = w0[3];
+    w1_t[1] = w1[0];
+    w1_t[2] = w1[1];
+    w1_t[3] = w1[2];
+    w2_t[0] = w1[3];
+    w2_t[1] = w2[0];
+    w2_t[2] = w2[1];
+    w2_t[3] = w2[2];
+    w3_t[0] = w2[3];
+    w3_t[1] = w3[0];
+    w3_t[2] = w3[1];
+    w3_t[3] = w3[2];
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = date_buf0[0];
+    w0_t[1] = date_buf0[1];
+    w0_t[2] = date_buf0[2];
+    w0_t[3] = date_buf0[3];
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + date_len) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // kregion
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = region_buf0[0];
+    w0_t[1] = region_buf0[1];
+    w0_t[2] = region_buf0[2];
+    w0_t[3] = region_buf0[3];
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + region_len) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // kservice
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = service_buf0[0];
+    w0_t[1] = service_buf0[1];
+    w0_t[2] = service_buf0[2];
+    w0_t[3] = service_buf0[3];
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + service_len) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // signingkey
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = 0x61777334;
+    w0_t[1] = 0x5f726571;
+    w0_t[2] = 0x75657374;
+    w0_t[3] = 0x80000000;
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + 12) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // signature
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector_64 (&ctx_signature, w0_t, w1_t, w2_t, w3_t);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+DECLSPEC void m28700s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifiers are taken from args
+   */
+
+  /**
+   * date
+   */
+
+  u32x date_buf0[4] = { 0 };
+
+  date_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 0]);
+  date_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 1]);
+  date_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[ 2]);
+  date_buf0[3] = 0;
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  /**
+   * region
+   */
+
+  u32x region_buf0[4] = { 0 };
+
+  region_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 0]);
+  region_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 1]);
+  region_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 2]);
+  region_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[ 3]);
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  /**
+   * service
+   */
+
+  u32x service_buf0[4] = { 0 };
+
+  service_buf0[0] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 0]);
+  service_buf0[1] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 1]);
+  service_buf0[2] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 2]);
+  service_buf0[3] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[ 3]);
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  /**
+   * stringtosign
+   */
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x ipad[8];
+    u32x opad[8];
+
+    u32x digest[8];
+
+    // kdate
+
+    u32x w0_t[4];
+    u32x w1_t[4];
+    u32x w2_t[4];
+    u32x w3_t[4];
+
+    w0_t[0] = 0x41575334;
+    w0_t[1] = w0lr;
+    w0_t[2] = w0[1];
+    w0_t[3] = w0[2];
+    w1_t[0] = w0[3];
+    w1_t[1] = w1[0];
+    w1_t[2] = w1[1];
+    w1_t[3] = w1[2];
+    w2_t[0] = w1[3];
+    w2_t[1] = w2[0];
+    w2_t[2] = w2[1];
+    w2_t[3] = w2[2];
+    w3_t[0] = w2[3];
+    w3_t[1] = w3[0];
+    w3_t[2] = w3[1];
+    w3_t[3] = w3[2];
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = date_buf0[0];
+    w0_t[1] = date_buf0[1];
+    w0_t[2] = date_buf0[2];
+    w0_t[3] = date_buf0[3];
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + date_len) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // kregion
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = region_buf0[0];
+    w0_t[1] = region_buf0[1];
+    w0_t[2] = region_buf0[2];
+    w0_t[3] = region_buf0[3];
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + region_len) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // kservice
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = service_buf0[0];
+    w0_t[1] = service_buf0[1];
+    w0_t[2] = service_buf0[2];
+    w0_t[3] = service_buf0[3];
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + service_len) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // signingkey
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    hmac_sha256_pad (w0_t, w1_t, w2_t, w3_t, ipad, opad);
+
+    w0_t[0] = 0x61777334;
+    w0_t[1] = 0x5f726571;
+    w0_t[2] = 0x75657374;
+    w0_t[3] = 0x80000000;
+    w1_t[0] = 0;
+    w1_t[1] = 0;
+    w1_t[2] = 0;
+    w1_t[3] = 0;
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = (64 + 12) * 8;
+
+    hmac_sha256_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
+
+    // signature
+
+    w0_t[0] = digest[0];
+    w0_t[1] = digest[1];
+    w0_t[2] = digest[2];
+    w0_t[3] = digest[3];
+    w1_t[0] = digest[4];
+    w1_t[1] = digest[5];
+    w1_t[2] = digest[6];
+    w1_t[3] = digest[7];
+    w2_t[0] = 0;
+    w2_t[1] = 0;
+    w2_t[2] = 0;
+    w2_t[3] = 0;
+    w3_t[0] = 0;
+    w3_t[1] = 0;
+    w3_t[2] = 0;
+    w3_t[3] = 0;
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector_64 (&ctx_signature, w0_t, w1_t, w2_t, w3_t);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_m04 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m28700m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ void m28700_m08 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m28700m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ void m28700_m16 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m28700m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ void m28700_s04 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m28700s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ void m28700_s08 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m28700s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ void m28700_s16 (KERN_ATTR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m28700s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}

--- a/OpenCL/m28700_a3-pure.cl
+++ b/OpenCL/m28700_a3-pure.cl
@@ -1,0 +1,469 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct aws4_sig_v4
+{
+  u32 date[3];
+  u32 date_len;
+
+  u32 longdate[4];
+  u32 longdate_len;
+
+  u32 region[4];
+  u32 region_len;
+
+  u32 service[4];
+  u32 service_len;
+
+  u32 canonical[8];
+  u32 canonical_len;
+
+  u32 stringtosign[64];
+  u32 stringtosign_len;
+
+} aws4_sig_v4_t;
+
+KERNEL_FQ void m28700_mxx (KERN_ATTR_VECTOR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  u32x date_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < date_len; i += 4, idx += 1)
+  {
+    date_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[idx]);
+  }
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  u32x region_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < region_len; i += 4, idx += 1)
+  {
+    region_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[idx]);
+  }
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  u32x service_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < service_len; i += 4, idx += 1)
+  {
+    service_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[idx]);
+  }
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    // kdate
+
+    u32x w_t[64];
+
+    w_t[0] = 0x41575334;
+
+    for (u32 i = 1; i < 64; i++)
+    {
+      w_t[i] = w[i - 1];
+    }
+
+    sha256_hmac_ctx_vector_t ctx_kdate;
+
+    sha256_hmac_init_vector (&ctx_kdate, w_t, pw_len + 4);
+
+    sha256_hmac_update_vector (&ctx_kdate, date_buf, date_len);
+
+    sha256_hmac_final_vector (&ctx_kdate);
+
+    // kregion
+
+    w_t[0] = ctx_kdate.opad.h[0];
+    w_t[1] = ctx_kdate.opad.h[1];
+    w_t[2] = ctx_kdate.opad.h[2];
+    w_t[3] = ctx_kdate.opad.h[3];
+    w_t[4] = ctx_kdate.opad.h[4];
+    w_t[5] = ctx_kdate.opad.h[5];
+    w_t[6] = ctx_kdate.opad.h[6];
+    w_t[7] = ctx_kdate.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_kregion;
+
+    sha256_hmac_init_vector (&ctx_kregion, w_t, 32);
+
+    sha256_hmac_update_vector (&ctx_kregion, region_buf, region_len);
+
+    sha256_hmac_final_vector (&ctx_kregion);
+
+    // kservice
+
+    w_t[0] = ctx_kregion.opad.h[0];
+    w_t[1] = ctx_kregion.opad.h[1];
+    w_t[2] = ctx_kregion.opad.h[2];
+    w_t[3] = ctx_kregion.opad.h[3];
+    w_t[4] = ctx_kregion.opad.h[4];
+    w_t[5] = ctx_kregion.opad.h[5];
+    w_t[6] = ctx_kregion.opad.h[6];
+    w_t[7] = ctx_kregion.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_kservice;
+
+    sha256_hmac_init_vector (&ctx_kservice, w_t, 32);
+
+    sha256_hmac_update_vector (&ctx_kservice, service_buf, service_len);
+
+    sha256_hmac_final_vector (&ctx_kservice);
+
+    // signingkey
+
+    w_t[0] = ctx_kservice.opad.h[0];
+    w_t[1] = ctx_kservice.opad.h[1];
+    w_t[2] = ctx_kservice.opad.h[2];
+    w_t[3] = ctx_kservice.opad.h[3];
+    w_t[4] = ctx_kservice.opad.h[4];
+    w_t[5] = ctx_kservice.opad.h[5];
+    w_t[6] = ctx_kservice.opad.h[6];
+    w_t[7] = ctx_kservice.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_signingkey;
+
+    sha256_hmac_init_vector (&ctx_signingkey, w_t, 32);
+
+    // aws4_request
+
+    w_t[0] = 0x61777334;
+    w_t[1] = 0x5f726571;
+    w_t[2] = 0x75657374;
+
+    for (u32 i = 3; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_update_vector (&ctx_signingkey, w_t, 12);
+
+    sha256_hmac_final_vector (&ctx_signingkey);
+
+    // signature
+
+    w_t[0] = ctx_signingkey.opad.h[0];
+    w_t[1] = ctx_signingkey.opad.h[1];
+    w_t[2] = ctx_signingkey.opad.h[2];
+    w_t[3] = ctx_signingkey.opad.h[3];
+    w_t[4] = ctx_signingkey.opad.h[4];
+    w_t[5] = ctx_signingkey.opad.h[5];
+    w_t[6] = ctx_signingkey.opad.h[6];
+    w_t[7] = ctx_signingkey.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector (&ctx_signature, w_t, 32);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28700_sxx (KERN_ATTR_VECTOR_ESALT (aws4_sig_v4_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 date_len = esalt_bufs[DIGESTS_OFFSET_HOST].date_len;
+
+  u32x date_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < date_len; i += 4, idx += 1)
+  {
+    date_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].date[idx]);
+  }
+
+  const u32 region_len = esalt_bufs[DIGESTS_OFFSET_HOST].region_len;
+
+  u32x region_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < region_len; i += 4, idx += 1)
+  {
+    region_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].region[idx]);
+  }
+
+  const u32 service_len = esalt_bufs[DIGESTS_OFFSET_HOST].service_len;
+
+  u32x service_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < service_len; i += 4, idx += 1)
+  {
+    service_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].service[idx]);
+  }
+
+  const u32 stringtosign_len = esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign_len;
+
+  u32x stringtosign_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < stringtosign_len; i += 4, idx += 1)
+  {
+    stringtosign_buf[idx] = hc_swap32_S (esalt_bufs[DIGESTS_OFFSET_HOST].stringtosign[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    u32x w_t[64];
+
+    w_t[0] = 0x41575334;
+
+    for (u32 i = 1; i < 64; i++)
+    {
+      w_t[i] = w[i - 1];
+    }
+
+    // kdate
+
+    sha256_hmac_ctx_vector_t ctx_kdate;
+
+    sha256_hmac_init_vector (&ctx_kdate, w_t, pw_len + 4);
+
+    sha256_hmac_update_vector (&ctx_kdate, date_buf, date_len);
+
+    sha256_hmac_final_vector (&ctx_kdate);
+
+    // kregion
+
+    w_t[0] = ctx_kdate.opad.h[0];
+    w_t[1] = ctx_kdate.opad.h[1];
+    w_t[2] = ctx_kdate.opad.h[2];
+    w_t[3] = ctx_kdate.opad.h[3];
+    w_t[4] = ctx_kdate.opad.h[4];
+    w_t[5] = ctx_kdate.opad.h[5];
+    w_t[6] = ctx_kdate.opad.h[6];
+    w_t[7] = ctx_kdate.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_kregion;
+
+    sha256_hmac_init_vector (&ctx_kregion, w_t, 32);
+
+    sha256_hmac_update_vector (&ctx_kregion, region_buf, region_len);
+
+    sha256_hmac_final_vector (&ctx_kregion);
+
+    // kservice
+
+    w_t[0] = ctx_kregion.opad.h[0];
+    w_t[1] = ctx_kregion.opad.h[1];
+    w_t[2] = ctx_kregion.opad.h[2];
+    w_t[3] = ctx_kregion.opad.h[3];
+    w_t[4] = ctx_kregion.opad.h[4];
+    w_t[5] = ctx_kregion.opad.h[5];
+    w_t[6] = ctx_kregion.opad.h[6];
+    w_t[7] = ctx_kregion.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_kservice;
+
+    sha256_hmac_init_vector (&ctx_kservice, w_t, 32);
+
+    sha256_hmac_update_vector (&ctx_kservice, service_buf, service_len);
+
+    sha256_hmac_final_vector (&ctx_kservice);
+
+    // signingkey
+
+    w_t[0] = ctx_kservice.opad.h[0];
+    w_t[1] = ctx_kservice.opad.h[1];
+    w_t[2] = ctx_kservice.opad.h[2];
+    w_t[3] = ctx_kservice.opad.h[3];
+    w_t[4] = ctx_kservice.opad.h[4];
+    w_t[5] = ctx_kservice.opad.h[5];
+    w_t[6] = ctx_kservice.opad.h[6];
+    w_t[7] = ctx_kservice.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_signingkey;
+
+    sha256_hmac_init_vector (&ctx_signingkey, w_t, 32);
+
+    // aws4_request
+
+    w_t[0] = 0x61777334;
+    w_t[1] = 0x5f726571;
+    w_t[2] = 0x75657374;
+
+    for (u32 i = 3; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_update_vector (&ctx_signingkey, w_t, 12);
+
+    sha256_hmac_final_vector (&ctx_signingkey);
+
+    // signature
+
+    w_t[0] = ctx_signingkey.opad.h[0];
+    w_t[1] = ctx_signingkey.opad.h[1];
+    w_t[2] = ctx_signingkey.opad.h[2];
+    w_t[3] = ctx_signingkey.opad.h[3];
+    w_t[4] = ctx_signingkey.opad.h[4];
+    w_t[5] = ctx_signingkey.opad.h[5];
+    w_t[6] = ctx_signingkey.opad.h[6];
+    w_t[7] = ctx_signingkey.opad.h[7];
+
+    for (u32 i = 8; i < 64; i++)
+    {
+      w_t[i] = 0;
+    }
+
+    sha256_hmac_ctx_vector_t ctx_signature;
+
+    sha256_hmac_init_vector (&ctx_signature, w_t, 32);
+
+    sha256_hmac_update_vector (&ctx_signature, stringtosign_buf, stringtosign_len);
+
+    sha256_hmac_final_vector (&ctx_signature);
+
+    const u32x r0 = ctx_signature.opad.h[DGST_R0];
+    const u32x r1 = ctx_signature.opad.h[DGST_R1];
+    const u32x r2 = ctx_signature.opad.h[DGST_R2];
+    const u32x r3 = ctx_signature.opad.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -4,6 +4,7 @@
 ## Algorithms
 ##
 
+- Added hash-mode: Amazon AWS4-HMAC-SHA256
 - Added hash-mode: Exodus Desktop Wallet (scrypt)
 - Added hash-mode: PostgreSQL SCRAM-SHA-256
 - Added hash-mode: Teamspeak 3 (channel hash)

--- a/src/modules/module_28700.c
+++ b/src/modules/module_28700.c
@@ -1,0 +1,432 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "emu_inc_hash_sha1.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 3;
+static const u32   DGST_POS1      = 7;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 6;
+static const u32   DGST_SIZE      = DGST_SIZE_4_8;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_RAW_HASH_AUTHENTICATED;
+static const char *HASH_NAME      = "Amazon AWS4-HMAC-SHA256";
+static const u64   KERN_TYPE      = 28700;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_ST_ADD80;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$AWS-Sig-v4$0$20220221T000000Z$us-east-1$s3$421ab6e4af9f49fa30fa9c253fcfeb2ce91668e139e6b23303c5f75b04f8a3c4$3755ed2bc1b2346e003ccaa7d02ae8b73c72bcbe9f452ccf066c78504d786bbb";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+static const char *SIGNATURE_AWS_SIG_V4 = "$AWS-Sig-v4$0$";
+
+typedef struct aws4_sig_v4
+{
+  u32 date[3];
+  u32 date_len;
+
+  u32 longdate[4];
+  u32 longdate_len;
+
+  u32 region[4];
+  u32 region_len;
+
+  u32 service[4];
+  u32 service_len;
+
+  u32 canonical[8];
+  u32 canonical_len;
+
+  u32 stringtosign[64];
+  u32 stringtosign_len;
+
+} aws4_sig_v4_t;
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (aws4_sig_v4_t);
+
+  return esalt_size;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // reduce pw_max by 4
+
+  u32 pw_max = PW_MAX - 4;
+
+  if (user_options->optimized_kernel_enable == true && hashconfig->has_optimized_kernel == true)
+  {
+    pw_max = PW_MAX_OLD - 4;
+  }
+
+  return pw_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  aws4_sig_v4_t *esalt = (aws4_sig_v4_t *) esalt_buf;
+
+  hc_token_t token;
+
+  token.token_cnt  = 6;
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_AWS_SIG_V4;
+
+  token.len[0]     = 14;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // longdate
+  token.len_min[1] = 16;
+  token.len_max[1] = 16;
+  token.sep[1]     = '$';
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // region
+  token.len_min[2] = 1;
+  token.len_max[2] = 16;
+  token.sep[2]     = '$';
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // service
+  token.len_min[3] = 1;
+  token.len_max[3] = 16;
+  token.sep[3]     = '$';
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // canonical
+  token.len_min[4] = 32 * 2;
+  token.len_max[4] = 32 * 2;
+  token.sep[4]     = '$';
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // digest
+  token.len_min[5] = 32 * 2;
+  token.len_max[5] = 32 * 2;
+  token.sep[5]     = '$';
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  memset (esalt, 0, sizeof (aws4_sig_v4_t));
+
+  bool parse_rc = false;
+
+  // longdate
+
+  const u8 *longdate_pos = token.buf[1];
+  const int longdate_len = token.len[1];
+
+  parse_rc = generic_salt_decode (hashconfig, longdate_pos, longdate_len, (u8 *) esalt->longdate, (int *) &esalt->longdate_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  // date
+
+  parse_rc = generic_salt_decode (hashconfig, (u8 *) longdate_pos, 8, (u8 *) esalt->date, (int *) &esalt->date_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  // region
+
+  const u8 *region_pos = token.buf[2];
+  const int region_len = token.len[2];
+
+  parse_rc = generic_salt_decode (hashconfig, region_pos, region_len, (u8 *) esalt->region, (int *) &esalt->region_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  // service
+
+  const u8 *service_pos = token.buf[3];
+  const int service_len = token.len[3];
+
+  parse_rc = generic_salt_decode (hashconfig, service_pos, service_len, (u8 *) esalt->service, (int *) &esalt->service_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  // canonical
+
+  const u8 *canonical_pos = token.buf[4];
+  const int canonical_len = token.len[4];
+
+  esalt->canonical_len = hex_decode (canonical_pos, canonical_len, (u8 *) esalt->canonical);
+
+  // handle unique salts detection
+
+  sha1_ctx_t sha1_ctx;
+
+  sha1_init   (&sha1_ctx);
+  sha1_update (&sha1_ctx, esalt->canonical, esalt->canonical_len);
+  sha1_final  (&sha1_ctx);
+
+  // store sha1(esalt->canonical) in salt_buf
+
+  salt->salt_iter = 1;
+
+  salt->salt_len = 20;
+
+  memcpy (salt->salt_buf, sha1_ctx.h, salt->salt_len);
+
+  // stringtosign
+
+  char *stringtosign_ptr = (char *) esalt->stringtosign;
+
+  size_t off = 0;
+
+  strncpy (stringtosign_ptr + off, (char *) "AWS4-HMAC-SHA256", 16);
+  off += 16;
+
+  stringtosign_ptr[off] = 0x0a;
+  off += 1;
+
+  strncpy (stringtosign_ptr + off, (char *) esalt->longdate, esalt->longdate_len);
+  off += esalt->longdate_len;
+
+  stringtosign_ptr[off] = 0x0a;
+  off += 1;
+
+  strncpy (stringtosign_ptr + off, (char *) esalt->date, esalt->date_len);
+  off += esalt->date_len;
+
+  stringtosign_ptr[off] = 0x2f;
+  off += 1;
+
+  strncpy (stringtosign_ptr + off, (char *) esalt->region, esalt->region_len);
+  off += esalt->region_len;
+
+  stringtosign_ptr[off] = 0x2f;
+  off += 1;
+
+  strncpy (stringtosign_ptr + off, (char *) esalt->service, esalt->service_len);
+  off += esalt->service_len;
+
+  stringtosign_ptr[off] = 0x2f;
+  off += 1;
+
+  strncpy (stringtosign_ptr + off, (char *) "aws4_request", 12);
+  off += 12;
+
+  stringtosign_ptr[off] = 0x0a;
+  off += 1;
+
+  strncpy (stringtosign_ptr + off, (char *) canonical_pos, canonical_len);
+  off += canonical_len;
+
+  esalt->stringtosign_len = off;
+
+  // digest
+
+  const u8 *hash_pos = token.buf[5];
+
+  digest[0] = hex_to_u32 (hash_pos +  0);
+  digest[1] = hex_to_u32 (hash_pos +  8);
+  digest[2] = hex_to_u32 (hash_pos + 16);
+  digest[3] = hex_to_u32 (hash_pos + 24);
+  digest[4] = hex_to_u32 (hash_pos + 32);
+  digest[5] = hex_to_u32 (hash_pos + 40);
+  digest[6] = hex_to_u32 (hash_pos + 48);
+  digest[7] = hex_to_u32 (hash_pos + 56);
+
+  digest[0] = byte_swap_32 (digest[0]);
+  digest[1] = byte_swap_32 (digest[1]);
+  digest[2] = byte_swap_32 (digest[2]);
+  digest[3] = byte_swap_32 (digest[3]);
+  digest[4] = byte_swap_32 (digest[4]);
+  digest[5] = byte_swap_32 (digest[5]);
+  digest[6] = byte_swap_32 (digest[6]);
+  digest[7] = byte_swap_32 (digest[7]);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  aws4_sig_v4_t *esalt = (aws4_sig_v4_t *) esalt_buf;
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  // signature
+
+  int out_len = snprintf (line_buf, line_size, "%s", SIGNATURE_AWS_SIG_V4);
+
+  // longdate
+
+  out_len += generic_salt_encode (hashconfig, (const u8 *) esalt->longdate, (const int) esalt->longdate_len, out_buf + out_len);
+
+  out_buf[out_len] = '$';
+
+  out_len++;
+
+  // region
+
+  out_len += generic_salt_encode (hashconfig, (const u8 *) esalt->region, (const int) esalt->region_len, out_buf + out_len);
+
+  out_buf[out_len] = '$';
+
+  out_len++;
+
+  // service
+
+  out_len += generic_salt_encode (hashconfig, (const u8 *) esalt->service, (const int) esalt->service_len, out_buf + out_len);
+
+  out_buf[out_len] = '$';
+
+  out_len++;
+
+  // canonical
+
+  out_len += hex_encode ((u8 *) esalt->canonical, esalt->canonical_len, out_buf + out_len);
+
+  out_buf[out_len] = '$';
+
+  out_len++;
+
+  // digest
+
+  u32 tmp[8];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = digest[2];
+  tmp[3] = digest[3];
+  tmp[4] = digest[4];
+  tmp[5] = digest[5];
+  tmp[6] = digest[6];
+  tmp[7] = digest[7];
+
+  tmp[0] = byte_swap_32 (tmp[0]);
+  tmp[1] = byte_swap_32 (tmp[1]);
+  tmp[2] = byte_swap_32 (tmp[2]);
+  tmp[3] = byte_swap_32 (tmp[3]);
+  tmp[4] = byte_swap_32 (tmp[4]);
+  tmp[5] = byte_swap_32 (tmp[5]);
+  tmp[6] = byte_swap_32 (tmp[6]);
+  tmp[7] = byte_swap_32 (tmp[7]);
+
+  u32_to_hex (tmp[0], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[1], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[4], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[5], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[6], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[7], out_buf + out_len); out_len += 8;
+
+  out_buf[out_len] = 0;
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_28700.c
+++ b/src/modules/module_28700.c
@@ -206,43 +206,43 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   size_t off = 0;
 
-  strncpy (stringtosign_ptr + off, (char *) "AWS4-HMAC-SHA256", 16);
+  memcpy (stringtosign_ptr + off, (char *) "AWS4-HMAC-SHA256", 16);
   off += 16;
 
   stringtosign_ptr[off] = 0x0a;
   off += 1;
 
-  strncpy (stringtosign_ptr + off, (char *) esalt->longdate, esalt->longdate_len);
+  memcpy (stringtosign_ptr + off, (char *) esalt->longdate, esalt->longdate_len);
   off += esalt->longdate_len;
 
   stringtosign_ptr[off] = 0x0a;
   off += 1;
 
-  strncpy (stringtosign_ptr + off, (char *) esalt->date, esalt->date_len);
+  memcpy (stringtosign_ptr + off, (char *) esalt->date, esalt->date_len);
   off += esalt->date_len;
 
   stringtosign_ptr[off] = 0x2f;
   off += 1;
 
-  strncpy (stringtosign_ptr + off, (char *) esalt->region, esalt->region_len);
+  memcpy (stringtosign_ptr + off, (char *) esalt->region, esalt->region_len);
   off += esalt->region_len;
 
   stringtosign_ptr[off] = 0x2f;
   off += 1;
 
-  strncpy (stringtosign_ptr + off, (char *) esalt->service, esalt->service_len);
+  memcpy (stringtosign_ptr + off, (char *) esalt->service, esalt->service_len);
   off += esalt->service_len;
 
   stringtosign_ptr[off] = 0x2f;
   off += 1;
 
-  strncpy (stringtosign_ptr + off, (char *) "aws4_request", 12);
+  memcpy (stringtosign_ptr + off, (char *) "aws4_request", 12);
   off += 12;
 
   stringtosign_ptr[off] = 0x0a;
   off += 1;
 
-  strncpy (stringtosign_ptr + off, (char *) canonical_pos, canonical_len);
+  memcpy (stringtosign_ptr + off, (char *) canonical_pos, canonical_len);
   off += canonical_len;
 
   esalt->stringtosign_len = off;

--- a/tools/test_modules/m28700.pm
+++ b/tools/test_modules/m28700.pm
@@ -1,0 +1,88 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA  qw (sha256);
+use Digest::HMAC qw (hmac hmac_hex);
+
+sub module_constraints { [[0, 252], [8, 8], [0, 51], [8, 8], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift; # date
+  my $region = shift // "us-east-1";
+  my $service = shift // "s3";
+  my $canonical = shift // random_hex_string (64);
+
+  my $date = 0;
+  my $longdate = 0;
+
+  if (length ($salt) == 8)
+  {
+    $date = $salt;
+    $longdate = sprintf ("%sT000000Z", $date);  
+  }
+
+  if (length ($salt) == 16)
+  {
+    $longdate = $salt;
+    $date = substr ($salt, 0, 8);
+  }
+
+  my $kPassKey = sprintf ("AWS4%s", $word);
+
+  my $kDate = hmac ($date, $kPassKey, \&sha256, 64);
+  my $kRegion = hmac ($region, $kDate, \&sha256, 64);
+  my $kService = hmac ($service, $kRegion, \&sha256, 64);
+  my $kSigning = hmac ("aws4_request", $kService, \&sha256, 64);
+
+  my $stringtosign = sprintf ("AWS4-HMAC-SHA256\n%s\n%s/%s/%s/aws4_request\n%s", $longdate, $date, $region, $service, $canonical);
+
+  my $digest = hmac_hex ($stringtosign, $kSigning, \&sha256, 64);
+
+  my $hash = sprintf ("\$AWS-Sig-v4\$0\$%s\$%s\$%s\$%s\$%s", $longdate, $region, $service, $canonical, $digest);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless length ($word) gt 0;
+  return unless substr ($hash, 0, 14) eq '$AWS-Sig-v4$0$';
+
+  my (undef, $signature, $version, $salt, $region, $service, $canonical, $digest) = split '\$', $hash;
+
+  return unless defined $signature;
+  return unless defined $version;
+  return unless defined $salt; # date
+  return unless defined $region;
+  return unless defined $service;
+  return unless defined $canonical;
+  return unless defined $digest;
+
+  return unless length ($salt) == 16;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $region, $service, $canonical);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Hi,

as requested in #3188, with this PR we add support to a new hash-mode: Amazon AWS4-HMAC-SHA256

Benchmark using Apple M1 / Metal API:

```
bash-3.2$ ./hashcat -m 28700 -b --backend-ignore-opencl
hashcat (v6.2.5-259-g78b82f0fd+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

METAL API (Metal 258.18)
========================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

Benchmark relevant options:
===========================
* --optimized-kernel-enable

-------------------------------------------
* Hash-Mode 28700 (Amazon AWS4-HMAC-SHA256)
-------------------------------------------

Speed.#1.........:  9082.4 kH/s (56.51ms) @ Accel:32 Loops:16 Thr:128 Vec:1

Started: Wed Feb 23 22:23:19 2022
Stopped: Wed Feb 23 22:23:25 2022
```

Following the test output using Apple M1 / Metal API:

```
bash-3.2$ ./tools/test.sh -m 28700 -a all -t all
[ test_1645642994 ] > Init test for hash type 28700.
[ test_1645642994 ] [ Type 28700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1645642994 ] [ Type 28700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645642994 ] [ Type 28700, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645642994 ] [ Type 28700, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645642994 ] [ Type 28700, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 3/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1645642994 ] [ Type 28700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645642994 ] [ Type 28700, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645642994 ] [ Type 28700, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645642994 ] [ Type 28700, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > Warning : 0/7 not found, 0/7 not matched, 3/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645642994 ] [ Type 28700, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
bash-3.2$ ./tools/test.sh -m 28700 -a all -t all -P
[ test_1645648180 ] > Init test for hash type 28700.
[ test_1645648180 ] [ Type 28700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1645648180 ] [ Type 28700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645648180 ] [ Type 28700, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645648180 ] [ Type 28700, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645648180 ] [ Type 28700, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 3/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1645648180 ] [ Type 28700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645648180 ] [ Type 28700, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645648180 ] [ Type 28700, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645648180 ] [ Type 28700, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > Warning : 0/7 not found, 0/7 not matched, 3/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645648180 ] [ Type 28700, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```

References:
https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html

Thanks :)