### PR TITLE
code style fix: remove extra spaces in source code

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -522,7 +522,7 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     event_log_advice (hashcat_ctx, "will add ALL plains/collisions found, even duplicates, to the potfile.");
     event_log_advice (hashcat_ctx, NULL);
   }
-  
+
   if (hashconfig->potfile_disable == true)
   {
     event_log_advice (hashcat_ctx, "ATTENTION! Potfile storage is disabled for this hash mode.");
@@ -765,7 +765,7 @@ static void main_monitor_performance_hint (MAYBE_UNUSED hashcat_ctx_t *hashcat_c
       }
     }
   }
-  
+
   event_log_advice (hashcat_ctx, "* Update your backend API runtime / driver the right way:");
   event_log_advice (hashcat_ctx, "  https://hashcat.net/faq/wrongdriver");
   event_log_advice (hashcat_ctx, NULL);

--- a/src/modules/module_25400.c
+++ b/src/modules/module_25400.c
@@ -24,8 +24,8 @@ static const char *HASH_NAME      = "PDF 1.4 - 1.6 (Acrobat 5 - 8) - user and ow
 static const u64   KERN_TYPE      = 25400;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_NOT_ITERATED;
-static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE 
-                                  | OPTS_TYPE_COPY_TMPS 
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_COPY_TMPS
                                   | OPTS_TYPE_PT_ALWAYS_ASCII
                                   | OPTS_TYPE_AUTODETECT_DISABLE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2097,9 +2097,9 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
   {
     if (hashcat_status->salts_cnt > 1)
     {
-      const int digests_new = hashcat_status->digests_done - hashcat_status->digests_done_pot; 
+      const int digests_new = hashcat_status->digests_done - hashcat_status->digests_done_pot;
       const double digests_new_perc = (double) digests_new / (double) hashcat_status->digests_cnt * 100;
-      
+
       if (digests_new > 1)
       {
         event_log_info (hashcat_ctx,
@@ -2126,13 +2126,13 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
           hashcat_status->salts_done,
           hashcat_status->salts_cnt,
           hashcat_status->salts_percent);
-      }  
+      }
     }
     else
     {
-      const int digests_new = hashcat_status->digests_done - hashcat_status->digests_done_pot; 
+      const int digests_new = hashcat_status->digests_done - hashcat_status->digests_done_pot;
       const double digests_new_perc = (double) digests_new / (double) hashcat_status->digests_cnt * 100;
-      
+
       if (digests_new > 1)
       {
         event_log_info (hashcat_ctx,


### PR DESCRIPTION
This is a minor formatting/code style fix. We do not need these extra whitespaces and normally try to avoid them in the source code (if not required, like some tabs/spaces in `Makefile` syntax etc).

Thanks