### PR TITLE
Added support to use 'John the Ripper' hash format with hash-type 18200

### DIFF
--- a/OpenCL/m18200_a0-optimized.cl
+++ b/OpenCL/m18200_a0-optimized.cl
@@ -25,6 +25,7 @@ typedef struct krb5asrep
   u32 checksum[4];
   u32 edata2[5120];
   u32 edata2_len;
+  u32 format;
 
 } krb5asrep_t;
 

--- a/OpenCL/m18200_a0-pure.cl
+++ b/OpenCL/m18200_a0-pure.cl
@@ -24,6 +24,7 @@ typedef struct krb5asrep
   u32 checksum[4];
   u32 edata2[5120];
   u32 edata2_len;
+  u32 format;
 
 } krb5asrep_t;
 

--- a/OpenCL/m18200_a1-optimized.cl
+++ b/OpenCL/m18200_a1-optimized.cl
@@ -23,6 +23,7 @@ typedef struct krb5asrep
   u32 checksum[4];
   u32 edata2[5120];
   u32 edata2_len;
+  u32 format;
 
 } krb5asrep_t;
 

--- a/OpenCL/m18200_a1-pure.cl
+++ b/OpenCL/m18200_a1-pure.cl
@@ -22,6 +22,7 @@ typedef struct krb5asrep
   u32 checksum[4];
   u32 edata2[5120];
   u32 edata2_len;
+  u32 format;
 
 } krb5asrep_t;
 

--- a/OpenCL/m18200_a3-optimized.cl
+++ b/OpenCL/m18200_a3-optimized.cl
@@ -23,6 +23,7 @@ typedef struct krb5asrep
   u32 checksum[4];
   u32 edata2[5120];
   u32 edata2_len;
+  u32 format;
 
 } krb5asrep_t;
 

--- a/OpenCL/m18200_a3-pure.cl
+++ b/OpenCL/m18200_a3-pure.cl
@@ -22,6 +22,7 @@ typedef struct krb5asrep
   u32 checksum[4];
   u32 edata2[5120];
   u32 edata2_len;
+  u32 format;
 
 } krb5asrep_t;
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -18,6 +18,7 @@
 - Added support to building universal macOS binary on Apple Silicon
 - Added hex encoding format for --separator option
 - Added password candidates range to --status-json output
+- Added support to use 'John the Ripper' hash format with hash-type 18200
 
 ##
 ## Bugs

--- a/src/modules/module_18200.c
+++ b/src/modules/module_18200.c
@@ -224,29 +224,31 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
 
-  u8 *checksum_pos = NULL;
-  u8 *data_pos = NULL;
+  const u8 *checksum_pos = NULL;
+  const u8 *data_pos = NULL;
 
   int data_len = 0;
 
   if (krb5asrep->format == 1)
   {
-    checksum_pos = (u8 *) token.buf[3];
+    checksum_pos = token.buf[3];
 
-    data_pos = (u8 *) token.buf[4];
+    data_pos = token.buf[4];
     data_len = token.len[4];
 
     memcpy (krb5asrep->account_info, token.buf[2], token.len[2]);
   }
   else
   {
-    checksum_pos = (u8 *) token.buf[2];
+    checksum_pos = token.buf[2];
 
-    data_pos = (u8 *) token.buf[3];
+    data_pos = token.buf[3];
     data_len = token.len[3];
 
     memcpy (krb5asrep->account_info, token.buf[1], token.len[1]);
   }
+
+  if (checksum_pos == NULL || data_pos == NULL) return (PARSER_SALT_VALUE);
 
   krb5asrep->checksum[0] = hex_to_u32 (checksum_pos +  0);
   krb5asrep->checksum[1] = hex_to_u32 (checksum_pos +  8);

--- a/src/modules/module_18200.c
+++ b/src/modules/module_18200.c
@@ -47,10 +47,11 @@ typedef struct krb5asrep
   u32 checksum[4];
   u32 edata2[5120];
   u32 edata2_len;
+  u32 format;
 
 } krb5asrep_t;
 
-static const char *SIGNATURE_KRB5ASREP = "$krb5asrep$23$";
+static const char *SIGNATURE_KRB5ASREP = "$krb5asrep$";
 
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
@@ -122,47 +123,130 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                 | TOKEN_ATTR_VERIFY_SIGNATURE;
 
   /**
-   * $krb5asrep$23$user_principal_name:checksum$edata2
+   * hc
+   * format 1: $krb5asrep$23$user_principal_name:checksum$edata2
+   *
+   * jtr
+   * format 2: $krb5asrep$user_principal_name:checksum$edata2
    */
 
-  if (line_len < 16) return (PARSER_SALT_LENGTH);
+  if (line_len < (int) strlen (SIGNATURE_KRB5ASREP)) return (PARSER_SALT_LENGTH);
 
-  char *upn_info_start = (char *) line_buf + strlen (SIGNATURE_KRB5ASREP);
-  char *upn_info_stop  = strchr ((const char *) upn_info_start, ':');
+  memset (krb5asrep, 0, sizeof (krb5asrep_t));
 
-  if (upn_info_stop == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+  size_t parse_off = 0;
 
-  upn_info_stop++; // we want the : char included
+  if (line_buf[token.len[0]] == '2' && line_buf[token.len[0] + 1] == '3' && line_buf[token.len[0] + 2] == '$')
+  {
+    // hashcat format
 
-  const int upn_info_len = upn_info_stop - upn_info_start;
+    krb5asrep->format = 1;
+
+    parse_off += 2;
+  }
+  else
+  {
+    // jtr format
+
+    krb5asrep->format = 2;
+  }
+
+  char *account_info_start = (char *) line_buf + strlen (SIGNATURE_KRB5ASREP) + parse_off;
+  char *account_info_stop  = strchr ((const char *) account_info_start, ':');
+
+  if (account_info_stop == NULL) return (PARSER_SEPARATOR_UNMATCHED);
+
+  account_info_stop++; // we want the : char included
+
+  const int account_info_len = account_info_stop - account_info_start;
 
   token.token_cnt  = 4;
 
-  token.len[1]     = upn_info_len;
-  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
+  if (krb5asrep->format == 1)
+  {
+    token.token_cnt++;
 
-  token.sep[2]     = '$';
-  token.len_min[2] = 32;
-  token.len_max[2] = 32;
-  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_HEX;
+    // etype
 
-  token.sep[3]     = '$';
-  token.len_min[3] = 64;
-  token.len_max[3] = 40960;
-  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_HEX;
+    token.sep[1]     = '$';
+    token.len[1]     = 2;
+    token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                     | TOKEN_ATTR_VERIFY_DIGIT;
+
+    // user_principal_name
+
+    token.sep[2]     = ':';
+    token.len[2]     = account_info_len;
+    token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH;
+
+    // checksum
+
+    token.sep[3]     = '$';
+    token.len_min[3] = 32;
+    token.len_max[3] = 32;
+    token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+    // edata2
+
+    token.sep[4]     = '$';
+    token.len_min[4] = 64;
+    token.len_max[4] = 40960;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+  }
+  else
+  {
+    // user_principal_name
+
+    token.sep[1]     = ':';
+    token.len[1]     = account_info_len;
+    token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
+
+    // checksum
+
+    token.sep[2]     = '$';
+    token.len_min[2] = 32;
+    token.len_max[2] = 32;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+    // edata2
+
+    token.sep[3]     = '$';
+    token.len_min[3] = 64;
+    token.len_max[3] = 40960;
+    token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+  }
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
 
   if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
 
-  const u8 *checksum_pos = token.buf[2];
+  u8 *checksum_pos = NULL;
+  u8 *data_pos = NULL;
 
-  const u8 *data_pos = token.buf[3];
-  const int data_len = token.len[3];
+  int data_len = 0;
 
-  memcpy (krb5asrep->account_info, token.buf[1], token.len[1]);
+  if (krb5asrep->format == 1)
+  {
+    checksum_pos = (u8 *) token.buf[3];
+
+    data_pos = (u8 *) token.buf[4];
+    data_len = token.len[4];
+
+    memcpy (krb5asrep->account_info, token.buf[2], token.len[2]);
+  }
+  else
+  {
+    checksum_pos = (u8 *) token.buf[2];
+
+    data_pos = (u8 *) token.buf[3];
+    data_len = token.len[3];
+
+    memcpy (krb5asrep->account_info, token.buf[1], token.len[1]);
+  }
 
   krb5asrep->checksum[0] = hex_to_u32 (checksum_pos +  0);
   krb5asrep->checksum[1] = hex_to_u32 (checksum_pos +  8);
@@ -213,14 +297,30 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     sprintf (data + j, "%02x", ptr_edata2[i]);
   }
 
-  const int line_len = snprintf (line_buf, line_size, "%s%s%08x%08x%08x%08x$%s",
-    SIGNATURE_KRB5ASREP,
-    (char *) krb5asrep->account_info,
-    byte_swap_32 (krb5asrep->checksum[0]),
-    byte_swap_32 (krb5asrep->checksum[1]),
-    byte_swap_32 (krb5asrep->checksum[2]),
-    byte_swap_32 (krb5asrep->checksum[3]),
-    data);
+  int line_len = 0;
+
+  if (krb5asrep->format == 1)
+  {
+    line_len = snprintf (line_buf, line_size, "%s23%s%08x%08x%08x%08x$%s",
+      SIGNATURE_KRB5ASREP,
+      (char *) krb5asrep->account_info,
+      byte_swap_32 (krb5asrep->checksum[0]),
+      byte_swap_32 (krb5asrep->checksum[1]),
+      byte_swap_32 (krb5asrep->checksum[2]),
+      byte_swap_32 (krb5asrep->checksum[3]),
+      data);
+  }
+  else
+  {
+    line_len = snprintf (line_buf, line_size, "%s%s%08x%08x%08x%08x$%s",
+      SIGNATURE_KRB5ASREP,
+      (char *) krb5asrep->account_info,
+      byte_swap_32 (krb5asrep->checksum[0]),
+      byte_swap_32 (krb5asrep->checksum[1]),
+      byte_swap_32 (krb5asrep->checksum[2]),
+      byte_swap_32 (krb5asrep->checksum[3]),
+      data);
+  }
 
   return line_len;
 }


### PR DESCRIPTION
Hi,

from evilmog request on discord, with this PR we add support to use jtr hash format with hash-type 18200.

Following the PoC's:

```
bash-3.2$ echo 'Upassword1' | ./hashcat 18200.hashes --potfile-disable --backend-ignore-opencl --quiet
Hash-mode was not specified with -m. Attempting to auto-detect hash mode.
The following mode was auto-detected as the only one matching your input hash:

18200 | Kerberos 5, etype 23, AS-REP | Network Protocol

NOTE: Auto-detect is best effort. The correct hash-mode is NOT guaranteed!
Do NOT report auto-detect issues unless you are certain of the hash type.

$krb5asrep$first.user@AllSafe.local:830c8d4a7aec666111b85baee43b2e1d$6463adb16fe7866f5d624fcf9da8367cf42afae17cf443255b20423c76b6c3024f3c762472217fa09cdc1bf87c9f380d202ce60f1e05ecedf285bab784f3e7204b4231164b543ba69e49d944e763c0499a133af6e73a09f40c9a275f722b7115f534dfa8b938ff8ccfad05163374bbe952c12dafc5fea8ff3d5c62d4377225cb51f701581cac860a56579d53d049f64d0f2d29a7af90c020901ab42e48cfe4e4a2ac16668e9932c82e3e6cc307fb88a52108b7038b434d8457ee336a0fa59fe8fb1daccd27d2c83bd5b9829a6429c9902c10047b8b4be2135465beab8bc5a56463c1ffb03c1f0c726b4715c78f52:Upassword1
$krb5asrep$23$first.user@AllSafe.local:eb1cff7a1153565befe32adca8598238$14f2680523ee2dc936b123e246066f7ce0fe48b4f56d25d7597981643bf6457cc06fa08356f45415abc6e9a35a4f308692707d23f0426b42e8d3bbd3aeba433c8a15663c94c3580246e0f612991a217dad9f93d50d6447751d96b66187cb18ae3ab0bafb2665be2c2fa9894a013a38987851f1f7f5bf9938d8926f4f8cbbd3b92b106c1d19d6c3b66135e2c92609b82a760b8a319fa0bb7650a03990acaf74dc364ec9115ede4117f356e9821ff65c378b460e6f3de22ea25b8f35005a7b7d955567d2f86a523186422db8b7723b88bc4393655313eb10106cb6d2cb92576ab5aab7db28938ab6ccd20769680d3a:Upassword1
Session..........: hashcat
Status...........: Cracked
Hash.Mode........: 18200 (Kerberos 5, etype 23, AS-REP)
Hash.Target......: 18200.hashes
Time.Started.....: Sun Feb 27 14:40:15 2022 (0 secs)
Time.Estimated...: Sun Feb 27 14:40:15 2022 (0 secs)
Kernel.Feature...: Pure Kernel
Guess.Base.......: Pipe
Speed.#1.........:     1070 H/s (0.18ms) @ Accel:1024 Loops:1 Thr:32 Vec:1
Recovered.Total..: 2/2 (100.00%) Digests, 2/2 (100.00%) Salts
Progress.........: 2
Rejected.........: 0
Restore.Point....: 0
Restore.Sub.#1...: Salt:1 Amplifier:0-1 Iteration:0-1
Candidate.Engine.: Device Generator
Candidates.#1....: Upassword1 -> Upassword1
Hardware.Mon.SMC.: Fan0: 37%
Hardware.Mon.#1..: Util: 87%
```

```
bash-3.2$ ./tools/test.sh -m 18200 -a all -t all
[ test_1645969220 ] > Init test for hash type 18200.
[ test_1645969220 ] [ Type 18200, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1645969220 ] [ Type 18200, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645969220 ] [ Type 18200, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645969220 ] [ Type 18200, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645969220 ] [ Type 18200, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Warning : 0/6 not found, 0/6 not matched, 1/6 timeout, 0/6 skipped
[ test_1645969220 ] [ Type 18200, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1645969220 ] [ Type 18200, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645969220 ] [ Type 18200, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645969220 ] [ Type 18200, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1645969220 ] [ Type 18200, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > Warning : 0/6 not found, 0/6 not matched, 1/6 timeout, 0/6 skipped
[ test_1645969220 ] [ Type 18200, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1645969220 ] [ Type 18200, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```

Thanks :)