### PR TITLE
Fix mask endianness for 25800

### DIFF
--- a/src/modules/module_25800.c
+++ b/src/modules/module_25800.c
@@ -20,7 +20,7 @@ static const u32   HASH_CATEGORY  = HASH_CATEGORY_FORUM_SOFTWARE;
 static const char *HASH_NAME      = "bcrypt(sha1($pass)) / bcryptsha1";
 static const u64   KERN_TYPE      = 25800;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
-static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_BE
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_DYNAMIC_SHARED;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";


### PR DESCRIPTION
Mode 25800 (bcryptsha1) has the wrong endianness set for mask attacks:

```
$ echo password | tools/test.pl passthrough 25800
$2a$05$LBSuLxe0KReuMBGyLRC3KOUeff18/Q.1GdlbmOA2XrXv6y78JCoL2

$ ./hashcat -m 25800 '$2a$05$LBSuLxe0KReuMBGyLRC3KOUeff18/Q.1GdlbmOA2XrXv6y78JCoL2' -a 3 password | grep Status
Status...........: Exhausted

$ ./hashcat -m 25800 '$2a$05$LBSuLxe0KReuMBGyLRC3KOUeff18/Q.1GdlbmOA2XrXv6y78JCoL2' -a 3 ssapdrow | grep Status
Status...........: Cracked
```

After change:
```
$ ./hashcat -m 25800 '$2a$05$LBSuLxe0KReuMBGyLRC3KOUeff18/Q.1GdlbmOA2XrXv6y78JCoL2' -a 3 ssapdrow | grep Status
Status...........: Exhausted

$ ./hashcat -m 25800 '$2a$05$LBSuLxe0KReuMBGyLRC3KOUeff18/Q.1GdlbmOA2XrXv6y78JCoL2' -a 3 password | grep Status
Status...........: Cracked
```