### PR TITLE
fixes #2560: mention "main driver" within the error message

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -7045,12 +7045,12 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
                 {
                   if (backend_ctx->rc_cuda_init == -1)
                   {
-                    event_log_warning (hashcat_ctx, "Failed to initialize NVIDIA CUDA library.");
+                    event_log_warning (hashcat_ctx, "Failed to initialize the NVIDIA main driver CUDA runtime library.");
                     event_log_warning (hashcat_ctx, NULL);
                   }
                   else
                   {
-                    event_log_warning (hashcat_ctx, "Successfully initialized NVIDIA CUDA library.");
+                    event_log_warning (hashcat_ctx, "Successfully initialized the NVIDIA main driver CUDA runtime library.");
                     event_log_warning (hashcat_ctx, NULL);
                   }
 


### PR DESCRIPTION
As mentioned in #2560 the error message was a little bit misleading because even if some users didn't install `CUDA` the error about missing or successful loading of `CUDA` was mentioned within the output. I think this way of describing the succes/failure is much better. Thanks

This is of course just a minor (output/display) change.

Best