### PR TITLE
fixed missing Register-Limit optimizer string in init screen

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -48,6 +48,7 @@
 - Fixed Unit Test false negative if there are spaces in the filesystem path to hashcat
 - Fixed Unit Test salt-max in case of optimized kernel, with hash-type 22 and 23
 - Fixed wordlist handling in -m 3000 when candidate passwords use the $HEX[...] syntax
+- Fixed display problem of the "Optimizers applied" list for algorithms using Register-Limit
 
 ##
 ## Technical

--- a/src/shared.c
+++ b/src/shared.c
@@ -78,6 +78,7 @@ static const char *const OPTI_STR_SINGLE_HASH          = "Single-Hash";
 static const char *const OPTI_STR_SINGLE_SALT          = "Single-Salt";
 static const char *const OPTI_STR_BRUTE_FORCE          = "Brute-Force";
 static const char *const OPTI_STR_RAW_HASH             = "Raw-Hash";
+static const char *const OPTI_STR_REGISTER_LIMIT       = "Register-Limit";
 static const char *const OPTI_STR_SLOW_HASH_SIMD_INIT  = "Slow-Hash-SIMD-INIT";
 static const char *const OPTI_STR_SLOW_HASH_SIMD_LOOP  = "Slow-Hash-SIMD-LOOP";
 static const char *const OPTI_STR_SLOW_HASH_SIMD_COMP  = "Slow-Hash-SIMD-COMP";
@@ -1006,6 +1007,7 @@ const char *stroptitype (const u32 opti_type)
     case OPTI_TYPE_SINGLE_SALT:         return OPTI_STR_SINGLE_SALT;
     case OPTI_TYPE_BRUTE_FORCE:         return OPTI_STR_BRUTE_FORCE;
     case OPTI_TYPE_RAW_HASH:            return OPTI_STR_RAW_HASH;
+    case OPTI_TYPE_REGISTER_LIMIT:      return OPTI_STR_REGISTER_LIMIT;
     case OPTI_TYPE_SLOW_HASH_SIMD_INIT: return OPTI_STR_SLOW_HASH_SIMD_INIT;
     case OPTI_TYPE_SLOW_HASH_SIMD_LOOP: return OPTI_STR_SLOW_HASH_SIMD_LOOP;
     case OPTI_TYPE_SLOW_HASH_SIMD_COMP: return OPTI_STR_SLOW_HASH_SIMD_COMP;


### PR DESCRIPTION
I've found this bug by accident.
When using one any of the hash modes that uses the `Register-Limit` optimizer e.g. (currently)
- -m 7900 = `Drupal7`
- -m 10700 = `PDF 1.7 Level 8 (Acrobat 10 - 11)`
- -m 12400 = `BSDi Crypt, Extended DES` or
- -m 16600 = `Electrum Wallet (Salt-Type 1-3)`

the user could see this strange point within the list of "`Optimizers applied`" (init/startup screen):
```
Optimizers applied:
* (null)
```

The problem was that the `Register-Limit` Optimizer did not have any corresponding "string" (in this case `OPTI_STR_REGISTER_LIMIT` was missing).

This problem should be fixed with this patch and therefore no more `(null)` should be shown within the init screen of `hashcat` when using this specific hash-modes.

Thanks