### PR TITLE
fixes #3151: max pass length in -m 10700 w/ optimized kernel

### DIFF
--- a/OpenCL/m10700-optimized.cl
+++ b/OpenCL/m10700-optimized.cl
@@ -653,7 +653,7 @@ KERNEL_FQ void m10700_loop (KERN_ATTR_TMPS_ESALT (pdf17l8_tmp_t, pdf_t))
   w0[2] = pws[gid].i[2];
   w0[3] = pws[gid].i[3];
 
-  const u32 pw_len = pws[gid].pw_len & 63;
+  const u32 pw_len = pws[gid].pw_len & 31;
 
   if (pw_len == 0) return;
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -49,6 +49,7 @@
 - Fixed Unit Test salt-max in case of optimized kernel, with hash-type 22 and 23
 - Fixed wordlist handling in -m 3000 when candidate passwords use the $HEX[...] syntax
 - Fixed display problem of the "Optimizers applied" list for algorithms using Register-Limit
+- Fixed password limit in optimized kernel for hash-mode 10700
 
 ##
 ## Technical


### PR DESCRIPTION
As first reported here #3151 , there was a problem with very long passwords (for instance when using rules, e.g. duplicate word rules etc) in -m 10700 -O (only optimized kernel).

The driver refused or stopped to run the `CUDA` / `OpenCL` kernel with the unfixed version with error code:
```
an illegal memory access was encountered
```

The problem was even easier to notice after this commit https://github.com/hashcat/hashcat/commit/1d33b5714474439b2bd81f882ef02ca947b253fb (again, this was all reported by @s3inlc in #3151 , kudos for finding this critical / nasty bug ! ) which introduced `shared memory` for the `s_sc` (or just named `sc` in other parts of the kernel code)... the buffer overflow made it trigger a driver exit/crash even faster due to the use of `shared memory` (but as far as I understand it, it's not the culprit, instead the wrong password limit was there for much longer time).

The fix proposed here limits the password to the size mentioned in the kernel `PWMAXSZ` (https://github.com/hashcat/hashcat/blob/8bc4a920892185ab52e5b05b92378a4658fc0864/OpenCL/m10700-optimized.cl#L213) which is exactly what the buffer sizes/lengths are able to support.

I was able to reproduce the bug with a single rule that duplicates the words a couple of time, but as suggested in #3151 it also works like this:
```
hashcat -m 10700 -O -r rules/dive.rule hash.txt example.dict
```

it doesn't give any error messages and all the unit tests still work for me after the fix.

Thanks