### PR TITLE
prevent integer overflows in rp.c

### DIFF
--- a/src/rp.c
+++ b/src/rp.c
@@ -770,6 +770,13 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
     {
       rule_len = (u32) fgetl (&fp, rule_buf, HCBUFSIZ_LARGE);
 
+      if (rule_line >= 0xffffffff)
+      {
+        event_log_error (hashcat_ctx, "Unsupported number of lines in rule file %s", rp_file);
+
+        return -1;
+      }
+
       rule_line++;
 
       if (rule_len == 0) continue;
@@ -805,6 +812,13 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
         memset (&kernel_rules_buf[kernel_rules_cnt], 0, sizeof (kernel_rule_t)); // needs to be cleared otherwise we could have some remaining data
 
         continue;
+      }
+
+      if (kernel_rules_cnt >= 0xffffffff)
+      {
+        event_log_error (hashcat_ctx, "Unsupported number of rules in file %s", rp_file);
+
+        return -1;
       }
 
       kernel_rules_cnt++;


### PR DESCRIPTION
This small patch should actually avoid a very specific case where we have a very, very long rule file (could be empty lines without rules or very, very many number of rules > 0xffffffff).

Currently we kind of restrict the number of rules indirectly, because each rule does consume several resources (space RAM/VRAM) and therefore we actually normally can't load that many rules (but there could still be empty lines in rule files).

With this patch no interger (`u32`) overflow should be possible in the rule file reading code.

Thx