### PR TITLE
sanity check for u32 cast for combs_cnt, bfs_cnt

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -3595,6 +3595,17 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
     }
     else
     {
+      // sanity check: do NOT cast to an u32 integer type without checking that it is safe (upper bits must NOT be set)
+
+      if (user_options_extra->attack_kern == ATTACK_KERN_COMBI)
+      {
+        if (combinator_ctx->combs_cnt >> 32) != 0) return -1;
+      }
+      else if (user_options_extra->attack_kern == ATTACK_KERN_BF)
+      {
+        if (mask_ctx->bfs_cnt >> 32) != 0) return -1;
+      }
+
       if   (hashconfig->attack_exec == ATTACK_EXEC_INSIDE_KERNEL) innerloop_step = device_param->kernel_loops;
       else                                                        innerloop_step = 1;
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -3599,11 +3599,11 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
 
       if (user_options_extra->attack_kern == ATTACK_KERN_COMBI)
       {
-        if (combinator_ctx->combs_cnt >> 32) != 0) return -1;
+        if ((combinator_ctx->combs_cnt >> 32) != 0) return -1;
       }
       else if (user_options_extra->attack_kern == ATTACK_KERN_BF)
       {
-        if (mask_ctx->bfs_cnt >> 32) != 0) return -1;
+        if ((mask_ctx->bfs_cnt >> 32) != 0) return -1;
       }
 
       if   (hashconfig->attack_exec == ATTACK_EXEC_INSIDE_KERNEL) innerloop_step = device_param->kernel_loops;


### PR DESCRIPTION
This is just a very harsh sanity check that makes sure that the `(u32) combinator_ctx->combs_cnt` and `(u32) mask_ctx->bfs_cnt`  (see https://github.com/hashcat/hashcat/blob/8bc4a920892185ab52e5b05b92378a4658fc0864/src/backend.c#L3602-L3603) can never result in wrong amount of amplifier iterations due to a wrong / unsafe cast (if upper bits are set).

This is just a hash / critical preventative fix for another problem reported in #3144 (basically the first part of the fix).
We still need to restict how large the values of `combs_cnt` and `bfs_cnt` can be by also patching `mpsp.c` and `combinator.c` (and maybe others).... i.e. the root of the problem needs to be fixed too.

Thx