### PR TITLE
status-json: also print device name and type

### DIFF
--- a/include/status.h
+++ b/include/status.h
@@ -88,6 +88,7 @@ int         status_get_innerloop_left_dev             (const hashcat_ctx_t *hash
 int         status_get_iteration_pos_dev              (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
 int         status_get_iteration_left_dev             (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
 char       *status_get_device_name                    (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
+cl_device_type  status_get_device_type                (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
 #ifdef WITH_BRAIN
 int         status_get_brain_session                  (const hashcat_ctx_t *hashcat_ctx);
 int         status_get_brain_attack                   (const hashcat_ctx_t *hashcat_ctx);

--- a/include/status.h
+++ b/include/status.h
@@ -87,6 +87,7 @@ int         status_get_innerloop_pos_dev              (const hashcat_ctx_t *hash
 int         status_get_innerloop_left_dev             (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
 int         status_get_iteration_pos_dev              (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
 int         status_get_iteration_left_dev             (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
+char       *status_get_device_name                    (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx);
 #ifdef WITH_BRAIN
 int         status_get_brain_session                  (const hashcat_ctx_t *hashcat_ctx);
 int         status_get_brain_attack                   (const hashcat_ctx_t *hashcat_ctx);

--- a/include/types.h
+++ b/include/types.h
@@ -2587,6 +2587,7 @@ typedef struct device_info
   int     iteration_pos_dev;
   int     iteration_left_dev;
   char   *device_name;
+  cl_device_type device_type;
   #ifdef WITH_BRAIN
   int     brain_link_client_id_dev;
   int     brain_link_status_dev;

--- a/include/types.h
+++ b/include/types.h
@@ -2586,6 +2586,7 @@ typedef struct device_info
   int     innerloop_left_dev;
   int     iteration_pos_dev;
   int     iteration_left_dev;
+  char   *device_name;
   #ifdef WITH_BRAIN
   int     brain_link_client_id_dev;
   int     brain_link_status_dev;

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -2018,6 +2018,7 @@ int hashcat_get_status (hashcat_ctx_t *hashcat_ctx, hashcat_status_t *hashcat_st
     device_info->iteration_pos_dev              = status_get_iteration_pos_dev              (hashcat_ctx, device_id);
     device_info->iteration_left_dev             = status_get_iteration_left_dev             (hashcat_ctx, device_id);
     device_info->device_name                    = status_get_device_name                    (hashcat_ctx, device_id);
+    device_info->device_type                    = status_get_device_type                    (hashcat_ctx, device_id);
     #ifdef WITH_BRAIN
     device_info->brain_link_client_id_dev       = status_get_brain_link_client_id_dev       (hashcat_ctx, device_id);
     device_info->brain_link_status_dev          = status_get_brain_link_status_dev          (hashcat_ctx, device_id);

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -2017,6 +2017,7 @@ int hashcat_get_status (hashcat_ctx_t *hashcat_ctx, hashcat_status_t *hashcat_st
     device_info->innerloop_left_dev             = status_get_innerloop_left_dev             (hashcat_ctx, device_id);
     device_info->iteration_pos_dev              = status_get_iteration_pos_dev              (hashcat_ctx, device_id);
     device_info->iteration_left_dev             = status_get_iteration_left_dev             (hashcat_ctx, device_id);
+    device_info->device_name                    = status_get_device_name                    (hashcat_ctx, device_id);
     #ifdef WITH_BRAIN
     device_info->brain_link_client_id_dev       = status_get_brain_link_client_id_dev       (hashcat_ctx, device_id);
     device_info->brain_link_status_dev          = status_get_brain_link_status_dev          (hashcat_ctx, device_id);

--- a/src/status.c
+++ b/src/status.c
@@ -1829,6 +1829,15 @@ int status_get_iteration_left_dev (const hashcat_ctx_t *hashcat_ctx, const int b
   return iteration_left;
 }
 
+char *status_get_device_name (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx)
+{
+  const backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
+
+  hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
+
+  return device_param->device_name;
+}
+
 #ifdef WITH_BRAIN
 int status_get_brain_link_client_id_dev (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx)
 {

--- a/src/status.c
+++ b/src/status.c
@@ -1838,6 +1838,15 @@ char *status_get_device_name (const hashcat_ctx_t *hashcat_ctx, const int backen
   return device_param->device_name;
 }
 
+cl_device_type status_get_device_type (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx)
+{
+  const backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
+
+  hc_device_param_t *device_param = &backend_ctx->devices_param[backend_devices_idx];
+
+  return device_param->opencl_device_type;
+}
+
 #ifdef WITH_BRAIN
 int status_get_brain_link_client_id_dev (const hashcat_ctx_t *hashcat_ctx, const int backend_devices_idx)
 {

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1660,7 +1660,12 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
     }
 
     printf (" { \"device_id\": %d,", device_id + 1);
-    printf (" { \"device_name\": \"%s\",", device_info->device_name);
+    printf (" \"device_name\": \"%s\",", device_info->device_name);
+
+    const char *device_type_desc = ((device_info->device_type & CL_DEVICE_TYPE_CPU) ? "CPU" :
+                                   ((device_info->device_type & CL_DEVICE_TYPE_GPU) ? "GPU" : "Accelerator"));
+    printf(" \"device_type\": \"%s\",", device_type_desc);
+
     printf (" \"speed\": %" PRIu64 ",", (u64) (device_info->hashes_msec_dev * 1000));
 
     if (hwmon_ctx->enabled == true)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1660,6 +1660,7 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
     }
 
     printf (" { \"device_id\": %d,", device_id + 1);
+    printf (" { \"device_name\": \"%s\",", device_info->device_name);
     printf (" \"speed\": %" PRIu64 ",", (u64) (device_info->hashes_msec_dev * 1000));
 
     if (hwmon_ctx->enabled == true)


### PR DESCRIPTION
The patch adds device name to the (json) output of hashcat.

```
"devices": [{
		"device_id": 1,
		"device_name": "NVIDIA GeForce GTX 960M",
		"device_type": "GPU",
		"speed": 1027377466,
		"temp": 91,
		"util": 96
	}],
```

This info is useful for distributed password cracking systems* to show more details about cracking nodes (speed, temp, util is currently provided, but need to somehow get device name and this way looks simple and effective).

*As one of Fitcrack developers, we have a immediate use case for this new extension.