### PR TITLE
Do not use term colors if output is not terminal

### DIFF
--- a/include/terminal.h
+++ b/include/terminal.h
@@ -46,6 +46,8 @@ int tty_break(void);
 int tty_getchar(void);
 int tty_fix(void);
 
+bool is_stdout_terminal(void);
+
 void compress_terminal_line_length (char *out_buf, const size_t keep_from_beginning, const size_t keep_from_end);
 
 void hash_info                          (hashcat_ctx_t *hashcat_ctx);

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,8 @@ int _dowildcard = -1;
 
 static void main_log_clear_line (MAYBE_UNUSED const size_t prev_len, MAYBE_UNUSED FILE *fp)
 {
+  if (!is_stdout_terminal()) return;
+
   #if defined (_WIN)
 
   fputc ('\r', fp);
@@ -69,61 +71,63 @@ static void main_log (hashcat_ctx_t *hashcat_ctx, FILE *fp, const int loglevel)
   }
 
   // color stuff pre
-
+  if (is_stdout_terminal()) {
   #if defined (_WIN)
-  HANDLE hConsole = GetStdHandle (STD_OUTPUT_HANDLE);
+    HANDLE hConsole = GetStdHandle (STD_OUTPUT_HANDLE);
 
-  CONSOLE_SCREEN_BUFFER_INFO con_info;
+    CONSOLE_SCREEN_BUFFER_INFO con_info;
 
-  GetConsoleScreenBufferInfo (hConsole, &con_info);
+    GetConsoleScreenBufferInfo (hConsole, &con_info);
 
-  const int orig = con_info.wAttributes;
+    const int orig = con_info.wAttributes;
 
-  switch (loglevel)
-  {
-    case LOGLEVEL_INFO:
-      break;
-    case LOGLEVEL_WARNING: SetConsoleTextAttribute (hConsole, 6);
-      break;
-    case LOGLEVEL_ERROR:   SetConsoleTextAttribute (hConsole, FOREGROUND_RED | FOREGROUND_INTENSITY);
-      break;
-    case LOGLEVEL_ADVICE:  SetConsoleTextAttribute (hConsole, 6);
-      break;
-  }
+    switch (loglevel)
+    {
+      case LOGLEVEL_INFO:
+        break;
+      case LOGLEVEL_WARNING: SetConsoleTextAttribute (hConsole, 6);
+        break;
+      case LOGLEVEL_ERROR:   SetConsoleTextAttribute (hConsole, FOREGROUND_RED | FOREGROUND_INTENSITY);
+        break;
+      case LOGLEVEL_ADVICE:  SetConsoleTextAttribute (hConsole, 6);
+        break;
+    }
 
   #else
-  switch (loglevel)
-  {
-    case LOGLEVEL_INFO:                                   break;
-    case LOGLEVEL_WARNING: fwrite ("\033[33m", 5, 1, fp); break;
-    case LOGLEVEL_ERROR:   fwrite ("\033[31m", 5, 1, fp); break;
-    case LOGLEVEL_ADVICE:  fwrite ("\033[33m", 5, 1, fp); break;
-  }
+    switch (loglevel)
+    {
+      case LOGLEVEL_INFO:                                   break;
+      case LOGLEVEL_WARNING: fwrite ("\033[33m", 5, 1, fp); break;
+      case LOGLEVEL_ERROR:   fwrite ("\033[31m", 5, 1, fp); break;
+      case LOGLEVEL_ADVICE:  fwrite ("\033[33m", 5, 1, fp); break;
+    }
   #endif
+  }
 
   // finally, print
 
   fwrite (msg_buf, msg_len, 1, fp);
 
   // color stuff post
-
+  if (is_stdout_terminal()) {
   #if defined (_WIN)
-  switch (loglevel)
-  {
-    case LOGLEVEL_INFO:                                              break;
-    case LOGLEVEL_WARNING: SetConsoleTextAttribute (hConsole, orig); break;
-    case LOGLEVEL_ERROR:   SetConsoleTextAttribute (hConsole, orig); break;
-    case LOGLEVEL_ADVICE:  SetConsoleTextAttribute (hConsole, orig); break;
-  }
+    switch (loglevel)
+    {
+      case LOGLEVEL_INFO:                                              break;
+      case LOGLEVEL_WARNING: SetConsoleTextAttribute (hConsole, orig); break;
+      case LOGLEVEL_ERROR:   SetConsoleTextAttribute (hConsole, orig); break;
+      case LOGLEVEL_ADVICE:  SetConsoleTextAttribute (hConsole, orig); break;
+    }
   #else
-  switch (loglevel)
-  {
-    case LOGLEVEL_INFO:                                  break;
-    case LOGLEVEL_WARNING: fwrite ("\033[0m", 4, 1, fp); break;
-    case LOGLEVEL_ERROR:   fwrite ("\033[0m", 4, 1, fp); break;
-    case LOGLEVEL_ADVICE:  fwrite ("\033[0m", 4, 1, fp); break;
-  }
+    switch (loglevel)
+    {
+      case LOGLEVEL_INFO:                                  break;
+      case LOGLEVEL_WARNING: fwrite ("\033[0m", 4, 1, fp); break;
+      case LOGLEVEL_ERROR:   fwrite ("\033[0m", 4, 1, fp); break;
+      case LOGLEVEL_ADVICE:  fwrite ("\033[0m", 4, 1, fp); break;
+    }
   #endif
+  }
 
   // eventual newline
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -600,6 +600,15 @@ int tty_fix ()
 }
 #endif
 
+bool is_stdout_terminal(void)
+{
+#if defined(_WIN)
+  return _isatty(_fileno(stdout));
+#else
+  return isatty(fileno(stdout));
+#endif
+}
+
 void compress_terminal_line_length (char *out_buf, const size_t keep_from_beginning, const size_t keep_from_end)
 {
   const size_t target_len = TERMINAL_LINE_LENGTH - keep_from_beginning;


### PR DESCRIPTION
Do not emit ANSI escape control characters if hashcat's output is not terminal - as some tools may read it via pipe, or user may redirect it to file, etc..