### PR TITLE
minor: removes whitespace in -m 23400 = Bitwarden

### DIFF
--- a/src/modules/module_23400.c
+++ b/src/modules/module_23400.c
@@ -106,7 +106,7 @@ u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED con
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
   u32 *digest = (u32 *) digest_buf;
-  
+
   hc_token_t token;
 
   token.token_cnt  = 6;


### PR DESCRIPTION
This pull request just remove a trailing space problem (cosmetic fix).

Thanks