### PR TITLE
fixes #3211: fixes -k in -a 7 with -O 

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -46,6 +46,7 @@
 - Fixed missing option flag OPTS_TYPE_SUGGEST_KG for hash-mode 11600 to inform the user about possible false positives in this mode
 - Fixed password limit in optimized kernel for hash-mode 10700
 - Fixed undefined function call to hc_byte_perm_S() in hash-mode 17010 on non-CUDA compute devices
+- Fixed usage of --rule-right (-k) in -a 7 with optimized (-O) kernels
 - Fixed Unit Test early exit on luks test file download/extract failure
 - Fixed Unit Test false negative if there are spaces in the filesystem path to hashcat
 - Fixed Unit Test salt-max in case of optimized kernel, with hash-type 22 and 23


### PR DESCRIPTION
as reported in #3211 by @Chick3nman, the problem behind this fix is that whenever `-k` (or `--rule-right`) was used in optimized mode (`-O`) together with `-a 7` (we also call this `HYBRID2`) the problem was that `hashcat` was only allowing/"checking" what was specified with the `-j` command line argument... but instead only the `-k` argument should be considered used for `-a 7`.
This is an optimized-specific problem, because otherwise the `-j`/`-k` parameters are handled differently and therefore we didn't catch this problem earlier (kudos to @Chick3nman for finding this bug, nice find !).

Indeed, we always had this scheme in mind which should be enforced (no matter if `-O` is used or not):
- in `-a 0` we can use `-j` for the dict(s)
- in `-a 1` we can use `-j` for left dict and `-k` for right dict
- in `-a 6` we can use `-j` for the dict (left positional argument in the command line, second/right one is mask)
- in `-a 7` we can use `-k` for the dict (right posional argument in the command line, first/left one is mask)

This patch should make `-k` work for this specific combination of command line arguments (`-O` + `-a 7` + `-k`).

Thanks and kudos for the bug finder (@Chick3nman )