### PR TITLE
Emit final status also in 'status-json' mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -317,6 +317,10 @@ static void main_cracker_finished (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYB
   {
     status_display (hashcat_ctx);
   }
+  else if (user_options->status_json == true)
+  {
+    status_display (hashcat_ctx);
+  }
   else
   {
     if (user_options->quiet == false)


### PR DESCRIPTION
Hashcat contains small but nasty oversight - in "status json" mode, there is no final status update. Let me explain it in following example:

```
xbolva00@xbolva00-G551JW:~/fitcrack/runner/testground$ ./hashcat64_v624_1.bin -m 0 --optimized-kernel-enable -a 0 ./data --status-timer=1 --outfile passwords.txt --outfile-format=1,3 --quiet --status --machine-readable --restore-disable --potfile-disable --logfile-disable ./dict1 --runtime 3
STATUS  5       SPEED   20837   1000    EXEC_RUNTIME    0.017632        CURKU   6       PROGRESS        6       6       RECHASH 0       2       RECSALT 0       1       TEMP    79      REJECTED        0       UTIL    20
xbolva00@xbolva00-G551JW:~/fitcrack/runner/testground$ ./hashcat64_v624_1.bin -m 0 --optimized-kernel-enable -a 0 ./data --status-timer=1 --outfile passwords.txt --outfile-format=1,3 --quiet --status-json --restore-disable --potfile-disable --logfile-disable ./dict1 
<nothing>
```

So basically for short cracking tasks, you will get no status info at all :/


