### PR TITLE
fixes #3253: memory leak in CPU rule engine fixed

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -44,6 +44,7 @@
 - Fixed handling of devices in benchmark mode for "kernel build error". Instead of canceling, skip the device and move on to the next
 - Fixed handling of password candidates that are shorter than the minimum password length in Association Attack
 - Fixed --hash-info example password output: force uppercase if OPTS_TYPE_PT_UPPER is set
+- Fixed memory leak in CPU rule engine
 - Fixed method of how OPTS_TYPE_AUX* kernels are called in an association attack, for example in WPA/WPA2 kernel
 - Fixed missing option flag OPTS_TYPE_SUGGEST_KG for hash-mode 11600 to inform the user about possible false positives in this mode
 - Fixed optimized (-O) candidate generation with --stdout and -a 7

--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -531,6 +531,8 @@ int _old_apply_rule (const char *rule, int rule_len, char in[RP_PASSWORD_SIZE], 
 
   char *rule_new = (char *) hcmalloc (rule_len);
 
+  #define HCFREE_AND_RETURN(x) { hcfree (rule_new); return (x); }
+
   int rule_len_new = 0;
 
   int rule_pos;
@@ -794,26 +796,26 @@ int _old_apply_rule (const char *rule, int rule_len, char in[RP_PASSWORD_SIZE], 
         break;
 
       case RULE_OP_MANGLE_EXTRACT_MEMORY:
-        if (mem_len < 1) return (RULE_RC_REJECT_ERROR);
+        if (mem_len < 1) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, upos);
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, ulen);
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, upos2);
-        if ((out_len = mangle_insert_multi (out, out_len, upos2, mem, mem_len, upos, ulen)) < 1) return (out_len);
+        if ((out_len = mangle_insert_multi (out, out_len, upos2, mem, mem_len, upos, ulen)) < 1) HCFREE_AND_RETURN (out_len);
         break;
 
       case RULE_OP_MANGLE_APPEND_MEMORY:
-        if (mem_len < 1) return (RULE_RC_REJECT_ERROR);
-        if ((out_len + mem_len) >= RP_PASSWORD_SIZE) return (RULE_RC_REJECT_ERROR);
+        if (mem_len < 1) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
+        if ((out_len + mem_len) >= RP_PASSWORD_SIZE) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         memcpy (out + out_len, mem, mem_len);
         out_len += mem_len;
         break;
 
       case RULE_OP_MANGLE_PREPEND_MEMORY:
-        if (mem_len < 1) return (RULE_RC_REJECT_ERROR);
-        if ((mem_len + out_len) >= RP_PASSWORD_SIZE) return (RULE_RC_REJECT_ERROR);
+        if (mem_len < 1) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
+        if ((mem_len + out_len) >= RP_PASSWORD_SIZE) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         memcpy (mem + mem_len, out, out_len);
         out_len += mem_len;
         memcpy (out, mem, out_len);
@@ -827,24 +829,24 @@ int _old_apply_rule (const char *rule, int rule_len, char in[RP_PASSWORD_SIZE], 
       case RULE_OP_REJECT_LESS:
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, upos);
-        if (out_len > upos) return (RULE_RC_REJECT_ERROR);
+        if (out_len > upos) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_GREATER:
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, upos);
-        if (out_len < upos) return (RULE_RC_REJECT_ERROR);
+        if (out_len < upos) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_EQUAL:
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, upos);
-        if (out_len != upos) return (RULE_RC_REJECT_ERROR);
+        if (out_len != upos) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_CONTAIN:
         NEXT_RULEPOS (rule_pos);
-        if (strchr (out, rule_new[rule_pos]) != NULL) return (RULE_RC_REJECT_ERROR);
+        if (strchr (out, rule_new[rule_pos]) != NULL) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_NOT_CONTAIN:
@@ -857,33 +859,33 @@ int _old_apply_rule (const char *rule, int rule_len, char in[RP_PASSWORD_SIZE], 
           }
           else
           {
-            return (RULE_RC_REJECT_ERROR);
+            HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
           }
         }
         break;
 
       case RULE_OP_REJECT_EQUAL_FIRST:
         NEXT_RULEPOS (rule_pos);
-        if (out[0] != rule_new[rule_pos]) return (RULE_RC_REJECT_ERROR);
+        if (out[0] != rule_new[rule_pos]) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_EQUAL_LAST:
         NEXT_RULEPOS (rule_pos);
-        if (out[out_len - 1] != rule_new[rule_pos]) return (RULE_RC_REJECT_ERROR);
+        if (out[out_len - 1] != rule_new[rule_pos]) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_EQUAL_AT:
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, upos);
-        if ((upos + 1) > out_len) return (RULE_RC_REJECT_ERROR);
+        if ((upos + 1) > out_len) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         NEXT_RULEPOS (rule_pos);
-        if (out[upos] != rule_new[rule_pos]) return (RULE_RC_REJECT_ERROR);
+        if (out[upos] != rule_new[rule_pos]) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_CONTAINS:
         NEXT_RULEPOS (rule_pos);
         NEXT_RPTOI (rule_new, rule_pos, upos);
-        if ((upos + 1) > out_len) return (RULE_RC_REJECT_ERROR);
+        if ((upos + 1) > out_len) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         NEXT_RULEPOS (rule_pos);
         int c; int cnt;
         for (c = 0, cnt = 0; c < out_len && cnt < upos; c++)
@@ -895,23 +897,23 @@ int _old_apply_rule (const char *rule, int rule_len, char in[RP_PASSWORD_SIZE], 
           }
         }
 
-        if (cnt < upos) return (RULE_RC_REJECT_ERROR);
+        if (cnt < upos) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       case RULE_OP_REJECT_MEMORY:
-        if ((out_len == mem_len) && (memcmp (out, mem, out_len) == 0)) return (RULE_RC_REJECT_ERROR);
+        if ((out_len == mem_len) && (memcmp (out, mem, out_len) == 0)) HCFREE_AND_RETURN (RULE_RC_REJECT_ERROR);
         break;
 
       default:
-        return (RULE_RC_SYNTAX_ERROR);
+        HCFREE_AND_RETURN (RULE_RC_SYNTAX_ERROR);
     }
   }
 
   memset (out + out_len, 0, RP_PASSWORD_SIZE - out_len);
 
-  hcfree (rule_new);
+  HCFREE_AND_RETURN (out_len);
 
-  return (out_len);
+  #undef HCFREE_AND_RETURN
 }
 
 int run_rule_engine (const int rule_len, const char *rule_buf)


### PR DESCRIPTION
This problem was first mentioned here https://github.com/hashcat/hashcat/issues/3253 by @Chick3nman  and I was now able to reproduce it. The main cause/culprit of the problem is clear if you debug this a little bit: every rule that "fails" to do its job to the password will/could return early from the CPU rule engine function and there was no clean memory cleanup in place.

The problem could also be worked around with other altnernatives like using stack (instead of heap) or using very ugly "gotos" (please dont!) etc... but I think this is quite a nice to read and elegant fix of the main problem. What do you think ?

As mentioned in the issue the problem can be easily reproduce with a rule that "fails" quite a lot of time to do anything to the plain, something like:
`./hashcat -a 0 -m 0 -j">A" 8743b52063cd84097a65d1633f5c74f5 large_example_dict`

kudos again to @Chick3nman for finding this ugly memory leak. Thx