### PR TITLE
Tune scrypt config for RTX 3090 Ti

### DIFF
--- a/src/modules/module_08900.c
+++ b/src/modules/module_08900.c
@@ -423,6 +423,7 @@ const char *module_extra_tuningdb_block (MAYBE_UNUSED const hashconfig_t *hashco
     "GeForce_RTX_3060_Ti                             *       8900    1      51       A\n"
     "GeForce_RTX_3070                                *       8900    1      46       A\n"
     "GeForce_RTX_3090                                *       8900    1      82       A\n"
+    "GeForce_RTX_3090_Ti                             *       8900    1      84       A\n"
     "ALIAS_AMD_RX480                                 *       8900    1      15       A\n"
     "ALIAS_AMD_Vega64                                *       8900    1      28       A\n"
     "ALIAS_AMD_MI100                                 *       8900    1      79       A\n"


### PR DESCRIPTION
RTX 3090 Ti appeared today and hashcat was the first benchmark I ran. Was getting about ~3800 H/s on master, so I ran the tuning steps in `src/modules/08900.c`. Best result in tuning was 4156.

```
hashcat (v5.1.0-3437-g6aa0d2082) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #1: WARNING! Kernel exec timeout is not disabled.
             This may cause "CL_OUT_OF_RESOURCES" or related errors.
             To disable the timeout, see: https://hashcat.net/q/timeoutpatch
* Device #2: WARNING! Kernel exec timeout is not disabled.
             This may cause "CL_OUT_OF_RESOURCES" or related errors.
             To disable the timeout, see: https://hashcat.net/q/timeoutpatch
CUDA API (CUDA 11.6)
====================
* Device #1: NVIDIA GeForce RTX 3090 Ti, 23351/24233 MB, 84MCU

OpenCL API (OpenCL 3.0 CUDA 11.6.127) - Platform #1 [NVIDIA Corporation]
========================================================================
* Device #2: NVIDIA GeForce RTX 3090 Ti, skipped

Benchmark relevant options:
===========================
* --optimized-kernel-enable

---------------------------------------------
* Hash-Mode 8900 (scrypt) [Iterations: 16384]
---------------------------------------------

Speed.#1.........:     4059 H/s (29.47ms) @ Accel:84 Loops:1024 Thr:32 Vec:1
```

