### PR TITLE
Port scrypt tuning for RTX 3090Ti to other scrypt-based hash types

### DIFF
--- a/src/modules/module_15700.c
+++ b/src/modules/module_15700.c
@@ -486,6 +486,7 @@ const char *module_extra_tuningdb_block (MAYBE_UNUSED const hashconfig_t *hashco
     "GeForce_RTX_3060_Ti                             *       15700   1      11       A\n"
     "GeForce_RTX_3070                                *       15700   1      22       A\n"
     "GeForce_RTX_3090                                *       15700   1      82       A\n"
+    "GeForce_RTX_3090_Ti                             *       22700   1      84       A\n"
     "ALIAS_AMD_RX480                                 *       15700   1      58       A\n"
     "ALIAS_AMD_Vega64                                *       15700   1      53       A\n"
     "ALIAS_AMD_MI100                                 *       15700   1     120       A\n"

--- a/src/modules/module_22700.c
+++ b/src/modules/module_22700.c
@@ -425,6 +425,7 @@ const char *module_extra_tuningdb_block (MAYBE_UNUSED const hashconfig_t *hashco
     "GeForce_RTX_3060_Ti                             *       22700   1      51       A\n"
     "GeForce_RTX_3070                                *       22700   1      46       A\n"
     "GeForce_RTX_3090                                *       22700   1      82       A\n"
+    "GeForce_RTX_3090_Ti                             *       22700   1      84       A\n"
     "ALIAS_AMD_RX480                                 *       22700   1      15       A\n"
     "ALIAS_AMD_Vega64                                *       22700   1      30       A\n"
     "ALIAS_AMD_MI100                                 *       22700   1      79       A\n"

--- a/src/modules/module_27700.c
+++ b/src/modules/module_27700.c
@@ -453,6 +453,7 @@ const char *module_extra_tuningdb_block (MAYBE_UNUSED const hashconfig_t *hashco
     "GeForce_RTX_3060_Ti                             *       27700   1      51       A\n"
     "GeForce_RTX_3070                                *       27700   1      46       A\n"
     "GeForce_RTX_3090                                *       27700   1      82       A\n"
+    "GeForce_RTX_3090_Ti                             *       27700   1      84       A\n"
     "ALIAS_AMD_RX480                                 *       27700   1      15       A\n"
     "ALIAS_AMD_Vega64                                *       27700   1      30       A\n"
     "ALIAS_AMD_MI100                                 *       27700   1      79       A\n"

--- a/src/modules/module_28200.c
+++ b/src/modules/module_28200.c
@@ -510,6 +510,7 @@ const char *module_extra_tuningdb_block (MAYBE_UNUSED const hashconfig_t *hashco
     "GeForce_RTX_3060_Ti                             *      28200    1      51       A\n"
     "GeForce_RTX_3070                                *      28200    1      46       A\n"
     "GeForce_RTX_3090                                *      28200    1      82       A\n"
+    "GeForce_RTX_3090_Ti                             *      28200    1      84       A\n"
     "ALIAS_AMD_RX480                                 *      28200    1      15       A\n"
     "ALIAS_AMD_Vega64                                *      28200    1      30       A\n"
     "ALIAS_AMD_MI100                                 *      28200    1      79       A\n"


### PR DESCRIPTION
Per discussion on #3265, @jsteube said we could probably roll forward the same tuning to other scrypt-based hash types. I tested most on my platform but cut the lowest and highest ends of the iterations to between 50-120, as there did not appear to be returns outside of this range with 84 being the local maximum in most cases anyhow.

This pull request ports forward the tuned values for the RTX 3090 Ti to these other hash types.


Fastest speeds during testing:

15700: 32 H/s 
22700: 4315 H/s
27700: 4324 H/s
28200: 4134 H/s

I warn that the usual `hashcat -b -m 15700` shows 0 H/s for the `15700 (Ethereum Wallet, SCRYPT)` type but it appeared fine when running the extended tests. It does that with or without this patch.