### PR TITLE
change to allow for non-hex salts in Authme (20711)

### DIFF
--- a/src/modules/module_20711.c
+++ b/src/modules/module_20711.c
@@ -82,8 +82,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.sep[1]     = '$';
   token.len_min[1] = 16;
   token.len_max[1] = 16;
-  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_HEX;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   token.sep[2]     = '$';
   token.len_min[2] = 64;


### PR DESCRIPTION
This change is to allow for non-hex salts to exist in AuthMe (20711) hashes.

Encountered some authme formatted hashes that did not have hex [a-f0-9] salts. However, given that AuthMe is just `sha256(sha256($plain).$salt)` with just a different hash format (similar to how Django-sha1 (-m 124) is just `sha1($salt.$plain)` in a different hash format), the hashes were valid otherwise. 