### PR TITLE
fix DES (14000) for more 16 or more passwords

### DIFF
--- a/OpenCL/m14000_a3-pure.cl
+++ b/OpenCL/m14000_a3-pure.cl
@@ -2171,8 +2171,8 @@ KERNEL_FQ void m14000_mxx (KERN_ATTR_BITSLICE ())
       #endif
       for (int i = 0; i < 32; i++)
       {
-        out0[i] = out[ 0 + i];
-        out1[i] = out[32 + i];
+        out0[i] = out[ 0 + 31 - i];
+        out1[i] = out[32 + 31 - i];
       }
 
       transpose32c (out0);
@@ -2183,8 +2183,8 @@ KERNEL_FQ void m14000_mxx (KERN_ATTR_BITSLICE ())
       #endif
       for (int slice = 0; slice < 32; slice++)
       {
-        const u32 r0 = out0[slice];
-        const u32 r1 = out1[slice];
+        const u32 r0 = out0[31 - slice];
+        const u32 r1 = out1[31 - slice];
         const u32 r2 = 0;
         const u32 r3 = 0;
 


### PR DESCRIPTION
This pr fixes cracking DES keys in cases where there are 16 or more different passwords with identical plain texts.

To be honest I don't understand the code around this enough to be confident to say this is the correct fix, someone else should definitively double check! l basically just looked for similar patterns elsewhere in the code and found slightly different two versions:
https://github.com/hashcat/hashcat/blob/39b768a620d9446018c5bc5658ab0a445bfe3548/OpenCL/m01500_a3-pure.cl#L2264-L2275
https://github.com/hashcat/hashcat/blob/39b768a620d9446018c5bc5658ab0a445bfe3548/OpenCL/m03000_a3-pure.cl#L2105-L2116

