### PR TITLE
changes.txt incorrectly already announces RAdmin3 support

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -12,8 +12,8 @@
 - Added hash-mode: Kerberos 5, etype 18, DB
 - Added hash-mode: PostgreSQL SCRAM-SHA-256
 - Added hash-mode: Teamspeak 3 (channel hash)
-- Added hash-mode: RAdmin3
 - Added hash-mode: bcrypt(sha512($pass)) / bcryptsha512
+- Added hash-mode: sha1($salt.sha1(utf16le($username).':'.utf16le($pass)))
 - Added hash-mode: sha256($salt.sha256_bin($pass))
 
 ##


### PR DESCRIPTION
The RAdmin3 support is not yet ready, see https://github.com/hashcat/hashcat/issues/3259... the algorithm added with pull request https://github.com/hashcat/hashcat/pull/3276 is only the first part of what RAdmin3 algorithm does.

RAdmin3 also adds **big number** exponentiation (and big number multiplication) of a **prime number** base/generator by a scalar exponent and a final verification step of the exponentiation result (for Radmin3 the sha1 hash output is the exponent, it's basically a key derivation function KDF).

We will hopefully have support soon, but for now let's not confuse these 2 algorithms. Thank you