### PR TITLE
RAdmin3 is not supported yet

### DIFF
--- a/src/modules/module_29000.c
+++ b/src/modules/module_29000.c
@@ -18,7 +18,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 1;
 static const u32   DGST_SIZE      = DGST_SIZE_4_5;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_OS;
-static const char *HASH_NAME      = "Radmin3";
+static const char *HASH_NAME      = "sha1($salt.sha1(utf16le($username).':'.utf16le($pass)))";
 static const u64   KERN_TYPE      = 29000;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_EARLY_SKIP


### PR DESCRIPTION
As already mentioned here (https://github.com/hashcat/hashcat/pull/3281) we do not yet have full support of RAdmin3... The algorithm `sha1($salt.sha1(utf16le($username).':'.utf16le($pass)))` is just the first part of what Radmin3 software does (it uses bignum calculation, exponentiation of a prime generator/base by a scalar/exponent, which is the output/key derived from the sha1). We shouldn't mix/confuse these 2 algorithms 