### PR TITLE
add our hash extraction scripts to release/beta

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -29,6 +29,7 @@
 - Added parameter to Bitwarden mode for second iteration count
 - Added support to use 'John the Ripper' hash format with hash-type 13100
 - Added support to use 'John the Ripper' hash format with hash-type 18200
+- Added the hash extraction scripts from the tools folder also to beta/release versions
 - Added user advice if a hash throws 'token length exception'
 
 ##

--- a/src/Makefile
+++ b/src/Makefile
@@ -529,6 +529,7 @@ install_docs: install_make_shared_root
 	$(INSTALL) -m 755 -d                                                    $(DESTDIR)$(DOCUMENT_FOLDER)/rules
 	$(INSTALL) -m 755 -d                                                    $(DESTDIR)$(DOCUMENT_FOLDER)/extra
 	$(INSTALL) -m 755 -d                                                    $(DESTDIR)$(DOCUMENT_FOLDER)/extra/tab_completion
+	$(INSTALL) -m 755 -d                                                    $(DESTDIR)$(DOCUMENT_FOLDER)/tools
 	$(INSTALL) -m 644 example.dict                                          $(DESTDIR)$(DOCUMENT_FOLDER)/
 	$(INSTALL) -m 644 example0.hash                                         $(DESTDIR)$(DOCUMENT_FOLDER)/
 	$(INSTALL) -m 644 example400.hash                                       $(DESTDIR)$(DOCUMENT_FOLDER)/
@@ -549,6 +550,7 @@ install_docs: install_make_shared_root
 	$(FIND) masks/    -type f -exec $(INSTALL) -m 644 {}                    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
 	$(FIND) rules/    -type d -exec $(INSTALL) -m 755 -d                    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
 	$(FIND) rules/    -type f -exec $(INSTALL) -m 644 {}                    $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
+	$(FIND) tools/    -type f -name '*cat.p[ly]' -exec $(INSTALL) -m 755 {} $(DESTDIR)$(DOCUMENT_FOLDER)/{} \;
 	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'                         $(DESTDIR)$(DOCUMENT_FOLDER)/example0.sh
 	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'                         $(DESTDIR)$(DOCUMENT_FOLDER)/example400.sh
 	$(SED) $(SED_IN_PLACE) 's/\.\/hashcat/hashcat/'                         $(DESTDIR)$(DOCUMENT_FOLDER)/example500.sh

--- a/tools/package_bin.sh
+++ b/tools/package_bin.sh
@@ -13,6 +13,8 @@ rm -rf $OUT.7z
 
 mkdir -p $OUT
 
+mkdir -p $OUT/tools
+
 cp    $IN/hashcat.exe                   $OUT/
 cp    $IN/hashcat.bin                   $OUT/
 cp    $IN/hashcat.hctune                $OUT/
@@ -29,6 +31,7 @@ cp    $IN/example.dict                  $OUT/
 cp    $IN/example[0123456789]*.hash     $OUT/
 cp    $IN/example[0123456789]*.cmd      $OUT/
 cp -r $IN/OpenCL                        $OUT/
+cp    $IN/tools/*hashcat.p[ly]          $OUT/tools/
 
 # since for the binary distribution we still use .bin, we need to rewrite the commands
 # within the example*.sh files
@@ -46,6 +49,7 @@ dos2unix $OUT/rules/hybrid/*.rule
 dos2unix $OUT/docs/*
 dos2unix $OUT/docs/license_libs/*
 dos2unix $OUT/example*
+dos2unix $OUT/tools/*
 
 unix2dos $OUT/layouts/*.hckmap
 unix2dos $OUT/masks/*.hcmask
@@ -56,6 +60,7 @@ unix2dos $OUT/docs/license_libs/*
 unix2dos $OUT/example*.cmd
 unix2dos $OUT/OpenCL/*
 unix2dos $OUT/hashcat.hctune
+unix2dos $OUT/tools/*
 
 chmod 755 $OUT
 chmod 755 $OUT/rules
@@ -82,5 +87,6 @@ chmod 644 $OUT/*.exe
 chmod 755 $OUT/*.bin
 chmod 644 $OUT/hashcat.hctune
 chmod 644 $OUT/hashcat.hcstat2
+chmod 755 $OUT/tools/*hashcat.p[ly]
 
 time 7z a -t7z -m0=lzma2:d31 -mx=9 -mmt=8 -ms=on $OUT.7z $OUT


### PR DESCRIPTION
I've noticed that some `hashcat` users are sometimes confused where to find our own hash extraction scripts. I think it doesn't hurt (and is much better) that we also ship them with the beta/release versions. What do you think?

This is a minimal fix that would include the executable perl/python extraction scripts.

Thanks