### PR TITLE
fix -m 29100 = Flask -a 0 rule problem

### DIFF
--- a/OpenCL/m29100_a0-pure.cl
+++ b/OpenCL/m29100_a0-pure.cl
@@ -17,7 +17,7 @@
 #endif
 
 
-KERNEL_FQ void m29100_mxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m29100_mxx (KERN_ATTR_RULES ())
 {
   /**
    * modifier
@@ -104,7 +104,7 @@ KERNEL_FQ void m29100_mxx (KERN_ATTR_BASIC ())
   }
 }
 
-KERNEL_FQ void m29100_sxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m29100_sxx (KERN_ATTR_RULES ())
 {
   /**
    * modifier


### PR DESCRIPTION
I've noticed that the new -m 29100 = `Flask Session Cookie ($salt.$salt.$pass)` hash mode gives errors when using -a 0 on OpenCL (not CUDA ?) :

```
error: implicit conversion from address space "global" to address space "constant" is not supported when passing to parameter of destination type
    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
                              ^~~~~~~~~~~~~~~~~~~~~~
```

The culprit of this was the use of `KERN_ATTR_BASIC ()` instead of (correct:) `KERN_ATTR_RULES ()` in the kernel source file `OpenCL/m29100_a0-pure.cl`.

This small fix should solve the problem.

Thx