### PR TITLE
radmin 3: remove whitespace, add credits to tests

### DIFF
--- a/OpenCL/m29200_a0-pure.cl
+++ b/OpenCL/m29200_a0-pure.cl
@@ -1,7 +1,10 @@
 /**
  * Author......: See docs/credits.txt
  * License.....: MIT
- * This algorithm for password-storage for the Radmin 3 software was analyzed and made public by synacktiv: 
+ *
+ * Further credits:
+ * The password-storage algorithm used by Radmin 3 was analyzed and made public
+ * by synacktiv:
  * https://www.synacktiv.com/publications/cracking-radmin-server-3-passwords.html
  */
 

--- a/OpenCL/m29200_a1-pure.cl
+++ b/OpenCL/m29200_a1-pure.cl
@@ -1,10 +1,12 @@
 /**
  * Author......: See docs/credits.txt
  * License.....: MIT
- * This algorithm for password-storage for the Radmin 3 software was analyzed and made public by synacktiv: 
+ *
+ * Further credits:
+ * The password-storage algorithm used by Radmin 3 was analyzed and made public
+ * by synacktiv:
  * https://www.synacktiv.com/publications/cracking-radmin-server-3-passwords.html
  */
-
 
 //#define NEW_SIMD_CODE
 

--- a/OpenCL/m29200_a3-pure.cl
+++ b/OpenCL/m29200_a3-pure.cl
@@ -1,7 +1,10 @@
 /**
  * Author......: See docs/credits.txt
  * License.....: MIT
- * This algorithm for password-storage for the Radmin 3 software was analyzed and made public by synacktiv: 
+ *
+ * Further credits:
+ * The password-storage algorithm used by Radmin 3 was analyzed and made public
+ * by synacktiv:
  * https://www.synacktiv.com/publications/cracking-radmin-server-3-passwords.html
  */
 

--- a/src/modules/module_29200.c
+++ b/src/modules/module_29200.c
@@ -1,10 +1,12 @@
 /**
  * Author......: See docs/credits.txt
  * License.....: MIT
- * This algorithm for password-storage for the Radmin 3 software was analyzed and made public by synacktiv: 
+ *
+ * Further credits:
+ * The password-storage algorithm used by Radmin 3 was analyzed and made public
+ * by synacktiv:
  * https://www.synacktiv.com/publications/cracking-radmin-server-3-passwords.html
  */
-
 
 #include "common.h"
 #include "types.h"

--- a/tools/test_modules/m29200.pm
+++ b/tools/test_modules/m29200.pm
@@ -4,6 +4,11 @@
 ## Author......: See docs/credits.txt
 ## License.....: MIT
 ##
+## Further credits:
+## The password-storage algorithm used by Radmin 3 was analyzed and made public
+## by synacktiv:
+## https://www.synacktiv.com/publications/cracking-radmin-server-3-passwords.html
+##
 
 use strict;
 use warnings;


### PR DESCRIPTION
Here I just removed the space after the "synacktiv: " comment/credit and also added credits to our perl hash generation / verification script (unit test).

Thanks