### PR TITLE
radmin 3: update comment about PRECOMP_DATALEN size

### DIFF
--- a/OpenCL/m29200_a0-pure.cl
+++ b/OpenCL/m29200_a0-pure.cl
@@ -25,7 +25,7 @@ typedef struct radmin3
   u32 user[64];
   u32 user_len;
 
-  u32 pre[PRECOMP_DATALEN]; // 38400 for PRECOMP_BITS = 4
+  u32 pre[PRECOMP_DATALEN]; // 1047552 * 4 bytes for PRECOMP_BITS = 10
 
 } radmin3_t;
 

--- a/OpenCL/m29200_a1-pure.cl
+++ b/OpenCL/m29200_a1-pure.cl
@@ -24,7 +24,7 @@ typedef struct radmin3
   u32 user[64];
   u32 user_len;
 
-  u32 pre[PRECOMP_DATALEN]; // 38400 for PRECOMP_BITS = 4
+  u32 pre[PRECOMP_DATALEN]; // 1047552 * 4 bytes for PRECOMP_BITS = 10
 
 } radmin3_t;
 

--- a/OpenCL/m29200_a3-pure.cl
+++ b/OpenCL/m29200_a3-pure.cl
@@ -23,7 +23,7 @@ typedef struct radmin3
   u32 user[64];
   u32 user_len;
 
-  u32 pre[PRECOMP_DATALEN]; // 38400 for PRECOMP_BITS = 4
+  u32 pre[PRECOMP_DATALEN]; // 1047552 * 4 bytes for PRECOMP_BITS = 10
 
 } radmin3_t;
 

--- a/src/modules/module_29200.c
+++ b/src/modules/module_29200.c
@@ -58,7 +58,7 @@ typedef struct radmin3
   u32 user[64];
   u32 user_len;
 
-  u32 pre[PRECOMP_DATALEN]; // 38400 for PRECOMP_BITS = 4
+  u32 pre[PRECOMP_DATALEN]; // 1047552 * 4 bytes for PRECOMP_BITS = 10
 
 } radmin3_t;
 


### PR DESCRIPTION
We should mention the currently used `PRECOMP_DATALEN` size (which value is defined in `OpenCL/inc_radmin3_constants.h`) to make it clear which sizes this `esalt` structure actually has.

(just a comment update, but could be confusing otherwise)

Thank you