### PR TITLE
add make_utf16beN_S () and sha1_update_utf16beN ()

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -36773,6 +36773,44 @@ DECLSPEC void make_utf16be_S (PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out1, PR
   #endif
 }
 
+DECLSPEC void make_utf16beN_S (PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out1, PRIVATE_AS u32 *out2)
+{
+  #if defined IS_NV
+
+  out2[3] = hc_byte_perm_S (in[3], 0, 0x1707);
+  out2[2] = hc_byte_perm_S (in[3], 0, 0x3727);
+  out2[1] = hc_byte_perm_S (in[2], 0, 0x1707);
+  out2[0] = hc_byte_perm_S (in[2], 0, 0x3727);
+  out1[3] = hc_byte_perm_S (in[1], 0, 0x1707);
+  out1[2] = hc_byte_perm_S (in[1], 0, 0x3727);
+  out1[1] = hc_byte_perm_S (in[0], 0, 0x1707);
+  out1[0] = hc_byte_perm_S (in[0], 0, 0x3727);
+
+  #elif (defined IS_AMD || defined IS_HIP) && HAS_VPERM == 1
+
+  out2[3] = hc_byte_perm_S (in[3], 0, 0x01070007);
+  out2[2] = hc_byte_perm_S (in[3], 0, 0x03070207);
+  out2[1] = hc_byte_perm_S (in[2], 0, 0x01070007);
+  out2[0] = hc_byte_perm_S (in[2], 0, 0x03070207);
+  out1[3] = hc_byte_perm_S (in[1], 0, 0x01070007);
+  out1[2] = hc_byte_perm_S (in[1], 0, 0x03070207);
+  out1[1] = hc_byte_perm_S (in[0], 0, 0x01070007);
+  out1[0] = hc_byte_perm_S (in[0], 0, 0x03070207);
+
+  #else
+
+  out2[3] = ((in[3] << 16) & 0xFF000000) | ((in[3] << 8) & 0x0000FF00);
+  out2[2] = ((in[3] >>  0) & 0xFF000000) | ((in[3] >> 8) & 0x0000FF00);
+  out2[1] = ((in[2] << 16) & 0xFF000000) | ((in[2] << 8) & 0x0000FF00);
+  out2[0] = ((in[2] >>  0) & 0xFF000000) | ((in[2] >> 8) & 0x0000FF00);
+  out1[3] = ((in[1] << 16) & 0xFF000000) | ((in[1] << 8) & 0x0000FF00);
+  out1[2] = ((in[1] >>  0) & 0xFF000000) | ((in[1] >> 8) & 0x0000FF00);
+  out1[1] = ((in[0] << 16) & 0xFF000000) | ((in[0] << 8) & 0x0000FF00);
+  out1[0] = ((in[0] >>  0) & 0xFF000000) | ((in[0] >> 8) & 0x0000FF00);
+
+  #endif
+}
+
 DECLSPEC void make_utf16le_S (PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out1, PRIVATE_AS u32 *out2)
 {
   #if defined IS_NV

--- a/OpenCL/inc_common.h
+++ b/OpenCL/inc_common.h
@@ -315,6 +315,7 @@ DECLSPEC int hc_find_keyboard_layout_map (const u32 search, const int search_len
 DECLSPEC int hc_execute_keyboard_layout_mapping (PRIVATE_AS u32 *w, const int pw_len, LOCAL_AS keyboard_layout_mapping_t *s_keyboard_layout_mapping_buf, const int keyboard_layout_mapping_cnt);
 DECLSPEC void make_utf16be (PRIVATE_AS const u32x *in, PRIVATE_AS u32x *out1, PRIVATE_AS u32x *out2);
 DECLSPEC void make_utf16beN (PRIVATE_AS const u32x *in, PRIVATE_AS u32x *out1, PRIVATE_AS u32x *out2);
+DECLSPEC void make_utf16beN_S (PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out1, PRIVATE_AS u32 *out2);
 DECLSPEC void make_utf16le (PRIVATE_AS const u32x *in, PRIVATE_AS u32x *out1, PRIVATE_AS u32x *out2);
 DECLSPEC void make_utf16leN (PRIVATE_AS const u32x *in, PRIVATE_AS u32x *out1, PRIVATE_AS u32x *out2);
 DECLSPEC void undo_utf16be (PRIVATE_AS const u32x *in1, PRIVATE_AS const u32x *in2, PRIVATE_AS u32x *out);

--- a/OpenCL/inc_hash_sha1.cl
+++ b/OpenCL/inc_hash_sha1.cl
@@ -839,6 +839,48 @@ DECLSPEC void sha1_update_utf16be (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const 
   sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
 }
 
+DECLSPEC void sha1_update_utf16beN (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
+{
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  int pos1;
+  int pos4;
+
+  for (pos1 = 0, pos4 = 0; pos1 < len - 32; pos1 += 32, pos4 += 8)
+  {
+    w0[0] = w[pos4 + 0];
+    w0[1] = w[pos4 + 1];
+    w0[2] = w[pos4 + 2];
+    w0[3] = w[pos4 + 3];
+    w1[0] = w[pos4 + 4];
+    w1[1] = w[pos4 + 5];
+    w1[2] = w[pos4 + 6];
+    w1[3] = w[pos4 + 7];
+
+    make_utf16beN_S (w1, w2, w3);
+    make_utf16beN_S (w0, w0, w1);
+
+    sha1_update_64 (ctx, w0, w1, w2, w3, 32 * 2);
+  }
+
+  w0[0] = w[pos4 + 0];
+  w0[1] = w[pos4 + 1];
+  w0[2] = w[pos4 + 2];
+  w0[3] = w[pos4 + 3];
+  w1[0] = w[pos4 + 4];
+  w1[1] = w[pos4 + 5];
+  w1[2] = w[pos4 + 6];
+  w1[3] = w[pos4 + 7];
+
+  make_utf16beN_S (w1, w2, w3);
+  make_utf16beN_S (w0, w0, w1);
+
+  sha1_update_64 (ctx, w0, w1, w2, w3, (len - pos1) * 2);
+}
+
 DECLSPEC void sha1_update_utf16be_swap (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
 {
   u32 w0[4];

--- a/OpenCL/inc_hash_sha1.h
+++ b/OpenCL/inc_hash_sha1.h
@@ -99,6 +99,7 @@ DECLSPEC void sha1_update_utf16le (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const 
 DECLSPEC void sha1_update_utf16le_swap (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha1_update_utf16be (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha1_update_utf16be_swap (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
+DECLSPEC void sha1_update_utf16beN (PRIVATE_AS sha1_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha1_update_global (PRIVATE_AS sha1_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);
 DECLSPEC void sha1_update_global_swap (PRIVATE_AS sha1_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);
 DECLSPEC void sha1_update_global_utf16le (PRIVATE_AS sha1_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);


### PR DESCRIPTION
I think it makes sense for some kernels (e.g. `radmin3`, another pull request will follow soon), to have a non-SIMD / non-vector version of our `utf16beN` conversion. To do this, we need both a new function for the utf16 converstion and the missing `SHA1` function, that doesn't use SIMD/vector: `sha1_update_utf16beN ()`.

I think this is better than using the currently used approach (`sha1_init_vector_from_scalar ()` -> `sha1_update_vector_utf16beN ()` -> `sha1_final_vector ()` , even though we don't use the vectors at all here, so it's also very confusing).

What do you think ?

Thanks

(of course it doesn't, or at least shouldn't, make much speed difference... but it is still conceptually cleaner)