### PR TITLE
-m 27700: fix use of varied iteration counts

### DIFF
--- a/src/modules/module_27700.c
+++ b/src/modules/module_27700.c
@@ -296,14 +296,14 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
-  token.len_min[2] = 5;
-  token.len_max[2] = 5;
+  token.len_min[2] = 1;
+  token.len_max[2] = 10;
   token.sep[2]     = '*';
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[3] = 1;
-  token.len_max[3] = 1;
+  token.len_max[3] = 2;
   token.sep[3]     = '*';
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_DIGIT;
@@ -340,23 +340,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u32 scrypt_n = hc_strtoul ((const char *) scrypt_n_pos, NULL, 10);
 
-  if (scrypt_n != SCRYPT_N) return (PARSER_SALT_VALUE);
-
   const u8 *scrypt_r_pos = token.buf[3];
 
   const u32 scrypt_r = hc_strtoul ((const char *) scrypt_r_pos, NULL, 10);
-
-  if (scrypt_r != SCRYPT_R) return (PARSER_SALT_VALUE);
 
   const u8 *scrypt_p_pos = token.buf[4];
 
   const u32 scrypt_p = hc_strtoul ((const char *) scrypt_p_pos, NULL, 10);
 
-  if (scrypt_p != SCRYPT_P) return (PARSER_SALT_VALUE);
-
-  salt->scrypt_N = SCRYPT_N;
-  salt->scrypt_r = SCRYPT_R;
-  salt->scrypt_p = SCRYPT_P;
+  salt->scrypt_N = scrypt_n;
+  salt->scrypt_r = scrypt_r;
+  salt->scrypt_p = scrypt_p;
 
   salt->salt_iter    = salt->scrypt_N;
   salt->salt_repeats = salt->scrypt_p - 1;
@@ -404,9 +398,9 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int line_len = snprintf (line_buf, line_size, "%s%u*%" PRIu64 "*%" PRIu64 "*%" PRIu64 "*%08x%08x*%08x%08x%08x%08x%08x%08x%08x%08x",
     SIGNATURE_MULTIBIT,
     3,
-    SCRYPT_N,
-    SCRYPT_R,
-    SCRYPT_P,
+    salt->scrypt_N,
+    salt->scrypt_r,
+    salt->scrypt_p,
     salt->salt_buf[0],
     salt->salt_buf[1],
     byte_swap_32 (salt->salt_buf[2]),


### PR DESCRIPTION
Older versions of [Android "Bitcoin Wallet"](https://play.google.com/store/apps/details?id=de.schildbach.wallet) set the scrypt iterations [to 4096](https://github.com/bitcoin-wallet/bitcoin-wallet/blob/v4.63/wallet/src/de/schildbach/wallet/ui/EncryptKeysDialogFragment.java#L65), which conflicts with the minimum length of 5 and the hardcoded N=16384.

Example hash, pin=123456
```
$multibit$3*4096*8*1*976455c869487bac*67366a6ca0758389c524bb78f13a832f8826b7eba93ff4cc6842f669c7094835
```

From the documentation I've found:
N: bitcoinj once [considered 512 sufficient](https://github.com/bitcoinj/bitcoinj/blob/v0.12.1/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java#L95), and some implementations [cap at `2^0xff`](https://github.com/Tarsnap/scrypt/blob/83cda8b/lib/scryptenc/scryptenc.c#L220) (77 decimal digits).
r: "8 should still be optimal" ([2017](https://words.filippo.io/the-scrypt-parameters/))
p: All recommend 1

Filippo Valsorda [recommends](https://words.filippo.io/the-scrypt-parameters/) 2^20 (7 decimal digits) for file encryption, so [scrypt/8900](https://github.com/hashcat/hashcat/blob/f4e1bdf675d30dd01c9d2167f80090f55203faf7/src/modules/module_08900.c#L301) and other scrypt implementations may also need len_max raised.