### PR TITLE
Fixing names in old TrueCrypt modules

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -111,6 +111,7 @@
 - User Options: Add new module function module_hash_decode_postprocess() to override hash specific configurations from command line
 - User Options: Change --backend-info/-I option type, from bool to uint
 - Modules: New TrueCrypt modules (29311-29343) which do not use `module_hash_binary_parse` to get data from containers anymore (use new tool `tools/truecrypt2hashcat.py`).
+- Modules: Added suffix *legacy* to old TrueCrypt modules (06211-06243).
 - Modules: New VeraCrypt modules (29411-29483) which do not use `module_hash_binary_parse` to get data from containers anymore (use new tool `tools/veracrypt2hashcat.py`).
 - Modules: Added suffix *legacy* to old VeraCrypt modules (13711-13783).
 - Terminal: Increased size of hash name column in `--help` and `--identify` options.

--- a/src/modules/module_06211.c
+++ b/src/modules/module_06211.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 512 bit";
+static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 512 bit (legacy)";
 static const u64   KERN_TYPE      = 6211;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06212.c
+++ b/src/modules/module_06212.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1024 bit";
+static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1024 bit (legacy)";
 static const u64   KERN_TYPE      = 6212;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06213.c
+++ b/src/modules/module_06213.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1536 bit";
+static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1536 bit (legacy)";
 static const u64   KERN_TYPE      = 6213;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06221.c
+++ b/src/modules/module_06221.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt SHA512 + XTS 512 bit";
+static const char *HASH_NAME      = "TrueCrypt SHA512 + XTS 512 bit (legacy)";
 static const u64   KERN_TYPE      = 6221;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP

--- a/src/modules/module_06222.c
+++ b/src/modules/module_06222.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt SHA512 + XTS 1024 bit";
+static const char *HASH_NAME      = "TrueCrypt SHA512 + XTS 1024 bit (legacy)";
 static const u64   KERN_TYPE      = 6222;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP

--- a/src/modules/module_06223.c
+++ b/src/modules/module_06223.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt SHA512 + XTS 1536 bit";
+static const char *HASH_NAME      = "TrueCrypt SHA512 + XTS 1536 bit (legacy)";
 static const u64   KERN_TYPE      = 6223;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP

--- a/src/modules/module_06231.c
+++ b/src/modules/module_06231.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt Whirlpool + XTS 512 bit";
+static const char *HASH_NAME      = "TrueCrypt Whirlpool + XTS 512 bit (legacy)";
 static const u64   KERN_TYPE      = 6231;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06232.c
+++ b/src/modules/module_06232.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt Whirlpool + XTS 1024 bit";
+static const char *HASH_NAME      = "TrueCrypt Whirlpool + XTS 1024 bit (legacy)";
 static const u64   KERN_TYPE      = 6232;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06233.c
+++ b/src/modules/module_06233.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt Whirlpool + XTS 1536 bit";
+static const char *HASH_NAME      = "TrueCrypt Whirlpool + XTS 1536 bit (legacy)";
 static const u64   KERN_TYPE      = 6233;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06241.c
+++ b/src/modules/module_06241.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 512 bit + boot-mode";
+static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 512 bit + boot-mode (legacy)";
 static const u64   KERN_TYPE      = 6211;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06242.c
+++ b/src/modules/module_06242.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1024 bit + boot-mode";
+static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1024 bit + boot-mode (legacy)";
 static const u64   KERN_TYPE      = 6212;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;

--- a/src/modules/module_06243.c
+++ b/src/modules/module_06243.c
@@ -20,7 +20,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_32;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
-static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1536 bit + boot-mode";
+static const char *HASH_NAME      = "TrueCrypt RIPEMD160 + XTS 1536 bit + boot-mode (legacy)";
 static const u64   KERN_TYPE      = 6213;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;


### PR DESCRIPTION
Regarding to GH-3293 (specially https://github.com/hashcat/hashcat/pull/3293#issuecomment-1148735450) old TC modules now have suffix *legacy* to distinguish between old and new ones.

Draft PR until GH-3302 will be merged.