### PR TITLE
gid >= GID_CNT wasn't checked in some kernel functions

### DIFF
--- a/OpenCL/m01500_a3-pure.cl
+++ b/OpenCL/m01500_a3-pure.cl
@@ -1889,6 +1889,8 @@ KERNEL_FQ void m01500_tm (KERN_ATTR_TM)
 {
   const u64 gid = get_global_id (0);
 
+  // if (gid >= GID_CNT) return;
+
   const u32 block = gid / 32;
   const u32 slice = gid % 32;
 

--- a/OpenCL/m03000_a3-pure.cl
+++ b/OpenCL/m03000_a3-pure.cl
@@ -1734,6 +1734,8 @@ KERNEL_FQ void m03000_tm (KERN_ATTR_TM)
 {
   const u64 gid = get_global_id (0);
 
+  // if (gid >= GID_CNT) return;
+
   const u32 block = gid / 32;
   const u32 slice = gid % 32;
 

--- a/OpenCL/m14000_a3-pure.cl
+++ b/OpenCL/m14000_a3-pure.cl
@@ -1734,6 +1734,8 @@ KERNEL_FQ void m14000_tm (KERN_ATTR_TM)
 {
   const u64 gid = get_global_id (0);
 
+  // if (gid >= GID_CNT) return;
+
   const u32 block = gid / 32;
   const u32 slice = gid % 32;
 
@@ -1762,6 +1764,8 @@ KERNEL_FQ void m14000_mxx (KERN_ATTR_BITSLICE ())
 
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+
+  if (gid >= GID_CNT) return;
 
   /**
    * salt
@@ -2204,6 +2208,8 @@ KERNEL_FQ void m14000_sxx (KERN_ATTR_BITSLICE ())
 
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+
+  if (gid >= GID_CNT) return;
 
   /**
    * salt

--- a/OpenCL/m15400_a1-optimized.cl
+++ b/OpenCL/m15400_a1-optimized.cl
@@ -245,6 +245,8 @@ KERNEL_FQ void m15400_m04 (KERN_ATTR_ESALT (chacha20_t))
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
 
+  if (gid >= GID_CNT) return;
+
   u32 pw_buf0[4];
   u32 pw_buf1[4];
 
@@ -369,9 +371,8 @@ KERNEL_FQ void m15400_s04 (KERN_ATTR_ESALT (chacha20_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
-
   const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m15400_a3-optimized.cl
+++ b/OpenCL/m15400_a3-optimized.cl
@@ -255,6 +255,8 @@ KERNEL_FQ void m15400_m16 (KERN_ATTR_VECTOR_ESALT (chacha20_t))
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
 
+  if (gid >= GID_CNT) return;
+
   u32 w0[4];
   u32 w1[4];
 
@@ -342,6 +344,8 @@ KERNEL_FQ void m15400_s16 (KERN_ATTR_VECTOR_ESALT (chacha20_t))
 
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+
+  if (gid >= GID_CNT) return;
 
   u32 w0[4];
   u32 w1[4];

--- a/OpenCL/m29200_a0-pure.cl
+++ b/OpenCL/m29200_a0-pure.cl
@@ -40,6 +40,8 @@ KERNEL_FQ void m29200_mxx (KERN_ATTR_RULES_ESALT (radmin3_t))
 
   const u64 gid = get_global_id (0);
 
+  if (gid >= GID_CNT) return;
+
 
   /**
    * base
@@ -293,6 +295,8 @@ KERNEL_FQ void m29200_sxx (KERN_ATTR_RULES_ESALT (radmin3_t))
    */
 
   const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
 
 
   /**

--- a/OpenCL/m29200_a1-pure.cl
+++ b/OpenCL/m29200_a1-pure.cl
@@ -38,6 +38,8 @@ KERNEL_FQ void m29200_mxx (KERN_ATTR_ESALT (radmin3_t))
 
   const u64 gid = get_global_id (0);
 
+  if (gid >= GID_CNT) return;
+
 
   /**
    * base
@@ -296,6 +298,8 @@ KERNEL_FQ void m29200_sxx (KERN_ATTR_ESALT (radmin3_t))
    */
 
   const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
 
 
   /**

--- a/OpenCL/m29200_a3-pure.cl
+++ b/OpenCL/m29200_a3-pure.cl
@@ -38,6 +38,8 @@ KERNEL_FQ void m29200_mxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
 
   const u64 gid = get_global_id (0);
 
+  if (gid >= GID_CNT) return;
+
 
   /**
    * base
@@ -303,6 +305,8 @@ KERNEL_FQ void m29200_sxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
    */
 
   const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
 
 
   /**


### PR DESCRIPTION
I just noticed, by accident, that I completely removed the check for `gid >= GID_CNT` in the -m 29200 = `Radmin 3` kernel with this fix: https://github.com/hashcat/hashcat/pull/3309.

of course this was a mistake...

but after that I've found out that some other kernel functions also for now don't have this check, which for sure is a bug/problem.

I've also noticed that all the `*_tm` kernels (`OPTS_TYPE_TM_KERNEL` on the host / `KERN_ATTR_TM` in OpenCL) do not check this. This of course could also be correct, since we have some fixed settings there, but I think it's better to have it and comment it out and maybe you (@jsteube ) could double-check if it is correct that `*_tm` kernels don't need the `gid >= GID_CNT` check.

Thank you very much
( btw some kernels even got a bit faster, also in `-b` / benchmarks, due to this check, for me, could this be correct/significant !? )