### PR TITLE
add unit tests for -m 29000

### DIFF
--- a/tools/test_modules/m29000.pm
+++ b/tools/test_modules/m29000.pm
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA1 qw (sha1 sha1_hex);
+use Encode;
+
+sub module_constraints { [[0, 256], [0, 128], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $user = shift // random_mixedcase_string (random_number (0, 256 / 2));
+
+  my $word_utf16le = encode ("UTF-16LE", $word);
+  my $user_utf16le = encode ("UTF-16LE", $user);
+
+  my $digest = sha1_hex ($salt . sha1 ($user_utf16le . ':' . $word_utf16le));
+
+  my $hash = sprintf ("%s:%s:%s", $digest, unpack ("H*", $salt), unpack ("H*", $user));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $salt, $user, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $salt;
+  return unless defined $user;
+  return unless defined $word;
+
+  return unless ($hash =~ m/^[0-9a-fA-F]{40}$/);
+  return unless ($salt =~ m/^[0-9a-fA-F]{0,256}$/);
+  return unless ($user =~ m/^[0-9a-fA-F]{0,256}$/);
+
+  $salt = pack ("H*", $salt);
+  $user = pack ("H*", $user);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $user);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
I've noticed that we currently do not have any unit tests (perl) for our new hash mode -m 29000 = `sha1($salt.sha1(utf16le($username).':'.utf16le($pass)))`, so I've just added the perl module.

I think it's better to have this too, just to be sure everything is working correctly and as expected (sometimes it even nice to have the perl - higher level code - in front of you, just to be quickly get an idea what the hash mode algorithm is = convenience).

Thanks