### PR TITLE
fix -m 29100 unit test dependencies

### DIFF
--- a/tools/test_modules/m29100.pm
+++ b/tools/test_modules/m29100.pm
@@ -10,9 +10,8 @@ use warnings;
 
 use Digest::SHA  qw (sha1);
 use Digest::HMAC qw (hmac);
-use MIME::Base64 qw (encode_base64url decode_base64url);
-use JSON         qw (encode_json decode_json);
-use Data::Dumper;
+use MIME::Base64 qw (encode_base64url);
+use JSON         qw (encode_json);
 
 sub module_constraints { [[0, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 


### PR DESCRIPTION
in the unit tests of -m 29100 = `Flask` there are multiple perl module dependencies that are not needed (anymore).

This is just a little cleanup of the -m 29100 perl test module.

Thx