### PR TITLE
fixes vector bug in -m 27800 = MurmurHash 3 with -a 3

### DIFF
--- a/OpenCL/m27800_a0-optimized.cl
+++ b/OpenCL/m27800_a0-optimized.cl
@@ -15,22 +15,25 @@
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #endif
 
-DECLSPEC u32 Murmur32_Scramble(u32 k)
+DECLSPEC u32 Murmur32_Scramble (u32 k)
 {
   k = (k * 0x16A88000) | ((k * 0xCC9E2D51) >> 17);
+
   return (k * 0x1B873593);
 }
 
-DECLSPEC u32 MurmurHash3(const u32 seed, PRIVATE_AS const u32 *data, const u32 size)
+DECLSPEC u32 MurmurHash3 (const u32 seed, PRIVATE_AS const u32 *data, const u32 size)
 {
   u32 checksum = seed;
 
   const u32 nBlocks = (size / 4);
-  if (size >= 4) //Hash blocks, sizes of 4
+
+  if (size >= 4) // Hash blocks, sizes of 4
   {
     for (u32 i = 0; i < nBlocks; i++)
     {
-      checksum ^= Murmur32_Scramble(data[i]);
+      checksum ^= Murmur32_Scramble (data[i]);
+
       checksum = (checksum >> 19) | (checksum << 13); //rotateRight(checksum, 19)
       checksum = (checksum * 5) + 0xE6546B64;
     }
@@ -38,21 +41,23 @@ DECLSPEC u32 MurmurHash3(const u32 seed, PRIVATE_AS const u32 *data, const u32 s
 
   if (size % 4)
   {
-    PRIVATE_AS const u8 *remainder = (PRIVATE_AS u8 *)(data + nBlocks);
+    const u32 remainder = data[nBlocks];
+
     u32 val = 0;
 
-    switch(size & 3) //Hash remaining bytes as size isn't always aligned by 4
+    switch (size & 3) //Hash remaining bytes as size isn't always aligned by 4
     {
       case 3:
-        val ^= (remainder[2] << 16);
+        val ^= remainder & 0x00ff0000;
       case 2:
-        val ^= (remainder[1] << 8);
+        val ^= remainder & 0x0000ff00;
       case 1:
-        val ^= remainder[0];
-        checksum ^= Murmur32_Scramble(val);
+        val ^= remainder & 0x000000ff;
+
+        checksum ^= Murmur32_Scramble (val);
       default:
         break;
-    };
+    }
   }
 
   checksum ^= size;
@@ -60,6 +65,7 @@ DECLSPEC u32 MurmurHash3(const u32 seed, PRIVATE_AS const u32 *data, const u32 s
   checksum *= 0x85EBCA6B;
   checksum ^= checksum >> 13;
   checksum *= 0xC2B2AE35;
+
   return checksum ^ (checksum >> 16);
 }
 

--- a/OpenCL/m27800_a1-optimized.cl
+++ b/OpenCL/m27800_a1-optimized.cl
@@ -13,22 +13,25 @@
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #endif
 
-DECLSPEC u32 Murmur32_Scramble(u32 k)
+DECLSPEC u32 Murmur32_Scramble (u32 k)
 {
   k = (k * 0x16A88000) | ((k * 0xCC9E2D51) >> 17);
+
   return (k * 0x1B873593);
 }
 
-DECLSPEC u32 MurmurHash3(const u32 seed, PRIVATE_AS const u32 *data, const u32 size)
+DECLSPEC u32 MurmurHash3 (const u32 seed, PRIVATE_AS const u32 *data, const u32 size)
 {
   u32 checksum = seed;
 
   const u32 nBlocks = (size / 4);
-  if (size >= 4) //Hash blocks, sizes of 4
+
+  if (size >= 4) // Hash blocks, sizes of 4
   {
     for (u32 i = 0; i < nBlocks; i++)
     {
-      checksum ^= Murmur32_Scramble(data[i]);
+      checksum ^= Murmur32_Scramble (data[i]);
+
       checksum = (checksum >> 19) | (checksum << 13); //rotateRight(checksum, 19)
       checksum = (checksum * 5) + 0xE6546B64;
     }
@@ -36,21 +39,23 @@ DECLSPEC u32 MurmurHash3(const u32 seed, PRIVATE_AS const u32 *data, const u32 s
 
   if (size % 4)
   {
-    PRIVATE_AS const u8 *remainder = (PRIVATE_AS u8 *)(data + nBlocks);
+    const u32 remainder = data[nBlocks];
+
     u32 val = 0;
 
-    switch(size & 3) //Hash remaining bytes as size isn't always aligned by 4
+    switch (size & 3) //Hash remaining bytes as size isn't always aligned by 4
     {
       case 3:
-        val ^= (remainder[2] << 16);
+        val ^= remainder & 0x00ff0000;
       case 2:
-        val ^= (remainder[1] << 8);
+        val ^= remainder & 0x0000ff00;
       case 1:
-        val ^= remainder[0];
-        checksum ^= Murmur32_Scramble(val);
+        val ^= remainder & 0x000000ff;
+
+        checksum ^= Murmur32_Scramble (val);
       default:
         break;
-    };
+    }
   }
 
   checksum ^= size;
@@ -58,6 +63,7 @@ DECLSPEC u32 MurmurHash3(const u32 seed, PRIVATE_AS const u32 *data, const u32 s
   checksum *= 0x85EBCA6B;
   checksum ^= checksum >> 13;
   checksum *= 0xC2B2AE35;
+
   return checksum ^ (checksum >> 16);
 }
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -44,9 +44,10 @@
 - Fixed display problem of incorrect negative values in case of large numbers
 - Fixed display problem of the "Optimizers applied" list for algorithms using Register-Limit
 - Fixed example password output of --hash-info: force uppercase if OPTS_TYPE_PT_UPPER is set
-- Fixed false negative on hash-types 4510 and 4710 for hashes with long salts
 - Fixed false negative on Unit Test in case of out-of-memory with grep in single mode
 - Fixed false negative on Unit Test with hash-type 25400
+- Fixed false negative on hash-type 27800 if using vector width greater than 1 and -a 3
+- Fixed false negative on hash-types 4510 and 4710 for hashes with long salts
 - Fixed false negative on hash-types 8900, 15700, 22700, 27700 and 28200 if using the HIP backend
 - Fixed functional error when nonce-error-corrections that were set on the command line in hash-mode 22000/22001 were not accepted
 - Fixed handling of devices in benchmark mode for "kernel build error". Instead of canceling, skip the device and move on to the next


### PR DESCRIPTION
After adding the perl unit tests for -m 27800 = `MurmurHash 3` I have discovered that some tests fail. The problem was actually just due to this line in code:
https://github.com/hashcat/hashcat/blob/15a0ad5903688a0192ac42893c7c6fa62f3c5fb3/OpenCL/m27800_a3-optimized.cl#L67

which converts a `u32x *` into just a `u8 *` and could results in many false positives.

This problem is restricted to `-a 3` and `--backend-vector-width` > 1, or `-V` > 1 in `test.sh`.

The following command with the current/not-fixed code does NOT work/crack for me (note that which passwords crack and which don't might also depend a little bit on the hardware too, kernel power / shaders etc, i.e. a typical false negative bug):
```
hashcat -a 3 -m 27800 -O --backend-vector-width 4 f7fdeae4:49095171 ?d?d
```

password is: `64`

(works without the `--backend-vector-width` parameter, or - depending on hardware - when using the default one i.e. set to 1)

another example: `8602c7d2:92900203:0` (using ?d as mask)

Note: do not wonder if this is "just" a optimized kernel bug (`-O`), because this hash mode currently only has optimized kernels. Meaning, this also happens if you do not use/set `-O` in your command line (so it could trigger whenever higher vector widths are used in mask attacks). The problem seems to only affect -a 3 attacks, which is also typical and not surprising, because vectorization is **NOT** used (similar to many other hash modes) in the `-a 0` and `-a 1` kernels.

Thank you very much