### PR TITLE
Added mode 4410 - md5(sha1($pass).$salt)

### DIFF
--- a/OpenCL/m04410_a0-optimized.cl
+++ b/OpenCL/m04410_a0-optimized.cl
@@ -1,0 +1,1303 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.h)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m04410_m04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[4];
+  u32 salt_buf1[4];
+  u32 salt_buf2[4];
+  u32 salt_buf3[4];
+
+  salt_buf0[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 0];
+  salt_buf0[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 1];
+  salt_buf0[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 2];
+  salt_buf0[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 3];
+  salt_buf1[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 4];
+  salt_buf1[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 5];
+  salt_buf1[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 6];
+  salt_buf1[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 7];
+  salt_buf2[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 8];
+  salt_buf2[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 9];
+  salt_buf2[2] = salt_bufs[SALT_POS_HOST].salt_buf[10];
+  salt_buf2[3] = salt_bufs[SALT_POS_HOST].salt_buf[11];
+  salt_buf3[0] = salt_bufs[SALT_POS_HOST].salt_buf[12];
+  salt_buf3[1] = salt_bufs[SALT_POS_HOST].salt_buf[13];
+  salt_buf3[2] = salt_bufs[SALT_POS_HOST].salt_buf[14];
+  salt_buf3[3] = salt_bufs[SALT_POS_HOST].salt_buf[15];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += make_u32x (SHA1M_A);
+    b += make_u32x (SHA1M_B);
+    c += make_u32x (SHA1M_C);
+    d += make_u32x (SHA1M_D);
+    e += make_u32x (SHA1M_E);
+
+    /**
+     * md5
+     */
+
+    w0_t = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w1_t = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w2_t = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w3_t = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w4_t = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w5_t = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w6_t = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w7_t = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w8_t = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w9_t = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+
+    wa_t = 0;
+    wb_t = 0;
+    wc_t = 0;
+    wd_t = 0;
+    we_t = 0;
+    wf_t = 0;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+    e = 0;
+
+    u32x digest[4];
+
+    digest[0] = a;
+    digest[1] = b;
+    digest[2] = c;
+    digest[3] = d;
+
+    int pos = 40;
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf0[0];
+    s0[1] = salt_buf0[1];
+    s0[2] = salt_buf0[2];
+    s0[3] = salt_buf0[3];
+    s1[0] = salt_buf1[0];
+    s1[1] = salt_buf1[1];
+    s1[2] = salt_buf1[2];
+    s1[3] = salt_buf1[3];
+    s2[0] = salt_buf2[0];
+    s2[1] = salt_buf2[1];
+    s2[2] = salt_buf2[2];
+    s2[3] = salt_buf2[3];
+    s3[0] = salt_buf3[0];
+    s3[1] = salt_buf3[1];
+    s3[2] = salt_buf3[2];
+    s3[3] = salt_buf3[3];
+
+    if ((pos + salt_len) < 64)
+    {
+      switch_buffer_by_offset_be (s0, s1, s2, s3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+    }
+    else
+    {
+      u32x _w0[4] = { 0 };
+      u32x _w1[4] = { 0 };
+      u32x _w2[4] = { 0 };
+      u32x _w3[4] = { 0 };
+
+      switch_buffer_by_offset_carry_be (s0, s1, s2, s3, _w0, _w1, _w2, _w3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+
+      // md5 transform
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = _w0[0];
+      w1_t = _w0[1];
+      w2_t = _w0[2];
+      w3_t = _w0[3];
+      w4_t = _w1[0];
+      w5_t = _w1[1];
+      w6_t = _w1[2];
+      w7_t = _w1[3];
+      w8_t = _w2[0];
+      w9_t = _w2[1];
+      wa_t = _w2[2];
+      wb_t = _w2[3];
+      wc_t = _w3[0];
+      wd_t = _w3[1];
+      we_t = _w3[2];
+      wf_t = _w3[3];
+    }
+
+    const int ctx_len = 40 + salt_len;
+
+    pos = ctx_len & 63;
+
+    if (pos >= 56)
+    {
+      a = digest[0];
+      b = digest[1];
+      c = digest[2];
+      d = digest[3];
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = 0;
+      w1_t = 0;
+      w2_t = 0;
+      w3_t = 0;
+      w4_t = 0;
+      w5_t = 0;
+      w6_t = 0;
+      w7_t = 0;
+      w8_t = 0;
+      w9_t = 0;
+      wa_t = 0;
+      wb_t = 0;
+      wc_t = 0;
+      wd_t = 0;
+      we_t = 0;
+      wf_t = 0;
+    }
+
+    we_t = ctx_len * 8;
+    wf_t = 0;
+
+    a = digest[0];
+    b = digest[1];
+    c = digest[2];
+    d = digest[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+    a += digest[0] - MD5M_A;
+    b += digest[1] - MD5M_B;
+    c += digest[2] - MD5M_C;
+    d += digest[3] - MD5M_D;
+
+    COMPARE_M_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m04410_m08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m04410_m16 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m04410_s04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[4];
+  u32 salt_buf1[4];
+  u32 salt_buf2[4];
+  u32 salt_buf3[4];
+
+  salt_buf0[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 0];
+  salt_buf0[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 1];
+  salt_buf0[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 2];
+  salt_buf0[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 3];
+  salt_buf1[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 4];
+  salt_buf1[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 5];
+  salt_buf1[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 6];
+  salt_buf1[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 7];
+  salt_buf2[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 8];
+  salt_buf2[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 9];
+  salt_buf2[2] = salt_bufs[SALT_POS_HOST].salt_buf[10];
+  salt_buf2[3] = salt_bufs[SALT_POS_HOST].salt_buf[11];
+  salt_buf3[0] = salt_bufs[SALT_POS_HOST].salt_buf[12];
+  salt_buf3[1] = salt_bufs[SALT_POS_HOST].salt_buf[13];
+  salt_buf3[2] = salt_bufs[SALT_POS_HOST].salt_buf[14];
+  salt_buf3[3] = salt_bufs[SALT_POS_HOST].salt_buf[15];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = out_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += make_u32x (SHA1M_A);
+    b += make_u32x (SHA1M_B);
+    c += make_u32x (SHA1M_C);
+    d += make_u32x (SHA1M_D);
+    e += make_u32x (SHA1M_E);
+
+    /**
+     * md5
+     */
+
+    w0_t = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w1_t = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w2_t = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w3_t = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w4_t = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w5_t = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w6_t = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w7_t = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w8_t = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w9_t = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+
+    wa_t = 0;
+    wb_t = 0;
+    wc_t = 0;
+    wd_t = 0;
+    we_t = 0;
+    wf_t = 0;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+    e = 0;
+
+    u32x digest[4];
+
+    digest[0] = a;
+    digest[1] = b;
+    digest[2] = c;
+    digest[3] = d;
+
+    int pos = 40;
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf0[0];
+    s0[1] = salt_buf0[1];
+    s0[2] = salt_buf0[2];
+    s0[3] = salt_buf0[3];
+    s1[0] = salt_buf1[0];
+    s1[1] = salt_buf1[1];
+    s1[2] = salt_buf1[2];
+    s1[3] = salt_buf1[3];
+    s2[0] = salt_buf2[0];
+    s2[1] = salt_buf2[1];
+    s2[2] = salt_buf2[2];
+    s2[3] = salt_buf2[3];
+    s3[0] = salt_buf3[0];
+    s3[1] = salt_buf3[1];
+    s3[2] = salt_buf3[2];
+    s3[3] = salt_buf3[3];
+
+    if ((pos + salt_len) < 64)
+    {
+      switch_buffer_by_offset_be (s0, s1, s2, s3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+    }
+    else
+    {
+      u32x _w0[4] = { 0 };
+      u32x _w1[4] = { 0 };
+      u32x _w2[4] = { 0 };
+      u32x _w3[4] = { 0 };
+
+      switch_buffer_by_offset_carry_be (s0, s1, s2, s3, _w0, _w1, _w2, _w3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+
+      // md5 transform
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = _w0[0];
+      w1_t = _w0[1];
+      w2_t = _w0[2];
+      w3_t = _w0[3];
+      w4_t = _w1[0];
+      w5_t = _w1[1];
+      w6_t = _w1[2];
+      w7_t = _w1[3];
+      w8_t = _w2[0];
+      w9_t = _w2[1];
+      wa_t = _w2[2];
+      wb_t = _w2[3];
+      wc_t = _w3[0];
+      wd_t = _w3[1];
+      we_t = _w3[2];
+      wf_t = _w3[3];
+    }
+
+    const int ctx_len = 40 + salt_len;
+
+    pos = ctx_len & 63;
+
+    if (pos >= 56)
+    {
+      a = digest[0];
+      b = digest[1];
+      c = digest[2];
+      d = digest[3];
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = 0;
+      w1_t = 0;
+      w2_t = 0;
+      w3_t = 0;
+      w4_t = 0;
+      w5_t = 0;
+      w6_t = 0;
+      w7_t = 0;
+      w8_t = 0;
+      w9_t = 0;
+      wa_t = 0;
+      wb_t = 0;
+      wc_t = 0;
+      wd_t = 0;
+      we_t = 0;
+      wf_t = 0;
+    }
+
+    we_t = ctx_len * 8;
+    wf_t = 0;
+
+    a = digest[0];
+    b = digest[1];
+    c = digest[2];
+    d = digest[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+
+    if (MATCHES_NONE_VS ((a + digest[0] - make_u32x (MD5M_A)), search[0])) continue;
+
+    MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+    a += digest[0] - MD5M_A;
+    b += digest[1] - MD5M_B;
+    c += digest[2] - MD5M_C;
+    d += digest[3] - MD5M_D;
+
+    COMPARE_S_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m04410_s08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m04410_s16 (KERN_ATTR_RULES ())
+{
+}

--- a/OpenCL/m04410_a0-pure.cl
+++ b/OpenCL/m04410_a0-pure.cl
@@ -1,0 +1,280 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m04410_mxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx0;
+
+    sha1_init (&ctx0);
+
+    sha1_update_swap (&ctx0, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx0);
+
+    const u32 a = ctx0.h[0];
+    const u32 b = ctx0.h[1];
+    const u32 c = ctx0.h[2];
+    const u32 d = ctx0.h[3];
+    const u32 e = ctx0.h[4];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w0[1] = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w0[2] = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w0[3] = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w1[0] = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w1[1] = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w1[2] = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w1[3] = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w2[0] = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w2[1] = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    md5_update_64 (&ctx, w0, w1, w2, w3, 40);
+
+    md5_update(&ctx, s, salt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m04410_sxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_ctx_t ctx0;
+
+    sha1_init (&ctx0);
+
+    sha1_update_swap (&ctx0, tmp.i, tmp.pw_len);
+
+    sha1_final (&ctx0);
+
+    const u32 a = ctx0.h[0];
+    const u32 b = ctx0.h[1];
+    const u32 c = ctx0.h[2];
+    const u32 d = ctx0.h[3];
+    const u32 e = ctx0.h[4];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w0[1] = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w0[2] = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w0[3] = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w1[0] = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w1[1] = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w1[2] = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w1[3] = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w2[0] = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w2[1] = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    md5_update_64 (&ctx, w0, w1, w2, w3, 40);
+
+    md5_update(&ctx, s, salt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m04410_a1-optimized.cl
+++ b/OpenCL/m04410_a1-optimized.cl
@@ -1,0 +1,1417 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m04410_m04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[4];
+  u32 salt_buf1[4];
+  u32 salt_buf2[4];
+  u32 salt_buf3[4];
+
+  salt_buf0[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 0];
+  salt_buf0[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 1];
+  salt_buf0[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 2];
+  salt_buf0[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 3];
+  salt_buf1[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 4];
+  salt_buf1[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 5];
+  salt_buf1[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 6];
+  salt_buf1[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 7];
+  salt_buf2[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 8];
+  salt_buf2[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 9];
+  salt_buf2[2] = salt_bufs[SALT_POS_HOST].salt_buf[10];
+  salt_buf2[3] = salt_bufs[SALT_POS_HOST].salt_buf[11];
+  salt_buf3[0] = salt_bufs[SALT_POS_HOST].salt_buf[12];
+  salt_buf3[1] = salt_bufs[SALT_POS_HOST].salt_buf[13];
+  salt_buf3[2] = salt_bufs[SALT_POS_HOST].salt_buf[14];
+  salt_buf3[3] = salt_bufs[SALT_POS_HOST].salt_buf[15];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += make_u32x (SHA1M_A);
+    b += make_u32x (SHA1M_B);
+    c += make_u32x (SHA1M_C);
+    d += make_u32x (SHA1M_D);
+    e += make_u32x (SHA1M_E);
+
+    /**
+     * md5
+     */
+
+    w0_t = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w1_t = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w2_t = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w3_t = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w4_t = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w5_t = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w6_t = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w7_t = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w8_t = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w9_t = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+
+    wa_t = 0;
+    wb_t = 0;
+    wc_t = 0;
+    wd_t = 0;
+    we_t = 0;
+    wf_t = 0;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+    e = 0;
+
+    u32x digest[4];
+
+    digest[0] = a;
+    digest[1] = b;
+    digest[2] = c;
+    digest[3] = d;
+
+    int pos = 40;
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf0[0];
+    s0[1] = salt_buf0[1];
+    s0[2] = salt_buf0[2];
+    s0[3] = salt_buf0[3];
+    s1[0] = salt_buf1[0];
+    s1[1] = salt_buf1[1];
+    s1[2] = salt_buf1[2];
+    s1[3] = salt_buf1[3];
+    s2[0] = salt_buf2[0];
+    s2[1] = salt_buf2[1];
+    s2[2] = salt_buf2[2];
+    s2[3] = salt_buf2[3];
+    s3[0] = salt_buf3[0];
+    s3[1] = salt_buf3[1];
+    s3[2] = salt_buf3[2];
+    s3[3] = salt_buf3[3];
+
+    if ((pos + salt_len) < 64)
+    {
+      switch_buffer_by_offset_be (s0, s1, s2, s3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+    }
+    else
+    {
+      u32x _w0[4] = { 0 };
+      u32x _w1[4] = { 0 };
+      u32x _w2[4] = { 0 };
+      u32x _w3[4] = { 0 };
+
+      switch_buffer_by_offset_carry_be (s0, s1, s2, s3, _w0, _w1, _w2, _w3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+
+      // md5 transform
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = _w0[0];
+      w1_t = _w0[1];
+      w2_t = _w0[2];
+      w3_t = _w0[3];
+      w4_t = _w1[0];
+      w5_t = _w1[1];
+      w6_t = _w1[2];
+      w7_t = _w1[3];
+      w8_t = _w2[0];
+      w9_t = _w2[1];
+      wa_t = _w2[2];
+      wb_t = _w2[3];
+      wc_t = _w3[0];
+      wd_t = _w3[1];
+      we_t = _w3[2];
+      wf_t = _w3[3];
+    }
+
+    const int ctx_len = 40 + salt_len;
+
+    pos = ctx_len & 63;
+
+    if (pos >= 56)
+    {
+      a = digest[0];
+      b = digest[1];
+      c = digest[2];
+      d = digest[3];
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = 0;
+      w1_t = 0;
+      w2_t = 0;
+      w3_t = 0;
+      w4_t = 0;
+      w5_t = 0;
+      w6_t = 0;
+      w7_t = 0;
+      w8_t = 0;
+      w9_t = 0;
+      wa_t = 0;
+      wb_t = 0;
+      wc_t = 0;
+      wd_t = 0;
+      we_t = 0;
+      wf_t = 0;
+    }
+
+    we_t = ctx_len * 8;
+    wf_t = 0;
+
+    a = digest[0];
+    b = digest[1];
+    c = digest[2];
+    d = digest[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+    a += digest[0] - MD5M_A;
+    b += digest[1] - MD5M_B;
+    c += digest[2] - MD5M_C;
+    d += digest[3] - MD5M_D;
+
+    COMPARE_M_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m04410_m08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m04410_m16 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m04410_s04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[4];
+  u32 salt_buf1[4];
+  u32 salt_buf2[4];
+  u32 salt_buf3[4];
+
+  salt_buf0[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 0];
+  salt_buf0[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 1];
+  salt_buf0[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 2];
+  salt_buf0[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 3];
+  salt_buf1[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 4];
+  salt_buf1[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 5];
+  salt_buf1[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 6];
+  salt_buf1[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 7];
+  salt_buf2[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 8];
+  salt_buf2[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 9];
+  salt_buf2[2] = salt_bufs[SALT_POS_HOST].salt_buf[10];
+  salt_buf2[3] = salt_bufs[SALT_POS_HOST].salt_buf[11];
+  salt_buf3[0] = salt_bufs[SALT_POS_HOST].salt_buf[12];
+  salt_buf3[1] = salt_bufs[SALT_POS_HOST].salt_buf[13];
+  salt_buf3[2] = salt_bufs[SALT_POS_HOST].salt_buf[14];
+  salt_buf3[3] = salt_bufs[SALT_POS_HOST].salt_buf[15];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = wordl3[2] | wordr3[2];
+    w3[3] = wordl3[3] | wordr3[3];
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = hc_swap32 (w0[0]);
+    u32x w1_t = hc_swap32 (w0[1]);
+    u32x w2_t = hc_swap32 (w0[2]);
+    u32x w3_t = hc_swap32 (w0[3]);
+    u32x w4_t = hc_swap32 (w1[0]);
+    u32x w5_t = hc_swap32 (w1[1]);
+    u32x w6_t = hc_swap32 (w1[2]);
+    u32x w7_t = hc_swap32 (w1[3]);
+    u32x w8_t = hc_swap32 (w2[0]);
+    u32x w9_t = hc_swap32 (w2[1]);
+    u32x wa_t = hc_swap32 (w2[2]);
+    u32x wb_t = hc_swap32 (w2[3]);
+    u32x wc_t = hc_swap32 (w3[0]);
+    u32x wd_t = hc_swap32 (w3[1]);
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += make_u32x (SHA1M_A);
+    b += make_u32x (SHA1M_B);
+    c += make_u32x (SHA1M_C);
+    d += make_u32x (SHA1M_D);
+    e += make_u32x (SHA1M_E);
+
+    /**
+     * md5
+     */
+
+    w0_t = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w1_t = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w2_t = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w3_t = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w4_t = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w5_t = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w6_t = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w7_t = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w8_t = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w9_t = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+
+    wa_t = 0;
+    wb_t = 0;
+    wc_t = 0;
+    wd_t = 0;
+    we_t = 0;
+    wf_t = 0;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+    e = 0;
+
+    u32x digest[4];
+
+    digest[0] = a;
+    digest[1] = b;
+    digest[2] = c;
+    digest[3] = d;
+
+    int pos = 40;
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf0[0];
+    s0[1] = salt_buf0[1];
+    s0[2] = salt_buf0[2];
+    s0[3] = salt_buf0[3];
+    s1[0] = salt_buf1[0];
+    s1[1] = salt_buf1[1];
+    s1[2] = salt_buf1[2];
+    s1[3] = salt_buf1[3];
+    s2[0] = salt_buf2[0];
+    s2[1] = salt_buf2[1];
+    s2[2] = salt_buf2[2];
+    s2[3] = salt_buf2[3];
+    s3[0] = salt_buf3[0];
+    s3[1] = salt_buf3[1];
+    s3[2] = salt_buf3[2];
+    s3[3] = salt_buf3[3];
+
+    if ((pos + salt_len) < 64)
+    {
+      switch_buffer_by_offset_be (s0, s1, s2, s3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+    }
+    else
+    {
+      u32x _w0[4] = { 0 };
+      u32x _w1[4] = { 0 };
+      u32x _w2[4] = { 0 };
+      u32x _w3[4] = { 0 };
+
+      switch_buffer_by_offset_carry_be (s0, s1, s2, s3, _w0, _w1, _w2, _w3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+
+      // md5 transform
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = _w0[0];
+      w1_t = _w0[1];
+      w2_t = _w0[2];
+      w3_t = _w0[3];
+      w4_t = _w1[0];
+      w5_t = _w1[1];
+      w6_t = _w1[2];
+      w7_t = _w1[3];
+      w8_t = _w2[0];
+      w9_t = _w2[1];
+      wa_t = _w2[2];
+      wb_t = _w2[3];
+      wc_t = _w3[0];
+      wd_t = _w3[1];
+      we_t = _w3[2];
+      wf_t = _w3[3];
+    }
+
+    const int ctx_len = 40 + salt_len;
+
+    pos = ctx_len & 63;
+
+    if (pos >= 56)
+    {
+      a = digest[0];
+      b = digest[1];
+      c = digest[2];
+      d = digest[3];
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = 0;
+      w1_t = 0;
+      w2_t = 0;
+      w3_t = 0;
+      w4_t = 0;
+      w5_t = 0;
+      w6_t = 0;
+      w7_t = 0;
+      w8_t = 0;
+      w9_t = 0;
+      wa_t = 0;
+      wb_t = 0;
+      wc_t = 0;
+      wd_t = 0;
+      we_t = 0;
+      wf_t = 0;
+    }
+
+    we_t = ctx_len * 8;
+    wf_t = 0;
+
+    a = digest[0];
+    b = digest[1];
+    c = digest[2];
+    d = digest[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+
+    if (MATCHES_NONE_VS ((a + digest[0] - make_u32x (MD5M_A)), search[0])) continue;
+
+    MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+    a += digest[0] - MD5M_A;
+    b += digest[1] - MD5M_B;
+    c += digest[2] - MD5M_C;
+    d += digest[3] - MD5M_D;
+
+    COMPARE_S_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m04410_s08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m04410_s16 (KERN_ATTR_BASIC ())
+{
+}

--- a/OpenCL/m04410_a1-pure.cl
+++ b/OpenCL/m04410_a1-pure.cl
@@ -1,0 +1,274 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m04410_mxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    sha1_ctx_t ctx1 = ctx0;
+
+    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx1);
+
+    const u32 a = ctx1.h[0];
+    const u32 b = ctx1.h[1];
+    const u32 c = ctx1.h[2];
+    const u32 d = ctx1.h[3];
+    const u32 e = ctx1.h[4];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w0[1] = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w0[2] = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w0[3] = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w1[0] = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w1[1] = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w1[2] = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w1[3] = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w2[0] = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w2[1] = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    md5_update_64 (&ctx, w0, w1, w2, w3, 40);
+
+    md5_update(&ctx, s, salt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m04410_sxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  sha1_ctx_t ctx0;
+
+  sha1_init (&ctx0);
+
+  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    sha1_ctx_t ctx1 = ctx0;
+
+    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha1_final (&ctx1);
+
+    const u32 a = ctx1.h[0];
+    const u32 b = ctx1.h[1];
+    const u32 c = ctx1.h[2];
+    const u32 d = ctx1.h[3];
+    const u32 e = ctx1.h[4];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w0[1] = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w0[2] = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w0[3] = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w1[0] = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w1[1] = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w1[2] = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w1[3] = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w2[0] = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+          | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w2[1] = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+          | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    md5_update_64 (&ctx, w0, w1, w2, w3, 40);
+
+    md5_update(&ctx, s, salt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m04410_a3-optimized.cl
+++ b/OpenCL/m04410_a3-optimized.cl
@@ -1,0 +1,1617 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+DECLSPEC void m04410m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_BASIC (), LOCAL_AS u32 *l_bin2asc)
+{
+  /**
+   * modifiers are taken from args
+   */
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[4];
+  u32 salt_buf1[4];
+  u32 salt_buf2[4];
+  u32 salt_buf3[4];
+
+  salt_buf0[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 0];
+  salt_buf0[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 1];
+  salt_buf0[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 2];
+  salt_buf0[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 3];
+  salt_buf1[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 4];
+  salt_buf1[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 5];
+  salt_buf1[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 6];
+  salt_buf1[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 7];
+  salt_buf2[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 8];
+  salt_buf2[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 9];
+  salt_buf2[2] = salt_bufs[SALT_POS_HOST].salt_buf[10];
+  salt_buf2[3] = salt_bufs[SALT_POS_HOST].salt_buf[11];
+  salt_buf3[0] = salt_bufs[SALT_POS_HOST].salt_buf[12];
+  salt_buf3[1] = salt_bufs[SALT_POS_HOST].salt_buf[13];
+  salt_buf3[2] = salt_bufs[SALT_POS_HOST].salt_buf[14];
+  salt_buf3[3] = salt_bufs[SALT_POS_HOST].salt_buf[15];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = w0lr;
+    u32x w1_t = w0[1];
+    u32x w2_t = w0[2];
+    u32x w3_t = w0[3];
+    u32x w4_t = w1[0];
+    u32x w5_t = w1[1];
+    u32x w6_t = w1[2];
+    u32x w7_t = w1[3];
+    u32x w8_t = w2[0];
+    u32x w9_t = w2[1];
+    u32x wa_t = w2[2];
+    u32x wb_t = w2[3];
+    u32x wc_t = w3[0];
+    u32x wd_t = w3[1];
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += make_u32x (SHA1M_A);
+    b += make_u32x (SHA1M_B);
+    c += make_u32x (SHA1M_C);
+    d += make_u32x (SHA1M_D);
+    e += make_u32x (SHA1M_E);
+
+    /**
+     * md5
+     */
+
+    w0_t = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w1_t = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w2_t = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w3_t = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w4_t = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w5_t = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w6_t = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w7_t = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w8_t = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w9_t = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+
+    wa_t = 0;
+    wb_t = 0;
+    wc_t = 0;
+    wd_t = 0;
+    we_t = 0;
+    wf_t = 0;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+    e = 0;
+
+    u32x digest[4];
+
+    digest[0] = a;
+    digest[1] = b;
+    digest[2] = c;
+    digest[3] = d;
+
+    int pos = 40;
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf0[0];
+    s0[1] = salt_buf0[1];
+    s0[2] = salt_buf0[2];
+    s0[3] = salt_buf0[3];
+    s1[0] = salt_buf1[0];
+    s1[1] = salt_buf1[1];
+    s1[2] = salt_buf1[2];
+    s1[3] = salt_buf1[3];
+    s2[0] = salt_buf2[0];
+    s2[1] = salt_buf2[1];
+    s2[2] = salt_buf2[2];
+    s2[3] = salt_buf2[3];
+    s3[0] = salt_buf3[0];
+    s3[1] = salt_buf3[1];
+    s3[2] = salt_buf3[2];
+    s3[3] = salt_buf3[3];
+
+    if ((pos + salt_len) < 64)
+    {
+      switch_buffer_by_offset_be (s0, s1, s2, s3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+    }
+    else
+    {
+      u32x _w0[4] = { 0 };
+      u32x _w1[4] = { 0 };
+      u32x _w2[4] = { 0 };
+      u32x _w3[4] = { 0 };
+
+      switch_buffer_by_offset_carry_be (s0, s1, s2, s3, _w0, _w1, _w2, _w3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+
+      // md5 transform
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = _w0[0];
+      w1_t = _w0[1];
+      w2_t = _w0[2];
+      w3_t = _w0[3];
+      w4_t = _w1[0];
+      w5_t = _w1[1];
+      w6_t = _w1[2];
+      w7_t = _w1[3];
+      w8_t = _w2[0];
+      w9_t = _w2[1];
+      wa_t = _w2[2];
+      wb_t = _w2[3];
+      wc_t = _w3[0];
+      wd_t = _w3[1];
+      we_t = _w3[2];
+      wf_t = _w3[3];
+    }
+
+    const int ctx_len = 40 + salt_len;
+
+    pos = ctx_len & 63;
+
+    if (pos >= 56)
+    {
+      a = digest[0];
+      b = digest[1];
+      c = digest[2];
+      d = digest[3];
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = 0;
+      w1_t = 0;
+      w2_t = 0;
+      w3_t = 0;
+      w4_t = 0;
+      w5_t = 0;
+      w6_t = 0;
+      w7_t = 0;
+      w8_t = 0;
+      w9_t = 0;
+      wa_t = 0;
+      wb_t = 0;
+      wc_t = 0;
+      wd_t = 0;
+      we_t = 0;
+      wf_t = 0;
+    }
+
+    we_t = ctx_len * 8;
+    wf_t = 0;
+
+    a = digest[0];
+    b = digest[1];
+    c = digest[2];
+    d = digest[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+    a += digest[0] - MD5M_A;
+    b += digest[1] - MD5M_B;
+    c += digest[2] - MD5M_C;
+    d += digest[3] - MD5M_D;
+
+    COMPARE_M_SIMD (a, d, c, b);
+  }
+}
+
+DECLSPEC void m04410s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_BASIC (), LOCAL_AS u32 *l_bin2asc)
+{
+  /**
+   * modifiers are taken from args
+   */  
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf0[4];
+  u32 salt_buf1[4];
+  u32 salt_buf2[4];
+  u32 salt_buf3[4];
+
+  salt_buf0[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 0];
+  salt_buf0[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 1];
+  salt_buf0[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 2];
+  salt_buf0[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 3];
+  salt_buf1[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 4];
+  salt_buf1[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 5];
+  salt_buf1[2] = salt_bufs[SALT_POS_HOST].salt_buf[ 6];
+  salt_buf1[3] = salt_bufs[SALT_POS_HOST].salt_buf[ 7];
+  salt_buf2[0] = salt_bufs[SALT_POS_HOST].salt_buf[ 8];
+  salt_buf2[1] = salt_bufs[SALT_POS_HOST].salt_buf[ 9];
+  salt_buf2[2] = salt_bufs[SALT_POS_HOST].salt_buf[10];
+  salt_buf2[3] = salt_bufs[SALT_POS_HOST].salt_buf[11];
+  salt_buf3[0] = salt_bufs[SALT_POS_HOST].salt_buf[12];
+  salt_buf3[1] = salt_bufs[SALT_POS_HOST].salt_buf[13];
+  salt_buf3[2] = salt_bufs[SALT_POS_HOST].salt_buf[14];
+  salt_buf3[3] = salt_bufs[SALT_POS_HOST].salt_buf[15];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    /**
+     * sha1
+     */
+
+    u32x w0_t = w0lr;
+    u32x w1_t = w0[1];
+    u32x w2_t = w0[2];
+    u32x w3_t = w0[3];
+    u32x w4_t = w1[0];
+    u32x w5_t = w1[1];
+    u32x w6_t = w1[2];
+    u32x w7_t = w1[3];
+    u32x w8_t = w2[0];
+    u32x w9_t = w2[1];
+    u32x wa_t = w2[2];
+    u32x wb_t = w2[3];
+    u32x wc_t = w3[0];
+    u32x wd_t = w3[1];
+    u32x we_t = 0;
+    u32x wf_t = pw_len * 8;
+
+    u32x a = SHA1M_A;
+    u32x b = SHA1M_B;
+    u32x c = SHA1M_C;
+    u32x d = SHA1M_D;
+    u32x e = SHA1M_E;
+
+    #undef K
+    #define K SHA1C00
+
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w0_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w1_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w2_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w3_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w4_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, w5_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, w6_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, w7_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, w8_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, w9_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wa_t);
+    SHA1_STEP (SHA1_F0o, e, a, b, c, d, wb_t);
+    SHA1_STEP (SHA1_F0o, d, e, a, b, c, wc_t);
+    SHA1_STEP (SHA1_F0o, c, d, e, a, b, wd_t);
+    SHA1_STEP (SHA1_F0o, b, c, d, e, a, we_t);
+    SHA1_STEP (SHA1_F0o, a, b, c, d, e, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F0o, e, a, b, c, d, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F0o, d, e, a, b, c, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F0o, c, d, e, a, b, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F0o, b, c, d, e, a, w3_t);
+
+    #undef K
+    #define K SHA1C01
+
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w7_t);
+
+    #undef K
+    #define K SHA1C02
+
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F2o, a, b, c, d, e, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F2o, e, a, b, c, d, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F2o, d, e, a, b, c, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F2o, c, d, e, a, b, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F2o, b, c, d, e, a, wb_t);
+
+    #undef K
+    #define K SHA1C03
+
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, wf_t);
+    w0_t = hc_rotl32 ((wd_t ^ w8_t ^ w2_t ^ w0_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w0_t);
+    w1_t = hc_rotl32 ((we_t ^ w9_t ^ w3_t ^ w1_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w1_t);
+    w2_t = hc_rotl32 ((wf_t ^ wa_t ^ w4_t ^ w2_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w2_t);
+    w3_t = hc_rotl32 ((w0_t ^ wb_t ^ w5_t ^ w3_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w3_t);
+    w4_t = hc_rotl32 ((w1_t ^ wc_t ^ w6_t ^ w4_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w4_t);
+    w5_t = hc_rotl32 ((w2_t ^ wd_t ^ w7_t ^ w5_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, w5_t);
+    w6_t = hc_rotl32 ((w3_t ^ we_t ^ w8_t ^ w6_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, w6_t);
+    w7_t = hc_rotl32 ((w4_t ^ wf_t ^ w9_t ^ w7_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, w7_t);
+    w8_t = hc_rotl32 ((w5_t ^ w0_t ^ wa_t ^ w8_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, w8_t);
+    w9_t = hc_rotl32 ((w6_t ^ w1_t ^ wb_t ^ w9_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, w9_t);
+    wa_t = hc_rotl32 ((w7_t ^ w2_t ^ wc_t ^ wa_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wa_t);
+    wb_t = hc_rotl32 ((w8_t ^ w3_t ^ wd_t ^ wb_t), 1u); SHA1_STEP (SHA1_F1, a, b, c, d, e, wb_t);
+    wc_t = hc_rotl32 ((w9_t ^ w4_t ^ we_t ^ wc_t), 1u); SHA1_STEP (SHA1_F1, e, a, b, c, d, wc_t);
+    wd_t = hc_rotl32 ((wa_t ^ w5_t ^ wf_t ^ wd_t), 1u); SHA1_STEP (SHA1_F1, d, e, a, b, c, wd_t);
+    we_t = hc_rotl32 ((wb_t ^ w6_t ^ w0_t ^ we_t), 1u); SHA1_STEP (SHA1_F1, c, d, e, a, b, we_t);
+    wf_t = hc_rotl32 ((wc_t ^ w7_t ^ w1_t ^ wf_t), 1u); SHA1_STEP (SHA1_F1, b, c, d, e, a, wf_t);
+
+    a += make_u32x (SHA1M_A);
+    b += make_u32x (SHA1M_B);
+    c += make_u32x (SHA1M_C);
+    d += make_u32x (SHA1M_D);
+    e += make_u32x (SHA1M_E);
+
+    /**
+     * md5
+     */
+
+    w0_t = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    w1_t = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    w2_t = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    w3_t = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    w4_t = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    w5_t = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    w6_t = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    w7_t = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    w8_t = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+         | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    w9_t = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+         | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+
+    wa_t = 0;
+    wb_t = 0;
+    wc_t = 0;
+    wd_t = 0;
+    we_t = 0;
+    wf_t = 0;
+
+    a = MD5M_A;
+    b = MD5M_B;
+    c = MD5M_C;
+    d = MD5M_D;
+    e = 0;
+
+    u32x digest[4];
+
+    digest[0] = a;
+    digest[1] = b;
+    digest[2] = c;
+    digest[3] = d;
+
+    int pos = 40;
+
+    u32x s0[4];
+    u32x s1[4];
+    u32x s2[4];
+    u32x s3[4];
+
+    s0[0] = salt_buf0[0];
+    s0[1] = salt_buf0[1];
+    s0[2] = salt_buf0[2];
+    s0[3] = salt_buf0[3];
+    s1[0] = salt_buf1[0];
+    s1[1] = salt_buf1[1];
+    s1[2] = salt_buf1[2];
+    s1[3] = salt_buf1[3];
+    s2[0] = salt_buf2[0];
+    s2[1] = salt_buf2[1];
+    s2[2] = salt_buf2[2];
+    s2[3] = salt_buf2[3];
+    s3[0] = salt_buf3[0];
+    s3[1] = salt_buf3[1];
+    s3[2] = salt_buf3[2];
+    s3[3] = salt_buf3[3];
+
+    if ((pos + salt_len) < 64)
+    {
+      switch_buffer_by_offset_be (s0, s1, s2, s3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+    }
+    else
+    {
+      u32x _w0[4] = { 0 };
+      u32x _w1[4] = { 0 };
+      u32x _w2[4] = { 0 };
+      u32x _w3[4] = { 0 };
+
+      switch_buffer_by_offset_carry_be (s0, s1, s2, s3, _w0, _w1, _w2, _w3, pos);
+
+      w0_t |= s0[0];
+      w1_t |= s0[1];
+      w2_t |= s0[2];
+      w3_t |= s0[3];
+      w4_t |= s1[0];
+      w5_t |= s1[1];
+      w6_t |= s1[2];
+      w7_t |= s1[3];
+      w8_t |= s2[0];
+      w9_t |= s2[1];
+      wa_t |= s2[2];
+      wb_t |= s2[3];
+      wc_t |= s3[0];
+      wd_t |= s3[1];
+      we_t |= s3[2];
+      wf_t |= s3[3];
+
+      // md5 transform
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = _w0[0];
+      w1_t = _w0[1];
+      w2_t = _w0[2];
+      w3_t = _w0[3];
+      w4_t = _w1[0];
+      w5_t = _w1[1];
+      w6_t = _w1[2];
+      w7_t = _w1[3];
+      w8_t = _w2[0];
+      w9_t = _w2[1];
+      wa_t = _w2[2];
+      wb_t = _w2[3];
+      wc_t = _w3[0];
+      wd_t = _w3[1];
+      we_t = _w3[2];
+      wf_t = _w3[3];
+    }
+
+    const int ctx_len = 40 + salt_len;
+
+    pos = ctx_len & 63;
+
+    if (pos >= 56)
+    {
+      a = digest[0];
+      b = digest[1];
+      c = digest[2];
+      d = digest[3];
+
+      MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+      MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+      MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+      MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+      MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+      MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+      MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+      MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+      MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+      MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+      u32x t;
+
+      MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+      MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+      MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+      MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+      MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+      MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+      MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+      MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+      MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+      MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+      digest[0] += a;
+      digest[1] += b;
+      digest[2] += c;
+      digest[3] += d;
+
+      w0_t = 0;
+      w1_t = 0;
+      w2_t = 0;
+      w3_t = 0;
+      w4_t = 0;
+      w5_t = 0;
+      w6_t = 0;
+      w7_t = 0;
+      w8_t = 0;
+      w9_t = 0;
+      wa_t = 0;
+      wb_t = 0;
+      wc_t = 0;
+      wd_t = 0;
+      we_t = 0;
+      wf_t = 0;
+    }
+
+    we_t = ctx_len * 8;
+    wf_t = 0;
+
+    a = digest[0];
+    b = digest[1];
+    c = digest[2];
+    d = digest[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+
+    if (MATCHES_NONE_VS ((a + digest[0] - make_u32x (MD5M_A)), search[0])) continue;
+
+    MD5_STEP (MD5_I , d, a, b, c, wb_t, MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
+
+    a += digest[0] - MD5M_A;
+    b += digest[1] - MD5M_B;
+    c += digest[2] - MD5M_C;
+    d += digest[3] - MD5M_D;
+
+    COMPARE_S_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m04410_m04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m04410m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m04410_m08 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m04410m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m04410_m16 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = pws[gid].i[14];
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m04410m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m04410_s04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m04410s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m04410_s08 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m04410s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m04410_s16 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = pws[gid].i[14];
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m04410s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}

--- a/OpenCL/m04410_a3-pure.cl
+++ b/OpenCL/m04410_a3-pure.cl
@@ -1,0 +1,300 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m04410_mxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x _w0[4];
+  u32x _w1[4];
+  u32x _w2[4];
+  u32x _w3[4];
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx0;
+
+    sha1_init_vector (&ctx0);
+
+    sha1_update_vector (&ctx0, w, pw_len);
+
+    sha1_final_vector (&ctx0);
+
+    const u32x a = ctx0.h[0];
+    const u32x b = ctx0.h[1];
+    const u32x c = ctx0.h[2];
+    const u32x d = ctx0.h[3];
+    const u32x e = ctx0.h[4];
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    _w0[0] = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    _w0[1] = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    _w0[2] = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    _w0[3] = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    _w1[0] = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    _w1[1] = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    _w1[2] = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    _w1[3] = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    _w2[0] = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    _w2[1] = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+    _w2[2] = 0;
+    _w2[3] = 0;
+    _w3[0] = 0;
+    _w3[1] = 0;
+    _w3[2] = 0;
+    _w3[3] = 0;
+
+    md5_update_vector_64 (&ctx, _w0, _w1, _w2, _w3, 40);
+
+    md5_update_vector (&ctx, s, salt_len);
+
+    md5_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m04410_sxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x _w0[4];
+  u32x _w1[4];
+  u32x _w2[4];
+  u32x _w3[4];
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_ctx_vector_t ctx0;
+
+    sha1_init_vector (&ctx0);
+
+    sha1_update_vector (&ctx0, w, pw_len);
+
+    sha1_final_vector (&ctx0);
+
+    const u32x a = ctx0.h[0];
+    const u32x b = ctx0.h[1];
+    const u32x c = ctx0.h[2];
+    const u32x d = ctx0.h[3];
+    const u32x e = ctx0.h[4];
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    _w0[0] = uint_to_hex_lower8 ((a >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 16) & 255) << 16;
+    _w0[1] = uint_to_hex_lower8 ((a >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  0) & 255) << 16;
+    _w0[2] = uint_to_hex_lower8 ((b >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 16) & 255) << 16;
+    _w0[3] = uint_to_hex_lower8 ((b >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  0) & 255) << 16;
+    _w1[0] = uint_to_hex_lower8 ((c >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 16) & 255) << 16;
+    _w1[1] = uint_to_hex_lower8 ((c >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  0) & 255) << 16;
+    _w1[2] = uint_to_hex_lower8 ((d >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 16) & 255) << 16;
+    _w1[3] = uint_to_hex_lower8 ((d >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  0) & 255) << 16;
+    _w2[0] = uint_to_hex_lower8 ((e >> 24) & 255) <<  0
+           | uint_to_hex_lower8 ((e >> 16) & 255) << 16;
+    _w2[1] = uint_to_hex_lower8 ((e >>  8) & 255) <<  0
+           | uint_to_hex_lower8 ((e >>  0) & 255) << 16;
+    _w2[2] = 0;
+    _w2[3] = 0;
+    _w3[0] = 0;
+    _w3[1] = 0;
+    _w3[2] = 0;
+    _w3[3] = 0;
+
+    md5_update_vector_64 (&ctx, _w0, _w1, _w2, _w3, 40);
+
+    md5_update_vector (&ctx, s, salt_len);
+
+    md5_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -20,6 +20,7 @@
 - Added hash-mode: bcrypt(sha512($pass)) / bcryptsha512
 - Added hash-mode: sha1($salt.sha1(utf16le($username).':'.utf16le($pass)))
 - Added hash-mode: sha256($salt.sha256_bin($pass))
+- Added hash-mode: md5(sha1($pass).$salt)
 
 ##
 ## Features

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -86,6 +86,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - md5(md5($pass).md5($salt))
 - md5(md5(md5($pass)))
 - md5(sha1($pass))
+- md5(sha1($pass).$salt)
 - md5(sha1($pass).md5($pass).sha1($pass))
 - md5(sha1($salt).md5($pass))
 - md5(strtoupper(md5($pass)))

--- a/src/modules/module_04410.c
+++ b/src/modules/module_04410.c
@@ -1,0 +1,220 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 3;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 1;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_RAW_HASH_SALTED;
+static const char *HASH_NAME      = "md5(sha1($pass).$salt)";
+static const u64   KERN_TYPE      = 4410;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_EARLY_SKIP
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_RAW_HASH;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS15
+                                  | OPTS_TYPE_ST_ADD80;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "bc8319c0220bff8a0d7f5d703114a725:34659348756345251";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  hc_token_t token;
+
+  token.token_cnt  = 2;
+
+  token.sep[0]     = hashconfig->separator;
+  token.len_min[0] = 32;
+  token.len_max[0] = 32;
+  token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[1] = SALT_MIN;
+  token.len_max[1] = SALT_MAX;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  if (hashconfig->opts_type & OPTS_TYPE_ST_HEX)
+  {
+    token.len_min[1] *= 2;
+    token.len_max[1] *= 2;
+
+    token.attr[1] |= TOKEN_ATTR_VERIFY_HEX;
+  }
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *hash_pos = token.buf[0];
+
+  digest[0] = hex_to_u32 (hash_pos +  0);
+  digest[1] = hex_to_u32 (hash_pos +  8);
+  digest[2] = hex_to_u32 (hash_pos + 16);
+  digest[3] = hex_to_u32 (hash_pos + 24);
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    digest[0] -= MD5M_A;
+    digest[1] -= MD5M_B;
+    digest[2] -= MD5M_C;
+    digest[3] -= MD5M_D;
+  }
+
+  const u8 *salt_pos = token.buf[1];
+  const int salt_len = token.len[1];
+
+  const bool parse_rc = generic_salt_decode (hashconfig, salt_pos, salt_len, (u8 *) salt->salt_buf, (int *) &salt->salt_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  u32 tmp[4];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = digest[2];
+  tmp[3] = digest[3];
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    tmp[0] += MD5M_A;
+    tmp[1] += MD5M_B;
+    tmp[2] += MD5M_C;
+    tmp[3] += MD5M_D;
+  }
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  int out_len = 0;
+
+  u32_to_hex (tmp[0], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[1], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
+
+  out_buf[out_len] = hashconfig->separator;
+
+  out_len += 1;
+
+  out_len += generic_salt_encode (hashconfig, (const u8 *) salt->salt_buf, (const int) salt->salt_len, out_buf + out_len);
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m04410.pm
+++ b/tools/test_modules/m04410.pm
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::MD5 qw (md5_hex);
+use Digest::SHA qw (sha1_hex);
+
+sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 64], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $digest = md5_hex (sha1_hex ($word) . $salt);
+
+  my $hash = sprintf ("%s:%s", $digest, $salt);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $salt, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $salt;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Added mode 4410 - md5(sha1($pass).$salt) as requested in https://github.com/hashcat/hashcat/issues/3328

It seems like tests finished mostly without any errors except one timeout, although I'm afraid I don't know what could have caused it 

```
$ tools/test.sh -t all -m 4410 -V1 -P -o win -a all
[ test_1655567153 ] > Init test for hash type 4410.
[ test_1655567153 ] [ Type 4410, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1655567153 ] [ Type 4410, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1655567153 ] [ Type 4410, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567153 ] [ Type 4410, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1655567153 ] [ Type 4410, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567153 ] [ Type 4410, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1655567153 ] [ Type 4410, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567153 ] [ Type 4410, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567153 ] [ Type 4410, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567153 ] [ Type 4410, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped

$ tools/test.sh -t all -m 4410 -V1 -O -o win -a all
[ test_1655567622 ] > Init test for hash type 4410.
[ test_1655567622 ] [ Type 4410, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1655567622 ] [ Type 4410, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1655567622 ] [ Type 4410, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567622 ] [ Type 4410, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1655567622 ] [ Type 4410, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567622 ] [ Type 4410, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1655567622 ] [ Type 4410, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 1/7 timeout, 0/7 skipped
[ test_1655567622 ] [ Type 4410, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567622 ] [ Type 4410, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1655567622 ] [ Type 4410, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```