### PR TITLE
fixes #3337: rename function mul_mod to mul_mod128 for BigNum lib

### DIFF
--- a/OpenCL/inc_bignum_operations.cl
+++ b/OpenCL/inc_bignum_operations.cl
@@ -846,7 +846,7 @@ DECLSPEC void mul_masked (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *x, PRIVATE_AS
 // m   [128], modulo
 // fact[ 64], our m' (actually it is fact[65])
 
-DECLSPEC void mul_mod (PRIVATE_AS u32 *x, PRIVATE_AS const u32 *y, PRIVATE_AS const u32 *m, PRIVATE_AS const u32 *fact)
+DECLSPEC void mul_mod128 (PRIVATE_AS u32 *x, PRIVATE_AS const u32 *y, PRIVATE_AS const u32 *m, PRIVATE_AS const u32 *fact)
 {
   // 1st multiplication
   // p = x * y
@@ -1411,7 +1411,7 @@ DECLSPEC void pow_mod_precomp_g (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *b_pre,
 
     const u32 bit_set = (y[div] >> mod) & 1;
 
-    if (bit_set == 1) mul_mod (r, b_pre + i * 64, m, fact);
+    if (bit_set == 1) mul_mod128 (r, b_pre + i * 64, m, fact);
   }
 }
 
@@ -1445,9 +1445,9 @@ DECLSPEC void pow_mod (PRIVATE_AS u32 *r, PRIVATE_AS u32 *x, PRIVATE_AS const u3
 
     const u32 bit_set = (y[div] >> mod) & 1;
 
-    if (bit_set == 1) mul_mod (r, x, m, fact);
+    if (bit_set == 1) mul_mod128 (r, x, m, fact);
 
-    mul_mod (x, x, m, fact);
+    mul_mod128 (x, x, m, fact);
   }
 }
 

--- a/OpenCL/inc_bignum_operations.h
+++ b/OpenCL/inc_bignum_operations.h
@@ -9,7 +9,7 @@
 DECLSPEC void mod_4096   (PRIVATE_AS u32 *n, PRIVATE_AS const u32 *m);
 DECLSPEC void mul        (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *x, PRIVATE_AS const u32 *y);
 DECLSPEC void mul_masked (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *x, PRIVATE_AS const u32 *y);
-DECLSPEC void mul_mod    (PRIVATE_AS u32 *x, PRIVATE_AS const u32 *y, PRIVATE_AS const u32 *m, PRIVATE_AS const u32 *fact);
+DECLSPEC void mul_mod128 (PRIVATE_AS u32 *x, PRIVATE_AS const u32 *y, PRIVATE_AS const u32 *m, PRIVATE_AS const u32 *fact);
 
 DECLSPEC void pow_mod_precomp_g (PRIVATE_AS u32 *r, PRIVATE_AS const u32 *b_pre, PRIVATE_AS const u32 *y, PRIVATE_AS const u32 *m, PRIVATE_AS const u32 *fact);
 DECLSPEC void pow_mod           (PRIVATE_AS u32 *r, PRIVATE_AS       u32 *x,     PRIVATE_AS const u32 *y, PRIVATE_AS const u32 *m, PRIVATE_AS const u32 *fact);

--- a/OpenCL/m29200_a0-pure.cl
+++ b/OpenCL/m29200_a0-pure.cl
@@ -276,7 +276,7 @@ KERNEL_FQ void m29200_mxx (KERN_ATTR_RULES_ESALT (radmin3_t))
         esalt_bufs[DIGESTS_OFFSET_HOST].pre[pre_idx + 63],
       };
 
-      mul_mod (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
+      mul_mod128 (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
     }
 
     const u32 r0 = r_t[0];
@@ -544,7 +544,7 @@ KERNEL_FQ void m29200_sxx (KERN_ATTR_RULES_ESALT (radmin3_t))
         esalt_bufs[DIGESTS_OFFSET_HOST].pre[pre_idx + 63],
       };
 
-      mul_mod (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
+      mul_mod128 (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
     }
 
     const u32 r0 = r_t[0];

--- a/OpenCL/m29200_a1-pure.cl
+++ b/OpenCL/m29200_a1-pure.cl
@@ -279,7 +279,7 @@ KERNEL_FQ void m29200_mxx (KERN_ATTR_ESALT (radmin3_t))
         esalt_bufs[DIGESTS_OFFSET_HOST].pre[pre_idx + 63],
       };
 
-      mul_mod (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
+      mul_mod128 (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
     }
 
     const u32 r0 = r_t[0];
@@ -552,7 +552,7 @@ KERNEL_FQ void m29200_sxx (KERN_ATTR_ESALT (radmin3_t))
         esalt_bufs[DIGESTS_OFFSET_HOST].pre[pre_idx + 63],
       };
 
-      mul_mod (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
+      mul_mod128 (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
     }
 
     const u32 r0 = r_t[0];

--- a/OpenCL/m29200_a3-pure.cl
+++ b/OpenCL/m29200_a3-pure.cl
@@ -286,7 +286,7 @@ KERNEL_FQ void m29200_mxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
         esalt_bufs[DIGESTS_OFFSET_HOST].pre[pre_idx + 63],
       };
 
-      mul_mod (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
+      mul_mod128 (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
     }
 
     const u32 r0 = r_t[0];
@@ -567,7 +567,7 @@ KERNEL_FQ void m29200_sxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
         esalt_bufs[DIGESTS_OFFSET_HOST].pre[pre_idx + 63],
       };
 
-      mul_mod (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
+      mul_mod128 (r_t, pre, m, fact); // r_t = (r_t * RADMIN3_PRE[n]) % m
     }
 
     const u32 r0 = r_t[0];


### PR DESCRIPTION
It seems we need to rename the function `mul_mod ()` to something more specific like `mul_mod128 ()` , because we have a name conflict that was first reported here https://github.com/hashcat/hashcat/issues/3337 by @ventaquil (thanks !), due to a similar/same function name in our `secp256k1` (ECC, elliptic curve cryptography) code.

I think this is a valid/good fix.

Thanks for the report, @ventaquil .

For me it is compiling and working with this fix (only the `libhashcat` build was affected, it seems).

Thanks