### PR TITLE
fix code, add newline in 28503/28504

### DIFF
--- a/src/modules/module_28503.c
+++ b/src/modules/module_28503.c
@@ -102,7 +102,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.attr[1] = TOKEN_ATTR_FIXED_LENGTH
                 | TOKEN_ATTR_VERIFY_BECH32;
 
-  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token); if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
 
   // Bech32 decode:
 

--- a/src/modules/module_28504.c
+++ b/src/modules/module_28504.c
@@ -102,7 +102,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.attr[1] = TOKEN_ATTR_FIXED_LENGTH
                 | TOKEN_ATTR_VERIFY_BECH32;
 
-  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token); if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
 
   // Bech32 decode:
 


### PR DESCRIPTION
For some strange reason, it seems that I have missed to add a newline after the `input_tokenizer ()` call.
This of course was a mistake and this cleanup/code style fix is needed to make this code section more readable and fix this ugly code line.

It's just a minor fix to add a newline between `input_tokenizer ()` call and the `rc_tokenizer` variable (return code) check.
Thanks