### PR TITLE
fix whitespace in -m 4410 kernel

### DIFF
--- a/OpenCL/m04410_a3-optimized.cl
+++ b/OpenCL/m04410_a3-optimized.cl
@@ -608,7 +608,7 @@ DECLSPEC void m04410s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
 {
   /**
    * modifiers are taken from args
-   */  
+   */
 
   /**
    * salt


### PR DESCRIPTION
minor code style fix, remove unneccessary spaces at the end of the line in -m 4410 = `md5(sha1($pass).$salt)`.

Thanks