### PR TITLE
update tools/install_modules.sh (test deps)

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -70,11 +70,20 @@ ERRORS=$((ERRORS+$?))
 
 pip3 install pygost
 
+ERRORS=$((ERRORS+$?))
+
 # pip3 uninstall -y pycryptoplus pycrypto pycryptodome
 
 pip3 install pycryptoplus
+
+ERRORS=$((ERRORS+$?))
+
 # pip3 uninstall -y pycryptodome # latest versions do not require this work around anymore
 pip3 install pycrypto
+
+ERRORS=$((ERRORS+$?))
+
+pip3 install cryptography
 
 ERRORS=$((ERRORS+$?))
 


### PR DESCRIPTION
The `python` (more correct `python 3`) `cryptography` dependency was missing in the `tools/install_modules.sh` install script (for perl/python/php dependencies for our unit tests).

I also strongly believe (i.e. I am pretty sure) we need to update the `ERRORS` variable after **each and every** command we execute.

Thanks 