### PR TITLE
Add -m 28505/28506, Bitcoin WIF, P2SH(P2WPKH)/compat address

### DIFF
--- a/OpenCL/m28505_a0-pure.cl
+++ b/OpenCL/m28505_a0-pure.cl
@@ -1,0 +1,365 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_base58.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_hash_ripemd160.cl)
+#include M2S(INCLUDE_PATH/inc_ecc_secp256k1.cl)
+#endif
+
+KERNEL_FQ void m28505_mxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * base
+   */
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+  COPY_PW (pws[gid]);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t p = PASTE_PW;
+
+    p.pw_len = apply_rules (rules_buf[il_pos].cmds, p.i, p.pw_len);
+
+    if (p.pw_len != 52) continue;
+
+    const u32 b = hc_swap32_S (p.i[0]);
+
+    if ((b < 0x4b774469) ||         // 'KwDi'
+        (b > 0x4c356f4c)) continue; // 'L5oL'
+
+    const bool status_base58 = is_valid_base58 (p.i, 0, 52);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_52 (tmp, p.i);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // check that compression is enabled:
+
+    if ((tmp[8] & 0x00ff0000) != 0x00010000) continue; // 33th byte
+
+
+    // verify sha256 (sha256 (tmp[0..38 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_38 (tmp); // length is 34 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[16] = { 0 }; // why is re-using the "tmp" variable here slower ?
+
+    const u32 type = 0x02 | (y[0] & 1);
+
+    pub_key[8] =               (x[0] << 24);
+    pub_key[7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[0] = (x[7] >> 8) | (type << 24);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 33); // length of public key: 33
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28505_sxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+
+  /**
+   * base
+   */
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+  COPY_PW (pws[gid]);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t p = PASTE_PW;
+
+    p.pw_len = apply_rules (rules_buf[il_pos].cmds, p.i, p.pw_len);
+
+    if (p.pw_len != 52) continue;
+
+    const u32 b = hc_swap32_S (p.i[0]);
+
+    if ((b < 0x4b774469) ||         // 'KwDi'
+        (b > 0x4c356f4c)) continue; // 'L5oL'
+
+    const bool status_base58 = is_valid_base58 (p.i, 0, 52);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_52 (tmp, p.i);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // check that compression is enabled:
+
+    if ((tmp[8] & 0x00ff0000) != 0x00010000) continue; // 33th byte
+
+
+    // verify sha256 (sha256 (tmp[0..38 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_38 (tmp); // length is 34 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[16] = { 0 }; // why is re-using the "tmp" variable here slower ?
+
+    const u32 type = 0x02 | (y[0] & 1);
+
+    pub_key[8] =               (x[0] << 24);
+    pub_key[7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[0] = (x[7] >> 8) | (type << 24);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 33); // length of public key: 33
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m28505_a1-pure.cl
+++ b/OpenCL/m28505_a1-pure.cl
@@ -1,0 +1,443 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_base58.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_hash_ripemd160.cl)
+#include M2S(INCLUDE_PATH/inc_ecc_secp256k1.cl)
+#endif
+
+KERNEL_FQ void m28505_mxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  // copy password to w
+
+  u32 w[13] = { 0 }; // 52 bytes needed
+
+  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  for (u32 idx = 0; idx < 13; idx++)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  if (pw_len > 3)
+  {
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x4b774469) ||       // 'KwDi'
+        (b > 0x4c356f4c)) return; // 'L5oL'
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 0, pw_len);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    if ((pw_len + comb_len) != 52) continue;
+
+    u32 c[64] = { 0 };
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] = combs_buf[il_pos].i[i];
+    }
+
+    switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    const u32 b = hc_swap32_S (c[0]);
+
+    if ((b < 0x4b774469) ||         // 'KwDi'
+        (b > 0x4c356f4c)) continue; // 'L5oL'
+
+    const bool status_base58 = is_valid_base58 (c, pw_len, 52);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_52 (tmp, c);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // check that compression is enabled:
+
+    if ((tmp[8] & 0x00ff0000) != 0x00010000) continue; // 33th byte
+
+
+    // verify sha256 (sha256 (tmp[0..38 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_38 (tmp); // length is 34 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[16] = { 0 }; // why is re-using the "tmp" variable here slower ?
+
+    const u32 type = 0x02 | (y[0] & 1);
+
+    pub_key[8] =               (x[0] << 24);
+    pub_key[7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[0] = (x[7] >> 8) | (type << 24);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 33); // length of public key: 33
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28505_sxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  // copy password to w
+
+  u32 w[13] = { 0 }; // 52 bytes needed
+
+  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  for (u32 idx = 0; idx < 13; idx++)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  if (pw_len > 3)
+  {
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x4b774469) ||       // 'KwDi'
+        (b > 0x4c356f4c)) return; // 'L5oL'
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 0, pw_len);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    if ((pw_len + comb_len) != 52) continue;
+
+    u32 c[64] = { 0 };
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] = combs_buf[il_pos].i[i];
+    }
+
+    switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    const u32 b = hc_swap32_S (c[0]);
+
+    if ((b < 0x4b774469) ||         // 'KwDi'
+        (b > 0x4c356f4c)) continue; // 'L5oL'
+
+    const bool status_base58 = is_valid_base58 (c, pw_len, 52);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_52 (tmp, c);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // check that compression is enabled:
+
+    if ((tmp[8] & 0x00ff0000) != 0x00010000) continue; // 33th byte
+
+
+    // verify sha256 (sha256 (tmp[0..38 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_38 (tmp); // length is 34 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[16] = { 0 }; // why is re-using the "tmp" variable here slower ?
+
+    const u32 type = 0x02 | (y[0] & 1);
+
+    pub_key[8] =               (x[0] << 24);
+    pub_key[7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[0] = (x[7] >> 8) | (type << 24);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 33); // length of public key: 33
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m28505_a3-pure.cl
+++ b/OpenCL/m28505_a3-pure.cl
@@ -1,0 +1,399 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+// #define SECP256K1_TMPS_TYPE CONSTANT_AS
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_base58.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_hash_ripemd160.cl)
+#include M2S(INCLUDE_PATH/inc_ecc_secp256k1.cl)
+#endif
+
+KERNEL_FQ void m28505_mxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  if (pw_len != 52) return;
+
+
+  // copy password to w
+
+  u32 w[13]; // 52 bytes needed
+
+  for (u32 i = 0; i < 13; i++) // pw_len / 4
+  {
+    w[i] = pws[gid].i[i];
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 4, 52);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32 w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x4b774469) ||         // 'KwDi'
+        (b > 0x4c356f4c)) continue; // 'L5oL'
+
+    const bool status_base58 = is_valid_base58 (w, 0, 4);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_52 (tmp, w);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // check that compression is enabled:
+
+    if ((tmp[8] & 0x00ff0000) != 0x00010000) continue; // 33th byte
+
+
+    // verify sha256 (sha256 (tmp[0..38 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_38 (tmp); // length is 34 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[16] = { 0 }; // why is re-using the "tmp" variable here slower ?
+
+    const u32 type = 0x02 | (y[0] & 1);
+
+    pub_key[8] =               (x[0] << 24);
+    pub_key[7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[0] = (x[7] >> 8) | (type << 24);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 33); // length of public key: 33
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28505_sxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  if (pw_len != 52) return;
+
+
+  // copy password to w
+
+  u32 w[13]; // 52 bytes needed
+
+  for (u32 i = 0; i < 13; i++) // pw_len / 4
+  {
+    w[i] = pws[gid].i[i];
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 4, 52);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32 w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x4b774469) ||         // 'KwDi'
+        (b > 0x4c356f4c)) continue; // 'L5oL'
+
+    const bool status_base58 = is_valid_base58 (w, 0, 4);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_52 (tmp, w);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // check that compression is enabled:
+
+    if ((tmp[8] & 0x00ff0000) != 0x00010000) continue; // 33th byte
+
+
+    // verify sha256 (sha256 (tmp[0..38 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_38 (tmp); // length is 34 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[16] = { 0 }; // why is re-using the "tmp" variable here slower ?
+
+    const u32 type = 0x02 | (y[0] & 1);
+
+    pub_key[8] =               (x[0] << 24);
+    pub_key[7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[0] = (x[7] >> 8) | (type << 24);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 33); // length of public key: 33
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m28506_a0-pure.cl
+++ b/OpenCL/m28506_a0-pure.cl
@@ -1,0 +1,367 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_base58.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_hash_ripemd160.cl)
+#include M2S(INCLUDE_PATH/inc_ecc_secp256k1.cl)
+#endif
+
+KERNEL_FQ void m28506_mxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * base
+   */
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+  COPY_PW (pws[gid]);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t p = PASTE_PW;
+
+    p.pw_len = apply_rules (rules_buf[il_pos].cmds, p.i, p.pw_len);
+
+    if (p.pw_len != 51) continue;
+
+    const u32 b = hc_swap32_S (p.i[0]);
+
+    if ((b < 0x35487048) ||         // '5Hph'
+        (b > 0x354b6d32)) continue; // '5Km2'
+
+    const bool status_base58 = is_valid_base58 (p.i, 0, 51);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_51 (tmp, p.i);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // verify sha256 (sha256 (tmp[0..37 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_37 (tmp); // length is 33 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[32] = { 0 };
+
+    pub_key[16] =               (y[0] << 24);
+    pub_key[15] = (y[0] >> 8) | (y[1] << 24);
+    pub_key[14] = (y[1] >> 8) | (y[2] << 24);
+    pub_key[13] = (y[2] >> 8) | (y[3] << 24);
+    pub_key[12] = (y[3] >> 8) | (y[4] << 24);
+    pub_key[11] = (y[4] >> 8) | (y[5] << 24);
+    pub_key[10] = (y[5] >> 8) | (y[6] << 24);
+    pub_key[ 9] = (y[6] >> 8) | (y[7] << 24);
+    pub_key[ 8] = (y[7] >> 8) | (x[0] << 24);
+    pub_key[ 7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[ 6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[ 5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[ 4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[ 3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[ 2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[ 0] = (x[7] >> 8) | (0x04000000);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 65); // length of public key: 65
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28506_sxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+
+  /**
+   * base
+   */
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+  COPY_PW (pws[gid]);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t p = PASTE_PW;
+
+    p.pw_len = apply_rules (rules_buf[il_pos].cmds, p.i, p.pw_len);
+
+    if (p.pw_len != 51) continue;
+
+    const u32 b = hc_swap32_S (p.i[0]);
+
+    if ((b < 0x35487048) ||         // '5Hph'
+        (b > 0x354b6d32)) continue; // '5Km2'
+
+    const bool status_base58 = is_valid_base58 (p.i, 0, 51);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_51 (tmp, p.i);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // verify sha256 (sha256 (tmp[0..37 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_37 (tmp); // length is 33 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[32] = { 0 };
+
+    pub_key[16] =               (y[0] << 24);
+    pub_key[15] = (y[0] >> 8) | (y[1] << 24);
+    pub_key[14] = (y[1] >> 8) | (y[2] << 24);
+    pub_key[13] = (y[2] >> 8) | (y[3] << 24);
+    pub_key[12] = (y[3] >> 8) | (y[4] << 24);
+    pub_key[11] = (y[4] >> 8) | (y[5] << 24);
+    pub_key[10] = (y[5] >> 8) | (y[6] << 24);
+    pub_key[ 9] = (y[6] >> 8) | (y[7] << 24);
+    pub_key[ 8] = (y[7] >> 8) | (x[0] << 24);
+    pub_key[ 7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[ 6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[ 5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[ 4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[ 3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[ 2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[ 0] = (x[7] >> 8) | (0x04000000);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 65); // length of public key: 65
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m28506_a1-pure.cl
+++ b/OpenCL/m28506_a1-pure.cl
@@ -1,0 +1,445 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_base58.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_hash_ripemd160.cl)
+#include M2S(INCLUDE_PATH/inc_ecc_secp256k1.cl)
+#endif
+
+KERNEL_FQ void m28506_mxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  // copy password to w
+
+  u32 w[13] = { 0 }; // 51 bytes needed
+
+  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  for (u32 idx = 0; idx < 13; idx++)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  if (pw_len > 3)
+  {
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x35487048) ||       // '5Hph'
+        (b > 0x354b6d32)) return; // '5Km2'
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 0, pw_len);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    if ((pw_len + comb_len) != 51) continue;
+
+    u32 c[64] = { 0 };
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] = combs_buf[il_pos].i[i];
+    }
+
+    switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    const u32 b = hc_swap32_S (c[0]);
+
+    if ((b < 0x35487048) ||         // '5Hph'
+        (b > 0x354b6d32)) continue; // '5Km2'
+
+    const bool status_base58 = is_valid_base58 (c, pw_len, 51);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_51 (tmp, c);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // verify sha256 (sha256 (tmp[0..37 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_37 (tmp); // length is 33 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[32] = { 0 };
+
+    pub_key[16] =               (y[0] << 24);
+    pub_key[15] = (y[0] >> 8) | (y[1] << 24);
+    pub_key[14] = (y[1] >> 8) | (y[2] << 24);
+    pub_key[13] = (y[2] >> 8) | (y[3] << 24);
+    pub_key[12] = (y[3] >> 8) | (y[4] << 24);
+    pub_key[11] = (y[4] >> 8) | (y[5] << 24);
+    pub_key[10] = (y[5] >> 8) | (y[6] << 24);
+    pub_key[ 9] = (y[6] >> 8) | (y[7] << 24);
+    pub_key[ 8] = (y[7] >> 8) | (x[0] << 24);
+    pub_key[ 7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[ 6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[ 5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[ 4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[ 3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[ 2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[ 0] = (x[7] >> 8) | (0x04000000);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 65); // length of public key: 65
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28506_sxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  // copy password to w
+
+  u32 w[13] = { 0 }; // 51 bytes needed
+
+  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  for (u32 idx = 0; idx < 13; idx++)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  if (pw_len > 3)
+  {
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x35487048) ||       // '5Hph'
+        (b > 0x354b6d32)) return; // '5Km2'
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 0, pw_len);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    if ((pw_len + comb_len) != 51) continue;
+
+    u32 c[64] = { 0 };
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] = combs_buf[il_pos].i[i];
+    }
+
+    switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (u32 i = 0; i < 13; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    const u32 b = hc_swap32_S (c[0]);
+
+    if ((b < 0x35487048) ||         // '5Hph'
+        (b > 0x354b6d32)) continue; // '5Km2'
+
+    const bool status_base58 = is_valid_base58 (c, pw_len, 51);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_51 (tmp, c);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // verify sha256 (sha256 (tmp[0..37 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_37 (tmp); // length is 33 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[32] = { 0 };
+
+    pub_key[16] =               (y[0] << 24);
+    pub_key[15] = (y[0] >> 8) | (y[1] << 24);
+    pub_key[14] = (y[1] >> 8) | (y[2] << 24);
+    pub_key[13] = (y[2] >> 8) | (y[3] << 24);
+    pub_key[12] = (y[3] >> 8) | (y[4] << 24);
+    pub_key[11] = (y[4] >> 8) | (y[5] << 24);
+    pub_key[10] = (y[5] >> 8) | (y[6] << 24);
+    pub_key[ 9] = (y[6] >> 8) | (y[7] << 24);
+    pub_key[ 8] = (y[7] >> 8) | (x[0] << 24);
+    pub_key[ 7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[ 6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[ 5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[ 4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[ 3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[ 2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[ 0] = (x[7] >> 8) | (0x04000000);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 65); // length of public key: 65
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m28506_a3-pure.cl
+++ b/OpenCL/m28506_a3-pure.cl
@@ -1,0 +1,400 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_base58.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_hash_ripemd160.cl)
+#include M2S(INCLUDE_PATH/inc_ecc_secp256k1.cl)
+#endif
+
+KERNEL_FQ void m28506_mxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  if (pw_len != 51) return;
+
+
+  // copy password to w
+
+  u32 w[13]; // 51 bytes needed
+
+  for (u32 i = 0; i < 13; i++) // pw_len / 4
+  {
+    w[i] = pws[gid].i[i];
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 4, 51);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32 w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x35487048) ||         // '5Hph'
+        (b > 0x354b6d32)) continue; // '5Km2'
+
+    const bool status_base58 = is_valid_base58 (w, 0, 4);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_51 (tmp, w);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // verify sha256 (sha256 (tmp[0..37 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_37 (tmp); // length is 33 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[32] = { 0 };
+
+    pub_key[16] =               (y[0] << 24);
+    pub_key[15] = (y[0] >> 8) | (y[1] << 24);
+    pub_key[14] = (y[1] >> 8) | (y[2] << 24);
+    pub_key[13] = (y[2] >> 8) | (y[3] << 24);
+    pub_key[12] = (y[3] >> 8) | (y[4] << 24);
+    pub_key[11] = (y[4] >> 8) | (y[5] << 24);
+    pub_key[10] = (y[5] >> 8) | (y[6] << 24);
+    pub_key[ 9] = (y[6] >> 8) | (y[7] << 24);
+    pub_key[ 8] = (y[7] >> 8) | (x[0] << 24);
+    pub_key[ 7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[ 6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[ 5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[ 4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[ 3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[ 2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[ 0] = (x[7] >> 8) | (0x04000000);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 65); // length of public key: 65
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m28506_sxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  if (pw_len != 51) return;
+
+
+  // copy password to w
+
+  u32 w[13]; // 51 bytes needed
+
+  for (u32 i = 0; i < 13; i++) // pw_len / 4
+  {
+    w[i] = pws[gid].i[i];
+  }
+
+  const bool status_base58 = is_valid_base58 (w, 4, 51);
+
+  if (status_base58 != true) return;
+
+  secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
+
+  set_precomputed_basepoint_g (&preG);
+
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32 w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    const u32 b = hc_swap32_S (w[0]);
+
+    if ((b < 0x35487048) ||         // '5Hph'
+        (b > 0x354b6d32)) continue; // '5Km2'
+
+    const bool status_base58 = is_valid_base58 (w, 0, 4);
+
+    if (status_base58 != true) continue;
+
+
+    // convert password from b58 to binary
+
+    u32 tmp[16] = { 0 };
+
+    const bool status_dec = b58dec_51 (tmp, w);
+
+    if (status_dec != true) continue;
+
+
+    // check for bitcoin main network identifier:
+
+    if ((tmp[0] & 0xff000000) != 0x80000000) continue;
+
+
+    // verify sha256 (sha256 (tmp[0..37 - 4]))
+    // real work is done in b58check where sha256 is run twice
+
+    const bool status_check = b58check_37 (tmp); // length is 33 (+ 4 checksum bytes)
+
+    if (status_check != true) continue;
+
+
+    u32 prv_key[9]; // why is re-using the "tmp" variable here slower ?
+
+    prv_key[0] = (tmp[7] << 8) | (tmp[8] >> 24);
+    prv_key[1] = (tmp[6] << 8) | (tmp[7] >> 24);
+    prv_key[2] = (tmp[5] << 8) | (tmp[6] >> 24);
+    prv_key[3] = (tmp[4] << 8) | (tmp[5] >> 24);
+    prv_key[4] = (tmp[3] << 8) | (tmp[4] >> 24);
+    prv_key[5] = (tmp[2] << 8) | (tmp[3] >> 24);
+    prv_key[6] = (tmp[1] << 8) | (tmp[2] >> 24);
+    prv_key[7] = (tmp[0] << 8) | (tmp[1] >> 24);
+
+
+    // convert: pub_key = G * prv_key
+
+    u32 x[8];
+    u32 y[8];
+
+    point_mul_xy (x, y, prv_key, &preG);
+
+
+    // to public key:
+
+    u32 pub_key[32] = { 0 };
+
+    pub_key[16] =               (y[0] << 24);
+    pub_key[15] = (y[0] >> 8) | (y[1] << 24);
+    pub_key[14] = (y[1] >> 8) | (y[2] << 24);
+    pub_key[13] = (y[2] >> 8) | (y[3] << 24);
+    pub_key[12] = (y[3] >> 8) | (y[4] << 24);
+    pub_key[11] = (y[4] >> 8) | (y[5] << 24);
+    pub_key[10] = (y[5] >> 8) | (y[6] << 24);
+    pub_key[ 9] = (y[6] >> 8) | (y[7] << 24);
+    pub_key[ 8] = (y[7] >> 8) | (x[0] << 24);
+    pub_key[ 7] = (x[0] >> 8) | (x[1] << 24);
+    pub_key[ 6] = (x[1] >> 8) | (x[2] << 24);
+    pub_key[ 5] = (x[2] >> 8) | (x[3] << 24);
+    pub_key[ 4] = (x[3] >> 8) | (x[4] << 24);
+    pub_key[ 3] = (x[4] >> 8) | (x[5] << 24);
+    pub_key[ 2] = (x[5] >> 8) | (x[6] << 24);
+    pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
+    pub_key[ 0] = (x[7] >> 8) | (0x04000000);
+
+
+    // calculate HASH160 for pub key
+
+    sha256_ctx_t ctx;
+
+    sha256_init   (&ctx);
+    sha256_update (&ctx, pub_key, 65); // length of public key: 65
+    sha256_final  (&ctx);
+
+    for (u32 i = 0; i < 8; i++) tmp[i] = ctx.h[i];
+
+    // tmp[ 8] = 0; tmp[ 9] = 0; tmp[10] = 0; tmp[11] = 0;
+    // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
+
+    for (u32 i = 8; i < 16; i++) tmp[i] = 0;
+
+
+    // now let's do RIPEMD-160 on the sha256sum
+
+    ripemd160_ctx_t rctx;
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+
+    /*
+     * 2nd RIPEMD160 (SHA256 ()):
+     */
+
+    tmp[0] = (rctx.h[0] << 16) | (         0x1400); // (swapped) OP_0 operation (0x00),
+    tmp[1] = (rctx.h[1] << 16) | (rctx.h[0] >> 16); // 0x14 == 20, this indicates the
+    tmp[2] = (rctx.h[2] << 16) | (rctx.h[1] >> 16); // data len
+    tmp[3] = (rctx.h[3] << 16) | (rctx.h[2] >> 16);
+    tmp[4] = (rctx.h[4] << 16) | (rctx.h[3] >> 16);
+    tmp[5] =                     (rctx.h[4] >> 16);
+
+    for (u32 i = 6; i < 16; i++) tmp[i] = 0;
+
+    sha256_init        (&ctx);
+    sha256_update_swap (&ctx, tmp, 22);
+    sha256_final       (&ctx);
+
+    for (u32 i = 0; i <  8; i++) tmp[i] = ctx.h[i];
+
+    ripemd160_init        (&rctx);
+    ripemd160_update_swap (&rctx, tmp, 32);
+    ripemd160_final       (&rctx);
+
+    const u32 r0 = rctx.h[0];
+    const u32 r1 = rctx.h[1];
+    const u32 r2 = rctx.h[2];
+    const u32 r3 = rctx.h[3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -6,6 +6,7 @@
 
 - Added hash-mode: Amazon AWS4-HMAC-SHA256
 - Added hash-mode: Bitcoin WIF private key (P2PKH)
+- Added hash-mode: Bitcoin WIF private key (P2SH(P2WPKH))
 - Added hash-mode: Bitcoin WIF private key (P2WPKH, Bech32)
 - Added hash-mode: BLAKE2b-512($pass.$salt)
 - Added hash-mode: BLAKE2b-512($salt.$pass)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -404,6 +404,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - BitShares v0.x - sha512(sha512_bin(pass))
 - Bitcoin/Litecoin wallet.dat
 - Bitcoin WIF private key (P2PKH)
+- Bitcoin WIF private key (P2SH(P2WPKH))
 - Bitcoin WIF private key (P2WPKH, Bech32)
 - Electrum Wallet (Salt-Type 1-3)
 - Electrum Wallet (Salt-Type 4)

--- a/src/modules/module_28505.c
+++ b/src/modules/module_28505.c
@@ -1,0 +1,209 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "memory.h"
+
+#include "emu_inc_hash_base58.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_5;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_CRYPTOCURRENCY_WALLET;
+static const char *HASH_NAME      = "Bitcoin WIF private key (P2SH(P2WPKH)), compressed";
+static const u64   KERN_TYPE      = 28505;
+static const u32   OPTI_TYPE      = OPTI_TYPE_NOT_SALTED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_NONE;
+static const char *ST_PASS        = "L4hashcat7q6HMnMFcukyvxxVJvpabXYjxXLey8846NtWUyX4YLi";
+static const char *ST_HASH        = "3H1YvmSdrjEfj9LvtiKJ8XiYq5htJRuejA";
+static const char *BENCHMARK_MASK = "?b?b?b?b?b?b?bat7q6HMnMFcukyvxxVJvpabXYjxXLey8846NtWUyX4YLi";
+static const u32   PUBKEY_MAXLEN  = 64; // our max is actually always 25 (21 + 4)
+static const u32   WIF_LEN        = 52;
+
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+const char *module_benchmark_mask (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return WIF_LEN;
+}
+
+u32 module_pw_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return WIF_LEN;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u8 *digest = (u8 *) digest_buf;
+
+  u8 pubkey[PUBKEY_MAXLEN];
+
+  hc_token_t token;
+
+  token.token_cnt = 1;
+
+  token.len[0]    = 34;
+  token.attr[0]   = TOKEN_ATTR_FIXED_LENGTH
+                  | TOKEN_ATTR_VERIFY_BASE58;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  u32 pubkey_len = PUBKEY_MAXLEN;
+
+  bool res = b58dec (pubkey, &pubkey_len, (u8 *) line_buf, line_len);
+
+  if (res == false) return (PARSER_HASH_LENGTH);
+
+  // for now we support only P2SH(P2WPKH) addresses
+
+  if (pubkey_len != 25) return (PARSER_HASH_LENGTH); // most likely wrong Bitcoin address type
+
+  u32 l = PUBKEY_MAXLEN - pubkey_len;
+
+  if (pubkey[l] != 0x05) return (PARSER_HASH_VALUE); // wrong Bitcoin address type
+
+  // check if pubkey has correct sha256 sum included
+
+  u32 npubkey[16] = { 0 };
+
+  u8 *npubkey_ptr = (u8 *) npubkey;
+
+  for (u32 i = 0, j = PUBKEY_MAXLEN - pubkey_len; i < pubkey_len; i++, j++)
+  {
+    npubkey_ptr[i] = pubkey[j];
+  }
+
+  // if (b58check   (npubkey_ptr, pubkey_len) == false) return (PARSER_HASH_ENCODING);
+  // if (b58check64 (npubkey,     pubkey_len) == false) return (PARSER_HASH_ENCODING);
+
+  if (b58check_25 (npubkey) == false) return (PARSER_HASH_ENCODING);
+
+
+  for (u32 i = 0; i < 20; i++) // DGST_SIZE
+  {
+    digest[i] = pubkey[PUBKEY_MAXLEN - pubkey_len + i + 1];
+  }
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  u8 *digest = (u8 *) digest_buf;
+
+  u8 buf[64] = { 0 };
+
+  u32 len = 64;
+
+  b58check_enc (buf, &len, 0x05, digest, 20);
+
+  return snprintf (line_buf, line_size, "%s", buf);
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = module_benchmark_mask;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = module_pw_min;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_28506.c
+++ b/src/modules/module_28506.c
@@ -1,0 +1,209 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "memory.h"
+
+#include "emu_inc_hash_base58.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_5;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_CRYPTOCURRENCY_WALLET;
+static const char *HASH_NAME      = "Bitcoin WIF private key (P2SH(P2WPKH)), uncompressed";
+static const u64   KERN_TYPE      = 28506;
+static const u32   OPTI_TYPE      = OPTI_TYPE_NOT_SALTED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_NONE;
+static const char *ST_PASS        = "5JjDR424kMePbt5Uxnm2t1NizhdiVPcf8gCj68PQpP2ihashcat";
+static const char *ST_HASH        = "3LovFVx5zBRvusVcj7pf3JxV9V46kjKhKu";
+static const char *BENCHMARK_MASK = "?b?b?b?b?b?b?b4kMePbt5Uxnm2t1NizhdiVPcf8gCj68PQpP2ihashcat";
+static const u32   PUBKEY_MAXLEN  = 64; // our max is actually always 25 (21 + 4)
+static const u32   WIF_LEN        = 51;
+
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+const char *module_benchmark_mask (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return WIF_LEN;
+}
+
+u32 module_pw_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return WIF_LEN;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u8 *digest = (u8 *) digest_buf;
+
+  u8 pubkey[PUBKEY_MAXLEN];
+
+  hc_token_t token;
+
+  token.token_cnt = 1;
+
+  token.len[0]    = 34;
+  token.attr[0]   = TOKEN_ATTR_FIXED_LENGTH
+                  | TOKEN_ATTR_VERIFY_BASE58;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  u32 pubkey_len = PUBKEY_MAXLEN;
+
+  bool res = b58dec (pubkey, &pubkey_len, (u8 *) line_buf, line_len);
+
+  if (res == false) return (PARSER_HASH_LENGTH);
+
+  // for now we support only P2SH(P2WPKH) addresses
+
+  if (pubkey_len != 25) return (PARSER_HASH_LENGTH); // most likely wrong Bitcoin address type
+
+  u32 l = PUBKEY_MAXLEN - pubkey_len;
+
+  if (pubkey[l] != 0x05) return (PARSER_HASH_VALUE); // wrong Bitcoin address type
+
+  // check if pubkey has correct sha256 sum included
+
+  u32 npubkey[16] = { 0 };
+
+  u8 *npubkey_ptr = (u8 *) npubkey;
+
+  for (u32 i = 0, j = PUBKEY_MAXLEN - pubkey_len; i < pubkey_len; i++, j++)
+  {
+    npubkey_ptr[i] = pubkey[j];
+  }
+
+  // if (b58check   (npubkey_ptr, pubkey_len) == false) return (PARSER_HASH_ENCODING);
+  // if (b58check64 (npubkey,     pubkey_len) == false) return (PARSER_HASH_ENCODING);
+
+  if (b58check_25 (npubkey) == false) return (PARSER_HASH_ENCODING);
+
+
+  for (u32 i = 0; i < 20; i++) // DGST_SIZE
+  {
+    digest[i] = pubkey[PUBKEY_MAXLEN - pubkey_len + i + 1];
+  }
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  u8 *digest = (u8 *) digest_buf;
+
+  u8 buf[64] = { 0 };
+
+  u32 len = 64;
+
+  b58check_enc (buf, &len, 0x05, digest, 20);
+
+  return snprintf (line_buf, line_size, "%s", buf);
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = module_benchmark_mask;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = module_pw_min;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -44,7 +44,7 @@ SLOW_ALGOS=$(grep -l ATTACK_EXEC_OUTSIDE_KERNEL "${TDIR}"/../src/modules/module_
 # fake slow algos, due to specific password pattern (e.g. ?d from "mask_3" is invalid):
 # ("only" drawback is that just -a 0 is tested with this workaround)
 
-SLOW_ALGOS="${SLOW_ALGOS} 28501 28502 28503 28504"
+SLOW_ALGOS="${SLOW_ALGOS} 28501 28502 28503 28504 28505 28506"
 
 OUTD="test_$(date +%s)"
 

--- a/tools/test_modules/m28505.pm
+++ b/tools/test_modules/m28505.pm
@@ -1,0 +1,111 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto::Base58 qw (decode_base58check);
+
+sub module_constraints { [[52, 52], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+# Note:
+# We expect valid WIF format which for BTC private address is 51/52 base58 characters long.
+# For compressed P2SH(P2WPKH) keys the length of the WIF is always 52.
+# Standard test.pl is generating random passwords consisting only from digits.
+# That does not work for this mode.
+# So we have introduced new function: module_get_random_password ()
+# that will help to generate random valid password for the module from a given seed.
+#
+# It will be called from test.pl if it exists in the module, otherwise everything
+# will work as in legacy code. Search test.pl for module_get_random_password ()
+
+sub module_generate_hash
+{
+  my $word = shift; # expecting valid WIF formated private key
+
+  my @is_valid_base58 = eval
+  {
+    decode_base58check ($word); # or we could use validate_wif ()
+  };
+
+  return if (! @is_valid_base58);
+
+  # validate WIF (check password, "verify")
+
+  my $priv = "";
+
+  my @is_valid_wif = eval
+  {
+    $priv = btc_prv->from_wif ($word);
+  };
+
+  return if (! @is_valid_wif);
+
+  return if ($priv->compressed != 1);
+
+  my $pub  = $priv->get_public_key    ();
+  my $hash = $pub->get_compat_address ();
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = rindex ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless (defined ($hash));
+  return unless (defined ($word));
+
+  my @is_valid_base58 = eval
+  {
+    decode_base58check ($hash);
+    decode_base58check ($word);
+  };
+
+  return unless (@is_valid_base58);
+
+  return unless (length ($word) == 52);
+
+  my $first_byte = substr ($word, 0, 1);
+
+  return unless (($first_byte eq "K") || ($first_byte eq "L"));
+
+  my $new_hash = module_generate_hash ($word);
+
+  return ($new_hash, $word);
+}
+
+sub module_get_random_password
+{
+  # new function added to generate valid password for an algorithm
+  # from a given seed as a parameter
+
+  my $seed = shift;
+
+  my $master_key  = btc_extprv->from_seed ($seed); # expecting random seed from test.pl
+  my $derived_key = $master_key->derive_key ("m/0'");
+
+  my $priv = $derived_key->get_basic_key ();
+
+  my $IS_COMPRESSED = 1;
+
+  $priv->set_compressed ($IS_COMPRESSED);
+
+  # return WIF format
+
+  return $priv->to_wif ();
+}
+
+1;

--- a/tools/test_modules/m28506.pm
+++ b/tools/test_modules/m28506.pm
@@ -1,0 +1,109 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto::Base58 qw (decode_base58check);
+
+sub module_constraints { [[51, 51], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+# Note:
+# We expect valid WIF format which for BTC private address is 51/52 base58 characters long.
+# For uncompressed P2SH(P2WPKH) the length of the WIF is always 51.
+# Standard test.pl is generating random passwords consisting only from digits.
+# That does not work for this mode.
+# So we have introduced new function: module_get_random_password ()
+# that will help to generate random valid password for the module from a given seed.
+#
+# It will be called from test.pl if it exists in the module, otherwise everything
+# will work as in legacy code. Search test.pl for module_get_random_password ()
+
+sub module_generate_hash
+{
+  my $word = shift; # expecting valid WIF formated private key
+
+  my @is_valid_base58 = eval
+  {
+    decode_base58check ($word); # or we could use validate_wif ()
+  };
+
+  return if (! @is_valid_base58);
+
+  # validate WIF (check password, "verify")
+
+  my $priv = "";
+
+  my @is_valid_wif = eval
+  {
+    $priv = btc_prv->from_wif ($word);
+  };
+
+  return if (! @is_valid_wif);
+
+  return if ($priv->compressed != 0);
+
+  my $pub  = $priv->get_public_key    ();
+  my $hash = $pub->get_compat_address ();
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = rindex ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless (defined ($hash));
+  return unless (defined ($word));
+
+  my @is_valid_base58 = eval
+  {
+    decode_base58check ($hash);
+    decode_base58check ($word);
+  };
+
+  return unless (@is_valid_base58);
+
+  return unless (length ($word) == 51);
+
+  return unless (substr ($word, 0, 1) eq "5");
+
+  my $new_hash = module_generate_hash ($word);
+
+  return ($new_hash, $word);
+}
+
+sub module_get_random_password
+{
+  # new function added to generate valid password for an algorithm
+  # from a given seed as a parameter
+
+  my $seed = shift;
+
+  my $master_key  = btc_extprv->from_seed ($seed); # expecting random seed from test.pl
+  my $derived_key = $master_key->derive_key ("m/0'");
+
+  my $priv = $derived_key->get_basic_key ();
+
+  my $IS_COMPRESSED = 0;
+
+  $priv->set_compressed ($IS_COMPRESSED);
+
+  # return WIF format
+
+  return $priv->to_wif ();
+}
+
+1;


### PR DESCRIPTION
This is the last missing type of "Bitcoin address" that was not supported yet (the compatibility, `compat`, `P2SH` or rather `P2SH(P2WPKH)` address). The details again are already discussed over here: https://github.com/hashcat/hashcat/issues/3090#issuecomment-1159411910

These are the addresses starting with a "3" (we already added support for "1" and "bc1" addresses recently).

This type of address is very similar, but it needs an extra round of `RIPEMD(SHA256())`, so we need extra `OpenCL`/`CUDA` kernels for this type of bitcoin address (remember we didn't need them for just `P2WPKH` addresses, starting with "bc1").

This should now be the final address type that we could support easily after this was implemented https://github.com/hashcat/hashcat/issues/3090 with https://github.com/hashcat/hashcat/pull/3320 (so we have support of **3** / **3**, at least this is what I know about the most common addresses, for which the user could have a partially unknown `WIF`).

Thanks