### PR TITLE
refactor -m 25700 = MurmurHash

### DIFF
--- a/OpenCL/m25700_a0-optimized.cl
+++ b/OpenCL/m25700_a0-optimized.cl
@@ -15,7 +15,7 @@
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #endif
 
-DECLSPEC u32 MurmurHash (const u32 seed, PRIVATE_AS const u32 *w, const int pw_len)
+DECLSPEC u32 MurmurHash (const u32 seed, PRIVATE_AS const u32 *w, const u32 pw_len)
 {
   u32 hash = seed;
 
@@ -24,26 +24,21 @@ DECLSPEC u32 MurmurHash (const u32 seed, PRIVATE_AS const u32 *w, const int pw_l
 
   hash += 0xdeadbeef;
 
-  int i;
-  int j;
+  const u32 blocks = pw_len / 4;
 
-  for (i = 0, j = 0; i < pw_len - 3; i += 4, j += 1)
+  if (pw_len >= 4)
   {
-    const u32 tmp = w[j];
+    for (u32 i = 0; i < blocks; i++)
+    {
+      const u32 tmp = (hash + w[i]) * M;
 
-    hash += tmp;
-    hash *= M;
-    hash ^= hash >> R;
+      hash = tmp ^ (tmp >> R);
+    }
   }
 
-  if (pw_len & 3)
-  {
-    const u32 tmp = w[j];
+  const u32 tmp = (hash + w[blocks]) * M;
 
-    hash += tmp;
-    hash *= M;
-    hash ^= hash >> R;
-  }
+  hash = (pw_len & 3) ? (tmp ^ (tmp >> R)) : hash;
 
   hash *= M;
   hash ^= hash >> 10;

--- a/OpenCL/m25700_a1-optimized.cl
+++ b/OpenCL/m25700_a1-optimized.cl
@@ -14,7 +14,7 @@
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #endif
 
-DECLSPEC u32 MurmurHash (const u32 seed, PRIVATE_AS const u32 *w, const int pw_len)
+DECLSPEC u32 MurmurHash (const u32 seed, PRIVATE_AS const u32 *w, const u32 pw_len)
 {
   u32 hash = seed;
 
@@ -23,26 +23,21 @@ DECLSPEC u32 MurmurHash (const u32 seed, PRIVATE_AS const u32 *w, const int pw_l
 
   hash += 0xdeadbeef;
 
-  int i;
-  int j;
+  const u32 blocks = pw_len / 4;
 
-  for (i = 0, j = 0; i < pw_len - 3; i += 4, j += 1)
+  if (pw_len >= 4)
   {
-    const u32 tmp = w[j];
+    for (u32 i = 0; i < blocks; i++)
+    {
+      const u32 tmp = (hash + w[i]) * M;
 
-    hash += tmp;
-    hash *= M;
-    hash ^= hash >> R;
+      hash = tmp ^ (tmp >> R);
+    }
   }
 
-  if (pw_len & 3)
-  {
-    const u32 tmp = w[j];
+  const u32 tmp = (hash + w[blocks]) * M;
 
-    hash += tmp;
-    hash *= M;
-    hash ^= hash >> R;
-  }
+  hash = (pw_len & 3) ? (tmp ^ (tmp >> R)) : hash;
 
   hash *= M;
   hash ^= hash >> 10;


### PR DESCRIPTION
I accidentially found out, that for -m 25700 = `MurmurHash` we have a similar potential for speed increase and also can write more compact and cleaner code, like I've already suggest for -m 27800 = `MurmurHash 3` (see https://github.com/hashcat/hashcat/pull/3342).

This minor fix makes the code more cleaner and easier to read (removes branches and is also a "little bit faster" for me).

Thanks