### PR TITLE
change default pass for -m 23400 = Bitwarden

### DIFF
--- a/src/modules/module_23400.c
+++ b/src/modules/module_23400.c
@@ -26,8 +26,8 @@ static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_LOOP2
                                   | OPTS_TYPE_INIT2;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
-static const char *ST_PASS        = "hashcat1";
-static const char *ST_HASH        = "$bitwarden$2*100000*2*bm9yZXBseUBoYXNoY2F0Lm5ldA==*CWCy4KZEEw1W92qB7xfLRNoJpepTMSyr7WJGZ0/Xr8c=";
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$bitwarden$2*100000*2*bm9yZXBseUBoYXNoY2F0Lm5ldA==*+v5rHxYydSRUDlan+4pSoiYQwAgEhdmivlb+exQX+fg=";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }


### PR DESCRIPTION
The reason for this commit is that I think it is important that most example hashes should have the password "hashcat" as default password, because we always tend to say on discord or on forum/wiki that the default password is just "hashcat".

We shouldn't use any non-default password if not really needed (e.g. due to password limits `pw_min`/`PW_MIN`, which does not seem to be the case here).

Thanks