### PR TITLE
change default pass for -m 28800 = Kerberos 5, etype 17, DB

### DIFF
--- a/src/modules/module_28800.c
+++ b/src/modules/module_28800.c
@@ -25,8 +25,8 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
-static const char *ST_PASS        = "password";
-static const char *ST_HASH        = "$krb5db$17$test$TEST.LOCAL$6fb8b78e20ad3df6591cabb9cacf4594";
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$krb5db$17$test$TEST.LOCAL$1c41586d6c060071e08186ee214e725e";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }


### PR DESCRIPTION
There is (to my knowledge) absolutely no reason why we shouldn't use the default / standard password ("hashcat") for this hash type -m 28800 = `Kerberos 5, etype 17, DB`.

Other reasons would be minimum password length etc (but I see no non-default `pw_min` setting for this specific hash type).

Thanks