### PR TITLE
change default pass for -m 28900 = Kerberos 5, etype 18, DB

### DIFF
--- a/src/modules/module_28900.c
+++ b/src/modules/module_28900.c
@@ -25,8 +25,8 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
-static const char *ST_PASS        = "password";
-static const char *ST_HASH        = "$krb5db$18$test$TEST.LOCAL$487addf1717899f2ee45c4b67e159d54adec46d086f339b88fd7deaa25d49a65";
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$krb5db$18$test$TEST.LOCAL$266b5a53a6d663c3f69174f3309acada8e467c097c7973699f86286a6cf1a6c7";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }


### PR DESCRIPTION
The hash type -m 28900 = `Kerberos 5, etype 18, DB` has a non-default/non-standard password for its hash example, but I think there is no reason to not use "hashcat" as password for this specific hash type (no non-default mininum password etc).

I think we should use a normal "hashcat" hash also here, because we are used to tell the hashcat users that the default password is (kind of always) "hashcat" for example hashes (only few exceptions, which are needed). This is used in conversation on discord/forum/wiki etc

Thanks