### PR TITLE
Increase event buffers sizes

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -2798,11 +2798,11 @@ typedef struct hashlist_parse
 
 typedef struct event_ctx
 {
-  char   old_buf[MAX_OLD_EVENTS][HCBUFSIZ_SMALL];
+  char   old_buf[MAX_OLD_EVENTS][HCBUFSIZ_LARGE];
   size_t old_len[MAX_OLD_EVENTS];
   int    old_cnt;
 
-  char   msg_buf[HCBUFSIZ_SMALL];
+  char   msg_buf[HCBUFSIZ_LARGE];
   size_t msg_len;
   bool   msg_newline;
 

--- a/src/event.c
+++ b/src/event.c
@@ -231,7 +231,7 @@ size_t event_log_info (hashcat_ctx_t *hashcat_ctx, const char *fmt, ...)
 
     va_start (ap, fmt);
 
-    event_ctx->msg_len = event_log (fmt, ap, event_ctx->msg_buf, HCBUFSIZ_SMALL - 1);
+    event_ctx->msg_len = event_log (fmt, ap, event_ctx->msg_buf, HCBUFSIZ_LARGE - 1);
 
     va_end (ap);
   }


### PR DESCRIPTION
As far as I see those changes are necessary because LUKS v1 hashes are not fit into `HCBUFSIZ_SMALL`.

Fixes GH-3359.