### PR TITLE
LUKS code cleanup

### DIFF
--- a/OpenCL/m14611-pure.cl
+++ b/OpenCL/m14611-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14612-pure.cl
+++ b/OpenCL/m14612-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_serpent.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14613-pure.cl
+++ b/OpenCL/m14613-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_twofish.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14621-pure.cl
+++ b/OpenCL/m14621-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14622-pure.cl
+++ b/OpenCL/m14622-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_serpent.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14623-pure.cl
+++ b/OpenCL/m14623-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_twofish.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14631-pure.cl
+++ b/OpenCL/m14631-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14632-pure.cl
+++ b/OpenCL/m14632-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_serpent.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14633-pure.cl
+++ b/OpenCL/m14633-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_twofish.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14641-pure.cl
+++ b/OpenCL/m14641-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14642-pure.cl
+++ b/OpenCL/m14642-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_serpent.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/OpenCL/m14643-pure.cl
+++ b/OpenCL/m14643-pure.cl
@@ -18,9 +18,9 @@
 #include M2S(INCLUDE_PATH/inc_cipher_twofish.cl)
 #endif
 
-#define LUKS_STRIPES    4000
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES    (                                   4000)
+#define LUKS_CT_LEN     (                                    512)
+#define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
 
 typedef enum hc_luks_hash_type
 {
@@ -60,10 +60,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 

--- a/src/modules/module_14600.c
+++ b/src/modules/module_14600.c
@@ -155,14 +155,14 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[128];
 
-  u32 af_buf[((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES) / 4];
+  u32 af_buf[HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES / 4];
   u32 af_len;
 
 } luks_t;
@@ -187,9 +187,9 @@ void *module_benchmark_esalt (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
 {
   luks_t *luks = (luks_t *) hcmalloc (sizeof (luks_t));
 
-  luks->key_size      = HC_LUKS_KEY_SIZE_256;
-  luks->cipher_type   = HC_LUKS_CIPHER_TYPE_AES;
-  luks->cipher_mode   = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
+  luks->key_size    = HC_LUKS_KEY_SIZE_256;
+  luks->cipher_type = HC_LUKS_CIPHER_TYPE_AES;
+  luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
 
   return luks;
 }
@@ -554,7 +554,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (rc_seek1 == -1)
   {
-      hc_fclose (&fp);
+    hc_fclose (&fp);
 
     return (PARSER_LUKS_FILE_SIZE);
   }

--- a/src/modules/module_29511.c
+++ b/src/modules/module_29511.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-1 + AES";
-static const u64   KERN_TYPE      = 14611;
+static const u64   KERN_TYPE      = 14611; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,31 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
-
-typedef enum kern_type_luks
-{
-  KERN_TYPE_LUKS_SHA1_AES           = 14611,
-  KERN_TYPE_LUKS_SHA1_SERPENT       = 14612,
-  KERN_TYPE_LUKS_SHA1_TWOFISH       = 14613,
-  KERN_TYPE_LUKS_SHA256_AES         = 14621,
-  KERN_TYPE_LUKS_SHA256_SERPENT     = 14622,
-  KERN_TYPE_LUKS_SHA256_TWOFISH     = 14623,
-  KERN_TYPE_LUKS_SHA512_AES         = 14631,
-  KERN_TYPE_LUKS_SHA512_SERPENT     = 14632,
-  KERN_TYPE_LUKS_SHA512_TWOFISH     = 14633,
-  KERN_TYPE_LUKS_RIPEMD160_AES      = 14641,
-  KERN_TYPE_LUKS_RIPEMD160_SERPENT  = 14642,
-  KERN_TYPE_LUKS_RIPEMD160_TWOFISH  = 14643,
-  KERN_TYPE_LUKS_WHIRLPOOL_AES      = 14651,
-  KERN_TYPE_LUKS_WHIRLPOOL_SERPENT  = 14652,
-  KERN_TYPE_LUKS_WHIRLPOOL_TWOFISH  = 14653,
-
-} kern_type_luks_t;
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -107,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -199,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -286,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -309,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -324,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -347,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -358,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -366,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29512.c
+++ b/src/modules/module_29512.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-1 + Serpent";
-static const u64   KERN_TYPE      = 14612;
+static const u64   KERN_TYPE      = 14612; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29513.c
+++ b/src/modules/module_29513.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-1 + Twofish";
-static const u64   KERN_TYPE      = 14613;
+static const u64   KERN_TYPE      = 14613; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29521.c
+++ b/src/modules/module_29521.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-256 + AES";
-static const u64   KERN_TYPE      = 14621;
+static const u64   KERN_TYPE      = 14621; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29522.c
+++ b/src/modules/module_29522.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-256 + Serpent";
-static const u64   KERN_TYPE      = 14622;
+static const u64   KERN_TYPE      = 14622; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29523.c
+++ b/src/modules/module_29523.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-256 + Twofish";
-static const u64   KERN_TYPE      = 14623;
+static const u64   KERN_TYPE      = 14623; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29531.c
+++ b/src/modules/module_29531.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-512 + AES";
-static const u64   KERN_TYPE      = 14631;
+static const u64   KERN_TYPE      = 14631; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29532.c
+++ b/src/modules/module_29532.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-512 + Serpent";
-static const u64   KERN_TYPE      = 14632;
+static const u64   KERN_TYPE      = 14632; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29533.c
+++ b/src/modules/module_29533.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 SHA-512 + Twofish";
-static const u64   KERN_TYPE      = 14633;
+static const u64   KERN_TYPE      = 14633; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29541.c
+++ b/src/modules/module_29541.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 RIPEMD-160 + AES";
-static const u64   KERN_TYPE      = 14641;
+static const u64   KERN_TYPE      = 14641; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29542.c
+++ b/src/modules/module_29542.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 RIPEMD-160 + Serpent";
-static const u64   KERN_TYPE      = 14642;
+static const u64   KERN_TYPE      = 14642; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 

--- a/src/modules/module_29543.c
+++ b/src/modules/module_29543.c
@@ -19,7 +19,7 @@ static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_16;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_FDE;
 static const char *HASH_NAME      = "LUKS v1 RIPEMD-160 + Twofish";
-static const u64   KERN_TYPE      = 14643;
+static const u64   KERN_TYPE      = 14643; // old kernel used here
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
@@ -43,11 +43,15 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define LUKS_STRIPES    4000
-#define LUKS_SALT_LEN   32
-#define LUKS_CT_LEN     512
-#define LUKS_AF_MIN_LEN ((HC_LUKS_KEY_SIZE_128 / 8) * LUKS_STRIPES)
-#define LUKS_AF_MAX_LEN ((HC_LUKS_KEY_SIZE_512 / 8) * LUKS_STRIPES)
+#define LUKS_STRIPES        (                                   4000)
+#define LUKS_SALT_LEN       (                                     32)
+#define LUKS_SALT_HEX_LEN   (                      LUKS_SALT_LEN * 2)
+#define LUKS_CT_LEN         (                                    512)
+#define LUKS_CT_HEX_LEN     (                        LUKS_CT_LEN * 2)
+#define LUKS_AF_MIN_LEN     (HC_LUKS_KEY_SIZE_128 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MIN_HEX_LEN (                    LUKS_AF_MIN_LEN * 2)
+#define LUKS_AF_MAX_LEN     (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
+#define LUKS_AF_MAX_HEX_LEN (                    LUKS_AF_MAX_LEN * 2)
 
 typedef enum hc_luks_hash_type
 {
@@ -87,10 +91,10 @@ typedef enum hc_luks_cipher_mode
 
 typedef struct luks
 {
-  int hash_type;    // hc_luks_hash_type_t
-  int key_size;     // hc_luks_key_size_t
-  int cipher_type;  // hc_luks_cipher_type_t
-  int cipher_mode;  // hc_luks_cipher_mode_t
+  int hash_type;   // hc_luks_hash_type_t
+  int key_size;    // hc_luks_key_size_t
+  int cipher_type; // hc_luks_cipher_type_t
+  int cipher_mode; // hc_luks_cipher_mode_t
 
   u32 ct_buf[LUKS_CT_LEN / 4];
 
@@ -179,22 +183,22 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
   token.sep[4]     = '$';
-  token.len_min[4] = LUKS_SALT_LEN * 2;
-  token.len_max[4] = LUKS_SALT_LEN * 2;
+  token.len_min[4] = LUKS_SALT_HEX_LEN;
+  token.len_max[4] = LUKS_SALT_HEX_LEN;
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // af
   token.sep[5]     = '$';
-  token.len_min[5] = LUKS_AF_MIN_LEN * 2;
-  token.len_max[5] = LUKS_AF_MAX_LEN * 2;
+  token.len_min[5] = LUKS_AF_MIN_HEX_LEN;
+  token.len_max[5] = LUKS_AF_MAX_HEX_LEN;
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // ct
   token.sep[6]     = '$';
-  token.len_min[6] = LUKS_CT_LEN * 2;
-  token.len_max[6] = LUKS_CT_LEN * 2;
+  token.len_min[6] = LUKS_CT_HEX_LEN;
+  token.len_max[6] = LUKS_CT_HEX_LEN;
   token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
@@ -266,12 +270,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *salt_pos = token.buf[4];
 
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    salt->salt_buf[i] = hex_to_u32 (salt_pos + j);
-  }
-
-  salt->salt_len = LUKS_SALT_LEN;
+  salt->salt_len = hex_decode (salt_pos, LUKS_SALT_HEX_LEN, (u8 *) salt->salt_buf);
 
   // iter
 
@@ -289,12 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *af_pos = token.buf[5];
 
-  for (u32 i = 0, j = 0; i < af_len / 4; i += 1, j += 8)
-  {
-    luks->af_buf[i] = hex_to_u32 (af_pos + j);
-  }
-
-  luks->af_len = af_len;
+  luks->af_len = hex_decode (af_pos, token.len[5], (u8 *) luks->af_buf);
 
   // ct
 
@@ -304,10 +298,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *ct_pos = token.buf[6];
 
-  for (u32 i = 0, j = 0; i < ct_len / 4; i += 1, j += 8)
-  {
-    luks->ct_buf[i] = hex_to_u32 (ct_pos + j);
-  }
+  hex_decode (ct_pos, LUKS_CT_HEX_LEN, (u8 *) luks->ct_buf);
 
   return (PARSER_OK);
 }
@@ -327,6 +318,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_CIPHER_MODE_CBC_PLAIN64:      cipher_mode = "cbc-plain64";      break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN:        cipher_mode = "xts-plain";        break;
     case HC_LUKS_CIPHER_MODE_XTS_PLAIN64:      cipher_mode = "xts-plain64";      break;
+    default:                                                                     return 0;
   }
 
   // key size
@@ -338,6 +330,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     case HC_LUKS_KEY_SIZE_128: key_size = 128; break;
     case HC_LUKS_KEY_SIZE_256: key_size = 256; break;
     case HC_LUKS_KEY_SIZE_512: key_size = 512; break;
+    default:                                   return 0;
   }
 
   // iterations
@@ -346,36 +339,21 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // salt
 
-  #define LUKS_SALT_HEX_LEN (LUKS_SALT_LEN * 2 + 1)
+  char salt_buf[LUKS_SALT_HEX_LEN + 1] = { 0 };
 
-  char salt_buf[LUKS_SALT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_SALT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (salt_buf + j, LUKS_SALT_HEX_LEN - j, "%08x", byte_swap_32 (salt->salt_buf[i]));
-  }
+  hex_encode ((const u8 *) salt->salt_buf, LUKS_SALT_LEN, (u8 *) salt_buf);
 
   // af
 
-  #define LUKS_AF_HEX_LEN (LUKS_AF_MAX_LEN * 2 + 1)
+  char af_buf[LUKS_AF_MAX_HEX_LEN + 1] = { 0 };
 
-  char af_buf[LUKS_AF_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < luks->af_len / 4; i += 1, j += 8)
-  {
-    snprintf (af_buf + j, LUKS_AF_HEX_LEN - j, "%08x", byte_swap_32 (luks->af_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->af_buf, luks->af_len, (u8 *) af_buf);
 
   // ct
 
-  #define LUKS_CT_HEX_LEN (LUKS_CT_LEN * 2 + 1)
+  char ct_buf[LUKS_CT_HEX_LEN + 1] = { 0 };
 
-  char ct_buf[LUKS_CT_HEX_LEN] = { 0 };
-
-  for (u32 i = 0, j = 0; i < LUKS_CT_LEN / 4; i += 1, j += 8)
-  {
-    snprintf (ct_buf + j, LUKS_CT_HEX_LEN - j, "%08x", byte_swap_32 (luks->ct_buf[i]));
-  }
+  hex_encode ((const u8 *) luks->ct_buf, LUKS_CT_LEN, (u8 *) ct_buf);
 
   // output
 


### PR DESCRIPTION
Done:

- [x] Added some extra defined values (like `LUKS_SALT_LEN` and `LUKS_SALT_HEX_LEN`).
- [x] Changed code to use `hex_decode` / `hex_encode`.
- [x] Extra `return 0;` in `default` case in `module_hash_encode` functions - see https://github.com/hashcat/hashcat/pull/3321#issuecomment-1172868787.
- [x] Some extra spaces added/removed.
- [x] License information in `luks2hashcat.py`. 
- [x] Dropped `main` function - now everything is in `if __name__ == "__main__":` block in `luck2hashcat.py`.
- [x] Changed `assert` checks to `ValueError` exceptions.