### PR TITLE
improved hash sanity checks for -m 26200 = OpenEdge

### DIFF
--- a/src/modules/module_26200.c
+++ b/src/modules/module_26200.c
@@ -109,7 +109,27 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const u8 *hash_pos = (u8 *) token.buf[0];
   const u32 hash_len = token.len[0];
 
-  memcpy ((u8 *)digest, hash_pos, hash_len);
+  /*
+   * Check encoding:
+   */
+
+  for (u32 i = 0; i < hash_len; i++)
+  {
+    // chars used (alphabet):
+    // ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
+
+    const u8 c = hash_pos[i];
+
+    if (           c < 'A') return (PARSER_HASH_ENCODING);
+    if (c > 'Z' && c < 'a') return (PARSER_HASH_ENCODING);
+    if (c > 'z'           ) return (PARSER_HASH_ENCODING);
+  }
+
+  /*
+   * digest:
+   */
+
+  memcpy ((u8 *) digest, hash_pos, hash_len);
 
   return (PARSER_OK);
 }


### PR DESCRIPTION
Similar to https://github.com/hashcat/hashcat/pull/3373 , I would suggest to add to -m 26200 = `OpenEdge Progress Encode` some (extra) sanity check code, just to make sure the correct characters are used within the hash line, supported are only `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz` characters.

This also helps with automatic hash detection (or `--identify`) checks and rejects a lot of invalid hashes... otherwise I had the problem that a (mid to large) hash file showed some wrong detecions and identified -m 26200 as the correct hash mode (yeah, automatic detection is dangerous, if we do not add MANY sanity checks).

Thank you