### PR TITLE
avoid OPTS_TYPE_HASH_COPY, just use digest_buf in -m 26200 = OpenEdge

### DIFF
--- a/src/modules/module_26200.c
+++ b/src/modules/module_26200.c
@@ -23,8 +23,7 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_NOT_ITERATED
                                   | OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
-                                  | OPTS_TYPE_PT_GENERATE_LE
-                                  | OPTS_TYPE_HASH_COPY;
+                                  | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE      = SALT_TYPE_NONE;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "lebVZteiEsdpkncc";
@@ -116,7 +115,15 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
 int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
 {
-  const int line_len = snprintf (line_buf, line_size, "%s", hash_info->orighash);
+  char *digest = (char *) digest_buf;
+
+  char buf[16 + 1] = { 0 };
+
+  memcpy (buf, digest, 16);
+
+  buf[16] = 0;
+
+  const int line_len = snprintf (line_buf, line_size, "%s", buf);
 
   return line_len;
 }


### PR DESCRIPTION
In general, we try to avoid `OPTS_TYPE_HASH_COPY` wherever possible... in this case (in my opinion) it's wrong to use `OPTS_TYPE_HASH_COPY` because we normally only use this in exceptional cases where we need to copy some extra data that we can't fit into `salt` or `esalt` and don't want to "store" in other buffers.

but in this case everything we need is in the `digest_buf` variable, so we should just use this (as with almost every other hash mode).

Thanks