### PR TITLE
warning about token length exception was showing incorrect values/percentage

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1897,7 +1897,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
   if (hashes->parser_token_length_cnt > 0)
   {
     event_log_advice (hashcat_ctx, NULL); // we can guarantee that the previous line was not an empty line
-    event_log_advice (hashcat_ctx, "* Token length exception: %u/%u hashes", hashes->parser_token_length_cnt, hashes->parser_token_length_cnt + hashes->hashes_cnt_orig);
+    event_log_advice (hashcat_ctx, "* Token length exception: %u/%u hashes", hashes->parser_token_length_cnt, hashes->parser_token_length_cnt + hashes->hashes_cnt);
     event_log_advice (hashcat_ctx, "  This error happens if the wrong hash type is specified, if the hashes are");
     event_log_advice (hashcat_ctx, "  malformed, or if input is otherwise not as expected (for example, if the");
     event_log_advice (hashcat_ctx, "  --username option is used but no username is present)");


### PR DESCRIPTION
this is a nasty/strange bug: the problem is that `hashes->hashes_cnt_orig` is set after this and therefore is always 0 (has the value zero) at this special section/time in the source code.

This basically adds always 0 (x + 0) and therefore is a NO-OP.

We need to use `hashes->hashes_cnt` instead here, otherwise some strange percentages are shown and also some strange behaviour will follow after the warning message (like it is still cracking, but said **100%** of the hashes was incorrect !), see:

```
echo -e "0\n0000000000000000" > hash.txt
hashcat -m 5100 hash.txt example.dict
```

says 1/1 hashes "wrong", but it is still starting to crack the 2nd hash.

correct: 1/2 hashes
wrong:   1/1 hashes

variable `hashes->hashes_cnt_orig` always 0 in `hashes_init_stage1 ()`

I think this should fix it correctly and I didn't see any problem by using the `hashes->hashes_cnt` variable (instead of the incorrect value in `hashes->hashes_cnt_orig`).

Thanks