### PR TITLE
Makefile: update MODULE_INTERFACE_VERSION

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ endif
 ## Do not modify
 ##
 
-MODULE_INTERFACE_VERSION := 630
+MODULE_INTERFACE_VERSION := 700
 
 ##
 ## Native compiler paths


### PR DESCRIPTION
Seems we kind of forgot to update the `Makefile` with this change: https://github.com/hashcat/hashcat/pull/3381

The minimum `MODULE_INTERFACE_VERSION` is now 700.

Thanks