### PR TITLE
src/filehandling.c: add missing include

### DIFF
--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "types.h"
+#include "limits.h"
 #include "memory.h"
 #include "shared.h"
 #include "filehandling.h"


### PR DESCRIPTION
We have found while building `hashcat` in Homebrew (https://github.com/Homebrew/homebrew-core/pull/106238) that it will fail when using system dependencies because `limits.h` is not included in `src/filehandling.c`. Presumably when the bundled dependencies are used it does get included somewhere.