### PR TITLE
add support for -a 9 to tab completion

### DIFF
--- a/extra/tab_completion/hashcat.sh
+++ b/extra/tab_completion/hashcat.sh
@@ -821,7 +821,7 @@ _hashcat ()
     *)
       case "${attack_mode}" in
 
-        0)
+        0|9)
           # dict/directory are files here
           _hashcat_files_folders_exclude "${cur}" "${HIDDEN_FILES_AGGRESSIVE}"
           COMPREPLY=($(compgen -W "${hashcat_file_list}" -- ${hashcat_select}))


### PR DESCRIPTION
it seems that tab completion for -a 9 = `Association attack` was not yet supported in the `hashcat.sh` tab completion script.

This minor fix makes tab completion also work with -a 9 (dictionary files completion).

Thanks