### PR TITLE
tests: disable logfile for test runs

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -5,7 +5,7 @@
 ## License.....: MIT
 ##
 
-OPTS="--quiet --potfile-disable --hwmon-disable"
+OPTS="--quiet --potfile-disable --hwmon-disable --logfile-disable"
 
 FORCE=0
 RUNTIME=400


### PR DESCRIPTION
My suggestion here is to use `--logfile-disable` in our test runs because otherwise a long running `test.sh` run or even multiple invocations of `test.sh` in a `while loop` produce too long `hashcat.log` files (several megabytes large oftentimes).

Do you agree that it makes sense to add this ?
Our unit tests, anyway, have there own logile in the `test_*` folder, so this type of extra info is normally not needed for test runs.

Thanks