### PR TITLE
updates example hash and password for -m 29600

### DIFF
--- a/src/modules/module_29600.c
+++ b/src/modules/module_29600.c
@@ -27,8 +27,8 @@ static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_HASH_COPY
                                   | OPTS_TYPE_PT_GENERATE_BE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
-static const char *ST_PASS        = "hashcathas";
-static const char *ST_HASH        = "a25b0fde71ebe13803a4707a657c54dd688a1659fb1e9bfd9f04412ea5dcc47e9sNxXqi14uSPbnjI+5gFanekzSwdOgwxUnbJA0xcxajPRwyNFomS7xaia3xidrx752LteXNligDb7Qs/cTwFAOm5OKzeh5b1o3OI5MrPEXU=";
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "67445496c838e96c1424a8dae4b146f0fc247c8c34ef33feffeb1e4412018512wZGtBMeN84XZE2LoOKwTGvA4Ee4m7PR1lDGIdWUV6OSUZKRiKFx9tlrnZLt8r8OfOzbwUS2a2Uo+nrrP6F85fh4eHstwPJw0KwzHWB8br58=";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }


### PR DESCRIPTION
I think it makes sense to also use a "hashcat hash example" for -m 29600 = `Terra Station Wallet`, i.e. the password is just "hashcat" (note: I didn't see any `pw_min`/`pw_max` restrictions, so we should definitely update this example hash:pass pair).

Thanks