### PR TITLE
fix length of salt_buf for -m 29600

### DIFF
--- a/OpenCL/m29600-pure.cl
+++ b/OpenCL/m29600-pure.cl
@@ -25,12 +25,14 @@ typedef struct pbkdf_sha1_tmp
 
   u32  dgst[32];
   u32  out[32];
+
 } pbkdf_sha1_tmp_t;
 
 typedef struct terra
 {
-  u32 salt_buf[8];
+  u32 salt_buf[4];
   u32 ct_block_a[4];
+
 } terra_t;
 
 #define FIXED_SALT_SIZE 16

--- a/src/modules/module_29600.c
+++ b/src/modules/module_29600.c
@@ -59,7 +59,7 @@ typedef struct pbkdf_sha1_tmp
 
 typedef struct terra
 {
-  u32 salt_buf[8];
+  u32 salt_buf[4];
   u32 ct_block_a[4];
   
 } terra_t;


### PR DESCRIPTION
For -m 29600 = `Terra Station Wallet` we have a tokenizer that only accepts 16 bytes (32 chars hex encoded) of salt, but the `esalt` `terra_t` struct is not in sync with this limits.

I think it's important to have the struct reflect this limit for the `salt_buf[]` struct elements.

Thanks