### PR TITLE
no need for OPTS_TYPE_HASH_COPY in -m 29600

### DIFF
--- a/OpenCL/m29600-pure.cl
+++ b/OpenCL/m29600-pure.cl
@@ -30,7 +30,8 @@ typedef struct pbkdf_sha1_tmp
 typedef struct terra
 {
   u32 salt_buf[8];
-  u32 ct_block_a[4];
+  u32 ct[16]; // 16 * 4 = 64 bytes (we have extra 16 bytes in digest: 64 + 16 = 80)
+  u32 iv[4];
 } terra_t;
 
 #define FIXED_SALT_SIZE 16
@@ -298,10 +299,10 @@ KERNEL_FQ void m29600_comp (KERN_ATTR_TMPS_ESALT (pbkdf_sha1_tmp_t,terra_t))
 
   u32 ks[60];
   u32 d[4];
-  d[0] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_block_a[0];
-  d[1] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_block_a[1];
-  d[2] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_block_a[2];
-  d[3] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_block_a[3];
+  d[0] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[0];
+  d[1] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[1];
+  d[2] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[2];
+  d[3] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[3];
   u32 CT[4] = { 0 };
   AES256_set_encrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3);
   AES256_encrypt(ks, d, CT, s_te0, s_te1, s_te2, s_te3, s_te4);


### PR DESCRIPTION
I think it makes sense to get rid of `OPTS_TYPE_HASH_COPY` in -m 29600 = `Terra Station Wallet` because we don't necessarily need it.

I only had to add the `iv` to the struct and increase the ciphertext `ct` length, but this is all negligible and I think it is better code at the end, i.e. our `module_hash_encode ()` and `module_hash_decode ()` are more consistent with other hash-modes and with this fix it doesn't fill anylonger that we kind of "cheat" by just copying the whole input hash line.

Thanks