### PR TITLE
cosmetic: use N/A in status prompt, typo fix

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -1752,7 +1752,7 @@ char *status_get_cpt (const hashcat_ctx_t *hashcat_ctx)
   }
   else if ((cpt_ctx->cpt_start + (60 * 60)) < now)
   {
-    hc_asprintf (&cpt, "CUR:%u,%u,N/A AVG:%.2f,%.2f,N/a (Min,Hour,Day)",
+    hc_asprintf (&cpt, "CUR:%u,%u,N/A AVG:%.2f,%.2f,N/A (Min,Hour,Day)",
       cpt_cur_min,
       cpt_cur_hour,
       cpt_avg_min,


### PR DESCRIPTION
This is just a minor cosmetic fix. I suggest to use `N/A` (upper-case A) to make it more consistent with other status prompt strings also in this line of code.

Thanks