### PR TITLE
fixes #3425: remove BOM from some rule files

### DIFF
--- a/rules/T0XlC_insert_HTML_entities_0_Z.rule
+++ b/rules/T0XlC_insert_HTML_entities_0_Z.rule
@@ -1,4 +1,4 @@
-﻿# Created by: T0XlC ᨐ
+# Created by: T0XlC ᨐ
 #
 # insert 241 HTLM entities & numbers from 0 to Z 
 # ex : &lt; &gt; &amp; &quot; &apos; &cent; &pound; &yen; &euro; &copy; &reg;  

--- a/rules/T0XlCv2.rule
+++ b/rules/T0XlCv2.rule
@@ -1,4 +1,4 @@
-﻿# Created by: T0XlC ᨐ
+# Created by: T0XlC ᨐ
 #
 # 20000 rules that just work!
 $ 


### PR DESCRIPTION
As mentioned in #3425 we have some BOM (Byte Order Mark) in rule files that make these rule files inconsistent with all other rule files. I would suggest to just remove the BOM from these 2 rule files:
1. `rules/T0XlCv2.rule`
2. `rules/T0XlC_insert_HTML_entities_0_Z.rule`

Thanks