### PR TITLE
Updated flask session max length for payload to be 2047

### DIFF
--- a/src/modules/module_29100.c
+++ b/src/modules/module_29100.c
@@ -62,7 +62,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[0]     = '.';
   token.len_min[0] =  0;
-  token.len_max[0] = 27;
+  token.len_max[0] = 2047;
   token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_BASE64C;
 

--- a/src/modules/module_29100.c
+++ b/src/modules/module_29100.c
@@ -62,7 +62,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[0]     = '.';
   token.len_min[0] =  0;
-  token.len_max[0] = 2047;
+  token.len_max[0] = 56;
   token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_BASE64C;
 


### PR DESCRIPTION
Pull request for issue: #3440 copies the max length from JWT and applies to flask session (mode 29100)