### PR TITLE
Add warning for potfile-disable in Assoc Attack mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -541,9 +541,17 @@ static void main_outerloop_mainscreen (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     event_log_advice (hashcat_ctx, NULL);
   }
 
-  if (hashconfig->potfile_disable == true)
+  if (hashconfig->potfile_disable == true && user_options->attack_mode != ATTACK_MODE_ASSOCIATION)
   {
     event_log_advice (hashcat_ctx, "ATTENTION! Potfile storage is disabled for this hash mode.");
+    event_log_advice (hashcat_ctx, "Passwords cracked during this session will NOT be stored to the potfile.");
+    event_log_advice (hashcat_ctx, "Consider using -o to save cracked passwords.");
+    event_log_advice (hashcat_ctx, NULL);
+  }
+
+  if (user_options->attack_mode == ATTACK_MODE_ASSOCIATION)
+  {
+    event_log_advice (hashcat_ctx, "ATTENTION! Potfile read/write is disabled for this attack mode.");
     event_log_advice (hashcat_ctx, "Passwords cracked during this session will NOT be stored to the potfile.");
     event_log_advice (hashcat_ctx, "Consider using -o to save cracked passwords.");
     event_log_advice (hashcat_ctx, NULL);

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -723,7 +723,7 @@ int wl_data_init (hashcat_ctx_t *hashcat_ctx)
       }
       else
       {
-        wl_data->func = get_next_word_lm_text;        // treat as nromal text
+        wl_data->func = get_next_word_lm_text;        // treat as normal text
       }
     }
   }


### PR DESCRIPTION
Adding a warning to alert users that the potfile is disabled in Association Attack mode.

https://hashcat.net/forum/thread-11007.html