### PR TITLE
Fixed missing status update when --status-json is used

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -75,7 +75,7 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
     remove_check = true;
   }
 
-  if (user_options->status == true)
+  if (user_options->status == true || user_options->status_json == true)
   {
     status_check = true;
   }


### PR DESCRIPTION
hashcat does not run periodic (defined by status-timer) status update in json format. Fixed.