### PR TITLE
Fix improper strings comparision in LUKS modules

### DIFF
--- a/src/modules/module_29511.c
+++ b/src/modules/module_29511.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29512.c
+++ b/src/modules/module_29512.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29513.c
+++ b/src/modules/module_29513.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29521.c
+++ b/src/modules/module_29521.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29522.c
+++ b/src/modules/module_29522.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29523.c
+++ b/src/modules/module_29523.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29531.c
+++ b/src/modules/module_29531.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29532.c
+++ b/src/modules/module_29532.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29533.c
+++ b/src/modules/module_29533.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29541.c
+++ b/src/modules/module_29541.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29542.c
+++ b/src/modules/module_29542.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }

--- a/src/modules/module_29543.c
+++ b/src/modules/module_29543.c
@@ -217,24 +217,25 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   // cipher mode
 
   const u8 *cipher_mode_pos = token.buf[1];
+  const u32 cipher_mode_len = token.len[1];
 
-  if (strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0)
+  if ((strncmp ((const char *) cipher_mode_pos, "cbc-essiv:sha256", 16) == 0) && (cipher_mode_len == 16))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_ESSIV_SHA256;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "cbc-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_CBC_PLAIN64;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain",    9) == 0) && (cipher_mode_len ==  9))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN;
   }
-  else if (strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0)
+  else if ((strncmp ((const char *) cipher_mode_pos, "xts-plain64", 11) == 0) && (cipher_mode_len == 11))
   {
     luks->cipher_mode = HC_LUKS_CIPHER_MODE_XTS_PLAIN64;
   }


### PR DESCRIPTION
Bug introduced here - GH-3321.

When LUKS container is using `cbc-plain64` or `xts-plain64` then `cbc-plain`/`xts-plain` respectively were used.

There shouldn't be any impact on cracking.

https://github.com/hashcat/hashcat/blob/161a5a2a3c968504115471e352390e2099b542b1/OpenCL/inc_luks_aes.cl#L2692

However potfiles can grow up because hashes after encoding don't match to hashes before decoding.