### PR TITLE
fix comment for combinator_ctx_init () call

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -768,7 +768,7 @@ static int outer_loop (hashcat_ctx_t *hashcat_ctx)
   if (straight_ctx_init (hashcat_ctx) == -1) return -1;
 
   /**
-   * straight mode init
+   * combinator mode init
    */
 
   if (combinator_ctx_init (hashcat_ctx) == -1) return -1;


### PR DESCRIPTION
This is a minor bug (only affecting documentations). I think we should fix this comment before the `combinator_ctx_init ()` because it is kind of confusing why the "straight mode init" (comment) is mentioned twice (before `straight_ctx_init ()` too).

Thanks
