### PR TITLE
rp: prevent crash in case of too little RAM for rules

### DIFF
--- a/src/rp.c
+++ b/src/rp.c
@@ -893,6 +893,18 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
 
   kernel_rule_t *kernel_rules_buf = (kernel_rule_t *) hccalloc (kernel_rules_cnt, sizeof (kernel_rule_t));
 
+  if (kernel_rules_buf == NULL)
+  {
+    event_log_error (hashcat_ctx, "Not enough allocatable memory (RAM) for this ruleset.");
+
+    hcfree (all_kernel_rules_cnt);
+    hcfree (all_kernel_rules_buf);
+
+    hcfree (repeats);
+
+    return -1;
+  }
+
   for (u32 i = 0; i < kernel_rules_cnt; i++)
   {
     u32 out_pos = 0;


### PR DESCRIPTION
I investigated this problem when I was trying to combine too many `-r` command line arguments (combined with large rule files)...
in such a case it could happen that the host has too little host memory to combine each and every rule with each and every other rule (`-r x.rule -r y.rule -r z.rule`). This could lead to exhausted memory/RAM and a crash/segfault due to a NULL pointer.

Thanks