### PR TITLE
Update exodus2hashcat.py

### DIFF
--- a/tools/exodus2hashcat.py
+++ b/tools/exodus2hashcat.py
@@ -21,10 +21,6 @@ if len(sys.argv) != 2 :
     print("Error, usage exodus2hashcat.py <path to exodus seed.seco file>")
     sys.exit(1)
 
-if os.path.basename(sys.argv[1])!= 'seed.seco':
-    print("Error, usage exodus2hashcat.py <path to exodus seed.seco file>")
-    sys.exit(1)
-
 with open(sys.argv[1],'rb') as fd:
     seedBuffer = fd.read()
 


### PR DESCRIPTION
Unnecessary validation for the filename when there are already five other adequate validation steps to confirm the contents are a valid seed.seco file and the filename doesn't matter, only it's contents matter