### PR TITLE
Add support for non-zero IV to lastpass (-m 6800)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@
 ## Technical
 ##
 
+- Modules: Added support for non-zero IVs for -m 6800 (Lastpass). Also added `tools/lastpass2hashcat.py`
 - Status Code: Add specific return code for self-test fail (-11)
 
 * changes v6.2.5 -> v6.2.6

--- a/tools/lastpass2hashcat.py
+++ b/tools/lastpass2hashcat.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Author: hansvh <6390369+hans-vh@users.noreply.github.com>
+# Version: 0.0.6
+# License: MIT
+
+"""
+Files can be found here:
+Android: /data/data/com.lastpass.lpandroid/files
+Others: See https://support.lastpass.com/help/where-is-my-lastpass-data-stored-on-my-computer-lp070008
+
+Tested OK with:
+- LastPass for Android (com.lastpass.lpandroid) v5.12.0.10004
+- LastPass for Chrome v4.101.1
+- LastPass for Opera v4.101.1
+- LastPass for Firefox v4.101.0
+"""
+
+import sys
+import os
+import sqlite3
+from base64 import b64decode
+from re import search
+
+
+def parse_encu(data):
+    """Parse ENCU and return IV and AES-256-CBC encrypted email to compare against"""
+    data = data.decode("utf-8")
+
+    initialization_vector = None
+    encrypted_email = None
+
+    try:
+        # Format: ![B64]|[B64]
+        result = search(r"^!(.*)\|(.*)$", data)
+        initialization_vector = result.group(1)
+        encrypted_email = result.group(2)
+
+        initialization_vector = b64decode(initialization_vector).hex()
+        encrypted_email = b64decode(encrypted_email).hex()
+    except:
+        # B64 Only. This implies EBC, not CBC, mode and IV is found elsewhere, e.g., in database
+        encrypted_email = b64decode(data).hex()
+
+    return initialization_vector, encrypted_email
+
+
+def open_file(file_name):
+    """Open file and return contents"""
+    with open(file_name, "rb") as file_handle:
+        return file_handle.read()
+
+
+def parse_vault(xml):
+    """Parse Vault according to format: 4 bytes ASCII identifier, 4 bytes size, size bytes data"""
+    magic_bytes = xml[:4].decode("utf-8")
+    if magic_bytes != "LPAV":
+        sys.exit(f"Expected LPAV in base 64 decoded XML, but found {magic_bytes}")
+
+    offset = 0
+    while offset < len(xml):
+        identifier = xml[offset:offset + 4].decode("utf-8")
+        offset = offset + 4
+        size = int.from_bytes(xml[offset:offset + 4], byteorder='big')
+        offset = offset + 4
+        data = xml[offset:offset + size]
+
+        if identifier == 'ENCU':
+            initialization_vector, encrypted_email = parse_encu(data)
+            return initialization_vector, encrypted_email
+
+        offset = offset + size
+
+    return None, None
+
+
+def sqlite_parse_chromium(cur):
+    """Chrome and Opera"""
+    iterations = -1
+    xml = ""
+    try:
+        res = cur.execute("SELECT data FROM LastPassData WHERE type='accts'")
+        (xml,) = res.fetchone()
+        result = search(r"^iterations=(\d+);(.*)$", xml)
+        iterations = result.group(1)
+        xml = result.group(2)
+        xml = b64decode(xml)
+    except:
+        return None, None
+
+    return iterations, xml
+
+
+def sqlite_parse_firefox(cur):
+    """Firefox"""
+    iterations = -1
+    encu = ""
+    try:
+        res = cur.execute("SELECT value FROM data WHERE key LIKE '%sch'")
+        encu, = res.fetchone()
+        encu = encu.decode("utf-8")
+        encu = encu[encu.find("!"):]
+        encu = encu[:encu.find("\n")]
+        encu = bytes(encu, "utf-8")
+        res = cur.execute("SELECT value FROM data WHERE key LIKE '%key_iter'")
+        iterations, = res.fetchone()
+        iterations = int(iterations)
+    except:
+        return None, None
+
+    return iterations, encu
+
+
+def main():
+    """Entry point"""
+    if len(sys.argv) < 3:
+        sys.exit(f"Usage: {sys.argv[0]} <xml or sqlite file> <username (email)>")
+
+    file_name = sys.argv[1]
+    if not os.path.exists(file_name):
+        sys.exit(f"File {file_name} does not exist")
+
+    file_content = open_file(file_name)
+    magic_bytes = file_content[:5].decode("utf-8")
+
+    # Output will contain the following fields (in order), colon separated
+    encrypted_email = ""
+    iterations = -1
+    email = sys.argv[2].lower()
+    initialization_vector = ""
+
+    if magic_bytes == "LPB64":
+        # Android App
+        iterations = 100100
+        xml = b64decode(file_content[5:])
+        initialization_vector, encrypted_email = parse_vault(xml)
+
+    elif magic_bytes == "SQLit":
+        # Browser Extension
+        con = sqlite3.connect(file_name)
+        cur = con.cursor()
+
+        # First try Chromium based browsers
+        iterations, xml = sqlite_parse_chromium(cur)
+        if iterations and xml:
+            initialization_vector, encrypted_email = parse_vault(xml)
+
+        # Then try Firefox
+        if not encrypted_email or not iterations or not initialization_vector:
+            iterations, encu = sqlite_parse_firefox(cur)
+            initialization_vector, encrypted_email = parse_encu(encu)
+
+        # Finally give up
+        if not encrypted_email or not iterations or not initialization_vector:
+            sys.exit("Unexpected behaviour in SQLite database parsing")
+
+        con.close()
+    else:
+        sys.exit(f"Expected LPB64 or SQLit in file, but found {magic_bytes}")
+
+    print(f"{encrypted_email}:{iterations}:{email}:{initialization_vector}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_modules/m06800.pm
+++ b/tools/test_modules/m06800.pm
@@ -18,9 +18,9 @@ sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
-  my $iter = shift // 500;
+  my $iter = shift // 100100;
 
-  my $iv = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+  my $iv = random_bytes(16);
 
   my $hasher = Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256);
 
@@ -45,7 +45,9 @@ sub module_generate_hash
 
   my $hash_buf = substr (unpack ("H*", $encrypt), 0, 32);
 
-  my $hash = sprintf ("%s:%i:%s", $hash_buf, $iter, $salt);
+  my $iv_buf = unpack("H*", $iv);
+
+  my $hash = sprintf ("%s:%i:%s:%s", $hash_buf, $iter, $salt, $iv_buf);
 
   return $hash;
 }


### PR DESCRIPTION
New versions of Lastpass no longer use all zeroes for the IV, hence this change. They have also changed some other stuff like the default iterations, and also where the hashes can be found (as the desktop apps are discontinued). To help with that last part we also added ``lastpass2hashcat.py``.

The example hash has been updated to reflect a more current hash, but the old mode is still usable by specifying all zeroes for the IV. So the old example hash for example would be: ``82dbb8ccc9c7ead8c38a92a6b5740f94:500:pmix@trash-mail.com:00000000000000000000000000000000``

Also changed the test module to account for these changes.

I'm not sure what the "offline mode" in the kernel is referring to, or if it's even needed anymore. As far as I can see we're always done when we decrypt the ciphertext and get the salt as the plaintext. Perhaps someone can shed some light on that functionality/mode?

Let me know if any changes should be made! I'm a bit unsure if I did everything right with regards to the salt/esalt stuff in particular, as I've not had to use that stuff until now.