### PR TITLE
Update restore.c

### DIFF
--- a/OpenCL/m25500-pure.cl
+++ b/OpenCL/m25500-pure.cl
@@ -334,12 +334,12 @@ KERNEL_FQ void m25500_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, pbkdf2_sh
 
   // iv
 
-  const u32 iv[4] = {
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3]
-  };
+  u32 iv[4];
+
+  iv[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0];
+  iv[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1];
+  iv[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2];
+  iv[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3];
 
   const u32 iv_len = esalt_bufs[DIGESTS_OFFSET_HOST].iv_len;
 

--- a/OpenCL/m26600-pure.cl
+++ b/OpenCL/m26600-pure.cl
@@ -334,12 +334,12 @@ KERNEL_FQ void m26600_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, pbkdf2_sh
 
   // iv
 
-  const u32 iv[4] = {
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3]
-  };
+  u32 iv[4];
+
+  iv[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0];
+  iv[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1];
+  iv[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2];
+  iv[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3];
 
   const u32 iv_len = esalt_bufs[DIGESTS_OFFSET_HOST].iv_len;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1209,6 +1209,7 @@ int main (int argc, char **argv)
 
     return -1;
   }
+
   // install and shared folder need to be set to recognize "make install" use
 
   const char *install_folder = NULL;
@@ -1251,6 +1252,16 @@ int main (int argc, char **argv)
     user_options_destroy (hashcat_ctx);
 
     hashcat_destroy (hashcat_ctx);
+
+    hcfree (hashcat_ctx);
+
+    return -1;
+  }
+
+  // upper bound of 5000, a reasonable limit for the amount of wordlists in a directory
+  if (argc >= 5000)
+  {
+    event_log_error (hashcat_ctx, "Unusually high number of arguments (argc >= 5000)");
 
     hcfree (hashcat_ctx);
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -67,17 +67,15 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
 
   // we only use these 2 checks to avoid "tainted string" warnings
 
-  if (rd->argc < 1)
+  // raise upper bound to 5000 when --force'd
+  if(rd ->argc > 5000)
   {
-    event_log_error (hashcat_ctx, "Unusually low number of arguments (argc) within restore file %s", eff_restore_file);
+    event_log_error (hashcat_ctx, "Unusually high number of arguments (argc) within restore file %s", eff_restore_file);
 
     hc_fclose (&fp);
 
     return -1;
-  }
-
-  if (rd->argc > 250) // some upper bound check is always good (with some dirs/dicts it could be a large string)
-  {
+  } else if (hashcat_ctx->user_options->force == false && rd->argc > 250) // some upper bound check is always good (with some dirs/dicts it could be a large string)
     event_log_error (hashcat_ctx, "Unusually high number of arguments (argc) within restore file %s", eff_restore_file);
 
     hc_fclose (&fp);

--- a/src/restore.c
+++ b/src/restore.c
@@ -66,7 +66,6 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
   }
 
   // we only use these 2 checks to avoid "tainted string" warnings
-
   // raise upper bound to 5000 when --force'd
   if(rd ->argc > 5000)
   {
@@ -76,6 +75,7 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
 
     return -1;
   } else if (hashcat_ctx->user_options->force == false && rd->argc > 250) // some upper bound check is always good (with some dirs/dicts it could be a large string)
+    {
     event_log_error (hashcat_ctx, "Unusually high number of arguments (argc) within restore file %s", eff_restore_file);
 
     hc_fclose (&fp);

--- a/src/restore.c
+++ b/src/restore.c
@@ -66,16 +66,18 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
   }
 
   // we only use these 2 checks to avoid "tainted string" warnings
-  // raise upper bound to 5000 when --force'd
-  if(rd ->argc > 5000)
+
+  if (rd->argc < 1)
   {
-    event_log_error (hashcat_ctx, "Unusually high number of arguments (argc) within restore file %s", eff_restore_file);
+    event_log_error (hashcat_ctx, "Unusually low number of arguments (argc) within restore file %s", eff_restore_file);
 
     hc_fclose (&fp);
 
     return -1;
-  } else if (hashcat_ctx->user_options->force == false && rd->argc > 250) // some upper bound check is always good (with some dirs/dicts it could be a large string)
-    {
+  }
+  // upper bound of 5000, a reasonable limit for the amount of wordlists in a directory
+  else if (rd->argc > 5001)
+  {
     event_log_error (hashcat_ctx, "Unusually high number of arguments (argc) within restore file %s", eff_restore_file);
 
     hc_fclose (&fp);


### PR DESCRIPTION
Increase `--restore` max args limit to 5,000 when `--force`'d, especially helpful when restoring an attack with many wordlists for caching dictstat info.