### PR TITLE
Fix bug in -m 6800 where not all hashes are checked if they have the same salt

### DIFF
--- a/src/modules/module_06800.c
+++ b/src/modules/module_06800.c
@@ -163,6 +163,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const bool parse_rc = generic_salt_decode (hashconfig, salt_pos, salt_len, (u8 *) salt->salt_buf, (int *) &salt->salt_len);
 
+  // Add first word of ciphertext to salt struct to ensure correct grouping in the kernel _comp function
+  salt->salt_buf[63] = digest[0];
+
   if (parse_rc == false) return (PARSER_SALT_LENGTH);
 
   return (PARSER_OK);


### PR DESCRIPTION
Fixes issue https://github.com/hashcat/hashcat/issues/3488

``` bash
$ ./hashcat --potfile-disable --quiet -m 6800 hashes.txt passwords.txt
nvmlDeviceGetFanSpeed(): Not Supported

983f0f7d9f441079bb11807eee798a11:500:123456:password2
f2b814a9ff06929d377760b2848eacf1:500:123456:password1
f576a9f3ac3934519239e31e365f03c8:500:123456:password3
```