### PR TITLE
Tool `luks2hashcat.py` extract all active keys

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -12,6 +12,12 @@
 - Added hash-mode: Dahua NVR/DVR/HVR (md5($salt1.strtoupper(md5($salt2.$pass))))
 
 ##
+## Bugs
+##
+
+- Fixed keys extraction in luks2hashcat - now extracts all active keys
+
+##
 ## Technical
 ##
 

--- a/tools/luks2hashcat.py
+++ b/tools/luks2hashcat.py
@@ -273,8 +273,13 @@ def extract_version1(file):
     )
 
     # check for any active key
+    if all(key.active not in [KeyVersion1.Active.ENABLED, KeyVersion1.Active.ENABLED_OLD] for key in header.keys):
+        # all keys are disabled
+        raise ValueError("all keys are disabled")
+
     for key in header.keys:
         if key.active not in [KeyVersion1.Active.ENABLED, KeyVersion1.Active.ENABLED_OLD]:
+            # skip inactive keys
             continue
 
         hash = SIGNATURE + "$".join(
@@ -294,10 +299,6 @@ def extract_version1(file):
             )
         )
         print(hash)
-        break
-    else:
-        # all keys are disabled
-        raise ValueError("all keys are disabled")
 
 
 # main


### PR DESCRIPTION
Fixes GH-3497