### PR TITLE
Fix m14600 confusing error message on container without payload data

### DIFF
--- a/src/modules/module_14600.c
+++ b/src/modules/module_14600.c
@@ -243,7 +243,10 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
 
     if (parser_status != PARSER_OK)
     {
-      last_error = parser_status;
+      if (parser_status != PARSER_LUKS_KEY_DISABLED)
+      {
+        last_error = parser_status;
+      }
       continue;
     }
 
@@ -252,7 +255,14 @@ int module_hash_binary_parse (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
 
   if (hashes_cnt == 0)
   {
-    return last_error;
+    if (last_error != 0)
+    {
+      return last_error;
+    } 
+    else
+    {
+      return PARSER_LUKS_KEY_DISABLED;
+    }
   }
   else
   {


### PR DESCRIPTION
When multiple error messages are available, prioritize any parsing error over PARSER_LUKS_KEY_DISABLED.

This takes priority since it  more meaningfull to report to user.

For example the parser error message PARSER_FILE_SIZE on keyslot 1 takes priority over PARSER_LUKS_KEY_DISABLED on keyslot 6.

Fixes issue #3484