### PR TITLE
Corrected issue for module 25200 (SNMPv3 HMAC-SHA1-96)

### DIFF
--- a/src/modules/module_25200.c
+++ b/src/modules/module_25200.c
@@ -77,13 +77,6 @@ typedef struct snmpv3
 
 } snmpv3_t;
 
-u32 module_pw_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
-{
-  const u32 pw_min = 8;
-
-  return pw_min;
-}
-
 u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
   const u64 esalt_size = (const u64) sizeof (snmpv3_t);
@@ -326,7 +319,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
   module_ctx->module_pwdump_column            = MODULE_DEFAULT;
   module_ctx->module_pw_max                   = MODULE_DEFAULT;
-  module_ctx->module_pw_min                   = module_pw_min;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
   module_ctx->module_salt_max                 = MODULE_DEFAULT;
   module_ctx->module_salt_min                 = MODULE_DEFAULT;
   module_ctx->module_salt_type                = module_salt_type;

--- a/tools/test_modules/m25200.pm
+++ b/tools/test_modules/m25200.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::SHA  qw (sha1 sha1_hex);
 use Digest::HMAC qw (hmac_hex);
 
-sub module_constraints { [[8, 256], [24, 3000], [-1, -1], [-1, -1], [-1, -1]] }
+sub module_constraints { [[0, 256], [24, 3000], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
Password length should not be restricted to a minimum length
Corrects [issue 3520](https://github.com/hashcat/hashcat/issues/3520)