### PR TITLE
Fix clang14 warnings with unrar

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -229,6 +229,7 @@ CFLAGS_UNRAR            += -Wno-implicit-fallthrough
 CFLAGS_UNRAR            += -Wno-extra
 CFLAGS_UNRAR            += -Wno-unknown-pragmas
 CFLAGS_UNRAR            += -Wno-unused-but-set-variable
+CFLAGS_UNRAR            += -Wno-deprecated-declarations
 #Not supported on macOS 12.3
 #CFLAGS_UNRAR            += -Wno-format-overflow
 #Added hashcat 7.0.0


### PR DESCRIPTION
<img width="948" alt="Screen Shot 2022-12-08 at 17 04 24" src="https://user-images.githubusercontent.com/15381185/206499477-70400eed-a0dd-4332-ac45-2be7b7a1dd5e.png">
