### PR TITLE
Fix module 3730, Metal build errors

### DIFF
--- a/OpenCL/m03730_a0-pure.cl
+++ b/OpenCL/m03730_a0-pure.cl
@@ -98,7 +98,7 @@ KERNEL_FQ void m03730_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
     md5_ctx_t ctx1 = ctx0;
 
-    md5_update(&ctx1, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
 
     md5_final (&ctx1);
 
@@ -228,7 +228,7 @@ KERNEL_FQ void m03730_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
     md5_ctx_t ctx1 = ctx0;
 
-    md5_update (&ctx1, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
 
     md5_final (&ctx1);
 

--- a/OpenCL/m03730_a3-pure.cl
+++ b/OpenCL/m03730_a3-pure.cl
@@ -87,11 +87,20 @@ KERNEL_FQ void m03730_mxx (KERN_ATTR_VECTOR_ESALT (md5_double_salt_t))
     s[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
   }
 
+  const u32 salt_len2 = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32 s2[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len2; i += 4, idx += 1)
+  {
+    s2[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
   md5_ctx_vector_t ctx0;
 
   md5_init_vector (&ctx0);
 
-  md5_update_vector (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
+  md5_update_vector (&ctx0, s2, salt_len2);
 
   /**
    * loop
@@ -230,11 +239,20 @@ KERNEL_FQ void m03730_sxx (KERN_ATTR_VECTOR_ESALT (md5_double_salt_t))
     s[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
   }
 
+  const u32 salt_len2 = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32 s2[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len2; i += 4, idx += 1)
+  {
+    s2[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
   md5_ctx_vector_t ctx0;
 
   md5_init_vector (&ctx0);
 
-  md5_update_vector (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
+  md5_update_vector (&ctx0, s2, salt_len2);
 
   /**
    * loop


### PR DESCRIPTION
```
UNSUPPORTED (log once): buildComputeProgram: cl2Metal failed
clBuildProgram(): CL_BUILD_PROGRAM_FAILURE

Compilation failed: 

program_source:94:29: error: passing 'const __global u32 *' (aka 'const __global unsigned int *') to parameter of type 'const u32x *' (aka 'const unsigned int *') changes address space of pointer
  md5_update_vector (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]/OpenCL/inc_hash_md5.cl:1580:91: note: passing argument to parameter 'w' here
DECLSPEC void md5_update_vector (PRIVATE_AS md5_ctx_vector_t *ctx, PRIVATE_AS const u32x *w, const int len)
                                                                                          ^
program_source:237:29: error: passing 'const __global u32 *' (aka 'const __global unsigned int *') to parameter of type 'const u32x *' (aka 'const unsigned int *') changes address space of pointer
  md5_update_vector (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]/OpenCL/inc_hash_md5.cl:1580:91: note: passing argument to parameter 'w' here
DECLSPEC void md5_update_vector (PRIVATE_AS md5_ctx_vector_t *ctx, PRIVATE_AS const u32x *w, const int len)
                                                                                          ^

* Device #2: Kernel [...]/OpenCL/m03730_a3-pure.cl build failed.
```

and

```
UNSUPPORTED (log once): buildComputeProgram: cl2Metal failed
clBuildProgram(): CL_BUILD_PROGRAM_FAILURE

Compilation failed: 

program_source:101:23: error: passing '__global u32 *' (aka '__global unsigned int *') to parameter of type 'const u32 *' (aka 'const unsigned int *') changes address space of pointer
    md5_update(&ctx1, pws[gid].i, pws[gid].pw_len);
                      ^~~~~~~~~~
[...]/OpenCL/inc_hash_md5.cl:264:76: note: passing argument to parameter 'w' here
DECLSPEC void md5_update (PRIVATE_AS md5_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
                                                                           ^
program_source:231:24: error: passing '__global u32 *' (aka '__global unsigned int *') to parameter of type 'const u32 *' (aka 'const unsigned int *') changes address space of pointer
    md5_update (&ctx1, pws[gid].i, pws[gid].pw_len);
                       ^~~~~~~~~~
[...]/OpenCL/inc_hash_md5.cl:264:76: note: passing argument to parameter 'w' here
DECLSPEC void md5_update (PRIVATE_AS md5_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
                                                                           ^

* Device #2: Kernel [...]/OpenCL/m03730_a0-pure.cl build failed.
```