### PR TITLE
Allow using Metal < 300 with --force

### DIFF
--- a/OpenCL/inc_vendor.h
+++ b/OpenCL/inc_vendor.h
@@ -12,7 +12,7 @@
 #define IS_CUDA
 #elif defined __HIPCC__
 #define IS_HIP
-#elif defined __METAL__
+#elif defined __METAL__ || defined __METAL_MACOS__
 #define IS_METAL
 #else
 #define IS_OPENCL

--- a/include/types.h
+++ b/include/types.h
@@ -1640,8 +1640,8 @@ typedef struct hc_device_param
 
   #if defined (__APPLE__)
 
-  int               mtl_major;
-  int               mtl_minor;
+  //int               mtl_major;
+  //int               mtl_minor;
 
   int               device_physical_location;
   int               device_location_number;

--- a/src/backend.c
+++ b/src/backend.c
@@ -4507,20 +4507,40 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
       backend_ctx->metal_runtimeVersion = atoi (backend_ctx->metal_runtimeVersionStr);
 
-      if (user_options->force == false)
+      // disable metal < 200
+
+      if (backend_ctx->metal_runtimeVersion < 200)
       {
-        if (backend_ctx->metal_runtimeVersion < 300)
+        event_log_warning (hashcat_ctx, "Unsupported Apple Metal runtime version '%s' detected! Falling back to OpenCL...", backend_ctx->metal_runtimeVersionStr);
+        event_log_warning (hashcat_ctx, NULL);
+
+        rc_metal_init = -1;
+
+        backend_ctx->rc_metal_init = rc_metal_init;
+
+        backend_ctx->mtl = NULL;
+
+        mtl_close (hashcat_ctx);
+      }
+      else
+      {
+        if (user_options->force == false)
         {
-          event_log_warning (hashcat_ctx, "Unsupported Apple Metal runtime version '%s' detected! Falling back to OpenCL...", backend_ctx->metal_runtimeVersionStr);
-          event_log_warning (hashcat_ctx, NULL);
+          // disable metal < 300
 
-          rc_metal_init = -1;
+          if (backend_ctx->metal_runtimeVersion < 300)
+          {
+            event_log_warning (hashcat_ctx, "Unsupported Apple Metal runtime version '%s' detected! Falling back to OpenCL...", backend_ctx->metal_runtimeVersionStr);
+            event_log_warning (hashcat_ctx, NULL);
 
-          backend_ctx->rc_metal_init = rc_metal_init;
+            rc_metal_init = -1;
 
-          backend_ctx->mtl = NULL;
+            backend_ctx->rc_metal_init = rc_metal_init;
 
-          mtl_close (hashcat_ctx);
+            backend_ctx->mtl = NULL;
+
+            mtl_close (hashcat_ctx);
+          }
         }
       }
     }
@@ -5832,29 +5852,28 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
       device_param->opencl_device_vendor     = strdup ("Apple");
       device_param->opencl_device_c_version  = "";
 
+      /* unused and deprecated
+
       // sm_minor, sm_major
 
       int mtl_major = 0;
       int mtl_minor = 0;
 
-      /* unused and deprecated
       if (hc_mtlDeviceGetAttribute (hashcat_ctx, &mtl_major, MTL_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, metal_device) == -1)
       {
         device_param->skipped = true;
         continue;
       }
-      */
 
-      /* unused and deprecated
       if (hc_mtlDeviceGetAttribute (hashcat_ctx, &mtl_minor, MTL_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, metal_device) == -1)
       {
         device_param->skipped = true;
         continue;
       }
-      */
 
       device_param->mtl_major = mtl_major;
       device_param->mtl_minor = mtl_minor;
+      */
 
       // device_name
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -4505,18 +4505,23 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_mtlRuntimeGetVersionString (hashcat_ctx, backend_ctx->metal_runtimeVersionStr, &version_len) == -1) return -1;
 
-      if (atoi (backend_ctx->metal_runtimeVersionStr) < 300)
+      backend_ctx->metal_runtimeVersion = atoi (backend_ctx->metal_runtimeVersionStr);
+
+      if (user_options->force == false)
       {
-        event_log_warning (hashcat_ctx, "Unsupported Apple Metal runtime version '%s' detected! Falling back to OpenCL...", backend_ctx->metal_runtimeVersionStr);
-        event_log_warning (hashcat_ctx, NULL);
+        if (backend_ctx->metal_runtimeVersion < 300)
+        {
+          event_log_warning (hashcat_ctx, "Unsupported Apple Metal runtime version '%s' detected! Falling back to OpenCL...", backend_ctx->metal_runtimeVersionStr);
+          event_log_warning (hashcat_ctx, NULL);
 
-        rc_metal_init = -1;
+          rc_metal_init = -1;
 
-        backend_ctx->rc_metal_init = rc_metal_init;
+          backend_ctx->rc_metal_init = rc_metal_init;
 
-        backend_ctx->mtl = NULL;
+          backend_ctx->mtl = NULL;
 
-        mtl_close (hashcat_ctx);
+          mtl_close (hashcat_ctx);
+        }
       }
     }
     else

--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -16,6 +16,7 @@
 #include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
 
+/*
 typedef NS_ENUM(NSUInteger, hc_mtlFeatureSet)
 {
   MTL_FEATURESET_MACOS_GPUFAMILY_1_V1 = 10000,
@@ -25,6 +26,7 @@ typedef NS_ENUM(NSUInteger, hc_mtlFeatureSet)
   MTL_FEATURESET_MACOS_GPUFAMILY_2_V1 = 10005,
 
 } metalDeviceFeatureSet_macOS_t;
+*/
 
 typedef NS_ENUM(NSUInteger, hc_mtlLanguageVersion)
 {

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1221,18 +1221,10 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
     event_log_info (hashcat_ctx, NULL);
 
     int metal_devices_cnt = backend_ctx->metal_devices_cnt;
-    int metal_runtimeVersion = backend_ctx->metal_runtimeVersion;
+
     char *metal_runtimeVersionStr = backend_ctx->metal_runtimeVersionStr;
 
-    if (metal_runtimeVersionStr != NULL)
-    {
-      event_log_info (hashcat_ctx, "Metal.Version.: %s", metal_runtimeVersionStr);
-    }
-    else
-    {
-      event_log_info (hashcat_ctx, "Metal.Version.: %u", metal_runtimeVersion);
-    }
-
+    event_log_info (hashcat_ctx, "Metal.Version.: %s", metal_runtimeVersionStr);
     event_log_info (hashcat_ctx, NULL);
 
     for (int metal_devices_idx = 0; metal_devices_idx < metal_devices_cnt; metal_devices_idx++)
@@ -1542,6 +1534,7 @@ void backend_info_compact (hashcat_ctx_t *hashcat_ctx)
   if (backend_ctx->mtl)
   {
     int metal_devices_cnt    = backend_ctx->metal_devices_cnt;
+
     char *metal_runtimeVersionStr = backend_ctx->metal_runtimeVersionStr;
 
     size_t len = event_log_info (hashcat_ctx, "METAL API (Metal %s)", metal_runtimeVersionStr);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1234,8 +1234,8 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
       const hc_device_param_t *device_param = backend_ctx->devices_param + backend_devices_idx;
 
       int   device_id                 = device_param->device_id;
-      int   device_mtl_maj            = device_param->mtl_major;
-      int   device_mtl_min            = device_param->mtl_minor;
+      //int   device_mtl_maj            = device_param->mtl_major;
+      //int   device_mtl_min            = device_param->mtl_minor;
       int   device_max_transfer_rate  = device_param->device_max_transfer_rate;
       int   device_physical_location  = device_param->device_physical_location;
       int   device_location_number    = device_param->device_location_number;
@@ -1285,6 +1285,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
         default:                              event_log_info (hashcat_ctx, "  Phys.Location..: N/A"); break;
       }
 
+      /*
       if (device_mtl_maj > 0 && device_mtl_min > 0)
       {
         event_log_info (hashcat_ctx, "  Feature.Set....: macOS GPU Family %u v%u", device_mtl_maj, device_mtl_min);
@@ -1293,6 +1294,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
       {
         event_log_info (hashcat_ctx, "  Feature.Set....: N/A");
       }
+      */
 
       event_log_info (hashcat_ctx, "  Registry.ID....: %u", device_registryID);
 


### PR DESCRIPTION
```
bash-3.2$ ./hashcat -I --force
hashcat (v6.2.6-161-gbdf388f04+) starting in backend information mode

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

Metal Info:
===========

Metal.Version.: 263.8

Backend Device ID #1 (Alias: #2)
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Apple M1
  Processor(s)...: 8
  Clock..........: N/A
  Memory.Total...: 10922 MB (limited to 4096 MB allocatable in one block)
  Memory.Free....: 5408 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Feature.Set....: N/A
  Registry.ID....: 1587
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 0, removable 0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Aug  8 2022 21:29:55)

  Backend Device ID #2 (Alias: #1)
    Type...........: GPU
    Vendor.ID......: 2
    Vendor.........: Apple
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 1000
    Memory.Total...: 10922 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 960 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2 1.0

bash-3.2$ ./hashcat -b -m 1000 -d1 --force
hashcat (v6.2.6-161-gbdf388f04+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

METAL API (Metal 263.8)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Benchmark relevant options:
===========================
* --force
* --backend-devices=1
* --optimized-kernel-enable

-----------------------
* Hash-Mode 1000 (NTLM)
-----------------------

Speed.#1.........:  4776.7 MH/s (54.47ms) @ Accel:1024 Loops:1024 Thr:32 Vec:1

Started: Thu Dec  8 17:45:47 2022
Stopped: Thu Dec  8 17:45:59 2022
```