### PR TITLE
fix kernel 27900 a3 build warnings/errors

### DIFF
--- a/OpenCL/m27900_a3-pure.cl
+++ b/OpenCL/m27900_a3-pure.cl
@@ -111,7 +111,7 @@ DECLSPEC u32x crc32c (PRIVATE_AS const u32x *w, const u32 pw_len, const u32 iv)
 
   PRIVATE_AS const u8 *w_ptr = (PRIVATE_AS const u8 *) w;
 
-  for (int i = 0; i < pw_len; i++)
+  for (u32 i = 0; i < pw_len; i++)
   {
     const u32 v = (const u32) w_ptr[i];
 
@@ -121,7 +121,7 @@ DECLSPEC u32x crc32c (PRIVATE_AS const u32x *w, const u32 pw_len, const u32 iv)
   return ~a;
 }
 
-KERNEL_FQ void m27900_mxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m27900_mxx (KERN_ATTR_VECTOR ())
 {
   /**
    * modifier
@@ -174,7 +174,7 @@ KERNEL_FQ void m27900_mxx (KERN_ATTR_BASIC ())
   }
 }
 
-KERNEL_FQ void m27900_sxx (KERN_ATTR_BASIC ())
+KERNEL_FQ void m27900_sxx (KERN_ATTR_VECTOR ())
 {
   /**
    * modifier


### PR DESCRIPTION
Metal

```
hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:114:21: warning: comparison of integers of different signs: 'int' and 'const u32' (aka 'const unsigned int')
  for (int i = 0; i < pw_len; i++)
                  ~ ^ ~~~~~~
program_source:163:22: error: use of undeclared identifier 'words_buf_r'
    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
                     ^
program_source:228:22: error: use of undeclared identifier 'words_buf_r'
    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
                     ^


* Device #1: Kernel [...]/OpenCL/m27900_a3-pure.cl build failed.
```