### PR TITLE
fix kernel 28000 a3 build warnings/errors

### DIFF
--- a/OpenCL/m28000_a3-pure.cl
+++ b/OpenCL/m28000_a3-pure.cl
@@ -171,7 +171,7 @@ DECLSPEC u64 crc64jones (PRIVATE_AS const u32 *w, const u32 pw_len, const u64 iv
 
   PRIVATE_AS const u8 *w_ptr = (PRIVATE_AS const u8 *) w;
 
-  for (int i = 0; i < pw_len; i++)
+  for (u32 i = 0; i < pw_len; i++)
   {
     const u64 v = (const u64) w_ptr[i];
 
@@ -181,7 +181,7 @@ DECLSPEC u64 crc64jones (PRIVATE_AS const u32 *w, const u32 pw_len, const u64 iv
   return a;
 }
 
-KERNEL_FQ void m28000_mxx (KERN_ATTR_ESALT (crc64_t))
+KERNEL_FQ void m28000_mxx (KERN_ATTR_VECTOR_ESALT (crc64_t))
 {
   /**
    * modifier
@@ -254,7 +254,7 @@ KERNEL_FQ void m28000_mxx (KERN_ATTR_ESALT (crc64_t))
   }
 }
 
-KERNEL_FQ void m28000_sxx (KERN_ATTR_ESALT (crc64_t))
+KERNEL_FQ void m28000_sxx (KERN_ATTR_VECTOR_ESALT (crc64_t))
 {
   /**
    * modifier


### PR DESCRIPTION
Metal

```
hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:174:21: warning: comparison of integers of different signs: 'int' and 'const u32' (aka 'const unsigned int')
  for (int i = 0; i < pw_len; i++)
                  ~ ^ ~~~~~~
program_source:240:22: error: use of undeclared identifier 'words_buf_r'
    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
                     ^
program_source:325:22: error: use of undeclared identifier 'words_buf_r'
    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
                     ^


* Device #1: Kernel [...]/OpenCL/m28000_a3-pure.cl build failed.
```