### PR TITLE
Allow up to 11 chars for the P value of PDFs

### DIFF
--- a/src/modules/module_10400.c
+++ b/src/modules/module_10400.c
@@ -150,7 +150,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[4] = 1;
-  token.len_max[4] = 6;
+  token.len_max[4] = 11;
   token.sep[4]     = '*';
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
 

--- a/src/modules/module_10410.c
+++ b/src/modules/module_10410.c
@@ -171,7 +171,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[4] = 1;
-  token.len_max[4] = 6;
+  token.len_max[4] = 11;
   token.sep[4]     = '*';
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
 

--- a/src/modules/module_10420.c
+++ b/src/modules/module_10420.c
@@ -151,7 +151,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[4] = 1;
-  token.len_max[4] = 6;
+  token.len_max[4] = 11;
   token.sep[4]     = '*';
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
 

--- a/src/modules/module_10500.c
+++ b/src/modules/module_10500.c
@@ -181,7 +181,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[4] = 1;
-  token.len_max[4] = 6;
+  token.len_max[4] = 11;
   token.sep[4]     = '*';
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
 

--- a/src/modules/module_10600.c
+++ b/src/modules/module_10600.c
@@ -127,7 +127,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[4] = 1;
-  token.len_max[4] = 6;
+  token.len_max[4] = 11;
   token.sep[4]     = '*';
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
 

--- a/src/modules/module_10700.c
+++ b/src/modules/module_10700.c
@@ -198,7 +198,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[4] = 1;
-  token.len_max[4] = 6;
+  token.len_max[4] = 11;
   token.sep[4]     = '*';
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
 

--- a/src/modules/module_25400.c
+++ b/src/modules/module_25400.c
@@ -191,7 +191,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
   token.len_min[4] = 1;
-  token.len_max[4] = 6;
+  token.len_max[4] = 11;
   token.sep[4]     = '*';
   token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
 


### PR DESCRIPTION
According to  the PDF standard, the P value is a signed 32 bit integer, therefore the value can get longer than 6 chars (what hashcat currently accepts as limit).

A generated example hash (-m 10400) of with such a value like it can happen from some PDFs:
```
$pdf$1*2*40*-2147483647*0*16*65425250680715858027578013731348*32*7d586b1742bd978aa1834d14cbc5265920268faca3980014b1f50b064a6116c8*32*0000000000000000000000000000000000000000000000000000000000000000:hashcat
```