### PR TITLE
Remove check which may lead to false negatives on pkzip in rare cases

### DIFF
--- a/OpenCL/m17200_a0-pure.cl
+++ b/OpenCL/m17200_a0-pure.cl
@@ -681,7 +681,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
     update_key3 (key2, key3);
     plain = unpack_v8a_from_v32_S (next) ^ key3;
-    if ((plain & 6) == 0 || (plain & 6) == 6) continue;
+    if ((plain & 6) == 6) continue;
     tmp[0] = plain;
     update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -907,7 +907,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
     update_key3 (key2, key3);
     plain = unpack_v8a_from_v32_S (next) ^ key3;
-    if ((plain & 6) == 0 || (plain & 6) == 6) continue;
+    if ((plain & 6) == 6) continue;
     tmp[0] = plain;
     update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17200_a1-pure.cl
+++ b/OpenCL/m17200_a1-pure.cl
@@ -683,7 +683,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_ESALT (pkzip_t))
 
     update_key3 (key2, key3);
     plain = unpack_v8a_from_v32_S (next) ^ key3;
-    if ((plain & 6) == 0 || (plain & 6) == 6) continue;
+    if ((plain & 6) == 6) continue;
     tmp[0] = plain;
     update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -913,7 +913,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_ESALT (pkzip_t))
 
     update_key3 (key2, key3);
     plain = unpack_v8a_from_v32_S (next) ^ key3;
-    if ((plain & 6) == 0 || (plain & 6) == 6) continue;
+    if ((plain & 6) == 6) continue;
     tmp[0] = plain;
     update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17200_a3-pure.cl
+++ b/OpenCL/m17200_a3-pure.cl
@@ -696,7 +696,7 @@ KERNEL_FQ void m17200_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
 
     update_key3 (key2, key3);
     plain = unpack_v8a_from_v32_S (next) ^ key3;
-    if ((plain & 6) == 0 || (plain & 6) == 6) continue;
+    if ((plain & 6) == 6) continue;
     tmp[0] = plain;
     update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -938,7 +938,7 @@ KERNEL_FQ void m17200_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
 
     update_key3 (key2, key3);
     plain = unpack_v8a_from_v32_S (next) ^ key3;
-    if ((plain & 6) == 0 || (plain & 6) == 6) continue;
+    if ((plain & 6) == 6) continue;
     tmp[0] = plain;
     update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17220_a0-pure.cl
+++ b/OpenCL/m17220_a0-pure.cl
@@ -676,7 +676,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if ((plain & 6) == 0 || (plain & 6) == 6) break;
+      if ((plain & 6) == 6) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -941,7 +941,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if ((plain & 6) == 0 || (plain & 6) == 6) break;
+      if ((plain & 6) == 6) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17220_a1-pure.cl
+++ b/OpenCL/m17220_a1-pure.cl
@@ -676,7 +676,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if ((plain & 6) == 0 || (plain & 6) == 6) break;
+      if ((plain & 6) == 6) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -943,7 +943,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if ((plain & 6) == 0 || (plain & 6) == 6) break;
+      if ((plain & 6) == 6) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17220_a3-pure.cl
+++ b/OpenCL/m17220_a3-pure.cl
@@ -688,7 +688,7 @@ KERNEL_FQ void m17220_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if ((plain & 6) == 0 || (plain & 6) == 6) break;
+      if ((plain & 6) == 6) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -967,7 +967,7 @@ KERNEL_FQ void m17220_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if ((plain & 6) == 0 || (plain & 6) == 6) break;
+      if ((plain & 6) == 6) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17225_a0-pure.cl
+++ b/OpenCL/m17225_a0-pure.cl
@@ -681,7 +681,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -1009,7 +1009,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17225_a1-pure.cl
+++ b/OpenCL/m17225_a1-pure.cl
@@ -681,7 +681,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -1010,7 +1010,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17225_a3-pure.cl
+++ b/OpenCL/m17225_a3-pure.cl
@@ -693,7 +693,7 @@ KERNEL_FQ void m17225_sxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 
@@ -1034,7 +1034,7 @@ KERNEL_FQ void m17225_mxx (KERN_ATTR_VECTOR_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
       tmp[0] = plain;
       update_key012 (key0, key1, key2, plain, l_crc32tab);
 

--- a/OpenCL/m17230_a0-pure.cl
+++ b/OpenCL/m17230_a0-pure.cl
@@ -363,7 +363,7 @@ KERNEL_FQ void m17230_sxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
 
       if (idx + 1 == esalt_bufs[DIGESTS_OFFSET_HOST].hash_count)
       {
@@ -533,7 +533,7 @@ KERNEL_FQ void m17230_mxx (KERN_ATTR_RULES_ESALT (pkzip_t))
 
       update_key3 (key2, key3);
       plain = unpack_v8a_from_v32_S (next) ^ key3;
-      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 0 || (plain & 6) == 6)) break;
+      if (esalt_bufs[DIGESTS_OFFSET_HOST].hashes[idx].compression_type == 8 && ((plain & 6) == 6)) break;
 
       if (idx + 1 == esalt_bufs[DIGESTS_OFFSET_HOST].hash_count)
       {


### PR DESCRIPTION
Removed check for 00 bits for compressed hashes as it may be valid for the case, when zip stores a file part as compressed file, but the first block or the content itself is stored and not deflated.

closes #3277 