### PR TITLE
stdout mode: fix pwd copy for optimized kernels

### DIFF
--- a/src/stdout.c
+++ b/src/stdout.c
@@ -205,22 +205,17 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
           {
             const u32 off = device_param->innerloop_pos + il_pos;
 
+            for (u32 i = 0; i < pw_idx->cnt; i++)
+            {
+              plain_buf[i] = pw[i];
+            }
+
             if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
             {
-              for (int i = 0; i < 8; i++)
-              {
-                plain_buf[i] = pw[i];
-              }
-
               plain_len = apply_rules_optimized (straight_ctx->kernel_rules_buf[off].cmds, &plain_buf[0], &plain_buf[4], pw_idx->len);
             }
             else
             {
-              for (u32 i = 0; i < pw_idx->cnt; i++)
-              {
-                plain_buf[i] = pw[i];
-              }
-
               plain_len = apply_rules (straight_ctx->kernel_rules_buf[off].cmds, plain_buf, pw_idx->len);
             }
 


### PR DESCRIPTION
An additional part of the fix for https://github.com/hashcat/hashcat/issues/3537 that was meant to be included in https://github.com/hashcat/hashcat/pull/3545.

This ensures the stdout output buffer is correctly padded with trailing zeroes when using an optimized kernel.

expected result:
```
$ while IFS='' read -r line; do echo "${line}${line}"; done < example.dict | md5sum
8647554c52ac0baa17148983479df0af  -
```
without fix:
```
$ git log --oneline -n 1
6d3cf3689 (HEAD) stdout mode: zero output buffer between rules (fixes #3537)
$ ./hashcat -O --stdout -m 99999 -a 0 example.dict -r bug-#3537/duplicate.txt | md5sum
e22ef2709c6995bc82d58bd288cfa100  -
```

with fix:
```
$ git log --oneline -n 1
c23ee3331 (HEAD -> bugfix-stdout-rules-#3537, github/bugfix-stdout-rules-#3537) stdout mode: fix pwd copy for optimized kernels
$ ./hashcat -O --stdout -m 99999 -a 0 example.dict -r bug-#3537/duplicate.txt | md5sum
8647554c52ac0baa17148983479df0af  -
$ ./hashcat --stdout -m 99999 -a 0 example.dict -r bug-#3537/duplicate.txt | md5sum
8647554c52ac0baa17148983479df0af  -

```