### PR TITLE
fix whitespace in -m 30700 = Anope IRC Services

### DIFF
--- a/OpenCL/m30700_a1-optimized.cl
+++ b/OpenCL/m30700_a1-optimized.cl
@@ -65,7 +65,7 @@ KERNEL_FQ void m30700_m04 (KERN_ATTR_BASIC ())
   const u32 IV_E = salt_bufs[SALT_POS_HOST].salt_buf_pc[4];
   const u32 IV_F = salt_bufs[SALT_POS_HOST].salt_buf_pc[5];
   const u32 IV_G = salt_bufs[SALT_POS_HOST].salt_buf_pc[6];
-  const u32 IV_H = salt_bufs[SALT_POS_HOST].salt_buf_pc[7];  
+  const u32 IV_H = salt_bufs[SALT_POS_HOST].salt_buf_pc[7];
 
   /**
    * loop


### PR DESCRIPTION
This minor patch just removes some trailing spaces from  -m 30700 (`Anope IRC Services`) -a 1 kernel code.

Thanks