### PR TITLE
Removed check which aborted on empty passwords for mode 10700

### DIFF
--- a/OpenCL/m10700-optimized.cl
+++ b/OpenCL/m10700-optimized.cl
@@ -647,8 +647,6 @@ KERNEL_FQ void m10700_loop (KERN_ATTR_TMPS_ESALT (pdf17l8_tmp_t, pdf_t))
 
   const u32 pw_len = pws[gid].pw_len & 31;
 
-  if (pw_len == 0) return;
-
   /**
    * digest
    */

--- a/OpenCL/m10700-pure.cl
+++ b/OpenCL/m10700-pure.cl
@@ -1256,8 +1256,6 @@ KERNEL_FQ void m10700_loop (KERN_ATTR_TMPS_ESALT (pdf17l8_tmp_t, pdf_t))
 
   const u32 pw_len = pws[gid].pw_len;
 
-  if (pw_len == 0) return;
-
   u32 w[64] = { 0 };
 
   for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)


### PR DESCRIPTION
the check for pw_len == 0 made pdf hashes of mode 10700 with empty user password to never crack. closes #3562 