### PR TITLE
There can be PDF 104xx hashes which have V == 2

### DIFF
--- a/src/modules/module_10400.c
+++ b/src/modules/module_10400.c
@@ -218,7 +218,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int R = strtol ((const char *) R_pos, NULL, 10);
   const int P = strtol ((const char *) P_pos, NULL, 10);
 
-  if (V != 1) return (PARSER_SALT_VALUE);
+  if (V != 1 && V != 2) return (PARSER_SALT_VALUE);
   if (R != 2) return (PARSER_SALT_VALUE);
 
   const int enc_md = strtol ((const char *) enc_md_pos, NULL, 10);

--- a/src/modules/module_10410.c
+++ b/src/modules/module_10410.c
@@ -239,7 +239,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int R = strtol ((const char *) R_pos, NULL, 10);
   const int P = strtol ((const char *) P_pos, NULL, 10);
 
-  if (V != 1) return (PARSER_SALT_VALUE);
+  if (V != 1 && V != 2) return (PARSER_SALT_VALUE);
   if (R != 2) return (PARSER_SALT_VALUE);
 
   const int enc_md = strtol ((const char *) enc_md_pos, NULL, 10);

--- a/src/modules/module_10420.c
+++ b/src/modules/module_10420.c
@@ -226,7 +226,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int R = strtol ((const char *) R_pos, NULL, 10);
   const int P = strtol ((const char *) P_pos, NULL, 10);
 
-  if (V != 1) return (PARSER_SALT_VALUE);
+  if (V != 1 && V != 2) return (PARSER_SALT_VALUE);
   if (R != 2) return (PARSER_SALT_VALUE);
 
   const int enc_md = strtol ((const char *) enc_md_pos, NULL, 10);


### PR DESCRIPTION
Encrypted PDFs can have version 2, revision 2 and use the 40bit RC4 encryption (aka starting with `$pdf$2*2*40*...`).
This pull request extends the check so that these hashes are accepted as well (and can be recovered).