### PR TITLE
Support for longer scrypt hashes in module 8900

### DIFF
--- a/src/modules/module_08900.c
+++ b/src/modules/module_08900.c
@@ -304,7 +304,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_BASE64A;
 
   token.len_min[5] = 44;
-  token.len_max[5] = 44;
+  token.len_max[5] = 88;
   token.sep[5]     = ':';
   token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_BASE64A;
@@ -333,7 +333,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const u8 *salt_pos = token.buf[4];
   const int salt_len = token.len[4];
 
-  u8 tmp_buf[33] = { 0 };
+  u8 tmp_buf[63] = { 0 };
 
   const int tmp_len = base64_decode (base64_to_int, (const u8 *) salt_pos, salt_len, tmp_buf);
 


### PR DESCRIPTION
The is a open source tool that creates crypted file systems, the hash is normal scrypt but the module 8900 does not support the token size.

The example hash (resolves to the password "hashcat"):
`SCRYPT:65536:8:1:M/oaRDW94PYv/L0qjTpcFrViwtPJapZxe8UWIipf/n4=:3ntSy4wA+TNxmSlOzJdFLmqQOm5UqbDlgYXckF+MDmrmD5E+krpW9bkKMzaBFqqwkZIZV9nMHkTptcYOO0Imew==` results in `Hashfile './testhash.hash' on line 1 (SCRYPT...MzaBFqqwkZIZV9nMHkTptcYOO0Imew==): Token length exception`

The digest max length in the module was 44, but in this case the digest has a length of 88.
The token validation in the module accepts 88 length now and the digest buffer was doubled in size.

I could successfully crack the hash now.
