### PR TITLE
Log error for gpu temp failure when in quiet mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -829,9 +829,8 @@ static void main_monitor_temp_abort (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MA
   const user_options_t       *user_options       = hashcat_ctx->user_options;
   const user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
 
-  if (user_options->quiet == true) return;
 
-  if ((user_options_extra->wordlist_mode == WL_MODE_FILE) || (user_options_extra->wordlist_mode == WL_MODE_MASK))
+  if (((user_options_extra->wordlist_mode == WL_MODE_FILE) || (user_options_extra->wordlist_mode == WL_MODE_MASK)) && user_options->quiet == false)
   {
     clear_prompt (hashcat_ctx);
   }


### PR DESCRIPTION
When running Hashcat, no error is logged when --quiet is specified when Hashcat aborts due to GPU temp. Other errors are still logged when --quiet is used, but this one not.

This pull requests enables printing of the error in case the GPU temp hits the temp-abort:

Before the change:
```
./hashcat -a3 -m 0 2c4c1657b9b980ac75396b85ff3a836e --quiet --hwmon-temp-abort=30 ?a?a?a?a?a
```

After the change:

```
./hashcat -a3 -m 0 2c4c1657b9b980ac75396b85ff3a836e --quiet --hwmon-temp-abort=30 ?a?a?a?a?a
Temperature limit on GPU #1 reached, aborting

Temperature limit on GPU #1 reached, aborting

```
