### PR TITLE
Fixes #3596: bug in --stdout w/ rules

### DIFF
--- a/src/stdout.c
+++ b/src/stdout.c
@@ -223,7 +223,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
 
             out_push (&out, plain_ptr, plain_len);
 
-            memset (plain_ptr, 0, BUF_SZ);
+            memset (plain_ptr, 0, PW_MAX);
           }
 
           pw_idx++;


### PR DESCRIPTION
Changes BUF_SZ to PW_MAX to correctly memset the pw buffer to 0 between candidates.