### PR TITLE
Fixes hashcat#3580: bug in --skip/--limit w/ --stdout

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -787,7 +787,7 @@ static int outer_loop (hashcat_ctx_t *hashcat_ctx)
   {
     if ((mask_ctx->masks_cnt > 1) || (straight_ctx->dicts_cnt > 1))
     {
-      event_log_error (hashcat_ctx, "Use of --skip/--limit is not supported with --increment or mask files.");
+      event_log_error (hashcat_ctx, "Use of --skip/--limit is not supported with --increment, mask files, or --stdout.");
 
       return -1;
     }


### PR DESCRIPTION
Fixes #3580 

Before fix:
```
$ ./hashcat --stdout -a 0 in1.txt in2.txt         
1
2
3
a
b
c
```
```
$ ./hashcat --stdout --skip 1 -a 0 in1.txt in2.txt 
Use of --skip/--limit is not supported with --increment or mask files.
```
```
$ ./hashcat --stdout --limit 1 -a 0 in1.txt in2.txt
Use of --skip/--limit is not supported with --increment or mask files.
```

After fix:
```
$ ./hashcat --stdout -a 0 in1.txt in2.txt
1
2
3
a
b
c
```
```
$ ./hashcat --stdout --skip 1 -a 0 in1.txt in2.txt
Use of --skip/--limit is not supported with --stdout.
```
```
$ ./hashcat --stdout --limit 1 -a 0 in1.txt in2.txt 
Use of --skip/--limit is not supported with --stdout.
```