### PR TITLE
Add tuning records for a number of algorithms for the AMD RX 7900XTX

### DIFF
--- a/tunings/Alias.hctune
+++ b/tunings/Alias.hctune
@@ -260,5 +260,8 @@ Device_73bf                                     ALIAS_AMD_RX6900XT
 gfx1030                                         ALIAS_AMD_RX6900XT
 Radeon_RX_6900_XT                               ALIAS_AMD_RX6900XT
 
+gfx1100                                         ALIAS_AMD_RX7900XTX
+Radeon_RX_7900_XTX                              ALIAS_AMD_RX7900XTX
+
 Radeon_Pro_W5700X                               ALIAS_AMD_W5700X
 Radeon_Pro_W5700X_Compute_Engine                ALIAS_AMD_W5700X

--- a/tunings/Module_08900.hctune
+++ b/tunings/Module_08900.hctune
@@ -34,4 +34,5 @@ ALIAS_AMD_RX480                                 *       8900    1       15      
 ALIAS_AMD_Vega64                                *       8900    1       30      A
 ALIAS_AMD_MI100                                 *       8900    1       79      A
 ALIAS_AMD_RX6900XT                              *       8900    1       123     A
+ALIAS_AMD_RX7900XTX                             *       8900    1       91      A 
 ALIAS_AMD_W5700X                                *       8900    1       4       A

--- a/tunings/Module_09300.hctune
+++ b/tunings/Module_09300.hctune
@@ -32,4 +32,5 @@ ALIAS_AMD_RX480                                 *       9300    1       232     
 ALIAS_AMD_Vega64                                *       9300    1       440     A
 ALIAS_AMD_MI100                                 *       9300    1       1000    A
 ALIAS_AMD_RX6900XT                              *       9300    1       720     A
+ALIAS_AMD_RX7900XTX                             *       9300    1       858     A
 ALIAS_AMD_W5700X                                *       9300    1       3       A

--- a/tunings/Module_15700.hctune
+++ b/tunings/Module_15700.hctune
@@ -33,4 +33,5 @@ ALIAS_AMD_RX480                                 *       15700   1       58      
 ALIAS_AMD_Vega64                                *       15700   1       53      A
 ALIAS_AMD_MI100                                 *       15700   1       120     A
 ALIAS_AMD_RX6900XT                              *       15700   1       56      A
+ALIAS_AMD_RX7900XTX                             *       15700   1       45      A
 ALIAS_AMD_W5700X                                *       15700   1       1       A

--- a/tunings/Module_22700.hctune
+++ b/tunings/Module_22700.hctune
@@ -34,4 +34,5 @@ ALIAS_AMD_RX480                                 *       22700   1       15      
 ALIAS_AMD_Vega64                                *       22700   1       30      A
 ALIAS_AMD_MI100                                 *       22700   1       79      A
 ALIAS_AMD_RX6900XT                              *       22700   1       123     A
+ALIAS_AMD_RX7900XTX                             *       22700   1       186     A
 ALIAS_AMD_W5700X                                *       22700   1       4       A

--- a/tunings/Module_27700.hctune
+++ b/tunings/Module_27700.hctune
@@ -34,4 +34,5 @@ ALIAS_AMD_RX480                                 *       27700   1       15      
 ALIAS_AMD_Vega64                                *       27700   1       30      A
 ALIAS_AMD_MI100                                 *       27700   1       79      A
 ALIAS_AMD_RX6900XT                              *       27700   1       123     A
+ALIAS_AMD_RX7900XTX                             *       27700   1       171     A
 ALIAS_AMD_W5700X                                *       27700   1       4       A

--- a/tunings/Module_28200.hctune
+++ b/tunings/Module_28200.hctune
@@ -34,4 +34,5 @@ ALIAS_AMD_RX480                                 *       28200   1       15      
 ALIAS_AMD_Vega64                                *       28200   1       30      A
 ALIAS_AMD_MI100                                 *       28200   1       79      A
 ALIAS_AMD_RX6900XT                              *       28200   1       123     A
+ALIAS_AMD_RX7900XTX                             *       28200   1       46      A
 ALIAS_AMD_W5700X                                *       28200   1       4       A


### PR DESCRIPTION
It's my first time building tunings for a card, so please correct me if I'm done anything incorrectly. 

I added an alias for the full name and gfx1100 for the 7900XTX, and added tunings for the majority of the algorithms with current tunings files.

The uplift is a mixed bag, averaging somewhere around 15%, with the outliers being 09300 (cisco-ios scrypt), and 15700 (eth, scrypt) with > 100% improvements.

It's a start at least.