### PR TITLE
Added graceful exiting on SIGINT: In response to issue #3618

### DIFF
--- a/include/thread.h
+++ b/include/thread.h
@@ -58,7 +58,7 @@
 
 #endif
 
-/*
+
 #if defined (_WIN)
 
 BOOL WINAPI sigHandler_default (DWORD sig);
@@ -72,7 +72,7 @@ void sigHandler_benchmark (int sig);
 void hc_signal (void (callback) (int));
 
 #endif
-*/
+
 
 int mycracked (hashcat_ctx_t *hashcat_ctx);
 int myabort_runtime (hashcat_ctx_t *hashcat_ctx);

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -54,6 +54,9 @@
 #include "brain.h"
 #endif
 
+// hashcat_ctx stored globally for signal handling
+hashcat_ctx_t *hc_ctx;
+
 // inner2_loop iterates through wordlists, then calls kernel execution
 
 static int inner2_loop (hashcat_ctx_t *hashcat_ctx)
@@ -1093,6 +1096,7 @@ int hashcat_init (hashcat_ctx_t *hashcat_ctx, void (*event) (const u32, struct h
   hashcat_ctx->user_options       = (user_options_t *)        hcmalloc (sizeof (user_options_t));
   hashcat_ctx->wl_data            = (wl_data_t *)             hcmalloc (sizeof (wl_data_t));
 
+  hc_ctx = hashcat_ctx;
   return 0;
 }
 
@@ -1742,6 +1746,19 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
     if (user_options->identify == true) return 0;
 
     user_options->autodetect = false;
+  }
+
+  /**
+   * enable custom signal handler(s)
+   */
+
+  if (user_options->benchmark == false)
+  {
+    hc_signal (sigHandler_default);
+  }
+  else
+  {
+    hc_signal (sigHandler_benchmark);
   }
 
   /**

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -54,9 +54,6 @@
 #include "brain.h"
 #endif
 
-// hashcat_ctx stored globally for signal handling
-hashcat_ctx_t *hc_ctx;
-
 // inner2_loop iterates through wordlists, then calls kernel execution
 
 static int inner2_loop (hashcat_ctx_t *hashcat_ctx)
@@ -1095,8 +1092,7 @@ int hashcat_init (hashcat_ctx_t *hashcat_ctx, void (*event) (const u32, struct h
   hashcat_ctx->user_options_extra = (user_options_extra_t *)  hcmalloc (sizeof (user_options_extra_t));
   hashcat_ctx->user_options       = (user_options_t *)        hcmalloc (sizeof (user_options_t));
   hashcat_ctx->wl_data            = (wl_data_t *)             hcmalloc (sizeof (wl_data_t));
-
-  hc_ctx = hashcat_ctx;
+  
   return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,9 @@
 int _dowildcard = -1;
 #endif
 
+// hashcat_ctx stored globally for signal handling
+hashcat_ctx_t *hc_ctx;
+
 static void main_log_clear_line (MAYBE_UNUSED const size_t prev_len, MAYBE_UNUSED FILE *fp)
 {
   if (!is_stdout_terminal ()) return;
@@ -1283,6 +1286,10 @@ int main (int argc, char **argv)
 
     return 0;
   }
+
+  // Initializing the hashcat ctx global pointer for the signal handler 
+  
+  hc_ctx = hashcat_ctx;
 
   // init a hashcat session; this initializes backend devices, hwmon, etc
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -92,16 +92,24 @@ void hc_signal (BOOL WINAPI (callback) (DWORD))
 
 void sigHandler_default (int sig)
 {
-  myabort (hc_ctx);
+  if (hc_ctx) 
+  {
+    hc_ctx = NULL;
+    myabort (hc_ctx);
+  }
 
-  signal (sig, NULL);
+  // signal (sig, NULL);
 }
 
 void sigHandler_benchmark (int sig)
 {
-  myquit (hc_ctx);
+  if (hc_ctx) 
+  {
+    hc_ctx = NULL;
+    myquit (hc_ctx);
+  }
 
-  signal (sig, NULL);
+  // signal (sig, NULL);
 }
 
 void hc_signal (void (callback) (int))

--- a/src/thread.c
+++ b/src/thread.c
@@ -9,7 +9,9 @@
 #include "timer.h"
 #include "thread.h"
 
-/*
+// hashcat_ctx stored globally for signal handling
+extern hashcat_ctx_t *hc_ctx;
+
 #if defined (_WIN)
 
 BOOL WINAPI sigHandler_default (DWORD sig)
@@ -24,7 +26,7 @@ BOOL WINAPI sigHandler_default (DWORD sig)
        * function otherwise it is too late (e.g. after returning from this function)
        *
 
-      myabort (hashcat_ctx->status_ctx);
+      myabort (hc_ctx);
 
       SetConsoleCtrlHandler (NULL, TRUE);
 
@@ -36,7 +38,7 @@ BOOL WINAPI sigHandler_default (DWORD sig)
     case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
 
-      myabort (hashcat_ctx->status_ctx);
+      myabort (hc_ctx);
 
       SetConsoleCtrlHandler (NULL, TRUE);
 
@@ -52,7 +54,7 @@ BOOL WINAPI sigHandler_benchmark (DWORD sig)
   {
     case CTRL_CLOSE_EVENT:
 
-      myquit (hashcat_ctx->status_ctx);
+      myquit (hc_ctx);
 
       SetConsoleCtrlHandler (NULL, TRUE);
 
@@ -64,7 +66,7 @@ BOOL WINAPI sigHandler_benchmark (DWORD sig)
     case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
 
-      myquit (hashcat_ctx->status_ctx);
+      myquit (hc_ctx);
 
       SetConsoleCtrlHandler (NULL, TRUE);
 
@@ -90,14 +92,14 @@ void hc_signal (BOOL WINAPI (callback) (DWORD))
 
 void sigHandler_default (int sig)
 {
-  myabort (hashcat_ctx->status_ctx);
+  myabort (hc_ctx);
 
   signal (sig, NULL);
 }
 
 void sigHandler_benchmark (int sig)
 {
-  myquit (hashcat_ctx->status_ctx);
+  myquit (hc_ctx);
 
   signal (sig, NULL);
 }
@@ -112,7 +114,7 @@ void hc_signal (void (callback) (int))
 }
 
 #endif
-*/
+
 
 int mycracked (hashcat_ctx_t *hashcat_ctx)
 {

--- a/src/thread.c
+++ b/src/thread.c
@@ -20,15 +20,19 @@ BOOL WINAPI sigHandler_default (DWORD sig)
   {
     case CTRL_CLOSE_EVENT:
 
-       *
+       /*
        * special case see: https://stackoverflow.com/questions/3640633/c-setconsolectrlhandler-routine-issue/5610042#5610042
        * if the user interacts w/ the user-interface (GUI/cmd), we need to do the finalization job within this signal handler
        * function otherwise it is too late (e.g. after returning from this function)
-       *
+       */
 
-      myabort (hc_ctx);
+      if (hc_ctx) 
+      {
+        hc_ctx = NULL;
+        myabort (hc_ctx);
+      }
 
-      SetConsoleCtrlHandler (NULL, TRUE);
+      // SetConsoleCtrlHandler (NULL, TRUE);
 
       sleep (10);
 
@@ -38,9 +42,13 @@ BOOL WINAPI sigHandler_default (DWORD sig)
     case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
 
-      myabort (hc_ctx);
+      if (hc_ctx) 
+      {
+        hc_ctx = NULL;
+        myabort (hc_ctx);
+      }
 
-      SetConsoleCtrlHandler (NULL, TRUE);
+      // SetConsoleCtrlHandler (NULL, TRUE);
 
       return TRUE;
   }
@@ -54,9 +62,13 @@ BOOL WINAPI sigHandler_benchmark (DWORD sig)
   {
     case CTRL_CLOSE_EVENT:
 
-      myquit (hc_ctx);
+      if (hc_ctx) 
+      {
+        hc_ctx = NULL;
+        myquit (hc_ctx);
+      }
 
-      SetConsoleCtrlHandler (NULL, TRUE);
+      // SetConsoleCtrlHandler (NULL, TRUE);
 
       sleep (10);
 
@@ -66,9 +78,13 @@ BOOL WINAPI sigHandler_benchmark (DWORD sig)
     case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
 
-      myquit (hc_ctx);
+      if (hc_ctx) 
+      {
+        hc_ctx = NULL;
+        myquit (hc_ctx);
+      }
 
-      SetConsoleCtrlHandler (NULL, TRUE);
+      // SetConsoleCtrlHandler (NULL, TRUE);
 
       return TRUE;
   }


### PR DESCRIPTION
Implemented graceful exiting on SIGINT using already existing code and a newly added global variable holding a pointer to the hashcat context which is need for the signal handlers to be able to call the myquit and myabort functions.