### PR TITLE
Bcrypt tuning

### DIFF
--- a/tunings/Modules_bcrypt.hctune
+++ b/tunings/Modules_bcrypt.hctune
@@ -5,4 +5,4 @@
 DEVICE_TYPE_CPU                                 *       3200    1       N       A
 DEVICE_TYPE_CPU                                 *       25600   1       N       A
 DEVICE_TYPE_CPU                                 *       25800   1       N       A
-
+DEVICE_TYPE_CPU                                 *       30600   1       N       A

--- a/tunings/Modules_bcrypt.hctune
+++ b/tunings/Modules_bcrypt.hctune
@@ -5,4 +5,5 @@
 DEVICE_TYPE_CPU                                 *       3200    1       N       A
 DEVICE_TYPE_CPU                                 *       25600   1       N       A
 DEVICE_TYPE_CPU                                 *       25800   1       N       A
+DEVICE_TYPE_CPU                                 *       28400   1       N       A
 DEVICE_TYPE_CPU                                 *       30600   1       N       A


### PR DESCRIPTION
Add 30600 / bcrypt(sha256($pass)) and 28400 / bcrypt(sha512($pass)) to the bcrypt hctune, with a noticeable speed increase.
bcrypt(sha256):
```
Speed.#3.........:      194 H/s (82.11ms) @ Accel:4 Loops:256 Thr:1 Vec:8
Speed.#3.........:      212 H/s (75.22ms) @ Accel:16 Loops:64 Thr:1 Vec:1
```
bcrypt(sha512):
```
Speed.#3.........:       41 H/s (96.79ms) @ Accel:4 Loops:256 Thr:1 Vec:8
Speed.#3.........:       49 H/s (82.15ms) @ Accel:16 Loops:64 Thr:1 Vec:1
```