### PR TITLE
Wallet const fix

### DIFF
--- a/OpenCL/m25500-pure.cl
+++ b/OpenCL/m25500-pure.cl
@@ -334,7 +334,7 @@ KERNEL_FQ void m25500_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, pbkdf2_sh
 
   // iv
 
-  const u32 iv[4] = {
+  u32 iv[4] = {
     esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0],
     esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1],
     esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2],

--- a/OpenCL/m25500-pure.cl
+++ b/OpenCL/m25500-pure.cl
@@ -334,12 +334,12 @@ KERNEL_FQ void m25500_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, pbkdf2_sh
 
   // iv
 
-  const u32 iv[4];
-
-  iv[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0];
-  iv[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1];
-  iv[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2];
-  iv[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3];
+  const u32 iv[4] = {
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0],
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1],
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2],
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3]
+  };
 
   const u32 iv_len = esalt_bufs[DIGESTS_OFFSET_HOST].iv_len;
 

--- a/OpenCL/m25500-pure.cl
+++ b/OpenCL/m25500-pure.cl
@@ -334,12 +334,12 @@ KERNEL_FQ void m25500_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, pbkdf2_sh
 
   // iv
 
-  u32 iv[4] = {
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3]
-  };
+  u32 iv[4];
+
+  iv[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0];
+  iv[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1];
+  iv[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2];
+  iv[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3];
 
   const u32 iv_len = esalt_bufs[DIGESTS_OFFSET_HOST].iv_len;
 

--- a/OpenCL/m26600-pure.cl
+++ b/OpenCL/m26600-pure.cl
@@ -334,12 +334,12 @@ KERNEL_FQ void m26600_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, pbkdf2_sh
 
   // iv
 
-  const u32 iv[4] = {
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2],
-    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3]
-  };
+  u32 iv[4];
+
+  iv[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0];
+  iv[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1];
+  iv[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2];
+  iv[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3];
 
   const u32 iv_len = esalt_bufs[DIGESTS_OFFSET_HOST].iv_len;
 

--- a/OpenCL/m26600-pure.cl
+++ b/OpenCL/m26600-pure.cl
@@ -334,12 +334,12 @@ KERNEL_FQ void m26600_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, pbkdf2_sh
 
   // iv
 
-  const u32 iv[4];
-
-  iv[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0];
-  iv[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1];
-  iv[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2];
-  iv[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3];
+  const u32 iv[4] = {
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0],
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1],
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2],
+    esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3]
+  };
 
   const u32 iv_len = esalt_bufs[DIGESTS_OFFSET_HOST].iv_len;
 


### PR DESCRIPTION
Fix blocking errors with -m 26600 and -m 25500 as `const`s must have a value when initialised, partially reversing changes from [d5a74b2536a32e19cd9e31941c5f735caa57a19c](https://github.com/hashcat/hashcat/commit/d5a74b2536a32e19cd9e31941c5f735caa57a19c)