### PR TITLE
Fixed buffer overflow on m31400_a3-pure.cl / aes256_scrt_format_VV()

### DIFF
--- a/OpenCL/m31400_a3-pure.cl
+++ b/OpenCL/m31400_a3-pure.cl
@@ -135,7 +135,7 @@ DECLSPEC void aes256_scrt_format_VV (PRIVATE_AS u32 *aes_ks, PRIVATE_AS u32x *w,
   #endif
 
   #if VECT_SIZE >= 2
-  u32 tmp_w[16];
+  u32 tmp_w[64];
   u32 tmp_h[8];
   u32 tmp_out[4];
 


### PR DESCRIPTION
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==16232==ERROR: AddressSanitizer: SEGV on unknown address 0x0000000002ac (pc 0x0001111cea3a bp 0x700008c00260 sp 0x700008c00150 T3)
==16232==The signal is caused by a READ memory access.
==16232==Hint: address points to the zero page.
    #0 0x1111cea3a in aes256_scrt_format_VV+0xea (cl_kernels:x86_64+0x3ba3a)

==16232==Register values:
rax = 0x00000000000002ac  rbx = 0x0000000072930c22  rcx = 0x2caba9358c3c92df  rdx = 0x000000002caba935  
rdi = 0x0000000000000000  rsi = 0x00000000e24a750e  rbp = 0x0000700008c00260  rsp = 0x0000700008c00150  
 r8 = 0x000000000a8e1382   r9 = 0x00000001111d46e0  r10 = 0x00000000ff000000  r11 = 0x00000000127e6fbf  
r12 = 0x00000001111d3ae0  r13 = 0x0000700008c00410  r14 = 0x000000008c3c92df  r15 = 0x0000000000d30000  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (cl_kernels:x86_64+0x3ba3a) in aes256_scrt_format_VV+0xea
Thread T3 created by T2 here:
    <empty stack>

Thread T2 created by T0 here:
    <empty stack>

==16232==ABORTING
Abort trap: 6
```