### PR TITLE
Add sanity check for --brain-port, fix errors

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -42,6 +42,7 @@
 - Fixed debug mode 5 by adding the missing colon between original-word and finding-rule
 - Skip generated rule that was the result of chaining rule operation and caused this generated rule to exceed the maximum number of function calls
 - Fixed incorrect plaintext check for 25400 and 26610. Increased plaintext check to 32 bytes to prevent false positives.
+- Fixed bug in --stdout that caused certain rules to malfunction
 
 ##
 ## Technical

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -52,6 +52,7 @@
 - Apple Driver: Automatically enable GPU support on Apple OpenCL instead of CPU support
 - Apple Driver: Updated requirements to use Apple OpenCL API to macOS 13.0 - use
 - Backend Checks: Described workaround in error message when detecting more than 64 backend devices
+- Brain: Added sanity check and corresponding error message for invalid --brain-port values
 - Modules: Added support for non-zero IVs for -m 6800 (Lastpass). Also added `tools/lastpass2hashcat.py`
 - Status Code: Add specific return code for self-test fail (-11)
 - SCRYPT: Increase buffer sizes in module for hash mode 8900 to allow longer SCRYPT digests

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -559,24 +559,31 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     return -1;
   }
 
-  #ifdef WITH_BRAIN
+#ifdef WITH_BRAIN
   if ((user_options->brain_client == true) && (user_options->brain_server == true))
   {
-    event_log_error (hashcat_ctx, "Can not have --brain-client and --brain-server at the same time");
+    event_log_error (hashcat_ctx, "Can not have --brain-client and --brain-server at the same time.");
 
     return -1;
   }
 
   if ((user_options->brain_client_features < 1) || (user_options->brain_client_features > 3))
   {
-    event_log_error (hashcat_ctx, "Invalid --brain-client-feature argument");
+    event_log_error (hashcat_ctx, "Invalid --brain-client-feature argument.");
 
     return -1;
   }
+  
+  if (user_options->brain_port > 65535)
+  {
+    event_log_error (hashcat_ctx, "Invalid brain port specified (greater than 65535).");
 
+    return -1;
+  }
+  
   if ((user_options->brain_client == true) && (user_options->brain_password_chgd == false))
   {
-    event_log_error (hashcat_ctx, "Brain clients need to set --brain-password");
+    event_log_error (hashcat_ctx, "Brain clients must specify --brain-password.");
 
     return -1;
   }


### PR DESCRIPTION
Added a sanity check for --brain-port for ports that are greater than 65535. Updated error messages and updated docs/changes.txt