### PR TITLE
Add error message when mixing --show and --username

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -55,6 +55,7 @@
 - Status Code: Add specific return code for self-test fail (-11)
 - SCRYPT: Increase buffer sizes in module for hash mode 8900 to allow longer SCRYPT digests
 - Unicode: Update UTF8 to UTF16 conversion to match RFC 3629
+- User Options: Added error message when mixing --username and --show to warn users of exponential delay 
 
 * changes v6.2.5 -> v6.2.6
 

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1002,7 +1002,7 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
 
   if ((user_options->show == true) && (user_options->username == true))
   {
-    event_log_advice (hashcat_ctx, "Mixing --show with --username can cause exponential delay in output.");
+    event_log_error (hashcat_ctx, "Mixing --show with --username can cause exponential delay in output.");
     
     return 0;
   }

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1007,7 +1007,7 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     return 0;
   }
 
-  if (user_options->show == true || user_options->left == true)
+  if ((user_options->show == true || user_options->left == true))
   {
     if (user_options->remove == true)
     {

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1000,6 +1000,13 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
+  if (user_options->show == true) && (user_options->username == true)
+  {
+    event_log_advice (hashcat_ctx, "Mixing --show with --username can cause exponential delay in output.");
+    
+    return 0;
+  }
+
   if (user_options->show == true || user_options->left == true)
   {
     if (user_options->remove == true)

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1000,14 +1000,14 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
-  if (user_options->show == true) && (user_options->username == true)
+  if ((user_options->show == true) && (user_options->username == true))
   {
     event_log_advice (hashcat_ctx, "Mixing --show with --username can cause exponential delay in output.");
     
     return 0;
   }
 
-  if ((user_options->show == true || user_options->left == true))
+  if (user_options->show == true || user_options->left == true)
   {
     if (user_options->remove == true)
     {


### PR DESCRIPTION
Mixing --show and --username can cause an exponential delay in output, added an error message to warn users who may not wish to wait. Message is log level ERROR to avoid polluting files that the user wishes to send the cracks to.