### PR TITLE
Fixed minimum password length in module of hash-mode 28200

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -56,6 +56,7 @@
 - Fixed display problem of the "Optimizers applied" list for algorithms using OPTI_TYPE_SLOW_HASH_SIMD_INIT2 and/or OPTI_TYPE_SLOW_HASH_SIMD_LOOP2
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 31700 a3 kernel
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 3730 a3 kernel
+- Fixed minimum password length in module of hash-mode 28200
 - Handle signed/unsigned PDF permission P value for all PDF hash-modes
 
 ##

--- a/tools/test_modules/m28200.pm
+++ b/tools/test_modules/m28200.pm
@@ -12,7 +12,7 @@ use Crypt::AuthEnc::GCM;
 use Crypt::ScryptKDF qw (scrypt_raw);
 use MIME::Base64     qw (decode_base64 encode_base64);
 
-sub module_constraints { [[0, 256], [64, 64], [-1, -1], [-1, -1], [-1, -1]] }
+sub module_constraints { [[4, 256], [64, 64], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
test errors for 28200

```
$ ./tools/test.sh -m 28200 -t single -V1 
[ test_1682182272 ] > Init test for hash type 28200.
[ test_1682182272 ] [ Type 28200, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > Error : 1/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

after patching

```
$ ./tools/test.sh -m 28200 -t single -V1 
[ test_1682182366 ] > Init test for hash type 28200.
[ test_1682182366 ] [ Type 28200, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```