### PR TITLE
Fixed build failed for 31700 with Apple Metal

### DIFF
--- a/OpenCL/m31700_a0-pure.cl
+++ b/OpenCL/m31700_a0-pure.cl
@@ -38,7 +38,7 @@ typedef struct md5_double_salt
 
 } md5_double_salt_t;
 
-KERNEL_FQ void m31700_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
+KERNEL_FQ void m31700_mxx (KERN_ATTR_RULES_ESALT (md5_double_salt_t))
 {
   /**
    * modifier
@@ -180,7 +180,7 @@ KERNEL_FQ void m31700_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
   }
 }
 
-KERNEL_FQ void m31700_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
+KERNEL_FQ void m31700_sxx (KERN_ATTR_RULES_ESALT (md5_double_salt_t))
 {
   /**
    * modifier

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -55,6 +55,7 @@
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
 - Fixed build failed for 18400 with Apple Metal
 - Fixed build failed for 18600 with Apple Metal
+- Fixed build failed for 31700 with Apple Metal
 - Fixed display problem of the "Optimizers applied" list for algorithms using OPTI_TYPE_SLOW_HASH_SIMD_INIT2 and/or OPTI_TYPE_SLOW_HASH_SIMD_LOOP2
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 31700 a3 kernel
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 3730 a3 kernel


### PR DESCRIPTION
31700_a0 build errors:

```
$ echo  | ./hashcat --potfile-disable --quiet --hwmon-disable --self-test-disable --machine-readable --logfile-disable --force -d1 --runtime 30 -m 31700 '68bc8c37563e0c50f747d56c53ba3254::49213918970344075499642885131966796498336877968529921024191506610891930672767715855885762086766947362563135318302786480383329253299874231184047008001415005830' -a 0
hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:103:18: error: no matching function for call to 'apply_rules'
    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
                 ^~~~~~~~~~~
[...]/OpenCL/inc_rp.cl:797:14: note: candidate function not viable: no known conversion from 'u32 const device[32]' to 'const constant u32 *' (aka 'const constant unsigned int *') for 1st argument
DECLSPEC int apply_rules (CONSTANT_AS const u32 *cmds, PRIVATE_AS u32 *buf, const int in_len)
             ^
program_source:257:18: error: no matching function for call to 'apply_rules'
    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
                 ^~~~~~~~~~~
[...]/OpenCL/inc_rp.cl:797:14: note: candidate function not viable: no known conversion from 'u32 const device[32]' to 'const constant u32 *' (aka 'const constant unsigned int *') for 1st argument
DECLSPEC int apply_rules (CONSTANT_AS const u32 *cmds, PRIVATE_AS u32 *buf, const int in_len)
             ^


* Device #1: Kernel [...]/OpenCL/m31700_a0-pure.cl build failed.
```
