### PR TITLE
Fix 31900 hash parsing error

### DIFF
--- a/src/modules/module_31900.c
+++ b/src/modules/module_31900.c
@@ -131,6 +131,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  memset (&token, 0, sizeof (hc_token_t));
+
   token.token_cnt  = 4;
 
   token.signatures_cnt    = 1;
@@ -141,21 +143,18 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_SIGNATURE;
 
   token.sep[1]     = '$';
-  token.len_min[1] = 24;
-  token.len_max[1] = 24;
-  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+  token.len[1]     = 24;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_BASE64A;
 
   token.sep[2]     = '$';
-  token.len_min[2] = 32;
-  token.len_max[2] = 32;
-  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+  token.len[2]     = 32;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
   token.sep[3]     = '$';
-  token.len_min[3] = 24;
-  token.len_max[3] = 24;
-  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+  token.len[3]     = 24;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_BASE64A;
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);


### PR DESCRIPTION
due to missing memset ...

```
$ ./hashcat -m 31900 '$metamaskMobile$NDgzNDYzNjkyMTkwMzY4NQ==$eb4ce9427d0ae89fdcd0f88a0be05309$8P/wQdD3KyOqwphMRUT6fg==' --force
hashcat (v6.2.6-470-gf847593a6+) starting

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

The device #1 has been disabled as it most likely also exists as an OpenCL device, but it is not possible to automatically map it.
You can use -d 1 to use Metal API instead of OpenCL API. In some rare cases this is more stable.

METAL API (Metal 263.8)
=======================
* Device #1: Apple M1, skipped

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, GPU, 960/10922 MB (1024 MB allocatable), 8MCU

Minimum password length supported by kernel: 8
Maximum password length supported by kernel: 256

Hash '$metamaskMobile$NDgzNDYzNjkyMTkwMzY4NQ==$eb4ce9427d0ae89fdcd0f88a0be05309$8P/wQdD3KyOqwphMRUT6fg==': Separator unmatched
No hashes loaded.
```