### PR TITLE
Fixed bug in 29600 module OPTS_TYPE setting

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -54,6 +54,7 @@
 - Fixed bug in --stdout that caused certain rules to malfunction
 - Fixed bug in 18400 module_hash_encode
 - Fixed bug in 26900 module_hash_encode
+- Fixed bug in 29600 module OPTS_TYPE setting
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
 - Fixed build failed for 18400 with Apple Metal

--- a/src/modules/module_29600.c
+++ b/src/modules/module_29600.c
@@ -22,8 +22,7 @@ static const char *HASH_NAME      = "Terra Station Wallet (AES256-CBC(PBKDF2($pa
 static const u64   KERN_TYPE      = 29600;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
-                                  | OPTS_TYPE_ST_HEX
-                                  | OPTS_TYPE_PT_GENERATE_BE;
+                                  | OPTS_TYPE_ST_HEX;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "67445496c838e96c1424a8dae4b146f0fc247c8c34ef33feffeb1e4412018512wZGtBMeN84XZE2LoOKwTGvA4Ee4m7PR1lDGIdWUV6OSUZKRiKFx9tlrnZLt8r8OfOzbwUS2a2Uo+nrrP6F85fh4eHstwPJw0KwzHWB8br58=";


### PR DESCRIPTION
By removing OPTS_TYPE_PT_GENERATE_BE from OPTS_TYPE, it was possible to make the a3 attacks work.

Before the patch

```
bash-3.2$ ./hashcat --potfile-disable --hwmon-disable --self-test-disable --logfile-disable --runtime 270 --force -d1 -m 29600 '343832333433353338363339373431353eb61032fc998e4b03fab2b99eb17a7ck9L+orQRYO5N40MSJLu+bY5MxYO6ObtuJAePj8vNAJdjTOjkJiV1PmAzEZeYm5f1uohzDsz34bGs8MP3e2Yvk1jP+8jJ6oHsWh/uISx1aog=' -a3 ?d?d --quiet
bash-3.2$ echo $?
1
```

After the patch
```
bash-3.2$ ./hashcat --potfile-disable --hwmon-disable --self-test-disable --logfile-disable --runtime 270 --force -d1 -m 29600 '343832333433353338363339373431353eb61032fc998e4b03fab2b99eb17a7ck9L+orQRYO5N40MSJLu+bY5MxYO6ObtuJAePj8vNAJdjTOjkJiV1PmAzEZeYm5f1uohzDsz34bGs8MP3e2Yvk1jP+8jJ6oHsWh/uISx1aog=' -a3 ?d?d --quiet
343832333433353338363339373431353eb61032fc998e4b03fab2b99eb17a7ck9L+orQRYO5N40MSJLu+bY5MxYO6ObtuJAePj8vNAJdjTOjkJiV1PmAzEZeYm5f1uohzDsz34bGs8MP3e2Yvk1jP+8jJ6oHsWh/uISx1aog=:78
bash-3.2$ echo $?
0
```