### PR TITLE
Fixed build failed for 4410 with vector width > 1

### DIFF
--- a/OpenCL/m04410_a0-optimized.cl
+++ b/OpenCL/m04410_a0-optimized.cl
@@ -641,10 +641,10 @@ KERNEL_FQ void m04410_m04 (KERN_ATTR_RULES ())
     MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
     MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
 
-    a += digest[0] - MD5M_A;
-    b += digest[1] - MD5M_B;
-    c += digest[2] - MD5M_C;
-    d += digest[3] - MD5M_D;
+    a += digest[0] - make_u32x (MD5M_A);
+    b += digest[1] - make_u32x (MD5M_B);
+    c += digest[2] - make_u32x (MD5M_C);
+    d += digest[3] - make_u32x (MD5M_D);
 
     COMPARE_M_SIMD (a, d, c, b);
   }
@@ -1285,10 +1285,10 @@ KERNEL_FQ void m04410_s04 (KERN_ATTR_RULES ())
     MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
     MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
 
-    a += digest[0] - MD5M_A;
-    b += digest[1] - MD5M_B;
-    c += digest[2] - MD5M_C;
-    d += digest[3] - MD5M_D;
+    a += digest[0] - make_u32x (MD5M_A);
+    b += digest[1] - make_u32x (MD5M_B);
+    c += digest[2] - make_u32x (MD5M_C);
+    d += digest[3] - make_u32x (MD5M_D);
 
     COMPARE_S_SIMD (a, d, c, b);
   }

--- a/OpenCL/m04410_a1-optimized.cl
+++ b/OpenCL/m04410_a1-optimized.cl
@@ -697,10 +697,10 @@ KERNEL_FQ void m04410_m04 (KERN_ATTR_BASIC ())
     MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
     MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
 
-    a += digest[0] - MD5M_A;
-    b += digest[1] - MD5M_B;
-    c += digest[2] - MD5M_C;
-    d += digest[3] - MD5M_D;
+    a += digest[0] - make_u32x (MD5M_A);
+    b += digest[1] - make_u32x (MD5M_B);
+    c += digest[2] - make_u32x (MD5M_C);
+    d += digest[3] - make_u32x (MD5M_D);
 
     COMPARE_M_SIMD (a, d, c, b);
   }
@@ -1399,10 +1399,10 @@ KERNEL_FQ void m04410_s04 (KERN_ATTR_BASIC ())
     MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
     MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
 
-    a += digest[0] - MD5M_A;
-    b += digest[1] - MD5M_B;
-    c += digest[2] - MD5M_C;
-    d += digest[3] - MD5M_D;
+    a += digest[0] - make_u32x (MD5M_A);
+    b += digest[1] - make_u32x (MD5M_B);
+    c += digest[2] - make_u32x (MD5M_C);
+    d += digest[3] - make_u32x (MD5M_D);
 
     COMPARE_S_SIMD (a, d, c, b);
   }

--- a/OpenCL/m04410_a3-optimized.cl
+++ b/OpenCL/m04410_a3-optimized.cl
@@ -595,10 +595,10 @@ DECLSPEC void m04410m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
     MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
 
-    a += digest[0] - MD5M_A;
-    b += digest[1] - MD5M_B;
-    c += digest[2] - MD5M_C;
-    d += digest[3] - MD5M_D;
+    a += digest[0] - make_u32x (MD5M_A);
+    b += digest[1] - make_u32x (MD5M_B);
+    c += digest[2] - make_u32x (MD5M_C);
+    d += digest[3] - make_u32x (MD5M_D);
 
     COMPARE_M_SIMD (a, d, c, b);
   }
@@ -1187,10 +1187,10 @@ DECLSPEC void m04410s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     MD5_STEP (MD5_I , c, d, a, b, w2_t, MD5C3e, MD5S32);
     MD5_STEP (MD5_I , b, c, d, a, w9_t, MD5C3f, MD5S33);
 
-    a += digest[0] - MD5M_A;
-    b += digest[1] - MD5M_B;
-    c += digest[2] - MD5M_C;
-    d += digest[3] - MD5M_D;
+    a += digest[0] - make_u32x (MD5M_A);
+    b += digest[1] - make_u32x (MD5M_B);
+    c += digest[2] - make_u32x (MD5M_C);
+    d += digest[3] - make_u32x (MD5M_D);
 
     COMPARE_S_SIMD (a, d, c, b);
   }

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -56,6 +56,7 @@
 - Fixed bug in 26900 module_hash_encode
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
+- Fixed build failed for 4410 with vector width > 1
 - Fixed build failed for 18400 with Apple Metal
 - Fixed build failed for 18600 with Apple Metal
 - Fixed build failed for 31700 with Apple Metal


### PR DESCRIPTION
Example with a0 and vector width 2

```
$ echo  | ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable -d 1 --runtime 270 --force -O --backend-vector-width 2 -m 4410 '0144712dd81be0c3d9724f5e56ce6685:' -a 0
hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:644:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    a += digest[0] - MD5M_A;
         ~~~~~~~~~ ^ ~~~~~~
program_source:645:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    b += digest[1] - MD5M_B;
         ~~~~~~~~~ ^ ~~~~~~
program_source:646:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    c += digest[2] - MD5M_C;
         ~~~~~~~~~ ^ ~~~~~~
program_source:647:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    d += digest[3] - MD5M_D;
         ~~~~~~~~~ ^ ~~~~~~
program_source:1288:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    a += digest[0] - MD5M_A;
         ~~~~~~~~~ ^ ~~~~~~
program_source:1289:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    b += digest[1] - MD5M_B;
         ~~~~~~~~~ ^ ~~~~~~
program_source:1290:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    c += digest[2] - MD5M_C;
         ~~~~~~~~~ ^ ~~~~~~
program_source:1291:20: error: cannot convert between vector values of different size ('u32x' (aka 'uint2') and 'md5_constants')
    d += digest[3] - MD5M_D;
         ~~~~~~~~~ ^ ~~~~~~


* Device #1: Kernel [...]/OpenCL/m04410_a0-optimized.cl build failed.
```

same errors with a1, a3, a6, a7

