### PR TITLE
Fixed build failed for 31000/Blake2s with vector width > 1

### DIFF
--- a/OpenCL/inc_hash_blake2s.cl
+++ b/OpenCL/inc_hash_blake2s.cl
@@ -447,7 +447,7 @@ DECLSPEC void blake2s_transform_vector (PRIVATE_AS u32x *h, PRIVATE_AS const u32
   v[ 9] = BLAKE2S_IV_01;
   v[10] = BLAKE2S_IV_02;
   v[11] = BLAKE2S_IV_03;
-  v[12] = BLAKE2S_IV_04 ^ t0;
+  v[12] = make_u32x (BLAKE2S_IV_04) ^ t0;
   v[13] = BLAKE2S_IV_05; // ^ t1;
   v[14] = BLAKE2S_IV_06 ^ f0;
   v[15] = BLAKE2S_IV_07; // ^ f1;

--- a/OpenCL/m31000_a0-optimized.cl
+++ b/OpenCL/m31000_a0-optimized.cl
@@ -48,8 +48,6 @@ KERNEL_FQ void m31000_m04 (KERN_ATTR_RULES ())
   {
     u32x w0[4] = { 0 };
     u32x w1[4] = { 0 };
-    u32x w2[4] = { 0 };
-    u32x w3[4] = { 0 };
 
     const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -59,6 +59,7 @@
 - Fixed build failed for 18400 with Apple Metal
 - Fixed build failed for 18600 with Apple Metal
 - Fixed build failed for 31700 with Apple Metal
+- Fixed build failed for 31000/Blake2s with vector width > 1
 - Fixed display problem of the "Optimizers applied" list for algorithms using OPTI_TYPE_SLOW_HASH_SIMD_INIT2 and/or OPTI_TYPE_SLOW_HASH_SIMD_LOOP2
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 31700 a3 kernel
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 3730 a3 kernel


### PR DESCRIPTION
```
$ echo  | ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable -d 1 --runtime 270 --force -O --backend-vector-width 2 -m 31000 '$BLAKE2$69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9' -a 0
hc_mtlCreateLibraryWithSource(): failed to create metal library, In file included from program_source:16:
[...]/OpenCL/inc_hash_blake2s.cl:450:25: error: cannot convert between vector values of different size ('blake2s_constants' and 'u32x' (aka 'uint2'))
  v[12] = BLAKE2S_IV_04 ^ t0;
          ~~~~~~~~~~~~~ ^ ~~
program_source:51:10: warning: unused variable 'w2'
    u32x w2[4] = { 0 };
         ^
program_source:52:10: warning: unused variable 'w3'
    u32x w3[4] = { 0 };
         ^


* Device #1: Kernel [...]/OpenCL/m31000_a0-optimized.cl build failed.
```