### PR TITLE
Hardware Monitor: avoid sprintf in src/ext_iokit.c

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -86,6 +86,7 @@
 - SecureCRT MasterPassphrase v2: update module, pure kernels and test unit. Add optimized kernels.
 - Metal Backend: added workaround to prevent 'Infinite Loop' bug when build kernels
 - User Options: added --metal-compiler-runtime option
+- Hardware Monitor: avoid sprintf in src/ext_iokit.c
 
 * changes v6.2.5 -> v6.2.6
 

--- a/src/ext_iokit.c
+++ b/src/ext_iokit.c
@@ -37,7 +37,7 @@ void hm_IOKIT_ultostr (char *str, UInt32 val)
 {
   str[0] = '\0';
 
-  sprintf (str, "%c%c%c%c", (unsigned int) (val >> 24), (unsigned int) (val >> 16), (unsigned int) (val >> 8), (unsigned int) (val));
+  snprintf (str, 5, "%c%c%c%c", (unsigned int) (val >> 24), (unsigned int) (val >> 16), (unsigned int) (val >> 8), (unsigned int) (val));
 }
 
 kern_return_t hm_IOKIT_SMCOpen (void *hashcat_ctx, io_connect_t *conn)
@@ -301,6 +301,9 @@ int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf)
 
     if (totalFans <= 0) return -1;
 
+    // limit totalFans to 10
+    if (totalFans > 10) totalFans = 10;
+
     char tmp_buf[16];
 
     for (int i = 0; i < totalFans; i++)
@@ -310,12 +313,12 @@ int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf)
       float maximum_speed = 0.0f;
 
       memset (&key, 0, sizeof (UInt32Char_t));
-      sprintf (key, "F%dAc", i);
+      snprintf (key, 5, "F%dAc", i);
       hm_IOKIT_SMCGetFanRPM (key, iokit->conn, &actual_speed);
       if (actual_speed < 0.f) continue;
 
       memset (&key, 0, sizeof (UInt32Char_t));
-      sprintf (key, "F%dMx", i);
+      snprintf (key, 5, "F%dMx", i);
       hm_IOKIT_SMCGetFanRPM (key, iokit->conn, &maximum_speed);
       if (maximum_speed < 0.f) continue;
 


### PR DESCRIPTION
build warnings with clang and DEBUG=2

```
clang -c -std=gnu99 -W -Wall -Wextra -Wno-typedef-redefinition -DDEBUG -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -DWITH_HWMON -arch arm64 -arch x86_64 src/folder.c -o obj/folder.NATIVE.o -fpic
src/ext_iokit.c:40:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  sprintf (str, "%c%c%c%c", (unsigned int) (val >> 24), (unsigned int) (val >> 16), (unsigned int) (val >> 8), (unsigned int) (val));
  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
src/ext_iokit.c:313:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
      sprintf (key, "F%dAc", i);
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
src/ext_iokit.c:318:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
      sprintf (key, "F%dMx", i);
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
3 warnings generated.
clang -c -std=gnu99 -W -Wall -Wextra -Wno-typedef-redefinition -DDEBUG -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -DWITH_HWMON -arch arm64 -arch x86_64 src/hashcat.c -o obj/hashcat.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-typedef-redefinition -DDEBUG -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -DWITH_HWMON -arch arm64 -arch x86_64 src/hashes.c -o obj/hashes.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-typedef-redefinition -DDEBUG -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -DWITH_HWMON -arch arm64 -arch x86_64 src/hlfmt.c -o obj/hlfmt.NATIVE.o -fpic
clang -c -std=gnu99 -W -Wall -Wextra -Wno-typedef-redefinition -DDEBUG -O0 -ggdb -fsanitize=address -fno-omit-frame-pointer -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -DWITH_HWMON -arch arm64 -arch x86_64 src/hwmon.c -o obj/hwmon.NATIVE.o -fpic
src/ext_iokit.c:40:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  sprintf (str, "%c%c%c%c", (unsigned int) (val >> 24), (unsigned int) (val >> 16), (unsigned int) (val >> 8), (unsigned int) (val));
  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
src/ext_iokit.c:313:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
      sprintf (key, "F%dAc", i);
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
src/ext_iokit.c:318:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
      sprintf (key, "F%dMx", i);
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
3 warnings generated.
```
