### PR TITLE
Added verification of token buffer length when using TOKEN_ATTR_FIXED_LENGTH

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -58,6 +58,7 @@
 - Fixed bug in 29600 module OPTS_TYPE setting
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
+- Added verification of token buffer length when using TOKEN_ATTR_FIXED_LENGTH
 - Fixed build failed for 4410 with vector width > 1
 - Fixed build failed for 18400 with Apple Metal
 - Fixed build failed for 18600 with Apple Metal

--- a/src/shared.c
+++ b/src/shared.c
@@ -1190,6 +1190,11 @@ int input_tokenizer (const u8 *input_buf, const int input_len, hc_token_t *token
 
       const int len = next_pos - token->buf[token_idx];
 
+      if (token->attr[token_idx] & TOKEN_ATTR_FIXED_LENGTH)
+      {
+        if (len != token->len[token_idx]) return (PARSER_TOKEN_LENGTH);
+      }
+
       token->len[token_idx] = len;
 
       token->buf[token_idx + 1] = next_pos + 1; // +1 = separator


### PR DESCRIPTION
Hi,

this patch continue the work done with #3683 

If we use TOKEN_ATTR_FIXED_LENGTH instead of TOKEN_ATTR_VERIFY_LENGTH, the token len will be not verified ... this is bad.

Following an example with metamask mobile using a wrong formatted hash. The expected output should be an error, but it is not :)


```
$ ./hashcat '$metamaskMobile$MjU1NTA5MTU2ODY5MjY4OQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==$3cccb51c401e54abc82987fd9310a8d3$WQhIECN0blOaV31RC3lKfQ==' --force -d1
hashcat (v6.2.6-520-g18639745e) starting in autodetect mode

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

METAL API (Metal 263.8)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Hash-mode was not specified with -m. Attempting to auto-detect hash mode.
The following mode was auto-detected as the only one matching your input hash:

31900 | MetaMask Mobile Wallet | Cryptocurrency Wallet

NOTE: Auto-detect is best effort. The correct hash-mode is NOT guaranteed!
Do NOT report auto-detect issues unless you are certain of the hash type.

Minimum password length supported by kernel: 8
Maximum password length supported by kernel: 256

Hashes: 1 digests; 1 unique digests, 1 unique salts
Bitmaps: 16 bits, 65536 entries, 0x0000ffff mask, 262144 bytes, 5/13 rotates
Rules: 1

Optimizers applied:
* Zero-Byte
* Single-Hash
* Single-Salt
* Slow-Hash-SIMD-LOOP

Watchdog: Temperature abort trigger set to 100c

Host memory required for this attack: 140 MB

Starting attack in stdin mode
```

After patching the new output is correct

```
$ ./hashcat '$metamaskMobile$MjU1NTA5MTU2ODY5MjY4OQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==$3cccb51c401e54abc82987fd9310a8d3$WQhIECN0blOaV31RC3lKfQ==' --force -d1 -m 31900
hashcat (v6.2.6-520-g18639745e+) starting

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

METAL API (Metal 263.8)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Minimum password length supported by kernel: 8
Maximum password length supported by kernel: 256

Hash '$metamaskMobile$MjU1NTA5MTU2ODY5MjY4OQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==$3cccb51c401e54abc82987fd9310a8d3$WQhIECN0blOaV31RC3lKfQ==': Token length exception

* Token length exception: 1/1 hashes
  This error happens if the wrong hash type is specified, if the hashes are
  malformed, or if input is otherwise not as expected (for example, if the
  --username option is used but no username is present)

No hashes loaded.
```

Thanks ;)