### PR TITLE
added missing memset for token2 in module_hash_decode(), module_00501.c

### DIFF
--- a/src/modules/module_00501.c
+++ b/src/modules/module_00501.c
@@ -273,6 +273,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token2;
 
+  memset (&token2, 0, sizeof (hc_token_t));
+
   token2.token_cnt  = 3;
 
   token2.signatures_cnt    = 1;
@@ -286,6 +288,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token2.len[1]     = 8;
   token2.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
 
+  token2.sep[2]     = '$';
   token2.len[2]     = 22;
   token2.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
                     | TOKEN_ATTR_VERIFY_BASE64B;


### PR DESCRIPTION
After merging #3726 the module 501 will produce the following error. 

```
$ ./hashcat -m 501 -b --force -d1
hashcat (v6.2.6-520-g18639745e+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

METAL API (Metal 263.8)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Benchmark relevant options:
===========================
* --force
* --backend-devices=1
* --backend-devices-virtual=1
* --optimized-kernel-enable

Self-test hash parsing error: Separator unmatched
```

From the tests I did it should be the only one, excluding some hash-modes not compatible on Metal (ex: 1800, 10700, etc.)
