### PR TITLE
Added plugins for AES128 and AES256 AS-REPs

### DIFF
--- a/OpenCL/m33100-pure.cl
+++ b/OpenCL/m33100-pure.cl
@@ -1,0 +1,1038 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+typedef struct krb5asrep_17
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+  u32 format;
+
+} krb5asrep_17_t;
+
+typedef struct krb5asrep_17_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[10];
+  u32 out[10];
+
+} krb5asrep_17_tmp_t;
+
+DECLSPEC void aes128_encrypt_cbc (PRIVATE_AS const u32 *aes_ks, PRIVATE_AS u32 *aes_iv, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 data[4];
+
+  data[0] = hc_swap32_S (in[0]);
+  data[1] = hc_swap32_S (in[1]);
+  data[2] = hc_swap32_S (in[2]);
+  data[3] = hc_swap32_S (in[3]);
+
+  data[0] ^= aes_iv[0];
+  data[1] ^= aes_iv[1];
+  data[2] ^= aes_iv[2];
+  data[3] ^= aes_iv[3];
+
+  aes128_encrypt (aes_ks, data, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  aes_iv[0] = out[0];
+  aes_iv[1] = out[1];
+  aes_iv[2] = out[2];
+  aes_iv[3] = out[3];
+
+  out[0] = hc_swap32_S (out[0]);
+  out[1] = hc_swap32_S (out[1]);
+  out[2] = hc_swap32_S (out[2]);
+  out[3] = hc_swap32_S (out[3]);
+}
+
+DECLSPEC void aes128_decrypt_cbc (PRIVATE_AS const u32 *ks1, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, PRIVATE_AS u32 *essiv, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4)
+{
+  aes128_decrypt (ks1, in, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  out[0] ^= essiv[0];
+  out[1] ^= essiv[1];
+  out[2] ^= essiv[2];
+  out[3] ^= essiv[3];
+
+  essiv[0] = in[0];
+  essiv[1] = in[1];
+  essiv[2] = in[2];
+  essiv[3] = in[3];
+}
+
+DECLSPEC void hmac_sha1_run_V (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad, PRIVATE_AS u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = 0x80000000;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 20) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+}
+
+KERNEL_FQ void m33100_init (KERN_ATTR_TMPS_ESALT (krb5asrep_17_tmp_t, krb5asrep_17_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * main
+   */
+
+  /* initialize hmac-sha1 for pbkdf2(password, account, 4096, account_len) */
+
+  sha1_hmac_ctx_t sha1_hmac_ctx;
+
+  sha1_hmac_init_global_swap (&sha1_hmac_ctx, pws[gid].i, pws[gid].pw_len);
+
+  tmps[gid].ipad[0] = sha1_hmac_ctx.ipad.h[0];
+  tmps[gid].ipad[1] = sha1_hmac_ctx.ipad.h[1];
+  tmps[gid].ipad[2] = sha1_hmac_ctx.ipad.h[2];
+  tmps[gid].ipad[3] = sha1_hmac_ctx.ipad.h[3];
+  tmps[gid].ipad[4] = sha1_hmac_ctx.ipad.h[4];
+
+  tmps[gid].opad[0] = sha1_hmac_ctx.opad.h[0];
+  tmps[gid].opad[1] = sha1_hmac_ctx.opad.h[1];
+  tmps[gid].opad[2] = sha1_hmac_ctx.opad.h[2];
+  tmps[gid].opad[3] = sha1_hmac_ctx.opad.h[3];
+  tmps[gid].opad[4] = sha1_hmac_ctx.opad.h[4];
+
+  sha1_hmac_update_global_swap (&sha1_hmac_ctx, esalt_bufs[DIGESTS_OFFSET_HOST].account_info, esalt_bufs[DIGESTS_OFFSET_HOST].account_info_len);
+
+ for (u32 i = 0, j = 1; i < 4; i += 5, j += 1)
+  {
+    sha1_hmac_ctx_t sha1_hmac_ctx2 = sha1_hmac_ctx;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = j;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx2, w0, w1, w2, w3, 4);
+
+    sha1_hmac_final (&sha1_hmac_ctx2);
+
+    tmps[gid].dgst[i + 0] = sha1_hmac_ctx2.opad.h[0];
+    tmps[gid].dgst[i + 1] = sha1_hmac_ctx2.opad.h[1];
+    tmps[gid].dgst[i + 2] = sha1_hmac_ctx2.opad.h[2];
+    tmps[gid].dgst[i + 3] = sha1_hmac_ctx2.opad.h[3];
+    tmps[gid].dgst[i + 4] = sha1_hmac_ctx2.opad.h[4];
+
+    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  }
+}
+
+KERNEL_FQ void m33100_loop (KERN_ATTR_TMPS_ESALT (krb5asrep_17_tmp_t, krb5asrep_17_t))
+{
+   /**
+   * base
+   */
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= GID_CNT) return;
+
+  u32x ipad[5];
+  u32x opad[5];
+
+  ipad[0] = packv (tmps, ipad, gid, 0);
+  ipad[1] = packv (tmps, ipad, gid, 1);
+  ipad[2] = packv (tmps, ipad, gid, 2);
+  ipad[3] = packv (tmps, ipad, gid, 3);
+  ipad[4] = packv (tmps, ipad, gid, 4);
+
+  opad[0] = packv (tmps, opad, gid, 0);
+  opad[1] = packv (tmps, opad, gid, 1);
+  opad[2] = packv (tmps, opad, gid, 2);
+  opad[3] = packv (tmps, opad, gid, 3);
+  opad[4] = packv (tmps, opad, gid, 4);
+
+  for (u32 i = 0; i < 4; i += 5)
+  {
+    u32x dgst[5];
+    u32x out[5];
+
+    dgst[0] = packv (tmps, dgst, gid, i + 0);
+    dgst[1] = packv (tmps, dgst, gid, i + 1);
+    dgst[2] = packv (tmps, dgst, gid, i + 2);
+    dgst[3] = packv (tmps, dgst, gid, i + 3);
+    dgst[4] = packv (tmps, dgst, gid, i + 4);
+
+    out[0] = packv (tmps, out, gid, i + 0);
+    out[1] = packv (tmps, out, gid, i + 1);
+    out[2] = packv (tmps, out, gid, i + 2);
+    out[3] = packv (tmps, out, gid, i + 3);
+    out[4] = packv (tmps, out, gid, i + 4);
+
+    for (u32 j = 0; j < LOOP_CNT; j++)
+    {
+      u32x w0[4];
+      u32x w1[4];
+      u32x w2[4];
+      u32x w3[4];
+
+      w0[0] = dgst[0];
+      w0[1] = dgst[1];
+      w0[2] = dgst[2];
+      w0[3] = dgst[3];
+      w1[0] = dgst[4];
+      w1[1] = 0x80000000;
+      w1[2] = 0;
+      w1[3] = 0;
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = (64 + 20) * 8;
+
+      hmac_sha1_run_V (w0, w1, w2, w3, ipad, opad, dgst);
+
+      out[0] ^= dgst[0];
+      out[1] ^= dgst[1];
+      out[2] ^= dgst[2];
+      out[3] ^= dgst[3];
+      out[4] ^= dgst[4];
+    }
+
+    unpackv (tmps, dgst, gid, i + 0, dgst[0]);
+    unpackv (tmps, dgst, gid, i + 1, dgst[1]);
+    unpackv (tmps, dgst, gid, i + 2, dgst[2]);
+    unpackv (tmps, dgst, gid, i + 3, dgst[3]);
+    unpackv (tmps, dgst, gid, i + 4, dgst[4]);
+
+    unpackv (tmps, out, gid, i + 0, out[0]);
+    unpackv (tmps, out, gid, i + 1, out[1]);
+    unpackv (tmps, out, gid, i + 2, out[2]);
+    unpackv (tmps, out, gid, i + 3, out[3]);
+    unpackv (tmps, out, gid, i + 4, out[4]);
+  }
+}
+
+KERNEL_FQ void m33100_comp (KERN_ATTR_TMPS_ESALT (krb5asrep_17_tmp_t, krb5asrep_17_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /*
+    at this point, the output ('seed') will be used to generate AES keys:
+
+    key_bytes = derive(seed, 'kerberos'.encode(), seedsize)
+
+    'key_bytes' will be the AES key used to generate 'ke' and 'ki'
+    'ke' will be the AES key to decrypt the ticket
+    'ki' will be the key to compute the final HMAC
+  */
+
+  u32 nfolded[4];
+
+  // we can precompute _nfold('kerberos', 16)
+  nfolded[0] = 0x6b657262;
+  nfolded[1] = 0x65726f73;
+  nfolded[2] = 0x7b9b5b2b;
+  nfolded[3] = 0x93132b93;
+
+  // then aes_cbc encrypt this nfolded value with 'seed' as key along with a null IV
+  u32 aes_key[4];
+
+  aes_key[0] = hc_swap32_S (tmps[gid].out[0]);
+  aes_key[1] = hc_swap32_S (tmps[gid].out[1]);
+  aes_key[2] = hc_swap32_S (tmps[gid].out[2]);
+  aes_key[3] = hc_swap32_S (tmps[gid].out[3]);
+
+  u32 aes_iv[4];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  u32 aes_ks[44];
+
+  aes128_set_encrypt_key (aes_ks, aes_key, s_te0, s_te1, s_te2, s_te3);
+
+  u32 key_bytes[4];
+
+  aes128_encrypt_cbc (aes_ks, aes_iv, nfolded, key_bytes, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  /*
+    We will now compute 'ki', having 'key_bytes'
+
+    Description of the key derivation function from RFC3961 Section 5.3:
+      The "well-known constant" used for the DK function is the key usage
+      number, expressed as four octets in big-endian order, followed by
+      one octet indicated below.
+        Kc = DK(base-key, usage | 0x99);
+        Ke = DK(base-key, usage | 0xAA);
+        Ki = DK(base-key, usage | 0x55);
+
+    The key usage numbers are defined in RFC4120. In Section 5.4.2, it
+    specifies that a key usage number of 3 is used for the EncASRepPart
+    of an AS-REP message.
+  */
+
+  u32 ki[4];
+
+  key_bytes[0] = hc_swap32_S (key_bytes[0]);
+  key_bytes[1] = hc_swap32_S (key_bytes[1]);
+  key_bytes[2] = hc_swap32_S (key_bytes[2]);
+  key_bytes[3] = hc_swap32_S (key_bytes[3]);
+
+  // we can precompute _nfold(pack('>IB', 3, 0x55), 16)
+  nfolded[0] = 0x6b60b058;
+  nfolded[1] = 0x2a6ba80d;
+  nfolded[2] = 0x5aad56ab;
+  nfolded[3] = 0x55406ad5;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes128_set_encrypt_key (aes_ks, key_bytes, s_te0, s_te1, s_te2, s_te3);
+
+  aes128_encrypt_cbc (aes_ks, aes_iv, nfolded, ki, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  /* we will now compute 'ke' */
+
+  u32 ke[4];
+
+  // we can precompute _nfold(pack('>IB', 3, 0xAA), 16)
+  nfolded[0] = 0xbe349a4d;
+  nfolded[1] = 0x24be500e;
+  nfolded[2] = 0xaf57abd5;
+  nfolded[3] = 0xea80757a;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes128_encrypt_cbc (aes_ks, aes_iv, nfolded, ke, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  /*
+      We now have 'ke' and 'ki'
+
+      We will decrypt (with 'ke') the 32 first bytes to search for ASN.1 structs
+      and if we find ASN.1 structs, we will compute the hmac (with 'ki')
+
+      For AS-REP EncASRepPart:
+      The first byte is 0x79 (01 1 11001, where 01 = "class=APPLICATION", 1 = "form=constructed", 11001 is application type 25)
+      
+      According to RFC4120 Section 5.4.2: "Some implementations unconditionally send an encrypted EncTGSRepPart (application
+      tag number 26) in this field regardless of whether the reply is a AS-REP or a TGS-REP.  In the interest of compatibility,
+      implementors MAY relax the check on the tag number of the decrypted ENC-PART"
+
+      The first byte can thus also be 0x7a (corresponding to application type 26) instead of 0x79
+
+      The next byte is the length:
+
+      if length < 128 bytes:
+          length is on 1 byte, and the next byte is 0x30 (class=SEQUENCE)
+      else if length <= 256:
+          length is on 2 bytes, the first byte is 0x81, and the third byte is 0x30 (class=SEQUENCE)
+      else if length > 256:
+          length is on 3 bytes, the first byte is 0x82, and the fourth byte is 0x30 (class=SEQUENCE)
+  */
+
+  u32 first_blocks[16];
+
+  u32 decrypted_block[4];
+
+  first_blocks[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[0];
+  first_blocks[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[1];
+  first_blocks[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[2];
+  first_blocks[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[3];
+
+  first_blocks[4] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[4]; // possible ASN1 structs
+  first_blocks[5] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[5];
+  first_blocks[6] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[6]; // possible ASN1 structs
+  first_blocks[7] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[7];
+
+  /*
+     we will decrypt them here in order to be able to compute hmac directly
+     if ASN1 structs were to be found
+  */
+  first_blocks[8]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[8];
+  first_blocks[9]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[9];
+  first_blocks[10] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[10];
+  first_blocks[11] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[11];
+
+  first_blocks[12] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[12];
+  first_blocks[13] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[13];
+  first_blocks[14] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[14];
+  first_blocks[15] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[15];
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  u32 aes_cts_decrypt_ks[44];
+
+  AES128_set_decrypt_key (aes_cts_decrypt_ks, ke, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w0[0] = hc_swap32_S (decrypted_block[0]);
+  w0[1] = hc_swap32_S (decrypted_block[1]);
+  w0[2] = hc_swap32_S (decrypted_block[2]);
+  w0[3] = hc_swap32_S (decrypted_block[3]);
+
+  aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w1[0] = hc_swap32_S (decrypted_block[0]);
+  w1[1] = hc_swap32_S (decrypted_block[1]);
+  w1[2] = hc_swap32_S (decrypted_block[2]);
+  w1[3] = hc_swap32_S (decrypted_block[3]);
+
+  if (((decrypted_block[0] & 0x00ff80ff) == 0x00300079) ||
+      ((decrypted_block[0] & 0x00ff80ff) == 0x0030007a) ||
+      ((decrypted_block[0] & 0xFF00FFFF) == 0x30008179) || 
+      ((decrypted_block[0] & 0xFF00FFFF) == 0x3000817a) ||
+      ((decrypted_block[0] & 0x0000FFFF) == 0x00008279 && (decrypted_block[1] & 0x000000FF) == 0x00000030) ||
+      ((decrypted_block[0] & 0x0000FFFF) == 0x0000827a && (decrypted_block[1] & 0x000000FF) == 0x00000030))
+  {
+    // now we decrypt all the ticket to verify checksum
+    int block_position;
+
+    int edata2_len = esalt_bufs[DIGESTS_OFFSET_HOST].edata2_len;
+
+    int edata2_left;
+
+    u32 block[16];
+
+    int last_block_size = edata2_len % 16;
+
+    if (last_block_size == 0)
+    {
+      last_block_size = 16;
+    }
+
+    int last_part = last_block_size + 16;
+
+    int need = edata2_len - last_part;
+
+    int last_block_cbc_position = (need - 16) / 4;
+
+    // we need to decrypt also the 2 following blocks in order to be able to compute the hmac directly
+    aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    w2[0] = hc_swap32_S (decrypted_block[0]);
+    w2[1] = hc_swap32_S (decrypted_block[1]);
+    w2[2] = hc_swap32_S (decrypted_block[2]);
+    w2[3] = hc_swap32_S (decrypted_block[3]);
+
+    aes128_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    w3[0] = hc_swap32_S (decrypted_block[0]);
+    w3[1] = hc_swap32_S (decrypted_block[1]);
+    w3[2] = hc_swap32_S (decrypted_block[2]);
+    w3[3] = hc_swap32_S (decrypted_block[3]);
+
+    sha1_hmac_ctx_t sha1_hmac_ctx;
+
+    /*
+      hmac message = plaintext
+      hmac key = ki
+    */
+
+    u32 k0[4];
+    u32 k1[4];
+    u32 k2[4];
+    u32 k3[4];
+
+    k0[0] = ki[0];
+    k0[1] = ki[1];
+    k0[2] = ki[2];
+    k0[3] = ki[3];
+
+    k1[0] = 0;
+    k1[1] = 0;
+    k1[2] = 0;
+    k1[3] = 0;
+
+    k2[0] = 0;
+    k2[1] = 0;
+    k2[2] = 0;
+    k2[3] = 0;
+
+    k3[0] = 0;
+    k3[1] = 0;
+    k3[2] = 0;
+    k3[3] = 0;
+
+    sha1_hmac_init_64 (&sha1_hmac_ctx, k0, k1, k2, k3);
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+    block_position = 16;
+
+    // first 4 blocks are already decrypted
+    for (edata2_left = need - 64; edata2_left >= 64; edata2_left -= 64)
+    {
+      block[0]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  0];
+      block[1]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  1];
+      block[2]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  2];
+      block[3]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  3];
+      block[4]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  4];
+      block[5]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  5];
+      block[6]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  6];
+      block[7]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  7];
+      block[8]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  8];
+      block[9]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  9];
+      block[10] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 10];
+      block[11] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 11];
+      block[12] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 12];
+      block[13] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 13];
+      block[14] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 14];
+      block[15] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 15];
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w1[0] = hc_swap32_S (decrypted_block[0]);
+      w1[1] = hc_swap32_S (decrypted_block[1]);
+      w1[2] = hc_swap32_S (decrypted_block[2]);
+      w1[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w2[0] = hc_swap32_S (decrypted_block[0]);
+      w2[1] = hc_swap32_S (decrypted_block[1]);
+      w2[2] = hc_swap32_S (decrypted_block[2]);
+      w2[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w3[0] = hc_swap32_S (decrypted_block[0]);
+      w3[1] = hc_swap32_S (decrypted_block[1]);
+      w3[2] = hc_swap32_S (decrypted_block[2]);
+      w3[3] = hc_swap32_S (decrypted_block[3]);
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+      block_position += 16;
+    }
+
+    if (edata2_left == 16)
+    {
+      block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 0];
+      block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 1];
+      block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 2];
+      block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 3];
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      w1[0] = 0;
+      w1[1] = 0;
+      w1[2] = 0;
+      w1[3] = 0;
+
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16);
+
+      block_position += 4;
+    }
+    else if (edata2_left == 32)
+    {
+      block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 0];
+      block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 1];
+      block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 2];
+      block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 3];
+      block[4] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 4];
+      block[5] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 5];
+      block[6] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 6];
+      block[7] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 7];
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w1[0] = hc_swap32_S (decrypted_block[0]);
+      w1[1] = hc_swap32_S (decrypted_block[1]);
+      w1[2] = hc_swap32_S (decrypted_block[2]);
+      w1[3] = hc_swap32_S (decrypted_block[3]);
+
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 32);
+
+      block_position += 8;
+    }
+    else if (edata2_left == 48)
+    {
+      block[0]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  0];
+      block[1]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  1];
+      block[2]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  2];
+      block[3]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  3];
+      block[4]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  4];
+      block[5]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  5];
+      block[6]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  6];
+      block[7]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  7];
+      block[8]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  8];
+      block[9]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  9];
+      block[10] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 10];
+      block[11] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 11];
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w1[0] = hc_swap32_S (decrypted_block[0]);
+      w1[1] = hc_swap32_S (decrypted_block[1]);
+      w1[2] = hc_swap32_S (decrypted_block[2]);
+      w1[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes128_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w2[0] = hc_swap32_S (decrypted_block[0]);
+      w2[1] = hc_swap32_S (decrypted_block[1]);
+      w2[2] = hc_swap32_S (decrypted_block[2]);
+      w2[3] = hc_swap32_S (decrypted_block[3]);
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 48);
+
+      block_position += 12;
+    }
+
+    /*
+      now all the ticket should be decrypted until block n-1 (not included)
+      and n
+    */
+
+    // this is block n-2, it will be xored with the n-1 block later crafted
+    u32 last_block_cbc[4];
+
+    last_block_cbc[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 0];
+    last_block_cbc[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 1];
+    last_block_cbc[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 2];
+    last_block_cbc[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 3];
+
+    // n-1 block is decrypted separately from the previous blocks which were cbc decrypted
+    block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 0];
+    block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 1];
+    block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 2];
+    block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 3];
+
+    aes128_decrypt (aes_cts_decrypt_ks, block, decrypted_block, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    u32 last_block[4];
+
+    int last_block_position = (edata2_len - last_block_size) / 4;
+
+    u32 n_1_crafted[4];
+
+    u32 last_plaintext[4];
+
+    last_plaintext[0] = 0;
+    last_plaintext[1] = 0;
+    last_plaintext[2] = 0;
+    last_plaintext[3] = 0;
+
+    /*
+      n-1 block is first computed as follows:
+        - fill n-1 block with the X first bytes of the encrypted last block (n)
+          with X == length of last block
+        - complete the rest of the block with
+
+      Final block (n) is computed as follows:
+        - fill with the X first bytes from n-1 block decrypted and xor them with last block (n)
+          with X == length of last block
+    */
+    int remaining_blocks = last_block_size / 4;
+
+    /*
+      last block is not necessarily aligned on 4 bytes so we will have
+      to shift values for the CTS crap...
+    */
+    u32 shift = last_block_size % 4;
+
+    u32 mask;
+
+    switch (remaining_blocks)
+    {
+      case 0:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+
+        mask = (0xffffffff >> ((4 - last_block_size) * 8));
+
+        last_plaintext[0] = last_block[0] ^ (decrypted_block[0] & mask);
+        last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+
+        n_1_crafted[0] = (last_block[0] & mask) | (decrypted_block[0] & (mask ^ 0xffffffff));
+        n_1_crafted[1] = decrypted_block[1];
+        n_1_crafted[2] = decrypted_block[2];
+        n_1_crafted[3] = decrypted_block[3];
+        break;
+
+      case 1:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+
+        if (shift == 0)
+        {
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = decrypted_block[1];
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+        }
+        else
+        {
+          last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+
+          mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ (decrypted_block[1] & mask);
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = (last_block[1] & mask) | (decrypted_block[1] & (mask ^ 0xffffffff));
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+        }
+        break;
+
+      case 2:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+        last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+
+        if (shift == 0)
+        {
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+        }
+        else
+        {
+          last_block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 2];
+
+          mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ (decrypted_block[2] & mask);
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+          last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = (last_block[2] & mask) | (decrypted_block[2] & (mask ^ 0xffffffff));
+          n_1_crafted[3] = decrypted_block[3];
+        }
+        break;
+
+      case 3:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+        last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+        last_block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 2];
+
+        if (shift == 0)
+        {
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = last_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+          last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+        }
+        else
+        {
+          last_block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 3];
+
+          mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+          last_plaintext[3] = last_block[3] ^ (decrypted_block[3] & mask);
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+          last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+          last_plaintext[3] = hc_swap32_S (last_plaintext[3]);
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = last_block[2];
+          n_1_crafted[3] = (last_block[3] & mask) | (decrypted_block[3] & (mask ^ 0xffffffff));
+        }
+        break;
+
+      case 4:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+        last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+        last_block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 2];
+        last_block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 3];
+
+        n_1_crafted[0] = last_block[0];
+        n_1_crafted[1] = last_block[1];
+        n_1_crafted[2] = last_block[2];
+        n_1_crafted[3] = last_block[3];
+
+        last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+        last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+        last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+        last_plaintext[3] = last_block[3] ^ decrypted_block[3];
+
+        last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+        last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+        last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+        last_plaintext[3] = hc_swap32_S (last_plaintext[3]);
+        break;
+
+      default:
+        return;
+    }
+
+    // then decrypt this newly created n-1 with 'ke'
+    aes128_decrypt (aes_cts_decrypt_ks, n_1_crafted, n_1_crafted, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    // then xor with the encrypted n-2 block
+    n_1_crafted[0] ^= last_block_cbc[0];
+    n_1_crafted[1] ^= last_block_cbc[1];
+    n_1_crafted[2] ^= last_block_cbc[2];
+    n_1_crafted[3] ^= last_block_cbc[3];
+
+    w0[0] = hc_swap32_S (n_1_crafted[0]);
+    w0[1] = hc_swap32_S (n_1_crafted[1]);
+    w0[2] = hc_swap32_S (n_1_crafted[2]);
+    w0[3] = hc_swap32_S (n_1_crafted[3]);
+
+    w1[0] = last_plaintext[0];
+    w1[1] = last_plaintext[1];
+    w1[2] = last_plaintext[2];
+    w1[3] = last_plaintext[3];
+
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16 + last_block_size);
+
+    sha1_hmac_final (&sha1_hmac_ctx);
+
+    if (sha1_hmac_ctx.opad.h[0]   == esalt_bufs[DIGESTS_OFFSET_HOST].checksum[0]
+      && sha1_hmac_ctx.opad.h[1] == esalt_bufs[DIGESTS_OFFSET_HOST].checksum[1]
+      && sha1_hmac_ctx.opad.h[2] == esalt_bufs[DIGESTS_OFFSET_HOST].checksum[2])
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        #define il_pos 0
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m33200-pure.cl
+++ b/OpenCL/m33200-pure.cl
@@ -1,0 +1,1101 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+typedef struct krb5asrep_18
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+  u32 format;
+
+} krb5asrep_18_t;
+
+typedef struct krb5asrep_18_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[16];
+  u32 out[16];
+
+} krb5asrep_18_tmp_t;
+
+DECLSPEC void aes256_encrypt_cbc (PRIVATE_AS const u32 *aes_ks, PRIVATE_AS u32 *aes_iv, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, SHM_TYPE u32 *s_te0, SHM_TYPE u32 *s_te1, SHM_TYPE u32 *s_te2, SHM_TYPE u32 *s_te3, SHM_TYPE u32 *s_te4)
+{
+  u32 data[4];
+
+  data[0] = hc_swap32_S (in[0]);
+  data[1] = hc_swap32_S (in[1]);
+  data[2] = hc_swap32_S (in[2]);
+  data[3] = hc_swap32_S (in[3]);
+
+  data[0] ^= aes_iv[0];
+  data[1] ^= aes_iv[1];
+  data[2] ^= aes_iv[2];
+  data[3] ^= aes_iv[3];
+
+  aes256_encrypt (aes_ks, data, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  aes_iv[0] = out[0];
+  aes_iv[1] = out[1];
+  aes_iv[2] = out[2];
+  aes_iv[3] = out[3];
+
+  out[0] = hc_swap32_S (out[0]);
+  out[1] = hc_swap32_S (out[1]);
+  out[2] = hc_swap32_S (out[2]);
+  out[3] = hc_swap32_S (out[3]);
+}
+
+DECLSPEC void aes256_decrypt_cbc (PRIVATE_AS const u32 *ks1, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, PRIVATE_AS u32 *essiv, SHM_TYPE u32 *s_td0, SHM_TYPE u32 *s_td1, SHM_TYPE u32 *s_td2, SHM_TYPE u32 *s_td3, SHM_TYPE u32 *s_td4)
+{
+  aes256_decrypt (ks1, in, out, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  out[0] ^= essiv[0];
+  out[1] ^= essiv[1];
+  out[2] ^= essiv[2];
+  out[3] ^= essiv[3];
+
+  essiv[0] = in[0];
+  essiv[1] = in[1];
+  essiv[2] = in[2];
+  essiv[3] = in[3];
+}
+
+DECLSPEC void hmac_sha1_run_V (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad, PRIVATE_AS u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = 0x80000000;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 20) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+
+  sha1_transform_vector (w0, w1, w2, w3, digest);
+}
+
+KERNEL_FQ void m33200_init (KERN_ATTR_TMPS_ESALT (krb5asrep_18_tmp_t, krb5asrep_18_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * main
+   */
+
+  /* initialize hmac-sha1 for pbkdf2(password, account, 4096, account_len) */
+
+  sha1_hmac_ctx_t sha1_hmac_ctx;
+
+  sha1_hmac_init_global_swap (&sha1_hmac_ctx, pws[gid].i, pws[gid].pw_len);
+
+  tmps[gid].ipad[0] = sha1_hmac_ctx.ipad.h[0];
+  tmps[gid].ipad[1] = sha1_hmac_ctx.ipad.h[1];
+  tmps[gid].ipad[2] = sha1_hmac_ctx.ipad.h[2];
+  tmps[gid].ipad[3] = sha1_hmac_ctx.ipad.h[3];
+  tmps[gid].ipad[4] = sha1_hmac_ctx.ipad.h[4];
+
+  tmps[gid].opad[0] = sha1_hmac_ctx.opad.h[0];
+  tmps[gid].opad[1] = sha1_hmac_ctx.opad.h[1];
+  tmps[gid].opad[2] = sha1_hmac_ctx.opad.h[2];
+  tmps[gid].opad[3] = sha1_hmac_ctx.opad.h[3];
+  tmps[gid].opad[4] = sha1_hmac_ctx.opad.h[4];
+
+  sha1_hmac_update_global_swap (&sha1_hmac_ctx, esalt_bufs[DIGESTS_OFFSET_HOST].account_info, esalt_bufs[DIGESTS_OFFSET_HOST].account_info_len);
+
+  for (u32 i = 0, j = 1; i < 8; i += 5, j += 1)
+  {
+    sha1_hmac_ctx_t sha1_hmac_ctx2 = sha1_hmac_ctx;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = j;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx2, w0, w1, w2, w3, 4);
+
+    sha1_hmac_final (&sha1_hmac_ctx2);
+
+    tmps[gid].dgst[i + 0] = sha1_hmac_ctx2.opad.h[0];
+    tmps[gid].dgst[i + 1] = sha1_hmac_ctx2.opad.h[1];
+    tmps[gid].dgst[i + 2] = sha1_hmac_ctx2.opad.h[2];
+    tmps[gid].dgst[i + 3] = sha1_hmac_ctx2.opad.h[3];
+    tmps[gid].dgst[i + 4] = sha1_hmac_ctx2.opad.h[4];
+
+    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  }
+}
+
+KERNEL_FQ void m33200_loop (KERN_ATTR_TMPS_ESALT (krb5asrep_18_tmp_t, krb5asrep_18_t))
+{
+   /**
+   * base
+   */
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= GID_CNT) return;
+
+  u32x ipad[5];
+  u32x opad[5];
+
+  ipad[0] = packv (tmps, ipad, gid, 0);
+  ipad[1] = packv (tmps, ipad, gid, 1);
+  ipad[2] = packv (tmps, ipad, gid, 2);
+  ipad[3] = packv (tmps, ipad, gid, 3);
+  ipad[4] = packv (tmps, ipad, gid, 4);
+
+  opad[0] = packv (tmps, opad, gid, 0);
+  opad[1] = packv (tmps, opad, gid, 1);
+  opad[2] = packv (tmps, opad, gid, 2);
+  opad[3] = packv (tmps, opad, gid, 3);
+  opad[4] = packv (tmps, opad, gid, 4);
+
+  for (u32 i = 0; i < 8; i += 5)
+  {
+    u32x dgst[5];
+    u32x out[5];
+
+    dgst[0] = packv (tmps, dgst, gid, i + 0);
+    dgst[1] = packv (tmps, dgst, gid, i + 1);
+    dgst[2] = packv (tmps, dgst, gid, i + 2);
+    dgst[3] = packv (tmps, dgst, gid, i + 3);
+    dgst[4] = packv (tmps, dgst, gid, i + 4);
+
+    out[0] = packv (tmps, out, gid, i + 0);
+    out[1] = packv (tmps, out, gid, i + 1);
+    out[2] = packv (tmps, out, gid, i + 2);
+    out[3] = packv (tmps, out, gid, i + 3);
+    out[4] = packv (tmps, out, gid, i + 4);
+
+    for (u32 j = 0; j < LOOP_CNT; j++)
+    {
+      u32x w0[4];
+      u32x w1[4];
+      u32x w2[4];
+      u32x w3[4];
+
+      w0[0] = dgst[0];
+      w0[1] = dgst[1];
+      w0[2] = dgst[2];
+      w0[3] = dgst[3];
+      w1[0] = dgst[4];
+      w1[1] = 0x80000000;
+      w1[2] = 0;
+      w1[3] = 0;
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = (64 + 20) * 8;
+
+      hmac_sha1_run_V (w0, w1, w2, w3, ipad, opad, dgst);
+
+      out[0] ^= dgst[0];
+      out[1] ^= dgst[1];
+      out[2] ^= dgst[2];
+      out[3] ^= dgst[3];
+      out[4] ^= dgst[4];
+    }
+
+    unpackv (tmps, dgst, gid, i + 0, dgst[0]);
+    unpackv (tmps, dgst, gid, i + 1, dgst[1]);
+    unpackv (tmps, dgst, gid, i + 2, dgst[2]);
+    unpackv (tmps, dgst, gid, i + 3, dgst[3]);
+    unpackv (tmps, dgst, gid, i + 4, dgst[4]);
+
+    unpackv (tmps, out, gid, i + 0, out[0]);
+    unpackv (tmps, out, gid, i + 1, out[1]);
+    unpackv (tmps, out, gid, i + 2, out[2]);
+    unpackv (tmps, out, gid, i + 3, out[3]);
+    unpackv (tmps, out, gid, i + 4, out[4]);
+  }
+}
+
+KERNEL_FQ void m33200_comp (KERN_ATTR_TMPS_ESALT (krb5asrep_18_tmp_t, krb5asrep_18_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /*
+    at this point, the output ('seed') will be used to generate AES keys:
+
+    key_bytes = derive(seed, 'kerberos'.encode(), seedsize)
+
+    'key_bytes' will be the AES key used to generate 'ke' and 'ki'
+    'ke' will be the AES key to decrypt the ticket
+    'ki' will be the key to compute the final HMAC
+  */
+
+  u32 nfolded[4];
+
+  // we can precompute _nfold('kerberos', 16)
+  nfolded[0] = 0x6b657262;
+  nfolded[1] = 0x65726f73;
+  nfolded[2] = 0x7b9b5b2b;
+  nfolded[3] = 0x93132b93;
+
+  // then aes_cbc encrypt this nfolded value with 'seed' as key along with a null IV
+  u32 aes_key[8];
+
+  aes_key[0] = hc_swap32_S (tmps[gid].out[0]);
+  aes_key[1] = hc_swap32_S (tmps[gid].out[1]);
+  aes_key[2] = hc_swap32_S (tmps[gid].out[2]);
+  aes_key[3] = hc_swap32_S (tmps[gid].out[3]);
+  aes_key[4] = hc_swap32_S (tmps[gid].out[4]);
+  aes_key[5] = hc_swap32_S (tmps[gid].out[5]);
+  aes_key[6] = hc_swap32_S (tmps[gid].out[6]);
+  aes_key[7] = hc_swap32_S (tmps[gid].out[7]);
+
+  u32 aes_iv[4];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  u32 aes_ks[60];
+
+  aes256_set_encrypt_key (aes_ks, aes_key, s_te0, s_te1, s_te2, s_te3);
+
+  u32 key_bytes[8];
+
+  u32 out[4];
+  aes256_encrypt_cbc (aes_ks, aes_iv, nfolded, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  key_bytes[0] = out[0];
+  key_bytes[1] = out[1];
+  key_bytes[2] = out[2];
+  key_bytes[3] = out[3];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, out, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  key_bytes[4] = out[0];
+  key_bytes[5] = out[1];
+  key_bytes[6] = out[2];
+  key_bytes[7] = out[3];
+
+  /*
+    We will now compute 'ki', having 'key_bytes'
+
+    Description of the key derivation function from RFC3961 Section 5.3:
+      The "well-known constant" used for the DK function is the key usage
+      number, expressed as four octets in big-endian order, followed by
+      one octet indicated below.
+        Kc = DK(base-key, usage | 0x99);
+        Ke = DK(base-key, usage | 0xAA);
+        Ki = DK(base-key, usage | 0x55);
+
+    The key usage numbers are defined in RFC4120. In Section 5.4.2, it
+    specifies that a key usage number of 3 is used for the EncASRepPart
+    of an AS-REP message.
+  */
+
+  u32 ki[8];
+
+  // we can precompute _nfold(pack('>IB', 3, 0x55), 16)
+  nfolded[0] = 0x6b60b058;
+  nfolded[1] = 0x2a6ba80d;
+  nfolded[2] = 0x5aad56ab;
+  nfolded[3] = 0x55406ad5;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  key_bytes[0] = hc_swap32_S (key_bytes[0]);
+  key_bytes[1] = hc_swap32_S (key_bytes[1]);
+  key_bytes[2] = hc_swap32_S (key_bytes[2]);
+  key_bytes[3] = hc_swap32_S (key_bytes[3]);
+  key_bytes[4] = hc_swap32_S (key_bytes[4]);
+  key_bytes[5] = hc_swap32_S (key_bytes[5]);
+  key_bytes[6] = hc_swap32_S (key_bytes[6]);
+  key_bytes[7] = hc_swap32_S (key_bytes[7]);
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes256_set_encrypt_key (aes_ks, key_bytes, s_te0, s_te1, s_te2, s_te3);
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, nfolded, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ki[0] = out[0];
+  ki[1] = out[1];
+  ki[2] = out[2];
+  ki[3] = out[3];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, out, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ki[4] = out[0];
+  ki[5] = out[1];
+  ki[6] = out[2];
+  ki[7] = out[3];
+
+  /* we will now compute 'ke' */
+
+  u32 ke[8];
+
+  // we can precompute _nfold(pack('>IB', 3, 0xAA), 16)
+  nfolded[0] = 0xbe349a4d;
+  nfolded[1] = 0x24be500e;
+  nfolded[2] = 0xaf57abd5;
+  nfolded[3] = 0xea80757a;
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  // then aes_cbc encrypt this nfolded value with 'key_bytes' as key along with a null IV
+  aes256_encrypt_cbc (aes_ks, aes_iv, nfolded, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ke[0] = out[0];
+  ke[1] = out[1];
+  ke[2] = out[2];
+  ke[3] = out[3];
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_encrypt_cbc (aes_ks, aes_iv, out, out, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  ke[4] = out[0];
+  ke[5] = out[1];
+  ke[6] = out[2];
+  ke[7] = out[3];
+
+  /*
+      We now have 'ke' and 'ki'
+
+      We will decrypt (with 'ke') the 32 first bytes to search for ASN.1 structs
+      and if we find ASN.1 structs, we will compute the hmac (with 'ki')
+
+      For AS-REP EncASRepPart:
+      The first byte is 0x79 (01 1 11001, where 01 = "class=APPLICATION", 1 = "form=constructed", 11001 is application type 25)
+      
+      According to RFC4120 Section 5.4.2: "Some implementations unconditionally send an encrypted EncTGSRepPart (application
+      tag number 26) in this field regardless of whether the reply is a AS-REP or a TGS-REP.  In the interest of compatibility,
+      implementors MAY relax the check on the tag number of the decrypted ENC-PART"
+
+      The first byte can thus also be 0x7a (corresponding to application type 26) instead of 0x79
+
+      The next byte is the length:
+
+      if length < 128 bytes:
+          length is on 1 byte, and the next byte is 0x30 (class=SEQUENCE)
+      else if length <= 256:
+          length is on 2 bytes, the first byte is 0x81, and the third byte is 0x30 (class=SEQUENCE)
+      else if length > 256:
+          length is on 3 bytes, the first byte is 0x82, and the fourth byte is 0x30 (class=SEQUENCE)
+  */
+
+  u32 first_blocks[16];
+
+  u32 decrypted_block[8];
+
+  first_blocks[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[0];
+  first_blocks[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[1];
+  first_blocks[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[2];
+  first_blocks[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[3];
+
+  first_blocks[4] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[4];  // possible ASN1 structs
+  first_blocks[5] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[5];
+  first_blocks[6] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[6];  // possible ASN1 structs
+  first_blocks[7] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[7];
+
+  /*
+     we will decrypt them here in order to be able to compute hmac directly
+     if ASN1 structs were to be found
+  */
+  first_blocks[8]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[8];
+  first_blocks[9]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[9];
+  first_blocks[10] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[10];
+  first_blocks[11] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[11];
+
+  first_blocks[12] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[12];
+  first_blocks[13] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[13];
+  first_blocks[14] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[14];
+  first_blocks[15] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[15];
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  u32 aes_cts_decrypt_ks[60];
+
+  AES256_set_decrypt_key (aes_cts_decrypt_ks, ke, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+  aes_iv[0] = 0;
+  aes_iv[1] = 0;
+  aes_iv[2] = 0;
+  aes_iv[3] = 0;
+
+  aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w0[0] = hc_swap32_S (decrypted_block[0]);
+  w0[1] = hc_swap32_S (decrypted_block[1]);
+  w0[2] = hc_swap32_S (decrypted_block[2]);
+  w0[3] = hc_swap32_S (decrypted_block[3]);
+
+  aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  w1[0] = hc_swap32_S (decrypted_block[0]);
+  w1[1] = hc_swap32_S (decrypted_block[1]);
+  w1[2] = hc_swap32_S (decrypted_block[2]);
+  w1[3] = hc_swap32_S (decrypted_block[3]);
+
+  if (((decrypted_block[0] & 0x00ff80ff) == 0x00300079) ||
+      ((decrypted_block[0] & 0x00ff80ff) == 0x0030007a) ||
+      ((decrypted_block[0] & 0xFF00FFFF) == 0x30008179) || 
+      ((decrypted_block[0] & 0xFF00FFFF) == 0x3000817a) ||
+      ((decrypted_block[0] & 0x0000FFFF) == 0x00008279 && (decrypted_block[1] & 0x000000FF) == 0x00000030) ||
+      ((decrypted_block[0] & 0x0000FFFF) == 0x0000827a && (decrypted_block[1] & 0x000000FF) == 0x00000030))
+  {
+    // now we decrypt all the ticket to verify checksum
+
+    // we need to decrypt also the 2 following blocks in order to be able to compute the hmac directly
+    aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    w2[0] = hc_swap32_S (decrypted_block[0]);
+    w2[1] = hc_swap32_S (decrypted_block[1]);
+    w2[2] = hc_swap32_S (decrypted_block[2]);
+    w2[3] = hc_swap32_S (decrypted_block[3]);
+
+    aes256_decrypt_cbc (aes_cts_decrypt_ks, first_blocks + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    w3[0] = hc_swap32_S (decrypted_block[0]);
+    w3[1] = hc_swap32_S (decrypted_block[1]);
+    w3[2] = hc_swap32_S (decrypted_block[2]);
+    w3[3] = hc_swap32_S (decrypted_block[3]);
+
+    int block_position;
+
+    int edata2_len = esalt_bufs[DIGESTS_OFFSET_HOST].edata2_len;
+
+    int edata2_left;
+
+    u32 block[16];
+
+    int last_block_size = edata2_len % 16;
+
+    if (last_block_size == 0)
+    {
+      last_block_size = 16;
+    }
+
+    int last_part = last_block_size + 16;
+
+    int need = edata2_len - last_part;
+
+    int last_block_cbc_position = (need - 16) / 4;
+
+    sha1_hmac_ctx_t sha1_hmac_ctx;
+
+    /*
+      hmac message = plaintext
+      hmac key = ki
+    */
+
+    u32 k0[4];
+    u32 k1[4];
+    u32 k2[4];
+    u32 k3[4];
+
+    k0[0] = ki[0];
+    k0[1] = ki[1];
+    k0[2] = ki[2];
+    k0[3] = ki[3];
+
+    k1[0] = ki[4];
+    k1[1] = ki[5];
+    k1[2] = ki[6];
+    k1[3] = ki[7];
+
+    k2[0] = 0;
+    k2[1] = 0;
+    k2[2] = 0;
+    k2[3] = 0;
+
+    k3[0] = 0;
+    k3[1] = 0;
+    k3[2] = 0;
+    k3[3] = 0;
+
+    sha1_hmac_init_64 (&sha1_hmac_ctx, k0, k1, k2, k3);
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+    block_position = 16;
+
+    // first 4 blocks are already decrypted
+    for (edata2_left = need - 64; edata2_left >= 64; edata2_left -= 64)
+    {
+      block[0]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  0];
+      block[1]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  1];
+      block[2]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  2];
+      block[3]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  3];
+      block[4]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  4];
+      block[5]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  5];
+      block[6]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  6];
+      block[7]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  7];
+      block[8]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  8];
+      block[9]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  9];
+      block[10] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 10];
+      block[11] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 11];
+      block[12] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 12];
+      block[13] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 13];
+      block[14] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 14];
+      block[15] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 15];
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w1[0] = hc_swap32_S (decrypted_block[0]);
+      w1[1] = hc_swap32_S (decrypted_block[1]);
+      w1[2] = hc_swap32_S (decrypted_block[2]);
+      w1[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w2[0] = hc_swap32_S (decrypted_block[0]);
+      w2[1] = hc_swap32_S (decrypted_block[1]);
+      w2[2] = hc_swap32_S (decrypted_block[2]);
+      w2[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 12, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w3[0] = hc_swap32_S (decrypted_block[0]);
+      w3[1] = hc_swap32_S (decrypted_block[1]);
+      w3[2] = hc_swap32_S (decrypted_block[2]);
+      w3[3] = hc_swap32_S (decrypted_block[3]);
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 64);
+
+      block_position += 16;
+    }
+
+    if (edata2_left == 16)
+    {
+
+      block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 0];
+      block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 1];
+      block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 2];
+      block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 3];
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      w1[0] = 0;
+      w1[1] = 0;
+      w1[2] = 0;
+      w1[3] = 0;
+
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16);
+
+      block_position += 4;
+    }
+    else if (edata2_left == 32)
+    {
+      block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 0];
+      block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 1];
+      block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 2];
+      block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 3];
+      block[4] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 4];
+      block[5] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 5];
+      block[6] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 6];
+      block[7] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 7];
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w1[0] = hc_swap32_S (decrypted_block[0]);
+      w1[1] = hc_swap32_S (decrypted_block[1]);
+      w1[2] = hc_swap32_S (decrypted_block[2]);
+      w1[3] = hc_swap32_S (decrypted_block[3]);
+
+      w2[0] = 0;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 32);
+
+      block_position += 8;
+    }
+    else if (edata2_left == 48)
+    {
+      block[0]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  0];
+      block[1]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  1];
+      block[2]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  2];
+      block[3]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  3];
+      block[4]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  4];
+      block[5]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  5];
+      block[6]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  6];
+      block[7]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  7];
+      block[8]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  8];
+      block[9]  = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position +  9];
+      block[10] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 10];
+      block[11] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 11];
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+      
+      w0[0] = hc_swap32_S (decrypted_block[0]);
+      w0[1] = hc_swap32_S (decrypted_block[1]);
+      w0[2] = hc_swap32_S (decrypted_block[2]);
+      w0[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 4, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w1[0] = hc_swap32_S (decrypted_block[0]);
+      w1[1] = hc_swap32_S (decrypted_block[1]);
+      w1[2] = hc_swap32_S (decrypted_block[2]);
+      w1[3] = hc_swap32_S (decrypted_block[3]);
+
+      aes256_decrypt_cbc (aes_cts_decrypt_ks, block + 8, decrypted_block, aes_iv, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+      w2[0] = hc_swap32_S (decrypted_block[0]);
+      w2[1] = hc_swap32_S (decrypted_block[1]);
+      w2[2] = hc_swap32_S (decrypted_block[2]);
+      w2[3] = hc_swap32_S (decrypted_block[3]);
+
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = 0;
+
+      sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 48);
+
+      block_position += 12;
+    }
+
+      /*
+      now all the ticket should be decrypted until block n-1 (not included)
+      and n
+    */
+
+    // this is block n-2, it will be xored with the n-1 block later crafted
+    u32 last_block_cbc[4];
+
+    last_block_cbc[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 0];
+    last_block_cbc[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 1];
+    last_block_cbc[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 2];
+    last_block_cbc[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_cbc_position + 3];
+
+    // n-1 block is decrypted separately from the previous blocks which were cbc decrypted
+    block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 0];
+    block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 1];
+    block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 2];
+    block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[block_position + 3];
+
+    aes256_decrypt (aes_cts_decrypt_ks, block, decrypted_block, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    u32 last_block[4];
+
+    int last_block_position = (edata2_len - last_block_size) / 4;
+
+    u32 n_1_crafted[4];
+
+    u32 last_plaintext[4];
+
+    last_plaintext[0] = 0;
+    last_plaintext[1] = 0;
+    last_plaintext[2] = 0;
+    last_plaintext[3] = 0;
+
+    /*
+      n-1 block is first computed as follows:
+        - fill n-1 block with the X first bytes of the encrypted last block (n)
+          with X == length of last block
+        - complete the rest of the block with
+
+      Final block (n) is computed as follows:
+        - fill with the X first bytes from n-1 block decrypted and xor them with last block (n)
+          with X == length of last block
+    */
+    int remaining_blocks = last_block_size / 4;
+
+    /*
+      last block is not necessarily aligned on 4 bytes so we will have
+      to shift values for the CTS crap...
+    */
+    u32 shift = last_block_size % 4;
+
+    u32 mask;
+
+    switch (remaining_blocks)
+    {
+      case 0:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+
+        mask = (0xffffffff >> ((4 - last_block_size) * 8));
+
+        last_plaintext[0] = last_block[0] ^ (decrypted_block[0] & mask);
+        last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+
+        n_1_crafted[0] = (last_block[0] & mask) | (decrypted_block[0] & (mask ^ 0xffffffff));
+        n_1_crafted[1] = decrypted_block[1];
+        n_1_crafted[2] = decrypted_block[2];
+        n_1_crafted[3] = decrypted_block[3];
+        break;
+
+      case 1:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+
+        if (shift == 0)
+        {
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = decrypted_block[1];
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+        }
+        else
+        {
+          last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+
+          mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ (decrypted_block[1] & mask);
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = (last_block[1] & mask) | (decrypted_block[1] & (mask ^ 0xffffffff));
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+        }
+        break;
+
+      case 2:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+        last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+
+        if (shift == 0)
+        {
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = decrypted_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+        }
+        else
+        {
+          last_block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 2];
+
+          mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ (decrypted_block[2] & mask);
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+          last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = (last_block[2] & mask) | (decrypted_block[2] & (mask ^ 0xffffffff));
+          n_1_crafted[3] = decrypted_block[3];
+        }
+        break;
+
+      case 3:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+        last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+        last_block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 2];
+
+        if (shift == 0)
+        {
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = last_block[2];
+          n_1_crafted[3] = decrypted_block[3];
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+          last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+        }
+        else
+        {
+          last_block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 3];
+
+          mask = (0xffffffff >> ((4 - (last_block_size % 4)) * 8));
+
+          last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+          last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+          last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+          last_plaintext[3] = last_block[3] ^ (decrypted_block[3] & mask);
+
+          last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+          last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+          last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+          last_plaintext[3] = hc_swap32_S (last_plaintext[3]);
+
+          n_1_crafted[0] = last_block[0];
+          n_1_crafted[1] = last_block[1];
+          n_1_crafted[2] = last_block[2];
+          n_1_crafted[3] = (last_block[3] & mask) | (decrypted_block[3] & (mask ^ 0xffffffff));
+        }
+        break;
+
+      case 4:
+
+        last_block[0] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 0];
+        last_block[1] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 1];
+        last_block[2] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 2];
+        last_block[3] = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[last_block_position + 3];
+
+        n_1_crafted[0] = last_block[0];
+        n_1_crafted[1] = last_block[1];
+        n_1_crafted[2] = last_block[2];
+        n_1_crafted[3] = last_block[3];
+
+        last_plaintext[0] = last_block[0] ^ decrypted_block[0];
+        last_plaintext[1] = last_block[1] ^ decrypted_block[1];
+        last_plaintext[2] = last_block[2] ^ decrypted_block[2];
+        last_plaintext[3] = last_block[3] ^ decrypted_block[3];
+
+        last_plaintext[0] = hc_swap32_S (last_plaintext[0]);
+        last_plaintext[1] = hc_swap32_S (last_plaintext[1]);
+        last_plaintext[2] = hc_swap32_S (last_plaintext[2]);
+        last_plaintext[3] = hc_swap32_S (last_plaintext[3]);
+        break;
+
+      default:
+        return;
+    }
+
+
+    // then decrypt this newly created n-1 with 'ke'
+    aes256_decrypt (aes_cts_decrypt_ks, n_1_crafted, n_1_crafted, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    // then xor with the encrypted n-2 block
+    n_1_crafted[0] ^= last_block_cbc[0];
+    n_1_crafted[1] ^= last_block_cbc[1];
+    n_1_crafted[2] ^= last_block_cbc[2];
+    n_1_crafted[3] ^= last_block_cbc[3];
+
+    w0[0] = hc_swap32_S (n_1_crafted[0]);
+    w0[1] = hc_swap32_S (n_1_crafted[1]);
+    w0[2] = hc_swap32_S (n_1_crafted[2]);
+    w0[3] = hc_swap32_S (n_1_crafted[3]);
+
+    w1[0] = last_plaintext[0];
+    w1[1] = last_plaintext[1];
+    w1[2] = last_plaintext[2];
+    w1[3] = last_plaintext[3];
+
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha1_hmac_update_64 (&sha1_hmac_ctx, w0, w1, w2, w3, 16 + last_block_size);
+
+    sha1_hmac_final (&sha1_hmac_ctx);
+
+    if (sha1_hmac_ctx.opad.h[0]   == esalt_bufs[DIGESTS_OFFSET_HOST].checksum[0]
+      && sha1_hmac_ctx.opad.h[1] == esalt_bufs[DIGESTS_OFFSET_HOST].checksum[1]
+      && sha1_hmac_ctx.opad.h[2] == esalt_bufs[DIGESTS_OFFSET_HOST].checksum[2])
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        #define il_pos 0
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/src/modules/module_33100.c
+++ b/src/modules/module_33100.c
@@ -1,0 +1,420 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "Kerberos 5, etype 17, AS-REP";
+static const u64   KERN_TYPE      = 33100;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$krb5asrep$17$user$EXAMPLE.COM$a419c4030e555734b06c2629$c09a1421f96eb126c757a4b87830381f142477d9a85b2beb3093dbfd44f38ddb6016a479537fb7b36e046315869fe79187217971ff6a12c1e0a2df3f68045e03814b21f756d8981f781803d65e8572823c88979581d93cf7d768f2efced16f3719b8d1004d9e73d798de255383476bced47d1982f16be77d0feb55a1f44f58bd013fa4caee58ac614caf0f1cf9101ec9623c5b8c2a1491b73f134f074790088fdb360b5ebce0d32a8145ed00a81ddf77188e150b92d8e8ddd0285d27f1514253e5546e6bba864b362bb1e6483b26d08fa4cc268bfbefe0f690039bcc524b774599df3680c1c3431d891bfa99514a877f964e";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+// Struct to store the hash structure - same fields as TGS-REP type 17
+typedef struct krb5asrep_17
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+  u32 format;
+
+} krb5asrep_17_t;
+
+typedef struct krb5asrep_17_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[16];
+  u32 out[16];
+
+} krb5asrep_17_tmp_t;
+
+static const char *SIGNATURE_KRB5ASREP = "$krb5asrep$17$";
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (krb5asrep_17_tmp_t);
+
+  return tmp_size;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (krb5asrep_17_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  krb5asrep_17_t *krb5asrep = (krb5asrep_17_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_KRB5ASREP;
+
+  token.len[0]  = strlen (SIGNATURE_KRB5ASREP);
+  token.attr[0] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  /**
+   * Haschat
+   * format 1: $krb5asrep$18$user$realm$checksum$edata2
+   *
+   * JtR
+   * format 2: $krb5asrep$18$salt$edata2$checksum
+   */
+
+  if (line_len < (int) strlen (SIGNATURE_KRB5ASREP)) return (PARSER_SALT_LENGTH);
+
+  memset (krb5asrep, 0, sizeof (krb5asrep_17_t));
+
+  /**
+   * JtR format has the checksum at the end, so can identify it based on the
+   * separator ('$') being at a fixed length from the end of the line. Checksum
+   * is 24 characters in length, so then there should be a '$' at line_len - 25
+   */
+  
+  if (line_buf[line_len - 25] == '$')
+  {
+    // JtR format
+    krb5asrep->format = 2;
+  }
+  else 
+  {
+    // Hashcat format
+    krb5asrep->format = 1;
+  }
+
+  token.token_cnt  = 4;
+
+  if (krb5asrep->format == 1)
+  {
+    token.token_cnt++;
+
+    // user
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    // realm
+    token.sep[2]     = '$';
+    token.len_min[2] = 1;
+    token.len_max[2] = 512;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    // checksum
+    token.sep[3]     = '$';
+    // hmac-sha1 stripped to 12bytes
+    token.len[3]     = 24;
+    token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+    // edata2
+    token.sep[4]     = '$';
+    token.len_min[4] = 64;
+    token.len_max[4] = 40960;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+  }
+  else
+  {
+    // salt
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    // edata2
+    token.sep[2]     = '$';
+    token.len_min[2] = 64;
+    token.len_max[2] = 40960;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+    // checksum
+    token.sep[3]     = '$';
+    // hmac-sha1 stripped to 12bytes
+    token.len[3]     = 24;
+    token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+  }
+
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+  
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *user_pos;
+  const u8 *domain_pos;
+  const u8 *salt_pos;
+  const u8 *checksum_pos;
+  const u8 *data_pos;
+
+  int user_len;
+  int domain_len;
+  int data_len;
+  int account_info_len;
+
+  if (krb5asrep->format == 1)
+  {
+    user_pos = token.buf[1];
+    user_len = token.len[1];
+
+    memcpy (krb5asrep->user, user_pos, user_len);
+
+    domain_pos = token.buf[2];
+    domain_len = token.len[2];
+
+    memcpy (krb5asrep->domain, domain_pos, domain_len);
+
+    checksum_pos = token.buf[3];
+
+    data_pos = token.buf[4];
+    data_len = token.len[4];
+
+    account_info_len = token.len[2] + token.len[1];
+  }
+  else
+  {
+    salt_pos = token.buf[1];
+    account_info_len = token.len[1];
+
+    memcpy (krb5asrep->account_info, salt_pos, account_info_len);
+    
+    /**
+     * JtR format only has the final salt/account_info value (combination of
+     * user and domain), rather than separate "user" and "domain" values. Since
+     * user and domain won't be used for the JtR format, their values won't
+     * matter, so set them both to the same value as account_info.
+     */
+
+    user_pos = token.buf[1];
+    user_len = token.len[1];
+
+    memcpy (krb5asrep->user, user_pos, user_len);
+
+    domain_pos = token.buf[1];
+    domain_len = token.len[1];
+
+    memcpy (krb5asrep->domain, domain_pos, domain_len);
+
+    data_pos = token.buf[2];
+    data_len = token.len[2];
+
+    checksum_pos = token.buf[3];
+  }
+
+  u8 *account_info_ptr = (u8 *) krb5asrep->account_info;
+  
+  // Domain must be uppercase
+  u8 domain[128];
+
+  if (krb5asrep->format == 1)
+  {
+    memcpy (domain, domain_pos, domain_len);
+    uppercase (domain, domain_len);
+
+    memcpy (account_info_ptr, domain, domain_len);
+    memcpy (account_info_ptr + domain_len, user_pos, user_len);
+  }
+  
+  krb5asrep->account_info_len = account_info_len;
+
+  // hmac-sha1 is reduced to 12 bytes
+  krb5asrep->checksum[0] = byte_swap_32 (hex_to_u32 (checksum_pos +  0));
+  krb5asrep->checksum[1] = byte_swap_32 (hex_to_u32 (checksum_pos +  8));
+  krb5asrep->checksum[2] = byte_swap_32 (hex_to_u32 (checksum_pos + 16));
+
+  u8 *edata_ptr = (u8 *) krb5asrep->edata2;
+
+  for (int i = 0; i < data_len; i += 2)
+  {
+    const u8 p0 = data_pos[i + 0];
+    const u8 p1 = data_pos[i + 1];
+
+    *edata_ptr++ = hex_convert (p1) << 0
+                 | hex_convert (p0) << 4;
+  }
+
+  krb5asrep->edata2_len = data_len / 2;
+
+  salt->salt_buf[0] = krb5asrep->checksum[0];
+  salt->salt_buf[1] = krb5asrep->checksum[1];
+  salt->salt_buf[2] = krb5asrep->checksum[2];
+
+  salt->salt_len = 12;
+
+  salt->salt_iter = 4096 - 1;
+
+  digest[0] = krb5asrep->checksum[0];
+  digest[1] = krb5asrep->checksum[1];
+  digest[2] = krb5asrep->checksum[2];
+  digest[3] = 0;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const krb5asrep_17_t *krb5asrep = (const krb5asrep_17_t *) esalt_buf;
+
+  char data[5120 * 4 * 2] = { 0 };
+
+  for (u32 i = 0, j = 0; i < krb5asrep->edata2_len; i += 1, j += 2)
+  {
+    u8 *ptr_edata2 = (u8 *) krb5asrep->edata2;
+
+    sprintf (data + j, "%02x", ptr_edata2[i]);
+  }
+
+  int line_len = 0;
+
+  if (krb5asrep->format == 1)
+  {
+    line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x$%s",
+      SIGNATURE_KRB5ASREP,
+      (char *) krb5asrep->user,
+      (char *) krb5asrep->domain,
+      krb5asrep->checksum[0],
+      krb5asrep->checksum[1],
+      krb5asrep->checksum[2],
+      data);
+  }
+  else
+  {
+    line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x",
+      SIGNATURE_KRB5ASREP,
+      (char *) krb5asrep->account_info,
+      data,
+      krb5asrep->checksum[0],
+      krb5asrep->checksum[1],
+      krb5asrep->checksum[2]);
+  }
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_33200.c
+++ b/src/modules/module_33200.c
@@ -1,0 +1,419 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "Kerberos 5, etype 18, AS-REP";
+static const u64   KERN_TYPE      = 33200;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$krb5asrep$18$user$EXAMPLE.COM$aa4c494f520b27873a4de8f7$ebc9976a77f62e8ccca02d43d68bafcc66a81fcbb44a336b00ce401982f32975a5f9bcdc752643252185866685b0a30aaf50e449e392a5994e6979f23aba25f7704c90b2efa03b703c3c2f9e3617cc588ed226d0417e7742d45407878fd946d046b4a9732b9a203cb857811714b009c195b7c96b9bccb7e48832b11a4e92ecf24c49e54de8d0d5d5351445b5126db90bb7eebc7861db1e61de1175824b0a45023a6fa06c2a9d3035fdcf863bea922648e3dc28b48e39b1dec0869e7fe4de399cb52dfcf2596599da54a4bb0169c72d9496de2e137a4594e0e8a69082fc558ac9ace65d32eae5e260a65ca3f2f5871aaeee7a3b090b50f39321d120c144421e0abe7d";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+// Struct to store the hash structure - same fields as TGS-REP type 18
+typedef struct krb5asrep_18
+{
+  u32 user[128];
+  u32 domain[128];
+  u32 account_info[512];
+  u32 account_info_len;
+
+  u32 checksum[3];
+  u32 edata2[5120];
+  u32 edata2_len;
+  u32 format;
+
+} krb5asrep_18_t;
+
+typedef struct krb5asrep_18_tmp
+{
+  u32 ipad[5];
+  u32 opad[5];
+  u32 dgst[16];
+  u32 out[16];
+
+} krb5asrep_18_tmp_t;
+
+static const char *SIGNATURE_KRB5ASREP = "$krb5asrep$18$";
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (krb5asrep_18_tmp_t);
+
+  return tmp_size;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (krb5asrep_18_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  krb5asrep_18_t *krb5asrep = (krb5asrep_18_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_KRB5ASREP;
+
+  token.len[0]  = strlen (SIGNATURE_KRB5ASREP);
+  token.attr[0] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  /**
+   * Haschat
+   * format 1: $krb5asrep$18$user$realm$checksum$edata2
+   *
+   * JtR
+   * format 2: $krb5asrep$18$salt$edata2$checksum
+   */
+
+  if (line_len < (int) strlen (SIGNATURE_KRB5ASREP)) return (PARSER_SALT_LENGTH);
+
+  memset (krb5asrep, 0, sizeof (krb5asrep_18_t));
+
+  /**
+   * JtR format has the checksum at the end, so can identify it based on the
+   * separator ('$') being at a fixed length from the end of the line. Checksum
+   * is 24 characters in length, so then there should be a '$' at line_len - 25
+   */
+  
+  if (line_buf[line_len - 25] == '$')
+  {
+    // JtR format
+    krb5asrep->format = 2;
+  }
+  else 
+  {
+    // Hashcat format
+    krb5asrep->format = 1;
+  }
+
+  token.token_cnt  = 4;
+
+  if (krb5asrep->format == 1)
+  {
+    token.token_cnt++;
+
+    // user
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    // realm
+    token.sep[2]     = '$';
+    token.len_min[2] = 1;
+    token.len_max[2] = 512;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    // checksum
+    token.sep[3]     = '$';
+    // hmac-sha1 stripped to 12bytes
+    token.len[3]     = 24;
+    token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+    // edata2
+    token.sep[4]     = '$';
+    token.len_min[4] = 64;
+    token.len_max[4] = 40960;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+  }
+  else
+  {
+    // salt
+    token.sep[1]     = '$';
+    token.len_min[1] = 1;
+    token.len_max[1] = 512;
+    token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+    // edata2
+    token.sep[2]     = '$';
+    token.len_min[2] = 64;
+    token.len_max[2] = 40960;
+    token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+    // checksum
+    token.sep[3]     = '$';
+    // hmac-sha1 stripped to 12bytes
+    token.len[3]     = 24;
+    token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+  }
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+  
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *user_pos;
+  const u8 *domain_pos;
+  const u8 *salt_pos;
+  const u8 *checksum_pos;
+  const u8 *data_pos;
+
+  int user_len;
+  int domain_len;
+  int data_len;
+  int account_info_len;
+
+  if (krb5asrep->format == 1)
+  {
+    user_pos = token.buf[1];
+    user_len = token.len[1];
+
+    memcpy (krb5asrep->user, user_pos, user_len);
+
+    domain_pos = token.buf[2];
+    domain_len = token.len[2];
+
+    memcpy (krb5asrep->domain, domain_pos, domain_len);
+
+    checksum_pos = token.buf[3];
+
+    data_pos = token.buf[4];
+    data_len = token.len[4];
+
+    account_info_len = token.len[2] + token.len[1];
+  }
+  else
+  {
+    salt_pos = token.buf[1];
+    account_info_len = token.len[1];
+
+    memcpy (krb5asrep->account_info, salt_pos, account_info_len);
+    
+    /**
+     * JtR format only has the final salt/account_info value (combination of
+     * user and domain), rather than separate "user" and "domain" values. Since
+     * user and domain won't be used for the JtR format, their values won't
+     * matter, so set them both to the same value as account_info.
+     */
+
+    user_pos = token.buf[1];
+    user_len = token.len[1];
+
+    memcpy (krb5asrep->user, user_pos, user_len);
+
+    domain_pos = token.buf[1];
+    domain_len = token.len[1];
+
+    memcpy (krb5asrep->domain, domain_pos, domain_len);
+
+    data_pos = token.buf[2];
+    data_len = token.len[2];
+
+    checksum_pos = token.buf[3];
+  }
+
+  u8 *account_info_ptr = (u8 *) krb5asrep->account_info;
+  
+  // Domain must be uppercase
+  u8 domain[128];
+
+  if (krb5asrep->format == 1)
+  {
+    memcpy (domain, domain_pos, domain_len);
+    uppercase (domain, domain_len);
+
+    memcpy (account_info_ptr, domain, domain_len);
+    memcpy (account_info_ptr + domain_len, user_pos, user_len);
+  }
+  
+  krb5asrep->account_info_len = account_info_len;
+
+  // hmac-sha1 is reduced to 12 bytes
+  krb5asrep->checksum[0] = byte_swap_32 (hex_to_u32 (checksum_pos +  0));
+  krb5asrep->checksum[1] = byte_swap_32 (hex_to_u32 (checksum_pos +  8));
+  krb5asrep->checksum[2] = byte_swap_32 (hex_to_u32 (checksum_pos + 16));
+
+  u8 *edata_ptr = (u8 *) krb5asrep->edata2;
+
+  for (int i = 0; i < data_len; i += 2)
+  {
+    const u8 p0 = data_pos[i + 0];
+    const u8 p1 = data_pos[i + 1];
+
+    *edata_ptr++ = hex_convert (p1) << 0
+                 | hex_convert (p0) << 4;
+  }
+
+  krb5asrep->edata2_len = data_len / 2;
+
+  salt->salt_buf[0] = krb5asrep->checksum[0];
+  salt->salt_buf[1] = krb5asrep->checksum[1];
+  salt->salt_buf[2] = krb5asrep->checksum[2];
+
+  salt->salt_len = 12;
+
+  salt->salt_iter = 4096 - 1;
+
+  digest[0] = krb5asrep->checksum[0];
+  digest[1] = krb5asrep->checksum[1];
+  digest[2] = krb5asrep->checksum[2];
+  digest[3] = 0;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const krb5asrep_18_t *krb5asrep = (const krb5asrep_18_t *) esalt_buf;
+
+  char data[5120 * 4 * 2] = { 0 };
+
+  for (u32 i = 0, j = 0; i < krb5asrep->edata2_len; i += 1, j += 2)
+  {
+    u8 *ptr_edata2 = (u8 *) krb5asrep->edata2;
+
+    sprintf (data + j, "%02x", ptr_edata2[i]);
+  }
+
+  int line_len = 0;
+
+  if (krb5asrep->format == 1)
+  {
+    line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x$%s",
+      SIGNATURE_KRB5ASREP,
+      (char *) krb5asrep->user,
+      (char *) krb5asrep->domain,
+      krb5asrep->checksum[0],
+      krb5asrep->checksum[1],
+      krb5asrep->checksum[2],
+      data);
+  }
+  else
+  {
+    line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x",
+      SIGNATURE_KRB5ASREP,
+      (char *) krb5asrep->account_info,
+      data,
+      krb5asrep->checksum[0],
+      krb5asrep->checksum[1],
+      krb5asrep->checksum[2]);
+  }
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m33100.pm
+++ b/tools/test_modules/m33100.pm
@@ -1,0 +1,217 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (hmac_sha1);
+use Crypt::Mode::CBC;
+use Crypt::PBKDF2;
+
+sub byte2hex
+{
+  my $input = shift;
+  return unpack ("H*", $input);
+}
+
+sub hex2byte
+{
+  my $input = shift;
+  return pack ("H*", $input);
+}
+
+sub pad
+{
+  my $n = shift;
+  my $size = shift;
+
+  return (~$n + 1) & ($size - 1);
+}
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word      = shift;
+  my $salt      = shift;
+  my $user      = shift // "user";
+  my $realm     = shift // "example.com";
+  my $checksum  = shift;
+  my $edata2    = shift;
+
+  my $mysalt = uc $realm;
+  $mysalt = $mysalt . $user;
+
+  # first we generate the 'seed'
+  my $iter = 4096;
+  my $pbkdf2 = Crypt::PBKDF2->new
+  (
+    hash_class => 'HMACSHA1',
+    iterations => $iter,
+    output_len => 16
+  );
+
+  my $b_seed = $pbkdf2->PBKDF2 ($mysalt, $word);
+
+  # we can precompute this
+  my $b_kerberos_nfolded = hex2byte ('6b65726265726f737b9b5b2b93132b93');
+
+  my $b_iv = hex2byte ('0' x 32);
+
+  # 'key_bytes' will be the AES key used to generate 'ki' (for final hmac-sha1)
+  # and 'ke' (AES key to decrypt/encrypt the ticket)
+  my $cbc       = Crypt::Mode::CBC->new ('AES', 0);
+  my $b_key_bytes = $cbc->encrypt ($b_kerberos_nfolded, $b_seed, $b_iv);
+
+  # precomputed stuff
+  my $b_nfolded1 = hex2byte ('6b60b0582a6ba80d5aad56ab55406ad5');
+  my $b_nfolded2 = hex2byte ('be349a4d24be500eaf57abd5ea80757a');
+
+  my $b_ki = $cbc->encrypt ($b_nfolded1, $b_key_bytes, $b_iv);
+  my $b_ke = $cbc->encrypt ($b_nfolded2, $b_key_bytes, $b_iv);
+
+  my $cleartext_ticket = '7981df3081dca01b3019a003020111a1120410e2aa1c894df7'.
+    '23b7277eef29700bf760a11c301a3018a003020100a111180f32303233303333313132303'.
+    '434355aa20602041d9d970ba311180f32303337303931343032343830355aa40703050040'.
+    'c10000a511180f32303233303333313132303434355aa611180f323032333033333131323'.
+    '03434355aa711180f32303233303333313232303434355aa811180f323032333034303731'.
+    '32303434355aa90d1b0b4558414d504c452e434f4daa20301ea003020102a11730151b066'.
+    'b72627467741b0b6578616d706c652e636f6d';
+
+  if (defined $edata2)
+  {
+    my $len_last_block  = length ($edata2) % 32;
+
+    my $tmp = $len_last_block + 32;
+
+    my $b_truncated_enc_ticket = hex2byte (substr $edata2, 0, -$tmp);
+
+    my $b_last_block = hex2byte (substr $edata2, -$len_last_block);
+
+    my $b_n_1_block = hex2byte (substr (substr ($edata2, -$tmp), 0, 32));
+
+    my $b_truncated_ticket_decrypted = $cbc->decrypt ($b_truncated_enc_ticket, $b_ke, $b_iv);
+
+    my $truncated_ticket_decrypted = byte2hex ($b_truncated_ticket_decrypted);
+
+    my $check_correct  = ((substr ($truncated_ticket_decrypted, 16, 4) eq "7981" || substr ($truncated_ticket_decrypted, 16, 4) eq "7a81") && (substr ($truncated_ticket_decrypted, 22, 2) eq "30")) ||
+                         ((substr ($truncated_ticket_decrypted, 16, 2) eq "79" || substr ($truncated_ticket_decrypted, 16, 2) eq "7a") && (substr ($truncated_ticket_decrypted, 20, 2) eq "30")) ||
+                         ((substr ($truncated_ticket_decrypted, 16, 4) eq "7982" || substr ($truncated_ticket_decrypted, 16, 4) eq "7a82")  && (substr ($truncated_ticket_decrypted, 24, 2) eq "30"));
+
+    if ($check_correct == 1)
+    {
+      my $b_n_2 = substr $b_truncated_enc_ticket, -16;
+
+      my $b_n_1_decrypted = $cbc->decrypt ($b_n_1_block, $b_ke, $b_iv);
+
+      my $b_last_plain = substr $b_n_1_decrypted, 0, $len_last_block / 2;
+
+      $b_last_plain =  $b_last_plain ^ $b_last_block;
+
+      my $omitted = substr $b_n_1_decrypted, -(16 - $len_last_block / 2);
+
+      my $b_n_1 = $b_last_block . $omitted;
+
+      $b_n_1 = $cbc->decrypt ($b_n_1, $b_ke, $b_iv);
+
+      $b_n_1 = $b_n_1 ^ $b_n_2;
+
+      my $b_cleartext_ticket = $b_truncated_ticket_decrypted . $b_n_1 . $b_last_plain;
+
+      $cleartext_ticket = byte2hex ($b_cleartext_ticket);
+    }
+    else # validation failed
+    {
+      # fake/wrong ticket (otherwise if we just decrypt/encrypt we end
+      #up with false positives all the time)
+      $cleartext_ticket = "0" x (length ($cleartext_ticket) + 32);
+    }
+  }
+
+  if (defined $checksum)
+  {
+    $checksum = pack ("H*", $checksum);
+  }
+  else
+  {
+    if (!defined $edata2)
+    {
+      my $nonce = unpack ("H*", random_bytes (16));
+
+      $cleartext_ticket = $nonce . $cleartext_ticket;
+    }
+      # we have what is required to compute checksum
+    $checksum = hmac_sha1 (hex2byte ($cleartext_ticket), $b_ki);
+
+    $checksum = substr $checksum, 0, 12;
+  }
+
+  my $len_cleartext_last_block = length ($cleartext_ticket) % 32;
+  my $cleartext_last_block = substr $cleartext_ticket, -$len_cleartext_last_block;
+
+  my $padding = pad (length ($cleartext_ticket), 32);
+
+  my $b_cleartext_last_block_padded = hex2byte ($cleartext_last_block . '0' x $padding);
+
+  # we will encrypt until n-1 block (included)
+  my $truncated_cleartext_ticket = substr $cleartext_ticket, 0, -$len_cleartext_last_block;
+
+  my $b_truncated_enc_ticket = $cbc->encrypt (hex2byte ($truncated_cleartext_ticket), $b_ke, $b_iv);
+
+  my $b_enc_ticket_n_1_block= substr $b_truncated_enc_ticket, -16;
+
+  my $b_enc_last_block = substr $b_enc_ticket_n_1_block, 0, $len_cleartext_last_block / 2;
+
+  # we now craft the new n-1 block
+  my $tmp = $b_enc_ticket_n_1_block ^ $b_cleartext_last_block_padded;
+
+  $b_enc_ticket_n_1_block = $cbc->encrypt ($tmp, $b_ke, $b_iv);
+
+  $tmp = substr $b_truncated_enc_ticket, 0, -16;
+
+  $edata2 = $tmp . $b_enc_ticket_n_1_block . $b_enc_last_block;
+
+  my $tmp_hash = sprintf ('$krb5asrep$17$%s$%s$%s$%s', $user, $realm, unpack ("H*", $checksum), unpack ("H*", $edata2));
+
+  return $tmp_hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @data = split ('\$', $hash);
+
+  return unless scalar @data == 7;
+
+  shift @data;
+
+  my $signature = shift @data;
+  my $algorithm = shift @data;
+  my $user      = shift @data;
+  my $realm     = shift @data;
+  my $checksum  = shift @data;
+  my $edata2    = shift @data;
+
+  return unless ($signature eq "krb5asrep");
+  return unless ($algorithm eq "17");
+  return unless (length ($checksum) == 24);
+  return unless (length ($edata2) >= 64);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, undef, $user, $realm, $checksum, $edata2);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m33200.pm
+++ b/tools/test_modules/m33200.pm
@@ -1,0 +1,224 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (hmac_sha1);
+use Crypt::Mode::CBC;
+use Crypt::PBKDF2;
+
+sub byte2hex
+{
+  my $input = shift;
+  return unpack ("H*", $input);
+}
+
+sub hex2byte
+{
+  my $input = shift;
+  return pack ("H*", $input);
+}
+
+sub pad
+{
+  my $n = shift;
+  my $size = shift;
+
+  return (~$n + 1) & ($size - 1);
+}
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word      = shift;
+  my $salt      = shift;
+  my $user      = shift // "user";
+  my $realm     = shift // "example.com";
+  my $checksum  = shift;
+  my $edata2    = shift;
+
+  my $mysalt = uc $realm;
+  $mysalt = $mysalt . $user;
+
+  # first we generate the 'seed'
+  my $iter = 4096;
+  my $pbkdf2 = Crypt::PBKDF2->new
+  (
+    hash_class => 'HMACSHA1',
+    iterations => $iter,
+    output_len => 32
+  );
+
+  my $b_seed = $pbkdf2->PBKDF2 ($mysalt, $word);
+
+  # we can precompute this
+  my $b_kerberos_nfolded = hex2byte ('6b65726265726f737b9b5b2b93132b93');
+
+  my $b_iv = hex2byte ('0' x 32);
+
+  # 'key_bytes' will be the AES key used to generate 'ki' (for final hmac-sha1)
+  # and 'ke' (AES key to decrypt/encrypt the ticket)
+  my $cbc         = Crypt::Mode::CBC->new ('AES', 0);
+  my $b_key_bytes = $cbc->encrypt ($b_kerberos_nfolded, $b_seed, $b_iv);
+
+  $b_key_bytes = $b_key_bytes . $cbc->encrypt ($b_key_bytes, $b_seed, $b_iv);
+
+  # precomputed stuff
+  my $b_nfolded1 = hex2byte ('6b60b0582a6ba80d5aad56ab55406ad5');
+  my $b_nfolded2 = hex2byte ('be349a4d24be500eaf57abd5ea80757a');
+
+  my $b_ki = $cbc->encrypt ($b_nfolded1, $b_key_bytes, $b_iv);
+
+  $b_ki = $b_ki . $cbc->encrypt ($b_ki, $b_key_bytes, $b_iv);
+
+  my $b_ke = $cbc->encrypt ($b_nfolded2, $b_key_bytes, $b_iv);
+
+  $b_ke = $b_ke . $cbc->encrypt ($b_ke, $b_key_bytes, $b_iv);
+
+  my $cleartext_ticket = '7981ef3081eca02b3029a003020112a12204200e97d1626616'.
+    '6e06252cbec52003e0f6b4f0280deec6dc58cdbf39845d6f0e77a11c301a3018a00302010'.
+    '0a111180f32303233303331363135353732315aa20602045b66ac3ea311180f3230333730'.
+    '3931343032343830355aa40703050050c10000a511180f323032333033313631353537323'.
+    '15aa611180f32303233303331363135353732315aa711180f323032333033313730313537'.
+    '32315aa811180f32303233303331373135353732315aa90d1b0b4558414d504c452e434f4'.
+    'daa20301ea003020101a11730151b066b72627467741b0b4558414d504c452e434f4d';
+
+  if (defined $edata2)
+  {
+    my $len_last_block  = length ($edata2) % 32;
+
+    my $tmp = $len_last_block + 32;
+
+    my $b_truncated_enc_ticket = hex2byte (substr $edata2, 0, -$tmp);
+
+    my $b_last_block = hex2byte (substr $edata2, -$len_last_block);
+
+    my $b_n_1_block = hex2byte (substr (substr ($edata2, -$tmp), 0, 32));
+
+    my $b_truncated_ticket_decrypted = $cbc->decrypt ($b_truncated_enc_ticket, $b_ke, $b_iv);
+
+    my $truncated_ticket_decrypted = byte2hex ($b_truncated_ticket_decrypted);
+
+    my $check_correct  = ((substr ($truncated_ticket_decrypted, 16, 4) eq "7981" || substr ($truncated_ticket_decrypted, 16, 4) eq "7a81") && (substr ($truncated_ticket_decrypted, 22, 2) eq "30")) ||
+                         ((substr ($truncated_ticket_decrypted, 16, 2) eq "79" || substr ($truncated_ticket_decrypted, 16, 2) eq "7a") && (substr ($truncated_ticket_decrypted, 20, 2) eq "30")) ||
+                         ((substr ($truncated_ticket_decrypted, 16, 4) eq "7982" || substr ($truncated_ticket_decrypted, 16, 4) eq "7a82")  && (substr ($truncated_ticket_decrypted, 24, 2) eq "30"));
+
+    if ($check_correct == 1)
+    {
+      my $b_n_2 = substr $b_truncated_enc_ticket, -16;
+
+      my $b_n_1_decrypted = $cbc->decrypt ($b_n_1_block, $b_ke, $b_iv);
+
+      my $b_last_plain = substr $b_n_1_decrypted, 0, $len_last_block / 2;
+
+      $b_last_plain =  $b_last_plain ^ $b_last_block;
+
+      my $omitted = substr $b_n_1_decrypted, -(16 - $len_last_block / 2);
+
+      my $b_n_1 = $b_last_block . $omitted;
+
+      $b_n_1 = $cbc->decrypt ($b_n_1, $b_ke, $b_iv);
+
+      $b_n_1 = $b_n_1 ^ $b_n_2;
+
+      my $b_cleartext_ticket = $b_truncated_ticket_decrypted . $b_n_1 . $b_last_plain;
+
+      $cleartext_ticket = byte2hex ($b_cleartext_ticket);
+    }
+    else # validation failed
+    {
+      # fake/wrong ticket (otherwise if we just decrypt/encrypt we end
+      #up with false positives all the time)
+      $cleartext_ticket = "0" x (length ($cleartext_ticket) + 32);
+    }
+  }
+
+  if (defined $checksum)
+  {
+    $checksum = pack ("H*", $checksum);
+  }
+  else
+  {
+    if (!defined $edata2)
+    {
+      my $nonce = unpack ("H*", random_bytes (16));
+
+      $cleartext_ticket = $nonce . $cleartext_ticket;
+    }
+      # we have what is required to compute checksum
+    $checksum = hmac_sha1 (hex2byte ($cleartext_ticket), $b_ki);
+
+    $checksum = substr $checksum, 0, 12;
+  }
+
+  my $len_cleartext_last_block = length ($cleartext_ticket) % 32;
+  my $cleartext_last_block = substr $cleartext_ticket, -$len_cleartext_last_block;
+
+  my $padding = pad (length ($cleartext_ticket), 32);
+
+  my $b_cleartext_last_block_padded = hex2byte ($cleartext_last_block . '0' x $padding);
+
+  # we will encrypt until n-1 block (included)
+  my $truncated_cleartext_ticket = substr $cleartext_ticket, 0, -$len_cleartext_last_block;
+
+  my $b_truncated_enc_ticket = $cbc->encrypt (hex2byte ($truncated_cleartext_ticket), $b_ke, $b_iv);
+
+  my $b_enc_ticket_n_1_block= substr $b_truncated_enc_ticket, -16;
+
+  my $b_enc_last_block = substr $b_enc_ticket_n_1_block, 0, $len_cleartext_last_block / 2;
+
+  # we now craft the new n-1 block
+  my $tmp = $b_enc_ticket_n_1_block ^ $b_cleartext_last_block_padded;
+
+  $b_enc_ticket_n_1_block = $cbc->encrypt ($tmp, $b_ke, $b_iv);
+
+  $tmp = substr $b_truncated_enc_ticket, 0, -16;
+
+  $edata2 = $tmp . $b_enc_ticket_n_1_block . $b_enc_last_block;
+
+  my $tmp_hash = sprintf ('$krb5asrep$18$%s$%s$%s$%s', $user, $realm, unpack ("H*", $checksum), unpack ("H*", $edata2));
+
+  return $tmp_hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @data = split ('\$', $hash);
+
+  return unless scalar @data == 7;
+
+  shift @data;
+
+  my $signature = shift @data;
+  my $algorithm = shift @data;
+  my $user      = shift @data;
+  my $realm     = shift @data;
+  my $checksum  = shift @data;
+  my $edata2    = shift @data;
+
+  return unless ($signature eq "krb5asrep");
+  return unless ($algorithm eq "18");
+  return unless (length ($checksum) == 24);
+  return unless (length ($edata2) >= 64);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, undef, $user, $realm, $checksum, $edata2);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Hi, I've added two new hash formats for Kerberos AS-REPs with AES encryption (addressing #2603):
* Hash-mode 33100: Kerberos 5, etype 17 (AES128), AS-REP
* Hash-mode 33200: Kerberos 5, etype 18 (AES256), AS-REP

I used hash-mode numbers that were a bit higher than the current highest ones as per the plugin development guide, so I'm assuming I'll need to change them once some official hash-mode numbers are reserved.

The plugins are basically just modified versions of the existing TGS-REP AES plugins (19600 and 19700) and some code was also used from the AS-REP RC4 plugin (18200), so most of the credit should still go to the authors of those.

I only implemented pure kernels for them, in line with what's been done for the other Kerberos AES plugins.

## Hash Format

I decided to make the hash format similar to the other Kerberos hash formats, e.g. 19600 and 19700.

Hash format for AS-REP type 18 (type 17 is obviously very similar):
```
$krb5asrep$18$user$realm$checksum$edata2
```

But I also added support for John the Ripper's hash format for ease of use, since its AS-REP plugin already supports AES encryption types. For comparison, John's format for type 18 is:
```
$krb5asrep$18$salt$edata2$checksum
```

## Example Hashes

Here are some example hashes, both have the password "hashcat".

Example AS-REP type 17 hash:
```
$krb5asrep$17$user$example.com$a419c4030e555734b06c2629$c09a1421f96eb126c757a4b87830381f142477d9a85b2beb3093dbfd44f38ddb6016a479537fb7b36e046315869fe79187217971ff6a12c1e0a2df3f68045e03814b21f756d8981f781803d65e8572823c88979581d93cf7d768f2efced16f3719b8d1004d9e73d798de255383476bced47d1982f16be77d0feb55a1f44f58bd013fa4caee58ac614caf0f1cf9101ec9623c5b8c2a1491b73f134f074790088fdb360b5ebce0d32a8145ed00a81ddf77188e150b92d8e8ddd0285d27f1514253e5546e6bba864b362bb1e6483b26d08fa4cc268bfbefe0f690039bcc524b774599df3680c1c3431d891bfa99514a877f964e
```

Example AS-REP type 18 hash:
```
$krb5asrep$18$user$example.com$aa4c494f520b27873a4de8f7$ebc9976a77f62e8ccca02d43d68bafcc66a81fcbb44a336b00ce401982f32975a5f9bcdc752643252185866685b0a30aaf50e449e392a5994e6979f23aba25f7704c90b2efa03b703c3c2f9e3617cc588ed226d0417e7742d45407878fd946d046b4a9732b9a203cb857811714b009c195b7c96b9bccb7e48832b11a4e92ecf24c49e54de8d0d5d5351445b5126db90bb7eebc7861db1e61de1175824b0a45023a6fa06c2a9d3035fdcf863bea922648e3dc28b48e39b1dec0869e7fe4de399cb52dfcf2596599da54a4bb0169c72d9496de2e137a4594e0e8a69082fc558ac9ace65d32eae5e260a65ca3f2f5871aaeee7a3b090b50f39321d120c144421e0abe7d
```

And the same Hashes in John's format if that's necessary for testing:

Example AS-REP type 17 hash (John format):
```
$krb5asrep$17$EXAMPLE.COMuser$c09a1421f96eb126c757a4b87830381f142477d9a85b2beb3093dbfd44f38ddb6016a479537fb7b36e046315869fe79187217971ff6a12c1e0a2df3f68045e03814b21f756d8981f781803d65e8572823c88979581d93cf7d768f2efced16f3719b8d1004d9e73d798de255383476bced47d1982f16be77d0feb55a1f44f58bd013fa4caee58ac614caf0f1cf9101ec9623c5b8c2a1491b73f134f074790088fdb360b5ebce0d32a8145ed00a81ddf77188e150b92d8e8ddd0285d27f1514253e5546e6bba864b362bb1e6483b26d08fa4cc268bfbefe0f690039bcc524b774599df3680c1c3431d891bfa99514a877f964e$a419c4030e555734b06c2629
```

Example AS-REP type 18 hash (John format):
```
$krb5asrep$18$EXAMPLE.COMuser$ebc9976a77f62e8ccca02d43d68bafcc66a81fcbb44a336b00ce401982f32975a5f9bcdc752643252185866685b0a30aaf50e449e392a5994e6979f23aba25f7704c90b2efa03b703c3c2f9e3617cc588ed226d0417e7742d45407878fd946d046b4a9732b9a203cb857811714b009c195b7c96b9bccb7e48832b11a4e92ecf24c49e54de8d0d5d5351445b5126db90bb7eebc7861db1e61de1175824b0a45023a6fa06c2a9d3035fdcf863bea922648e3dc28b48e39b1dec0869e7fe4de399cb52dfcf2596599da54a4bb0169c72d9496de2e137a4594e0e8a69082fc558ac9ace65d32eae5e260a65ca3f2f5871aaeee7a3b090b50f39321d120c144421e0abe7d$aa4c494f520b27873a4de8f7
```

## Testing and Benchmarks

Everything seems to work fine according to the testing I've done so far, and the benchmark results were basically the same as the TGS-REP AES plugins on a cracking rig with 3 RTX3080's. I'm hoping there are no issues given how similar these are to the TGS-REP plugins, but please let me know if I need to fix anything.

## Additions to Existing Checks for Valid ASN.1 Data

The kernel code for the AS-REP RC4 plugin has a check for valid ASN.1 structs in the first part of the decrypted data, which I used in my kernel code as well since I'd be looking for the same data. But I realised there was something that could be added to those checks, based on one of the test hashes from John the Ripper's AS-REP module (the `luser-18-12345678.pcap` hash in https://github.com/openwall/john/blob/bleeding-jumbo/src/krb5_asrep_fmt_plug.c, for reference).

The code checks if the first byte is `0x79`, which corresponds to an "APPLICATION 25" ASN.1 struct. The first byte from that example hash from John was `0x7a`, even though it looked like the right data from an AS-REP message, and cracked successfully. I found something about this in Section 5.4.2 of RFC4120:

> Compatibility note: Some implementations unconditionally send an encrypted EncTGSRepPart (application tag number 26) in this field regardless of whether the reply is a AS-REP or a TGS-REP. In the interest of compatibility, implementors MAY relax the check on the tag number of the decrypted ENC-PART.

It looks like that's what happened with the test hash from John, since `0x7a` would correspond to "APPLICATION 26" instead of the usual 25. So based on this, I modified the checks that look for `0x79` in the first byte to also match `0x7a`, and then it was able to crack the John test hash successfully.

This was the original if statement from the hash-mode 18200 kernel code:
```
if (((out0[2] & 0x00ff80ff) != 0x00300079) &&
	((out0[2] & 0xFF00FFFF) != 0x30008179) &&
	((out0[2] & 0x0000FFFF) != 0x00008279 || (out0[3] & 0x000000FF) != 0x00000030))
```

And this is the modified one in the kernel code for my plugins:
```
if (((decrypted_block[0] & 0x00ff80ff) == 0x00300079) ||
	((decrypted_block[0] & 0x00ff80ff) == 0x0030007a) ||
	((decrypted_block[0] & 0xFF00FFFF) == 0x30008179) || 
	((decrypted_block[0] & 0xFF00FFFF) == 0x3000817a) ||
	((decrypted_block[0] & 0x0000FFFF) == 0x00008279 && (decrypted_block[1] & 0x000000FF) == 0x00000030) ||
	((decrypted_block[0] & 0x0000FFFF) == 0x0000827a && (decrypted_block[1] & 0x000000FF) == 0x00000030))
```

The main reason I'm mentioning this here is that if this is okay, then we can probably add this modification to the 18200 hash format as well.
