### PR TITLE
Unit Test: removes salt constraints if no salt is used

### DIFF
--- a/tools/test_modules/m00070.pm
+++ b/tools/test_modules/m00070.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::MD5 qw (md5_hex);
 use Encode;
 
-sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m00170.pm
+++ b/tools/test_modules/m00170.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::SHA1 qw (sha1_hex);
 use Encode;
 
-sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m01470.pm
+++ b/tools/test_modules/m01470.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::SHA qw (sha256_hex);
 use Encode;
 
-sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m01770.pm
+++ b/tools/test_modules/m01770.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::SHA qw (sha512_hex);
 use Encode;
 
-sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m10870.pm
+++ b/tools/test_modules/m10870.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::SHA qw (sha384_hex);
 use Encode;
 
-sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m11700.pm
+++ b/tools/test_modules/m11700.pm
@@ -8,7 +8,7 @@
 use strict;
 use warnings;
 
-sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [-1, -1]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m24800.pm
+++ b/tools/test_modules/m24800.pm
@@ -13,7 +13,7 @@ use Digest::HMAC qw (hmac);
 use Encode       qw (encode);
 use MIME::Base64 qw (encode_base64);
 
-sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
Removed salt constraints on the following test modules, because no salt is used: 70, 170, 1470, 1770, 10870, 11700 and 24800