### PR TITLE
Fixed build failure for almost all hash modes that make use of hc_swap64 and/or hc_swap64_S with Apple Metal

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -1317,6 +1317,16 @@ DECLSPEC u64x hc_swap64 (const u64x v)
   asm volatile ("mov.b64 %0, {%1, %2};" : "=l"(r.sf) : "r"(tr.sf), "r"(tl.sf));
   #endif
 
+  #elif defined IS_METAL
+
+  const u32x a0 = h32_from_64 (v);
+  const u32x a1 = l32_from_64 (v);
+
+  u32x t0 = hc_swap32 (a0);
+  u32x t1 = hc_swap32 (a1);
+
+  r = hl32_to_64 (t1, t0);
+
   #else
 
   #if defined USE_BITSELECT && defined USE_ROTATE
@@ -1380,7 +1390,19 @@ DECLSPEC u64 hc_swap64_S (const u64 v)
   asm volatile ("prmt.b32 %0, %1, 0, 0x0123;" : "=r"(tr) : "r"(ir));
 
   asm volatile ("mov.b64 %0, {%1, %2};" : "=l"(r) : "r"(tr), "r"(tl));
+
+  #elif defined IS_METAL
+
+  const u32 v0 = h32_from_64_S (v);
+  const u32 v1 = l32_from_64_S (v);
+
+  u32 t0 = hc_swap32_S (v0);
+  u32 t1 = hc_swap32_S (v1);
+
+  r = hl32_to_64_S (t1, t0);
+
   #else
+
   #ifdef USE_SWIZZLE
   r = as_ulong (as_uchar8 (v).s76543210);
   #else

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -65,6 +65,7 @@
 - Fixed build failed for 31700 with Apple Metal
 - Fixed build failed for 31300 with vector width > 1
 - Fixed build failed for 31000/Blake2s with vector width > 1
+- Fixed build failure for almost all hash modes that make use of hc_swap64 and/or hc_swap64_S with Apple Metal
 - Fixed display problem of the "Optimizers applied" list for algorithms using OPTI_TYPE_SLOW_HASH_SIMD_INIT2 and/or OPTI_TYPE_SLOW_HASH_SIMD_LOOP2
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 31700 a3 kernel
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 3730 a3 kernel


### PR DESCRIPTION
Hi,

as the title, almost all hash-modes that make use of hc_swap64/hc_swap64_S will work after this patch.

Example with 1800 (optimized)

```
bash-3.2$ ./hashcat -m 1800 -b --force -d1
hashcat (v6.2.6-536-gc100ad7be) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

METAL API (Metal 263.9)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Benchmark relevant options:
===========================
* --force
* --backend-devices=1
* --backend-devices-virtual=1
* --optimized-kernel-enable

--------------------------------------------------------------------
* Hash-Mode 1800 (sha512crypt $6$, SHA512 (Unix)) [Iterations: 5000]
--------------------------------------------------------------------

hc_mtlCreateKernel_block_invoke(): failed to create 'm01800_init' pipeline, Compiler encountered an internal error

* Device #1: Kernel m01800_init create failed.
``` 

After the patch:

```
bash-3.2$ for a in $(echo 1800 11700 11750 11760 11800 11850 11860 13771 19200 21600); do ./hashcat -m $a -b --force -d1 --quiet; done
--------------------------------------------------------------------
* Hash-Mode 1800 (sha512crypt $6$, SHA512 (Unix)) [Iterations: 5000]
--------------------------------------------------------------------

Speed.#1.........:    14339 H/s (55.58ms) @ Accel:1024 Loops:128 Thr:32 Vec:1

--------------------------------------------------------------------
* Hash-Mode 11700 (GOST R 34.11-2012 (Streebog) 256-bit, big-endian)
--------------------------------------------------------------------

Speed.#1.........: 15238.9 kH/s (67.14ms) @ Accel:4 Loops:512 Thr:64 Vec:1

---------------------------------------------------------------
* Hash-Mode 11750 (HMAC-Streebog-256 (key = $pass), big-endian)
---------------------------------------------------------------

Speed.#1.........:  5191.0 kH/s (99.10ms) @ Accel:8 Loops:128 Thr:64 Vec:1

---------------------------------------------------------------
* Hash-Mode 11760 (HMAC-Streebog-256 (key = $salt), big-endian)
---------------------------------------------------------------

Speed.#1.........:  7056.0 kH/s (72.55ms) @ Accel:8 Loops:128 Thr:64 Vec:1

--------------------------------------------------------------------
* Hash-Mode 11800 (GOST R 34.11-2012 (Streebog) 512-bit, big-endian)
--------------------------------------------------------------------

Speed.#1.........: 14763.4 kH/s (69.34ms) @ Accel:8 Loops:256 Thr:64 Vec:1

---------------------------------------------------------------
* Hash-Mode 11850 (HMAC-Streebog-512 (key = $pass), big-endian)
---------------------------------------------------------------

Speed.#1.........:  4490.1 kH/s (56.71ms) @ Accel:8 Loops:64 Thr:64 Vec:1

---------------------------------------------------------------
* Hash-Mode 11860 (HMAC-Streebog-512 (key = $salt), big-endian)
---------------------------------------------------------------

Speed.#1.........:  6137.1 kH/s (83.57ms) @ Accel:4 Loops:256 Thr:64 Vec:1

--------------------------------------------------------------------------------------
* Hash-Mode 13771 (VeraCrypt Streebog-512 + XTS 512 bit (legacy)) [Iterations: 499999]
--------------------------------------------------------------------------------------

Speed.#1.........:       10 H/s (50.65ms) @ Accel:64 Loops:125 Thr:64 Vec:1

---------------------------------------------------------------
* Hash-Mode 19200 (QNX /etc/shadow (SHA512)) [Iterations: 1000]
---------------------------------------------------------------

Speed.#1.........:   188.6 kH/s (72.54ms) @ Accel:64 Loops:1000 Thr:32 Vec:1

----------------------------------------------------------
* Hash-Mode 21600 (Web2py pbkdf2-sha512) [Iterations: 999]
----------------------------------------------------------

Speed.#1.........:    28925 H/s (64.84ms) @ Accel:128 Loops:62 Thr:32 Vec:1

```

