### PR TITLE
Fix get_random_num function to be inclusive of max parameter

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -622,11 +622,11 @@ u32 get_random_num (const u32 min, const u32 max)
 
   #if defined (_WIN)
 
-  return (((u32) rand () % (max - min)) + min);
+  return (((u32) rand () % (max - min + 1)) + min);
 
   #else
 
-  return (((u32) random () % (max - min)) + min);
+  return (((u32) random () % (max - min + 1)) + min);
 
   #endif
 }


### PR DESCRIPTION
The get_random_num function does not currently include the max parameter. This causes issues such as the tilde character not being generated with random rule generation. This makes the max parameter value inclusive.

This pull request resolves #3688 