### PR TITLE
Fixed build failed for 13772 and 13773 with Apple Metal

### DIFF
--- a/OpenCL/m13772-pure.cl
+++ b/OpenCL/m13772-pure.cl
@@ -357,54 +357,98 @@ KERNEL_FQ void m13772_init (KERN_ATTR_TMPS_ESALT (vc64_sbog_tmp_t, vc_t))
 
   streebog512_hmac_update_global_swap (&streebog512_hmac_ctx, salt_bufs[SALT_POS_HOST].salt_buf, 64);
 
-  for (u32 i = 0, j = 1; i < 16; i += 8, j += 1)
-  {
-    streebog512_hmac_ctx_t streebog512_hmac_ctx2 = streebog512_hmac_ctx;
+  u32 i = 0;
+  u32 j = 1;
 
-    u32 w0[4];
-    u32 w1[4];
-    u32 w2[4];
-    u32 w3[4];
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
 
-    w0[0] = j;
-    w0[1] = 0;
-    w0[2] = 0;
-    w0[3] = 0;
-    w1[0] = 0;
-    w1[1] = 0;
-    w1[2] = 0;
-    w1[3] = 0;
-    w2[0] = 0;
-    w2[1] = 0;
-    w2[2] = 0;
-    w2[3] = 0;
-    w3[0] = 0;
-    w3[1] = 0;
-    w3[2] = 0;
-    w3[3] = 0;
+  streebog512_hmac_ctx_t streebog512_hmac_ctx_v1 = streebog512_hmac_ctx;
 
-    streebog512_hmac_update_64 (&streebog512_hmac_ctx2, w0, w1, w2, w3, 4);
+  w0[0] = j;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
 
-    streebog512_hmac_final (&streebog512_hmac_ctx2);
+  streebog512_hmac_update_64 (&streebog512_hmac_ctx_v1, w0, w1, w2, w3, 4);
 
-    tmps[gid].dgst[i + 0] = streebog512_hmac_ctx2.opad.h[0];
-    tmps[gid].dgst[i + 1] = streebog512_hmac_ctx2.opad.h[1];
-    tmps[gid].dgst[i + 2] = streebog512_hmac_ctx2.opad.h[2];
-    tmps[gid].dgst[i + 3] = streebog512_hmac_ctx2.opad.h[3];
-    tmps[gid].dgst[i + 4] = streebog512_hmac_ctx2.opad.h[4];
-    tmps[gid].dgst[i + 5] = streebog512_hmac_ctx2.opad.h[5];
-    tmps[gid].dgst[i + 6] = streebog512_hmac_ctx2.opad.h[6];
-    tmps[gid].dgst[i + 7] = streebog512_hmac_ctx2.opad.h[7];
+  streebog512_hmac_final (&streebog512_hmac_ctx_v1);
 
-    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
-    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
-    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
-    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
-    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
-    tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
-    tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
-    tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
-  }
+  tmps[gid].dgst[i + 0] = streebog512_hmac_ctx_v1.opad.h[0];
+  tmps[gid].dgst[i + 1] = streebog512_hmac_ctx_v1.opad.h[1];
+  tmps[gid].dgst[i + 2] = streebog512_hmac_ctx_v1.opad.h[2];
+  tmps[gid].dgst[i + 3] = streebog512_hmac_ctx_v1.opad.h[3];
+  tmps[gid].dgst[i + 4] = streebog512_hmac_ctx_v1.opad.h[4];
+  tmps[gid].dgst[i + 5] = streebog512_hmac_ctx_v1.opad.h[5];
+  tmps[gid].dgst[i + 6] = streebog512_hmac_ctx_v1.opad.h[6];
+  tmps[gid].dgst[i + 7] = streebog512_hmac_ctx_v1.opad.h[7];
+
+  tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+  tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+  tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+  tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+  tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
+  tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
+  tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
+
+  i=8;
+  j=2;
+
+  streebog512_hmac_ctx_t streebog512_hmac_ctx_v2 = streebog512_hmac_ctx;
+
+  w0[0] = j;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  streebog512_hmac_update_64 (&streebog512_hmac_ctx_v2, w0, w1, w2, w3, 4);
+
+  streebog512_hmac_final (&streebog512_hmac_ctx_v2);
+
+  tmps[gid].dgst[i + 0] = streebog512_hmac_ctx_v2.opad.h[0];
+  tmps[gid].dgst[i + 1] = streebog512_hmac_ctx_v2.opad.h[1];
+  tmps[gid].dgst[i + 2] = streebog512_hmac_ctx_v2.opad.h[2];
+  tmps[gid].dgst[i + 3] = streebog512_hmac_ctx_v2.opad.h[3];
+  tmps[gid].dgst[i + 4] = streebog512_hmac_ctx_v2.opad.h[4];
+  tmps[gid].dgst[i + 5] = streebog512_hmac_ctx_v2.opad.h[5];
+  tmps[gid].dgst[i + 6] = streebog512_hmac_ctx_v2.opad.h[6];
+  tmps[gid].dgst[i + 7] = streebog512_hmac_ctx_v2.opad.h[7];
+
+  tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+  tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+  tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+  tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+  tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
+  tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
+  tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
 }
 
 KERNEL_FQ void m13772_loop (KERN_ATTR_TMPS_ESALT (vc64_sbog_tmp_t, vc_t))

--- a/OpenCL/m13773-pure.cl
+++ b/OpenCL/m13773-pure.cl
@@ -422,54 +422,142 @@ KERNEL_FQ void m13773_init (KERN_ATTR_TMPS_ESALT (vc64_sbog_tmp_t, vc_t))
 
   streebog512_hmac_update_global_swap (&streebog512_hmac_ctx, salt_bufs[SALT_POS_HOST].salt_buf, 64);
 
-  for (u32 i = 0, j = 1; i < 24; i += 8, j += 1)
-  {
-    streebog512_hmac_ctx_t streebog512_hmac_ctx2 = streebog512_hmac_ctx;
+  u32 i = 0;
+  u32 j = 1;
 
-    u32 w0[4];
-    u32 w1[4];
-    u32 w2[4];
-    u32 w3[4];
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
 
-    w0[0] = j;
-    w0[1] = 0;
-    w0[2] = 0;
-    w0[3] = 0;
-    w1[0] = 0;
-    w1[1] = 0;
-    w1[2] = 0;
-    w1[3] = 0;
-    w2[0] = 0;
-    w2[1] = 0;
-    w2[2] = 0;
-    w2[3] = 0;
-    w3[0] = 0;
-    w3[1] = 0;
-    w3[2] = 0;
-    w3[3] = 0;
+  streebog512_hmac_ctx_t streebog512_hmac_ctx_v1 = streebog512_hmac_ctx;
 
-    streebog512_hmac_update_64 (&streebog512_hmac_ctx2, w0, w1, w2, w3, 4);
+  w0[0] = j;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
 
-    streebog512_hmac_final (&streebog512_hmac_ctx2);
+  streebog512_hmac_update_64 (&streebog512_hmac_ctx_v1, w0, w1, w2, w3, 4);
 
-    tmps[gid].dgst[i + 0] = streebog512_hmac_ctx2.opad.h[0];
-    tmps[gid].dgst[i + 1] = streebog512_hmac_ctx2.opad.h[1];
-    tmps[gid].dgst[i + 2] = streebog512_hmac_ctx2.opad.h[2];
-    tmps[gid].dgst[i + 3] = streebog512_hmac_ctx2.opad.h[3];
-    tmps[gid].dgst[i + 4] = streebog512_hmac_ctx2.opad.h[4];
-    tmps[gid].dgst[i + 5] = streebog512_hmac_ctx2.opad.h[5];
-    tmps[gid].dgst[i + 6] = streebog512_hmac_ctx2.opad.h[6];
-    tmps[gid].dgst[i + 7] = streebog512_hmac_ctx2.opad.h[7];
+  streebog512_hmac_final (&streebog512_hmac_ctx_v1);
 
-    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
-    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
-    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
-    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
-    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
-    tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
-    tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
-    tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
-  }
+  tmps[gid].dgst[i + 0] = streebog512_hmac_ctx_v1.opad.h[0];
+  tmps[gid].dgst[i + 1] = streebog512_hmac_ctx_v1.opad.h[1];
+  tmps[gid].dgst[i + 2] = streebog512_hmac_ctx_v1.opad.h[2];
+  tmps[gid].dgst[i + 3] = streebog512_hmac_ctx_v1.opad.h[3];
+  tmps[gid].dgst[i + 4] = streebog512_hmac_ctx_v1.opad.h[4];
+  tmps[gid].dgst[i + 5] = streebog512_hmac_ctx_v1.opad.h[5];
+  tmps[gid].dgst[i + 6] = streebog512_hmac_ctx_v1.opad.h[6];
+  tmps[gid].dgst[i + 7] = streebog512_hmac_ctx_v1.opad.h[7];
+
+  tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+  tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+  tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+  tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+  tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
+  tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
+  tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
+
+  i = 8;
+  j = 2;
+
+  streebog512_hmac_ctx_t streebog512_hmac_ctx_v2 = streebog512_hmac_ctx;
+
+  w0[0] = j;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  streebog512_hmac_update_64 (&streebog512_hmac_ctx_v2, w0, w1, w2, w3, 4);
+
+  streebog512_hmac_final (&streebog512_hmac_ctx_v2);
+
+  tmps[gid].dgst[i + 0] = streebog512_hmac_ctx_v2.opad.h[0];
+  tmps[gid].dgst[i + 1] = streebog512_hmac_ctx_v2.opad.h[1];
+  tmps[gid].dgst[i + 2] = streebog512_hmac_ctx_v2.opad.h[2];
+  tmps[gid].dgst[i + 3] = streebog512_hmac_ctx_v2.opad.h[3];
+  tmps[gid].dgst[i + 4] = streebog512_hmac_ctx_v2.opad.h[4];
+  tmps[gid].dgst[i + 5] = streebog512_hmac_ctx_v2.opad.h[5];
+  tmps[gid].dgst[i + 6] = streebog512_hmac_ctx_v2.opad.h[6];
+  tmps[gid].dgst[i + 7] = streebog512_hmac_ctx_v2.opad.h[7];
+
+  tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+  tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+  tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+  tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+  tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
+  tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
+  tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
+
+  i = 16;
+  j = 3;
+
+  streebog512_hmac_ctx_t streebog512_hmac_ctx_v3 = streebog512_hmac_ctx;
+
+  w0[0] = j;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  streebog512_hmac_update_64 (&streebog512_hmac_ctx_v3, w0, w1, w2, w3, 4);
+
+  streebog512_hmac_final (&streebog512_hmac_ctx_v3);
+
+  tmps[gid].dgst[i + 0] = streebog512_hmac_ctx_v3.opad.h[0];
+  tmps[gid].dgst[i + 1] = streebog512_hmac_ctx_v3.opad.h[1];
+  tmps[gid].dgst[i + 2] = streebog512_hmac_ctx_v3.opad.h[2];
+  tmps[gid].dgst[i + 3] = streebog512_hmac_ctx_v3.opad.h[3];
+  tmps[gid].dgst[i + 4] = streebog512_hmac_ctx_v3.opad.h[4];
+  tmps[gid].dgst[i + 5] = streebog512_hmac_ctx_v3.opad.h[5];
+  tmps[gid].dgst[i + 6] = streebog512_hmac_ctx_v3.opad.h[6];
+  tmps[gid].dgst[i + 7] = streebog512_hmac_ctx_v3.opad.h[7];
+
+  tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+  tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+  tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+  tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+  tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+  tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
+  tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
+  tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
 }
 
 KERNEL_FQ void m13773_loop (KERN_ATTR_TMPS_ESALT (vc64_sbog_tmp_t, vc_t))

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -60,6 +60,7 @@
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
 - Added verification of token buffer length when using TOKEN_ATTR_FIXED_LENGTH
 - Fixed build failed for 4410 with vector width > 1
+- Fixed build failed for 13772 and 13773 with Apple Metal
 - Fixed build failed for 18400 with Apple Metal
 - Fixed build failed for 18600 with Apple Metal
 - Fixed build failed for 31700 with Apple Metal


### PR DESCRIPTION
before:

```
---------------------------------------------------------------------------------------
* Hash-Mode 13772 (VeraCrypt Streebog-512 + XTS 1024 bit (legacy)) [Iterations: 499999]
---------------------------------------------------------------------------------------

hc_mtlCreateKernel_block_invoke(): failed to create 'm13772_init' pipeline, Compiler encountered an internal error

* Device #1: Kernel m13772_init create failed.
---------------------------------------------------------------------------------------
* Hash-Mode 13773 (VeraCrypt Streebog-512 + XTS 1536 bit (legacy)) [Iterations: 499999]
---------------------------------------------------------------------------------------

hc_mtlCreateKernel_block_invoke(): failed to create 'm13773_init' pipeline, Compiler encountered an internal error

* Device #1: Kernel m13773_init create failed.

```

after:

```
---------------------------------------------------------------------------------------
* Hash-Mode 13772 (VeraCrypt Streebog-512 + XTS 1024 bit (legacy)) [Iterations: 499999]
---------------------------------------------------------------------------------------

Speed.#1.........:        5 H/s (24.33ms) @ Accel:32 Loops:62 Thr:64 Vec:1

---------------------------------------------------------------------------------------
* Hash-Mode 13773 (VeraCrypt Streebog-512 + XTS 1536 bit (legacy)) [Iterations: 499999]
---------------------------------------------------------------------------------------

Speed.#1.........:        3 H/s (34.44ms) @ Accel:32 Loops:62 Thr:64 Vec:1

```

PR #3735 must be applied