### PR TITLE
Fixed build failed for 10700 optimized with Apple Metal

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -60,6 +60,7 @@
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
 - Added verification of token buffer length when using TOKEN_ATTR_FIXED_LENGTH
 - Fixed build failed for 4410 with vector width > 1
+- Fixed build failed for 10700 optimized with Apple Metal
 - Fixed build failed for 18400 with Apple Metal
 - Fixed build failed for 18600 with Apple Metal
 - Fixed build failed for 31700 with Apple Metal

--- a/src/modules/module_10700.c
+++ b/src/modules/module_10700.c
@@ -84,10 +84,13 @@ static const int   ROUNDS_PDF17L8 = 64;
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
-  // AppleM1, OpenCL, MTLCompilerService, createKernel: newComputePipelineState failed (or never-end with pure kernel)
+  // AppleM1, OpenCL, MTLCompilerService, createKernel never-end with pure kernel
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE) && (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU))
   {
-    return true;
+    if ((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0)
+    {
+      return true;
+    }
   }
 
   return false;
@@ -131,6 +134,11 @@ u32 module_kernel_threads_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYB
 char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
   char *jit_build_options = NULL;
+
+  if (device_param->is_metal == true)
+  {
+    hc_asprintf (&jit_build_options, "-D FORCE_DISABLE_SHM");
+  }
 
   if ((device_param->opencl_device_vendor_id == VENDOR_ID_AMD) && (device_param->has_vperm == false))
   {


### PR DESCRIPTION
before:

```
----------------------------------------------------------------------
* Hash-Mode 10700 (PDF 1.7 Level 8 (Acrobat 10 - 11)) [Iterations: 64]
----------------------------------------------------------------------

hc_mtlCreateKernel_block_invoke(): failed to create 'm10700_loop' pipeline, Compiler encountered an internal error

* Device #1: Kernel m10700_loop create failed.
```

after PR #3735 applied:

```
----------------------------------------------------------------------
* Hash-Mode 10700 (PDF 1.7 Level 8 (Acrobat 10 - 11)) [Iterations: 64]
----------------------------------------------------------------------

hc_mtlCreateKernel_block_invoke(): failed to create 'm10700_loop' pipeline, Threadgroup memory size (33792) exceeds the maximum threadgroup memory allowed (32768)

* Device #1: Kernel m10700_loop create failed.

```

after PR #3735 and this patch applied:

```
----------------------------------------------------------------------
* Hash-Mode 10700 (PDF 1.7 Level 8 (Acrobat 10 - 11)) [Iterations: 64]
----------------------------------------------------------------------

Speed.#1.........:     2447 H/s (102.27ms) @ Accel:4 Loops:8 Thr:64 Vec:1

```

Pure kernel still does not work ... 

