### PR TITLE
Fixed maximum password length in module/test_module of hash-mode 2400

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -71,6 +71,7 @@
 - Fixed minimum password length in module of hash-mode 28200
 - Handle signed/unsigned PDF permission P value for all PDF hash-modes
 - Fixed minimum password length in module of hash-mode 29800
+- Fixed maximum password length in module/test_module of hash-mode 2400
 - Fixed buffer overflow on module_26600.c / module_hash_encode()
 
 ##

--- a/src/modules/module_02400.c
+++ b/src/modules/module_02400.c
@@ -45,6 +45,20 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  u32 pw_max = PW_MAX;
+
+  if (optimized_kernel == true)
+  {
+    pw_max = 31;
+  }
+
+  return pw_max;
+}
+
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
   u32 *digest = (u32 *) digest_buf;
@@ -217,7 +231,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_potfile_disable          = MODULE_DEFAULT;
   module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
   module_ctx->module_pwdump_column            = MODULE_DEFAULT;
-  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
   module_ctx->module_pw_min                   = MODULE_DEFAULT;
   module_ctx->module_salt_max                 = MODULE_DEFAULT;
   module_ctx->module_salt_min                 = MODULE_DEFAULT;

--- a/tools/test_modules/m02400.pm
+++ b/tools/test_modules/m02400.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::MD5 qw (md5);
 use POSIX qw (ceil);
 
-sub module_constraints { [[-1, -1], [-1, -1], [1, 55], [-1, -1], [-1, -1]] }
+sub module_constraints { [[-1, -1], [-1, -1], [1, 31], [-1, -1], [-1, -1]] }
 
 sub pseudo_base64
 {


### PR DESCRIPTION
Hi,

before the pw_max limit in -a 3 was 55, but it is not correct.
The right one is 31

Thanks :)