### PR TITLE
Fixed maximum password length in module/test_module of hash-mode 2410

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -69,6 +69,7 @@
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 31700 a3 kernel
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 3730 a3 kernel
 - Fixed minimum password length in module of hash-mode 28200
+- Fixed maximum password length in module/test_module of hash-mode 2410
 - Handle signed/unsigned PDF permission P value for all PDF hash-modes
 - Fixed minimum password length in module of hash-mode 29800
 - Fixed buffer overflow on module_26600.c / module_hash_encode()

--- a/src/modules/module_02410.c
+++ b/src/modules/module_02410.c
@@ -44,6 +44,41 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  u32 pw_max = PW_MAX;
+
+  if (optimized_kernel == true)
+  {
+    if (user_options->attack_mode == ATTACK_MODE_BF)
+    {
+      pw_max = 47; // with salt_len 1, but 44 if salt_len is 4
+    }
+    else
+    {
+      pw_max = 31;
+    }
+  }
+
+  return pw_max;
+}
+
+u32 module_salt_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 salt_min = 1;
+
+  return salt_min;
+}
+
+u32 module_salt_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 salt_max = 4;
+
+  return salt_max;
+}
+
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
   u32 *digest = (u32 *) digest_buf;
@@ -233,10 +268,10 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_potfile_disable          = MODULE_DEFAULT;
   module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
   module_ctx->module_pwdump_column            = MODULE_DEFAULT;
-  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
   module_ctx->module_pw_min                   = MODULE_DEFAULT;
-  module_ctx->module_salt_max                 = MODULE_DEFAULT;
-  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = module_salt_max;
+  module_ctx->module_salt_min                 = module_salt_min;
   module_ctx->module_salt_type                = module_salt_type;
   module_ctx->module_separator                = MODULE_DEFAULT;
   module_ctx->module_st_hash                  = module_st_hash;

--- a/tools/test_modules/m02410.pm
+++ b/tools/test_modules/m02410.pm
@@ -11,7 +11,7 @@ use warnings;
 use Digest::MD5 qw (md5);
 use POSIX       qw (ceil);
 
-sub module_constraints { [[-1, -1], [-1, -1], [0, 55], [1, 4], [-1, -1]] }
+sub module_constraints { [[-1, -1], [-1, -1], [0, 47], [1, 4], [0, 48]] }
 
 sub pseudo_base64
 {


### PR DESCRIPTION
Hi,

by testing the edge cases, I see that this hash-mode fail to cracks password with length > 47 if the salt_len is 1 and > 44 if salt_len is 4.

Thanks