### PR TITLE
Change Module_15700.hctune command

### DIFF
--- a/tunings/Module_15700.hctune
+++ b/tunings/Module_15700.hctune
@@ -4,7 +4,7 @@
 #
 # 1. For example, to find the value for 15700, first create a valid hash for 15700 as follows:
 #
-# $ ./hashcat --example-hashes -m 15700 | grep Example.Hash | grep -v Format | cut -b 25- > tmp.hash.15700
+# $ ./hashcat --example-hashes --mach -m 15700 | grep -Eo '\$ethereum\$s[*a-f0-9]{1,}' > tmp.hash.15700
 #
 # 2. Now let it iterate through all -n values to a certain point. In this case, I'm using 200, but in general it's a value that is at least twice that of the multiprocessor. If you don't mind you can just leave it as it is, it just runs a little longer.
 #


### PR DESCRIPTION
Fix truncated hash outputted from the listed command output
Previous command output:
```
$ ./hashcat --example-hashes -m 15700 | grep Example.Hash | grep -v Format | cut -b 25-
$ethereum$s*262144*8*1*313431383733343433383830...05efd [Truncated, use --mach for full length]
```
New command output:
```
$ ./hashcat --example-hashes --mach -m 15700 | grep -Eo '\$ethereum\$s[*a-f0-9]{1,}'
$ethereum$s*262144*8*1*3134313837333434333838303231333633373433323633373534333136363537*73da7f80ec3bd4f2a128c3a815cfb4d576ecb1a9b47024c902e62ea926f7795b*910e0f8dc1f7ba41959e1089bb769f3e919109591913cc33ba03953d7a905efd
```