### PR TITLE
Support building windows binaries on macOS using MinGW, updated docum…

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -3,7 +3,7 @@ hashcat build documentation
 
 ### Revision ###
 
-* 1.5
+* 1.6
 
 ### Author ###
 
@@ -60,6 +60,10 @@ Otherwise:
 - Session related files go to: $HOME/.local/share/hashcat/sessions/
 - Cached kernels go to: $HOME/.cache/hashcat
 - Potfiles go to: $HOME/.local/share/hashcat/
+
+### Building hashcat for Windows (using macOS) ###
+
+Refer to [BUILD_macOS.md](BUILD_macOS.md)
 
 ### Building hashcat for Windows (using Windows Subsystem for Linux) ###
 

--- a/BUILD_macOS.md
+++ b/BUILD_macOS.md
@@ -1,0 +1,27 @@
+# Compiling hashcat for Windows with macOS.
+
+Tested on macOS 12.6.6 M1.
+
+Make sure to have the HomeBrew upgraded.
+
+### Installation ###
+
+```
+brew install mingw-w64
+git clone https://github.com/hashcat/hashcat
+git clone https://github.com/win-iconv/win-iconv
+cd win-iconv/
+patch < ../hashcat/tools/win-iconv-64.diff
+sudo make install
+cd ../
+```
+
+### Building ###
+
+You've already cloned the latest master revision of hashcat repository above, so switch to the folder and type "make win" to start compiling hashcat
+```
+cd hashcat/
+make win
+```
+
+The process may take a while, please be patient.

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -95,7 +95,9 @@
 - Apple Driver: Updated requirements to use Apple OpenCL API to macOS 13.0 - use
 - Backend Checks: Describe workaround in error message when detecting more than 64 backend devices
 - Brain: Added sanity check and corresponding error message for invalid --brain-port values
+- Building: Support building windows binaries on macOS using MinGW
 - Dependencies: Updated OpenCL-Headers to v2023.04.17
+- Documents: Updated BUILD.md and added BUILD_macOS.md (containing instructions for building windows binaries on macOS)
 - Modules: Added support for non-zero IVs for -m 6800 (Lastpass). Also added `tools/lastpass2hashcat.py`
 - Open Document Format: Added support for small documents with content length < 1024
 - Status Code: Add specific return code for self-test fail (-11)

--- a/src/Makefile
+++ b/src/Makefile
@@ -407,10 +407,6 @@ EMU_OBJS_ALL            += emu_inc_hash_base58
 
 OBJS_ALL                := affinity autotune backend benchmark bitmap bitops combinator common convert cpt cpu_crc32 debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_cpu ext_iokit ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
 
-ifeq ($(UNAME),Darwin)
-OBJS_ALL                += ext_metal
-endif
-
 ifeq ($(ENABLE_BRAIN),1)
 OBJS_ALL                += brain
 endif
@@ -418,6 +414,12 @@ endif
 NATIVE_OBJS             := $(foreach OBJ,$(OBJS_ALL),obj/$(OBJ).NATIVE.o)
 LINUX_OBJS              := $(foreach OBJ,$(OBJS_ALL),obj/$(OBJ).LINUX.o)
 WIN_OBJS                := $(foreach OBJ,$(OBJS_ALL),obj/$(OBJ).WIN.o)
+
+ifeq ($(UNAME),Darwin)
+OBJS_METAL              := ext_metal
+
+NATIVE_OBJS             += $(foreach OBJ,$(OBJS_METAL),obj/$(OBJ).METAL.NATIVE.o)
+endif
 
 ifeq ($(USE_SYSTEM_LZMA),0)
 OBJS_LZMA               := 7zCrc 7zCrcOpt 7zFile 7zStream Alloc Bra Bra86 BraIA64 CpuArch Delta LzmaDec Lzma2Dec Sha256 Sha256Opt Xz XzCrc64 XzCrc64Opt XzDec XzIn
@@ -618,8 +620,10 @@ uninstall:
 obj/%.NATIVE.o: src/%.c
 	$(CC) -c $(CCFLAGS) $(CFLAGS_NATIVE) $< -o $@ -fpic
 
-obj/%.NATIVE.o: src/%.m
+ifeq ($(UNAME),Darwin)
+obj/%.METAL.NATIVE.o: src/%.m
 	$(CC) -c $(CCFLAGS) $(CFLAGS_NATIVE) $< -o $@ -fpic
+endif
 
 ifeq ($(USE_SYSTEM_LZMA),0)
 obj/%.LZMA.NATIVE.o: $(DEPS_LZMA_PATH)/%.c
@@ -712,7 +716,7 @@ modules: $(MODULES_LIB)
 ## Cross Compilation (binary release version)
 ##
 
-ifeq ($(UNAME),Linux)
+ifneq (,$(filter $(UNAME),Linux Darwin))
 
 ##
 ## Compiler paths
@@ -758,10 +762,32 @@ LFLAGS_CROSS_WIN        += -lws2_32
 LFLAGS_CROSS_WIN        += -lpowrprof
 LFLAGS_CROSS_WIN        += -static -static-libgcc -static-libstdc++
 
+CFLAGS_LZMA_WIN         := $(CFLAGS_LZMA)
+CFLAGS_UNRAR_WIN        := $(CFLAGS_UNRAR)
+
+ifeq ($(UNAME),Darwin)
+CFLAGS_CROSS_WIN        := $(filter-out -Wno-typedef-redefinition,$(CFLAGS_CROSS_WIN))
+
+CFLAGS_LZMA_WIN         += -Wno-misleading-indentation
+
+CFLAGS_UNRAR_WIN        += -Wno-misleading-indentation
+CFLAGS_UNRAR_WIN        += -Wno-class-memaccess
+endif
+
 ##
 ## Targets
 ##
 
+ifeq ($(UNAME),Darwin)
+.PHONY: binaries
+binaries: win
+
+.PHONY: host_win
+host_win:   hashcat.exe
+
+.PHONY: win
+win:   host_win   modules_win
+else
 .PHONY: binaries
 binaries: linux win
 
@@ -772,6 +798,7 @@ host_win:   hashcat.exe
 .PHONY: linux win
 linux: host_linux modules_linux
 win:   host_win   modules_win
+endif
 
 ##
 ## cross compiled modules
@@ -802,10 +829,10 @@ obj/%.WIN.o:   src/%.c
 
 ifeq ($(USE_SYSTEM_LZMA),0)
 obj/%.LZMA.LINUX.o: $(DEPS_LZMA_PATH)/%.c
-	$(CC_LINUX) $(CCFLAGS) $(CFLAGS_CROSS_LINUX) $(CFLAGS_LZMA) -c -o $@ $<
+	$(CC_LINUX) $(CCFLAGS) $(CFLAGS_CROSS_LINUX) $(CFLAGS_LZMA)     -c -o $@ $<
 
 obj/%.LZMA.WIN.o:   $(DEPS_LZMA_PATH)/%.c
-	$(CC_WIN)   $(CCFLAGS) $(CFLAGS_CROSS_WIN)   $(CFLAGS_LZMA) -c -o $@ $<
+	$(CC_WIN)   $(CCFLAGS) $(CFLAGS_CROSS_WIN)   $(CFLAGS_LZMA_WIN) -c -o $@ $<
 endif
 
 ifeq ($(USE_SYSTEM_ZLIB),0)
@@ -829,10 +856,10 @@ endif
 ifeq ($(ENABLE_UNRAR),1)
 ifeq ($(USE_SYSTEM_UNRAR),0)
 obj/%.UNRAR.LINUX.o: $(DEPS_UNRAR_PATH)/%.cpp
-	$(CXX_LINUX) $(CXXFLAGS) $(CFLAGS_CROSS_LINUX) $(CFLAGS_UNRAR) -c -o $@ $<
+	$(CXX_LINUX) $(CXXFLAGS) $(CFLAGS_CROSS_LINUX) $(CFLAGS_UNRAR)     -c -o $@ $<
 
 obj/%.UNRAR.WIN.o:   $(DEPS_UNRAR_PATH)/%.cpp
-	$(CXX_WIN)   $(CXXFLAGS) $(CFLAGS_CROSS_WIN)   $(CFLAGS_UNRAR) -c -o $@ $<
+	$(CXX_WIN)   $(CXXFLAGS) $(CFLAGS_CROSS_WIN)   $(CFLAGS_UNRAR_WIN) -c -o $@ $<
 endif
 endif
 


### PR DESCRIPTION
Hi,

with this patch we enable the compilation of windows binaries on macOS using MinGW.

```
bash-3.2$ uname
Darwin
bash-3.2$ make win
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/affinity.WIN.o src/affinity.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/autotune.WIN.o src/autotune.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/backend.WIN.o src/backend.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/benchmark.WIN.o src/benchmark.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/bitmap.WIN.o src/bitmap.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/bitops.WIN.o src/bitops.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/combinator.WIN.o src/combinator.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/common.WIN.o src/common.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/convert.WIN.o src/convert.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/cpt.WIN.o src/cpt.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/cpu_crc32.WIN.o src/cpu_crc32.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/debugfile.WIN.o src/debugfile.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/dictstat.WIN.o src/dictstat.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/dispatch.WIN.o src/dispatch.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/dynloader.WIN.o src/dynloader.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/event.WIN.o src/event.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_ADL.WIN.o src/ext_ADL.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_cuda.WIN.o src/ext_cuda.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_hip.WIN.o src/ext_hip.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_nvapi.WIN.o src/ext_nvapi.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_nvml.WIN.o src/ext_nvml.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_nvrtc.WIN.o src/ext_nvrtc.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_hiprtc.WIN.o src/ext_hiprtc.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_OpenCL.WIN.o src/ext_OpenCL.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_sysfs_amdgpu.WIN.o src/ext_sysfs_amdgpu.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_sysfs_cpu.WIN.o src/ext_sysfs_cpu.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_iokit.WIN.o src/ext_iokit.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/ext_lzma.WIN.o src/ext_lzma.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/filehandling.WIN.o src/filehandling.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/folder.WIN.o src/folder.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/hashcat.WIN.o src/hashcat.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/hashes.WIN.o src/hashes.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/hlfmt.WIN.o src/hlfmt.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/hwmon.WIN.o src/hwmon.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/induct.WIN.o src/induct.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/interface.WIN.o src/interface.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/keyboard_layout.WIN.o src/keyboard_layout.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/locking.WIN.o src/locking.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/logfile.WIN.o src/logfile.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/loopback.WIN.o src/loopback.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/memory.WIN.o src/memory.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/monitor.WIN.o src/monitor.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/mpsp.WIN.o src/mpsp.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/outfile_check.WIN.o src/outfile_check.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/outfile.WIN.o src/outfile.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/pidfile.WIN.o src/pidfile.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/potfile.WIN.o src/potfile.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/restore.WIN.o src/restore.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/rp.WIN.o src/rp.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/rp_cpu.WIN.o src/rp_cpu.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/selftest.WIN.o src/selftest.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/slow_candidates.WIN.o src/slow_candidates.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/shared.WIN.o src/shared.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/status.WIN.o src/status.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/stdout.WIN.o src/stdout.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/straight.WIN.o src/straight.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/terminal.WIN.o src/terminal.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/thread.WIN.o src/thread.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/timer.WIN.o src/timer.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/tuningdb.WIN.o src/tuningdb.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/usage.WIN.o src/usage.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/user_options.WIN.o src/user_options.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/wordlist.WIN.o src/wordlist.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_general.WIN.o src/emu_general.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_inc_common.WIN.o src/emu_inc_common.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_inc_platform.WIN.o src/emu_inc_platform.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_inc_scalar.WIN.o src/emu_inc_scalar.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_inc_simd.WIN.o src/emu_inc_simd.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_inc_rp.WIN.o src/emu_inc_rp.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_inc_rp_optimized.WIN.o src/emu_inc_rp_optimized.c
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -c -o obj/emu_inc_hash_md4.WIN.o src/emu_inc_hash_md4.c
[...]
x86_64-w64-mingw32-g++    -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -Wno-missing-braces -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-misleading-indentation -Wno-class-memaccess -c -o obj/scantree.UNRAR.WIN.o deps/unrar/scantree.cpp
x86_64-w64-mingw32-g++    -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -Wno-missing-braces -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-misleading-indentation -Wno-class-memaccess -c -o obj/qopen.UNRAR.WIN.o deps/unrar/qopen.cpp
x86_64-w64-mingw32-g++    -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   -Wno-missing-braces -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-dangling-else -Wno-switch -Wno-parentheses -Wno-implicit-fallthrough -Wno-extra -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-misleading-indentation -Wno-class-memaccess -c -o obj/hc_decompress_rar.UNRAR.WIN.o deps/unrar/hc_decompress_rar.cpp
x86_64-w64-mingw32-ar rcs obj/combined.WIN.a obj/affinity.WIN.o obj/autotune.WIN.o obj/backend.WIN.o obj/benchmark.WIN.o obj/bitmap.WIN.o obj/bitops.WIN.o obj/combinator.WIN.o obj/common.WIN.o obj/convert.WIN.o obj/cpt.WIN.o obj/cpu_crc32.WIN.o obj/debugfile.WIN.o obj/dictstat.WIN.o obj/dispatch.WIN.o obj/dynloader.WIN.o obj/event.WIN.o obj/ext_ADL.WIN.o obj/ext_cuda.WIN.o obj/ext_hip.WIN.o obj/ext_nvapi.WIN.o obj/ext_nvml.WIN.o obj/ext_nvrtc.WIN.o obj/ext_hiprtc.WIN.o obj/ext_OpenCL.WIN.o obj/ext_sysfs_amdgpu.WIN.o obj/ext_sysfs_cpu.WIN.o obj/ext_iokit.WIN.o obj/ext_lzma.WIN.o obj/filehandling.WIN.o obj/folder.WIN.o obj/hashcat.WIN.o obj/hashes.WIN.o obj/hlfmt.WIN.o obj/hwmon.WIN.o obj/induct.WIN.o obj/interface.WIN.o obj/keyboard_layout.WIN.o obj/locking.WIN.o obj/logfile.WIN.o obj/loopback.WIN.o obj/memory.WIN.o obj/monitor.WIN.o obj/mpsp.WIN.o obj/outfile_check.WIN.o obj/outfile.WIN.o obj/pidfile.WIN.o obj/potfile.WIN.o obj/restore.WIN.o obj/rp.WIN.o obj/rp_cpu.WIN.o obj/selftest.WIN.o obj/slow_candidates.WIN.o obj/shared.WIN.o obj/status.WIN.o obj/stdout.WIN.o obj/straight.WIN.o obj/terminal.WIN.o obj/thread.WIN.o obj/timer.WIN.o obj/tuningdb.WIN.o obj/usage.WIN.o obj/user_options.WIN.o obj/wordlist.WIN.o obj/emu_general.WIN.o obj/emu_inc_common.WIN.o obj/emu_inc_platform.WIN.o obj/emu_inc_scalar.WIN.o obj/emu_inc_simd.WIN.o obj/emu_inc_rp.WIN.o obj/emu_inc_rp_optimized.WIN.o obj/emu_inc_hash_md4.WIN.o obj/emu_inc_hash_md5.WIN.o obj/emu_inc_hash_ripemd160.WIN.o obj/emu_inc_hash_sha1.WIN.o obj/emu_inc_hash_sha256.WIN.o obj/emu_inc_hash_sha384.WIN.o obj/emu_inc_hash_sha512.WIN.o obj/emu_inc_hash_streebog256.WIN.o obj/emu_inc_hash_streebog512.WIN.o obj/emu_inc_ecc_secp256k1.WIN.o obj/emu_inc_bignum_operations.WIN.o obj/emu_inc_cipher_aes.WIN.o obj/emu_inc_cipher_camellia.WIN.o obj/emu_inc_cipher_des.WIN.o obj/emu_inc_cipher_kuznyechik.WIN.o obj/emu_inc_cipher_serpent.WIN.o obj/emu_inc_cipher_twofish.WIN.o obj/emu_inc_hash_base58.WIN.o obj/brain.WIN.o obj/7zCrc.LZMA.WIN.o obj/7zCrcOpt.LZMA.WIN.o obj/7zFile.LZMA.WIN.o obj/7zStream.LZMA.WIN.o obj/Alloc.LZMA.WIN.o obj/Bra.LZMA.WIN.o obj/Bra86.LZMA.WIN.o obj/BraIA64.LZMA.WIN.o obj/CpuArch.LZMA.WIN.o obj/Delta.LZMA.WIN.o obj/LzmaDec.LZMA.WIN.o obj/Lzma2Dec.LZMA.WIN.o obj/Sha256.LZMA.WIN.o obj/Sha256Opt.LZMA.WIN.o obj/Xz.LZMA.WIN.o obj/XzCrc64.LZMA.WIN.o obj/XzCrc64Opt.LZMA.WIN.o obj/XzDec.LZMA.WIN.o obj/XzIn.LZMA.WIN.o obj/adler32.ZLIB.WIN.o obj/crc32.ZLIB.WIN.o obj/deflate.ZLIB.WIN.o obj/inflate.ZLIB.WIN.o obj/inffast.ZLIB.WIN.o obj/inftrees.ZLIB.WIN.o obj/trees.ZLIB.WIN.o obj/gzread.ZLIB.WIN.o obj/gzwrite.ZLIB.WIN.o obj/gzclose.ZLIB.WIN.o obj/zutil.ZLIB.WIN.o obj/gzlib.ZLIB.WIN.o obj/contrib/minizip/unzip.ZLIB.WIN.o obj/contrib/minizip/ioapi.ZLIB.WIN.o obj/xxhash.XXHASH.WIN.o obj/strlist.UNRAR.WIN.o obj/strfn.UNRAR.WIN.o obj/pathfn.UNRAR.WIN.o obj/smallfn.UNRAR.WIN.o obj/global.UNRAR.WIN.o obj/file.UNRAR.WIN.o obj/filefn.UNRAR.WIN.o obj/filcreat.UNRAR.WIN.o obj/archive.UNRAR.WIN.o obj/arcread.UNRAR.WIN.o obj/unicode.UNRAR.WIN.o obj/system.UNRAR.WIN.o obj/isnt.UNRAR.WIN.o obj/crypt.UNRAR.WIN.o obj/crc.UNRAR.WIN.o obj/rawread.UNRAR.WIN.o obj/encname.UNRAR.WIN.o obj/resource.UNRAR.WIN.o obj/match.UNRAR.WIN.o obj/timefn.UNRAR.WIN.o obj/rdwrfn.UNRAR.WIN.o obj/consio.UNRAR.WIN.o obj/options.UNRAR.WIN.o obj/errhnd.UNRAR.WIN.o obj/rarvm.UNRAR.WIN.o obj/secpassword.UNRAR.WIN.o obj/rijndael.UNRAR.WIN.o obj/getbits.UNRAR.WIN.o obj/sha1.UNRAR.WIN.o obj/sha256.UNRAR.WIN.o obj/blake2s.UNRAR.WIN.o obj/hash.UNRAR.WIN.o obj/extinfo.UNRAR.WIN.o obj/extract.UNRAR.WIN.o obj/volume.UNRAR.WIN.o obj/list.UNRAR.WIN.o obj/find.UNRAR.WIN.o obj/unpack.UNRAR.WIN.o obj/headers.UNRAR.WIN.o obj/threadpool.UNRAR.WIN.o obj/rs16.UNRAR.WIN.o obj/cmddata.UNRAR.WIN.o obj/ui.UNRAR.WIN.o obj/filestr.UNRAR.WIN.o obj/recvol.UNRAR.WIN.o obj/rs.UNRAR.WIN.o obj/scantree.UNRAR.WIN.o obj/qopen.UNRAR.WIN.o obj/hc_decompress_rar.UNRAR.WIN.o
x86_64-w64-mingw32-gcc   -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0      -o hashcat.exe src/main.c obj/combined.WIN.a /opt/win-iconv-64/lib/libiconv.a  -lstdc++ -Wl,--dynamicbase -Wl,--nxcompat -lpsapi -lws2_32 -lpowrprof -static -static-libgcc -static-libstdc++   -DCOMPTIME=1685302222 -DVERSION_TAG=\"v6.2.6-555-g7ab00af50\"
x86_64-w64-mingw32-gcc    -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   src/modules/module_00000.c obj/combined.WIN.a -o modules/module_00000.dll  -lstdc++ -Wl,--dynamicbase -Wl,--nxcompat -lpsapi -lws2_32 -lpowrprof -static -static-libgcc -static-libstdc++   -shared -fPIC -D MODULE_INTERFACE_VERSION_CURRENT=700
x86_64-w64-mingw32-gcc    -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   src/modules/module_00010.c obj/combined.WIN.a -o modules/module_00010.dll  -lstdc++ -Wl,--dynamicbase -Wl,--nxcompat -lpsapi -lws2_32 -lpowrprof -static -static-libgcc -static-libstdc++   -shared -fPIC -D MODULE_INTERFACE_VERSION_CURRENT=700
[...]
x86_64-w64-mingw32-gcc    -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   src/modules/module_32200.c obj/combined.WIN.a -o modules/module_32200.dll  -lstdc++ -Wl,--dynamicbase -Wl,--nxcompat -lpsapi -lws2_32 -lpowrprof -static -static-libgcc -static-libstdc++   -shared -fPIC -D MODULE_INTERFACE_VERSION_CURRENT=700
x86_64-w64-mingw32-gcc    -std=gnu99 -W -Wall -Wextra -O2 -pipe -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib -Ideps/OpenCL-Headers -DWITH_BRAIN -Ideps/xxHash -DWITH_CUBIN -Ideps/unrar -fPIC -I/opt/win-iconv-64/include/ -DWITH_HWMON -D__USE_MINGW_ANSI_STDIO=0   src/modules/module_99999.c obj/combined.WIN.a -o modules/module_99999.dll  -lstdc++ -Wl,--dynamicbase -Wl,--nxcompat -lpsapi -lws2_32 -lpowrprof -static -static-libgcc -static-libstdc++   -shared -fPIC -D MODULE_INTERFACE_VERSION_CURRENT=700
bash-3.2$ file hashcat.exe modules/module_00000.dll 
hashcat.exe:              PE32+ executable (console) x86-64, for MS Windows
modules/module_00000.dll: PE32+ executable (DLL) (console) x86-64, for MS Windows
```