### PR TITLE
Added hash-mode: Empire CMS (Admin password)

### DIFF
--- a/OpenCL/m32300_a0-optimized.cl
+++ b/OpenCL/m32300_a0-optimized.cl
@@ -1,0 +1,813 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.h)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+typedef struct md5_triple_salt
+{
+  u32 salt1_buf[64];
+  int salt1_len;
+
+  u32 salt2_buf[64];
+  int salt2_len;
+
+  u32 salt3_buf[64];
+  int salt3_len;
+
+} md5_triple_salt_t;
+
+KERNEL_FQ void m32300_m04 (KERN_ATTR_RULES_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt1
+   */
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  /**
+   * salt2
+   */
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  /**
+   * salt3
+   */
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    // md5($password)
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    w3[2] = out_len * 8;
+    w3[3] = 0;
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    // md5(md5($password).$salt)
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    // md5_final_vector
+
+    const int pos = ctx.len & 63;
+
+    append_0x80_4x4 (ctx.w0, ctx.w1, ctx.w2, ctx.w3, pos);
+
+    if (pos >= 56)
+    {
+      md5_transform_vector (ctx.w0, ctx.w1, ctx.w2, ctx.w3, ctx.h);
+
+      ctx.w0[0] = 0;
+      ctx.w0[1] = 0;
+      ctx.w0[2] = 0;
+      ctx.w0[3] = 0;
+      ctx.w1[0] = 0;
+      ctx.w1[1] = 0;
+      ctx.w1[2] = 0;
+      ctx.w1[3] = 0;
+      ctx.w2[0] = 0;
+      ctx.w2[1] = 0;
+      ctx.w2[2] = 0;
+      ctx.w2[3] = 0;
+      ctx.w3[0] = 0;
+      ctx.w3[1] = 0;
+      ctx.w3[2] = 0;
+      ctx.w3[3] = 0;
+    }
+
+    ctx.w3[2] = ctx.len * 8;
+    ctx.w3[3] = 0;
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w2[1], MD5C3f, MD5S33);
+
+    a += ctx.h[0] - make_u32x (MD5M_A);
+    b += ctx.h[1] - make_u32x (MD5M_B);
+    c += ctx.h[2] - make_u32x (MD5M_C);
+    d += ctx.h[3] - make_u32x (MD5M_D);
+
+    COMPARE_M_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m32300_m08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m32300_m16 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m32300_s04 (KERN_ATTR_RULES_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt1
+   */
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  /**
+   * salt2
+   */
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  /**
+   * salt3
+   */
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    w3[2] = out_len * 8;
+    w3[3] = 0;
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    // md5_final_vector
+
+    const int pos = ctx.len & 63;
+
+    append_0x80_4x4 (ctx.w0, ctx.w1, ctx.w2, ctx.w3, pos);
+
+    if (pos >= 56)
+    {
+      md5_transform_vector (ctx.w0, ctx.w1, ctx.w2, ctx.w3, ctx.h);
+
+      ctx.w0[0] = 0;
+      ctx.w0[1] = 0;
+      ctx.w0[2] = 0;
+      ctx.w0[3] = 0;
+      ctx.w1[0] = 0;
+      ctx.w1[1] = 0;
+      ctx.w1[2] = 0;
+      ctx.w1[3] = 0;
+      ctx.w2[0] = 0;
+      ctx.w2[1] = 0;
+      ctx.w2[2] = 0;
+      ctx.w2[3] = 0;
+      ctx.w3[0] = 0;
+      ctx.w3[1] = 0;
+      ctx.w3[2] = 0;
+      ctx.w3[3] = 0;
+    }
+
+    ctx.w3[2] = ctx.len * 8;
+    ctx.w3[3] = 0;
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w1[0], MD5C3c, MD5S30);
+
+    if (MATCHES_NONE_VS ((a + ctx.h[0] - make_u32x (MD5M_A)), search[0])) continue;
+
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w2[1], MD5C3f, MD5S33);
+
+    a += ctx.h[0] - make_u32x (MD5M_A);
+    b += ctx.h[1] - make_u32x (MD5M_B);
+    c += ctx.h[2] - make_u32x (MD5M_C);
+    d += ctx.h[3] - make_u32x (MD5M_D);
+
+    COMPARE_S_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m32300_s08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ void m32300_s16 (KERN_ATTR_RULES ())
+{
+}

--- a/OpenCL/m32300_a0-pure.cl
+++ b/OpenCL/m32300_a0-pure.cl
@@ -1,0 +1,388 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+typedef struct md5_triple_salt
+{
+  u32 salt1_buf[64];
+  int salt1_len;
+
+  u32 salt2_buf[64];
+  int salt2_len;
+
+  u32 salt3_buf[64];
+  int salt3_len;
+
+} md5_triple_salt_t;
+
+KERNEL_FQ void m32300_mxx (KERN_ATTR_RULES_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc uppercase table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32 salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32 salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32 salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    md5_ctx_t ctx0;
+
+    md5_init (&ctx0);
+
+    md5_update (&ctx0, tmp.i, tmp.pw_len);
+
+    md5_final (&ctx0);
+
+    u32 a = ctx0.h[0];
+    u32 b = ctx0.h[1];
+    u32 c = ctx0.h[2];
+    u32 d = ctx0.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update (&ctx, salt1_buf, salt1_len);
+
+    md5_final (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init (&ctx);
+
+    md5_update (&ctx, salt2_buf, salt2_len);
+
+    u32 ww0[4];
+    u32 ww1[4];
+    u32 ww2[4];
+    u32 ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update (&ctx, salt3_buf, salt3_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m32300_sxx (KERN_ATTR_RULES_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc uppercase table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32 salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32 salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32 salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    md5_ctx_t ctx0;
+
+    md5_init (&ctx0);
+
+    md5_update (&ctx0, tmp.i, tmp.pw_len);
+
+    md5_final (&ctx0);
+
+    u32 a = ctx0.h[0];
+    u32 b = ctx0.h[1];
+    u32 c = ctx0.h[2];
+    u32 d = ctx0.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update (&ctx, salt1_buf, salt1_len);
+
+    md5_final (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init (&ctx);
+
+    md5_update (&ctx, salt2_buf, salt2_len);
+
+    u32 ww0[4];
+    u32 ww1[4];
+    u32 ww2[4];
+    u32 ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update (&ctx, salt3_buf, salt3_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m32300_a1-optimized.cl
+++ b/OpenCL/m32300_a1-optimized.cl
@@ -1,0 +1,925 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+typedef struct md5_triple_salt
+{
+  u32 salt1_buf[64];
+  int salt1_len;
+
+  u32 salt2_buf[64];
+  int salt2_len;
+
+  u32 salt3_buf[64];
+  int salt3_len;
+
+} md5_triple_salt_t;
+
+KERNEL_FQ void m32300_m04 (KERN_ATTR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt1
+   */
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  /**
+   * salt2
+   */
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  /**
+   * salt3
+   */
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = pw_len * 8;
+    w3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    // md5_final_vector
+
+    const int pos = ctx.len & 63;
+
+    append_0x80_4x4 (ctx.w0, ctx.w1, ctx.w2, ctx.w3, pos);
+
+    if (pos >= 56)
+    {
+      md5_transform_vector (ctx.w0, ctx.w1, ctx.w2, ctx.w3, ctx.h);
+
+      ctx.w0[0] = 0;
+      ctx.w0[1] = 0;
+      ctx.w0[2] = 0;
+      ctx.w0[3] = 0;
+      ctx.w1[0] = 0;
+      ctx.w1[1] = 0;
+      ctx.w1[2] = 0;
+      ctx.w1[3] = 0;
+      ctx.w2[0] = 0;
+      ctx.w2[1] = 0;
+      ctx.w2[2] = 0;
+      ctx.w2[3] = 0;
+      ctx.w3[0] = 0;
+      ctx.w3[1] = 0;
+      ctx.w3[2] = 0;
+      ctx.w3[3] = 0;
+    }
+
+    ctx.w3[2] = ctx.len * 8;
+    ctx.w3[3] = 0;
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w2[1], MD5C3f, MD5S33);
+
+    a += ctx.h[0] - make_u32x (MD5M_A);
+    b += ctx.h[1] - make_u32x (MD5M_B);
+    c += ctx.h[2] - make_u32x (MD5M_C);
+    d += ctx.h[3] - make_u32x (MD5M_D);
+
+    COMPARE_M_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m32300_m08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m32300_m16 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m32300_s04 (KERN_ATTR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * salt1
+   */
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  /**
+   * salt2
+   */
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  /**
+   * salt3
+   */
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = pw_len * 8;
+    w3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    // md5_final_vector
+
+    const int pos = ctx.len & 63;
+
+    append_0x80_4x4 (ctx.w0, ctx.w1, ctx.w2, ctx.w3, pos);
+
+    if (pos >= 56)
+    {
+      md5_transform_vector (ctx.w0, ctx.w1, ctx.w2, ctx.w3, ctx.h);
+
+      ctx.w0[0] = 0;
+      ctx.w0[1] = 0;
+      ctx.w0[2] = 0;
+      ctx.w0[3] = 0;
+      ctx.w1[0] = 0;
+      ctx.w1[1] = 0;
+      ctx.w1[2] = 0;
+      ctx.w1[3] = 0;
+      ctx.w2[0] = 0;
+      ctx.w2[1] = 0;
+      ctx.w2[2] = 0;
+      ctx.w2[3] = 0;
+      ctx.w3[0] = 0;
+      ctx.w3[1] = 0;
+      ctx.w3[2] = 0;
+      ctx.w3[3] = 0;
+    }
+
+    ctx.w3[2] = ctx.len * 8;
+    ctx.w3[3] = 0;
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w1[0], MD5C3c, MD5S30);
+
+    if (MATCHES_NONE_VS ((a + ctx.h[0] - make_u32x (MD5M_A)), search[0])) continue;
+
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w2[1], MD5C3f, MD5S33);
+
+    a += ctx.h[0] - make_u32x (MD5M_A);
+    b += ctx.h[1] - make_u32x (MD5M_B);
+    c += ctx.h[2] - make_u32x (MD5M_C);
+    d += ctx.h[3] - make_u32x (MD5M_D);
+
+    COMPARE_S_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m32300_s08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ void m32300_s16 (KERN_ATTR_BASIC ())
+{
+}

--- a/OpenCL/m32300_a1-pure.cl
+++ b/OpenCL/m32300_a1-pure.cl
@@ -1,0 +1,382 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+typedef struct md5_triple_salt
+{
+  u32 salt1_buf[64];
+  int salt1_len;
+
+  u32 salt2_buf[64];
+  int salt2_len;
+
+  u32 salt3_buf[64];
+  int salt3_len;
+
+} md5_triple_salt_t;
+
+KERNEL_FQ void m32300_mxx (KERN_ATTR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc uppercase array
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32 salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32 salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32 salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * base
+   */
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    md5_ctx_t ctx1 = ctx0;
+
+    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_final (&ctx1);
+
+    u32 a = ctx1.h[0];
+    u32 b = ctx1.h[1];
+    u32 c = ctx1.h[2];
+    u32 d = ctx1.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update (&ctx, salt1_buf, salt1_len);
+
+    md5_final (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init (&ctx);
+
+    md5_update (&ctx, salt2_buf, salt2_len);
+
+    u32 ww0[4];
+    u32 ww1[4];
+    u32 ww2[4];
+    u32 ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update (&ctx, salt3_buf, salt3_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m32300_sxx (KERN_ATTR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc uppercase array
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32 salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32 salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32 salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * base
+   */
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    md5_ctx_t ctx1 = ctx0;
+
+    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_final (&ctx1);
+
+    u32 a = ctx1.h[0];
+    u32 b = ctx1.h[1];
+    u32 c = ctx1.h[2];
+    u32 d = ctx1.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update (&ctx, salt1_buf, salt1_len);
+
+    md5_final (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init (&ctx);
+
+    md5_update (&ctx, salt2_buf, salt2_len);
+
+    u32 ww0[4];
+    u32 ww1[4];
+    u32 ww2[4];
+    u32 ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update (&ctx, salt3_buf, salt3_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m32300_a3-optimized.cl
+++ b/OpenCL/m32300_a3-optimized.cl
@@ -1,0 +1,1169 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+typedef struct md5_triple_salt
+{
+  u32 salt1_buf[64];
+  int salt1_len;
+
+  u32 salt2_buf[64];
+  int salt2_len;
+
+  u32 salt3_buf[64];
+  int salt3_len;
+
+} md5_triple_salt_t;
+
+DECLSPEC void m32300m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_VECTOR_ESALT (md5_triple_salt_t), LOCAL_AS u32 *l_bin2asc)
+{
+  /**
+   * modifiers are taken from args
+   */
+
+  /**
+   * salt1
+   */
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  /**
+   * salt2
+   */
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  /**
+   * salt3
+   */
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x w0_t[4];
+    u32x w1_t[4];
+    u32x w2_t[4];
+    u32x w3_t[4];
+
+    w0_t[0] = w0lr;
+    w0_t[1] = w0[1];
+    w0_t[2] = w0[2];
+    w0_t[3] = w0[3];
+    w1_t[0] = w1[0];
+    w1_t[1] = w1[1];
+    w1_t[2] = w1[2];
+    w1_t[3] = w1[3];
+    w2_t[0] = w2[0];
+    w2_t[1] = w2[1];
+    w2_t[2] = w2[2];
+    w2_t[3] = w2[3];
+    w3_t[0] = w3[0];
+    w3_t[1] = w3[1];
+    w3_t[2] = w3[2];
+    w3_t[3] = w3[3];
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0_t[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0_t[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0_t[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1_t[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1_t[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1_t[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2_t[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2_t[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2_t[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3_t[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3_t[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3_t[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0_t[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1_t[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2_t[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1_t[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2_t[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3_t[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0_t[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2_t[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3_t[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0_t[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1_t[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3_t[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2_t[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2_t[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3_t[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0_t[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1_t[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1_t[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3_t[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0_t[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1_t[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2_t[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3_t[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0_t[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1_t[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3_t[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3_t[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0_t[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0_t[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2_t[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1_t[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3_t[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1_t[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2_t[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0_t[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2_t[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    // md5_final_vector
+
+    const int pos = ctx.len & 63;
+
+    append_0x80_4x4 (ctx.w0, ctx.w1, ctx.w2, ctx.w3, pos);
+
+    if (pos >= 56)
+    {
+      md5_transform_vector (ctx.w0, ctx.w1, ctx.w2, ctx.w3, ctx.h);
+
+      ctx.w0[0] = 0;
+      ctx.w0[1] = 0;
+      ctx.w0[2] = 0;
+      ctx.w0[3] = 0;
+      ctx.w1[0] = 0;
+      ctx.w1[1] = 0;
+      ctx.w1[2] = 0;
+      ctx.w1[3] = 0;
+      ctx.w2[0] = 0;
+      ctx.w2[1] = 0;
+      ctx.w2[2] = 0;
+      ctx.w2[3] = 0;
+      ctx.w3[0] = 0;
+      ctx.w3[1] = 0;
+      ctx.w3[2] = 0;
+      ctx.w3[3] = 0;
+    }
+
+    ctx.w3[2] = ctx.len * 8;
+    ctx.w3[3] = 0;
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w2[1], MD5C3f, MD5S33);
+
+    a += ctx.h[0] - make_u32x (MD5M_A);
+    b += ctx.h[1] - make_u32x (MD5M_B);
+    c += ctx.h[2] - make_u32x (MD5M_C);
+    d += ctx.h[3] - make_u32x (MD5M_D);
+
+    COMPARE_M_SIMD (a, d, c, b);
+  }
+}
+
+DECLSPEC void m32300s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_VECTOR_ESALT (md5_triple_salt_t), LOCAL_AS u32 *l_bin2asc)
+{
+  /**
+   * modifiers are taken from args
+   */
+
+  /**
+   * salt1
+   */
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  /**
+   * salt2
+   */
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  /**
+   * salt3
+   */
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x w0_t[4];
+    u32x w1_t[4];
+    u32x w2_t[4];
+    u32x w3_t[4];
+
+    w0_t[0] = w0lr;
+    w0_t[1] = w0[1];
+    w0_t[2] = w0[2];
+    w0_t[3] = w0[3];
+    w1_t[0] = w1[0];
+    w1_t[1] = w1[1];
+    w1_t[2] = w1[2];
+    w1_t[3] = w1[3];
+    w2_t[0] = w2[0];
+    w2_t[1] = w2[1];
+    w2_t[2] = w2[2];
+    w2_t[3] = w2[3];
+    w3_t[0] = w3[0];
+    w3_t[1] = w3[1];
+    w3_t[2] = w3[2];
+    w3_t[3] = w3[3];
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0_t[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0_t[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0_t[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0_t[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1_t[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1_t[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1_t[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1_t[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2_t[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2_t[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2_t[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2_t[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3_t[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3_t[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3_t[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3_t[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0_t[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1_t[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2_t[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0_t[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1_t[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2_t[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3_t[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1_t[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2_t[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3_t[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0_t[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2_t[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3_t[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0_t[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1_t[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3_t[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1_t[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2_t[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2_t[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3_t[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0_t[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1_t[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1_t[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2_t[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3_t[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0_t[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0_t[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1_t[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2_t[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3_t[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3_t[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0_t[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0_t[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1_t[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3_t[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1_t[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3_t[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0_t[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2_t[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0_t[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2_t[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3_t[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1_t[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3_t[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1_t[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2_t[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0_t[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2_t[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    // md5_final_vector
+
+    const int pos = ctx.len & 63;
+
+    append_0x80_4x4 (ctx.w0, ctx.w1, ctx.w2, ctx.w3, pos);
+
+    if (pos >= 56)
+    {
+      md5_transform_vector (ctx.w0, ctx.w1, ctx.w2, ctx.w3, ctx.h);
+
+      ctx.w0[0] = 0;
+      ctx.w0[1] = 0;
+      ctx.w0[2] = 0;
+      ctx.w0[3] = 0;
+      ctx.w1[0] = 0;
+      ctx.w1[1] = 0;
+      ctx.w1[2] = 0;
+      ctx.w1[3] = 0;
+      ctx.w2[0] = 0;
+      ctx.w2[1] = 0;
+      ctx.w2[2] = 0;
+      ctx.w2[3] = 0;
+      ctx.w3[0] = 0;
+      ctx.w3[1] = 0;
+      ctx.w3[2] = 0;
+      ctx.w3[3] = 0;
+    }
+
+    ctx.w3[2] = ctx.len * 8;
+    ctx.w3[3] = 0;
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, ctx.w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, ctx.w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, ctx.w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, ctx.w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, ctx.w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, ctx.w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, ctx.w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, ctx.w3[0], MD5C1f, MD5S13);
+
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, ctx.w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, ctx.w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, ctx.w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, ctx.w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, ctx.w1[0], MD5C3c, MD5S30);
+
+    if (MATCHES_NONE_VS ((a + ctx.h[0] - make_u32x (MD5M_A)), search[0])) continue;
+
+    MD5_STEP (MD5_I , d, a, b, c, ctx.w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, ctx.w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, ctx.w2[1], MD5C3f, MD5S33);
+
+    a += ctx.h[0] - make_u32x (MD5M_A);
+    b += ctx.h[1] - make_u32x (MD5M_B);
+    c += ctx.h[2] - make_u32x (MD5M_C);
+    d += ctx.h[3] - make_u32x (MD5M_D);
+
+    COMPARE_S_SIMD (a, d, c, b);
+  }
+}
+
+KERNEL_FQ void m32300_m04 (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = pws[gid].i[14];
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m32300m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m32300_m08 (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = pws[gid].i[14];
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * main
+   */
+
+  m32300m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m32300_m16 (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = pws[gid].i[14];
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * main
+   */
+
+  m32300m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m32300_s04 (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = pws[gid].i[14];
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * main
+   */
+
+  m32300s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m32300_s08 (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = pws[gid].i[14];
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * main
+   */
+
+  m32300s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}
+
+KERNEL_FQ void m32300_s16 (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = pws[gid].i[14];
+  w3[3] = pws[gid].i[15];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m32300s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, words_buf_r, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz, l_bin2asc);
+}

--- a/OpenCL/m32300_a3-pure.cl
+++ b/OpenCL/m32300_a3-pure.cl
@@ -1,0 +1,408 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+typedef struct md5_triple_salt
+{
+  u32 salt1_buf[64];
+  int salt1_len;
+
+  u32 salt2_buf[64];
+  int salt2_len;
+
+  u32 salt3_buf[64];
+  int salt3_len;
+
+} md5_triple_salt_t;
+
+KERNEL_FQ void m32300_mxx (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /*
+  * bin2asc uppercase table
+  */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    md5_ctx_vector_t ctx0;
+
+    md5_init_vector (&ctx0);
+
+    md5_update_vector (&ctx0, w, pw_len);
+
+    md5_final_vector (&ctx0);
+
+    u32x a = ctx0.h[0];
+    u32x b = ctx0.h[1];
+    u32x c = ctx0.h[2];
+    u32x d = ctx0.h[3];
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    md5_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m32300_sxx (KERN_ATTR_VECTOR_ESALT (md5_triple_salt_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /*
+  * bin2asc uppercase table
+  */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 salt1_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len;
+
+  u32x salt1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt1_len; i += 4, idx += 1)
+  {
+    salt1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf[idx];
+  }
+
+  const u32 salt2_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len;
+
+  u32x salt2_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt2_len; i += 4, idx += 1)
+  {
+    salt2_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf[idx];
+  }
+
+  const u32 salt3_len = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_len;
+
+  u32x salt3_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt3_len; i += 4, idx += 1)
+  {
+    salt3_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].salt3_buf[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    md5_ctx_vector_t ctx0;
+
+    md5_init_vector (&ctx0);
+
+    md5_update_vector (&ctx0, w, pw_len);
+
+    md5_final_vector (&ctx0);
+
+    u32x a = ctx0.h[0];
+    u32x b = ctx0.h[1];
+    u32x c = ctx0.h[2];
+    u32x d = ctx0.h[3];
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, salt1_buf, salt1_len);
+
+    md5_final_vector (&ctx);
+
+    a = ctx.h[0];
+    b = ctx.h[1];
+    c = ctx.h[2];
+    d = ctx.h[3];
+
+    md5_init_vector (&ctx);
+
+    md5_update_vector (&ctx, salt2_buf, salt2_len);
+
+    u32x ww0[4];
+    u32x ww1[4];
+    u32x ww2[4];
+    u32x ww3[4];
+
+    ww0[0] = uint_to_hex_lower8 ((a >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((a >>  8) & 255) << 16;
+    ww0[1] = uint_to_hex_lower8 ((a >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((a >> 24) & 255) << 16;
+    ww0[2] = uint_to_hex_lower8 ((b >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((b >>  8) & 255) << 16;
+    ww0[3] = uint_to_hex_lower8 ((b >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((b >> 24) & 255) << 16;
+    ww1[0] = uint_to_hex_lower8 ((c >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((c >>  8) & 255) << 16;
+    ww1[1] = uint_to_hex_lower8 ((c >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((c >> 24) & 255) << 16;
+    ww1[2] = uint_to_hex_lower8 ((d >>  0) & 255) <<  0
+           | uint_to_hex_lower8 ((d >>  8) & 255) << 16;
+    ww1[3] = uint_to_hex_lower8 ((d >> 16) & 255) <<  0
+           | uint_to_hex_lower8 ((d >> 24) & 255) << 16;
+
+    ww2[0] = 0;
+    ww2[1] = 0;
+    ww2[2] = 0;
+    ww2[3] = 0;
+    ww3[0] = 0;
+    ww3[1] = 0;
+    ww3[2] = 0;
+    ww3[3] = 0;
+
+    md5_update_vector_64 (&ctx, ww0, ww1, ww2, ww3, 32);
+
+    md5_update_vector (&ctx, salt3_buf, salt3_len);
+
+    md5_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -15,6 +15,7 @@
 - Added hash-mode: BLAKE2s-256
 - Added hash-mode: Dahua NVR/DVR/HVR (md5($salt1.strtoupper(md5($salt2.$pass))))
 - Added hash-mode: DANE RFC7929/RFC8162 SHA2-256
+- Added hash-mode: Empire CMS (Admin password)
 - Added hash-mode: ENCsecurity Datavault (MD5/keychain)
 - Added hash-mode: ENCsecurity Datavault (MD5/no keychain)
 - Added hash-mode: ENCsecurity Datavault (PBKDF2/keychain)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -387,6 +387,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - MediaWiki B type
 - Redmine
 - Umbraco HMAC-SHA1
+- Empire CMS (Admin password)
 - Joomla < 2.5.18
 - OpenCart
 - PrestaShop

--- a/src/modules/module_32300.c
+++ b/src/modules/module_32300.c
@@ -1,0 +1,301 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "emu_inc_hash_md5.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 3;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 1;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_FORUM_SOFTWARE;
+static const char *HASH_NAME      = "Empire CMS (Admin password)";
+static const u64   KERN_TYPE      = 32300;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_EARLY_SKIP
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_RAW_HASH;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS14;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "5962d4ada95d6493379cd9c05ce7a376:726620866134417802643053384570:6056291339665060317728572165496183";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct md5_triple_salt
+{
+  u32 salt1_buf[64];
+  int salt1_len;
+
+  u32 salt2_buf[64];
+  int salt2_len;
+
+  u32 salt3_buf[64];
+  int salt3_len;
+
+} md5_triple_salt_t;
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (md5_triple_salt_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  md5_triple_salt_t *md5_triple_salt = (md5_triple_salt_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 3;
+
+  token.sep[0]     = hashconfig->separator;
+  token.len[0]     = 32;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[1]     = hashconfig->separator;
+  token.len_min[1] = SALT_MIN;
+  token.len_max[1] = SALT_MAX;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  token.sep[2]     = hashconfig->separator;
+  token.len_min[2] = SALT_MIN;
+  token.len_max[2] = SALT_MAX;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  if (hashconfig->opts_type & OPTS_TYPE_ST_HEX)
+  {
+    token.len_min[1] *= 2;
+    token.len_max[1] *= 2;
+
+    token.attr[1] |= TOKEN_ATTR_VERIFY_HEX;
+
+    token.len_min[2] *= 2;
+    token.len_max[2] *= 2;
+
+    token.attr[2] |= TOKEN_ATTR_VERIFY_HEX;
+  }
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *hash_pos = token.buf[0];
+
+  digest[0] = hex_to_u32 (hash_pos +  0);
+  digest[1] = hex_to_u32 (hash_pos +  8);
+  digest[2] = hex_to_u32 (hash_pos + 16);
+  digest[3] = hex_to_u32 (hash_pos + 24);
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    digest[0] -= MD5M_A;
+    digest[1] -= MD5M_B;
+    digest[2] -= MD5M_C;
+    digest[3] -= MD5M_D;
+  }
+
+  memset (md5_triple_salt, 0, sizeof (md5_triple_salt_t));
+
+  const bool parse_rc1 = generic_salt_decode (hashconfig, token.buf[1], token.len[1], (u8 *) md5_triple_salt->salt1_buf, (int *) &md5_triple_salt->salt1_len);
+
+  if (parse_rc1 == false) return (PARSER_SALT_LENGTH);
+
+  const bool parse_rc2 = generic_salt_decode (hashconfig, token.buf[2], token.len[2], (u8 *) md5_triple_salt->salt2_buf, (int *) &md5_triple_salt->salt2_len);
+
+  if (parse_rc2 == false) return (PARSER_SALT_LENGTH);
+
+  const u8 *empire_salt1 = (const u8 *) "E!m^p-i(r#e.C:M?S";
+  const u32 empire_salt1_len = strlen ((char *) empire_salt1);
+
+  const u8 *empire_salt2 = (const u8 *) "d)i.g^o-d";
+  const u32 empire_salt2_len = strlen ((char *) empire_salt2);
+
+  memcpy ((u8 *) md5_triple_salt->salt2_buf + md5_triple_salt->salt2_len, empire_salt1, empire_salt1_len);
+
+  md5_triple_salt->salt2_len += empire_salt1_len;
+
+  memcpy ((u8 *) md5_triple_salt->salt3_buf, empire_salt2, empire_salt2_len);
+  memcpy ((u8 *) md5_triple_salt->salt3_buf + empire_salt2_len, (u8 *) md5_triple_salt->salt1_buf, md5_triple_salt->salt1_len);
+
+  md5_triple_salt->salt3_len = empire_salt2_len + md5_triple_salt->salt1_len;
+
+  // make salt sorter happy
+
+  md5_ctx_t md5_ctx;
+
+  md5_init   (&md5_ctx);
+  md5_update (&md5_ctx, md5_triple_salt->salt1_buf, md5_triple_salt->salt1_len);
+  md5_update (&md5_ctx, md5_triple_salt->salt2_buf, md5_triple_salt->salt2_len);
+  md5_update (&md5_ctx, md5_triple_salt->salt3_buf, md5_triple_salt->salt3_len);
+  md5_final  (&md5_ctx);
+
+  salt->salt_buf[0] = md5_ctx.h[0];
+  salt->salt_buf[1] = md5_ctx.h[1];
+  salt->salt_buf[2] = md5_ctx.h[2];
+  salt->salt_buf[3] = md5_ctx.h[3];
+
+  salt->salt_len = 16;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  const md5_triple_salt_t *md5_triple_salt = (const md5_triple_salt_t *) esalt_buf;
+
+  u32 tmp[4];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = digest[2];
+  tmp[3] = digest[3];
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    tmp[0] += MD5M_A;
+    tmp[1] += MD5M_B;
+    tmp[2] += MD5M_C;
+    tmp[3] += MD5M_D;
+  }
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  int out_len = 0;
+
+  u32_to_hex (tmp[0], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[1], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
+  u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
+
+  out_buf[out_len] = hashconfig->separator;
+
+  out_len += 1;
+
+  out_len += generic_salt_encode (hashconfig, (const u8 *) md5_triple_salt->salt1_buf, (const int) md5_triple_salt->salt1_len, out_buf + out_len);
+
+  out_buf[out_len] = hashconfig->separator;
+
+  out_len += 1;
+
+  out_len += generic_salt_encode (hashconfig, (const u8 *) md5_triple_salt->salt2_buf, (const int) md5_triple_salt->salt2_len, out_buf + out_len);
+
+  out_len -= 17; // remove empire_salt1
+
+  out_buf[out_len] = '\0';
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m32300.pm
+++ b/tools/test_modules/m32300.pm
@@ -1,0 +1,59 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::MD5 qw (md5_hex);
+
+sub module_constraints { [[0, 256], [0, 246], [0, 31], [0, 41], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word  = shift;
+  my $salt1 = shift;
+
+  my $IS_OPTIMIZED = 1;
+
+  if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"})
+  {
+    $IS_OPTIMIZED = $ENV{"IS_OPTIMIZED"};
+  }
+
+  my $salt2_max_len = $IS_OPTIMIZED == 1 ? 33 : 238;
+
+  my $salt2 = shift || random_numeric_string (random_number (0, $salt2_max_len));
+
+  my $empireCMS_salt1 = 'E!m^p-i(r#e.C:M?S';
+  my $empireCMS_salt2 = 'd)i.g^o-d';
+
+  my $digest = md5_hex ($salt2 . $empireCMS_salt1 . md5_hex (md5_hex ($word) . $salt1) . $empireCMS_salt2 . $salt1);
+
+  my $hash = sprintf ("%s:%s:%s", $digest, $salt1, $salt2);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $salt1, $salt2, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $salt1;
+  return unless defined $salt2;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt1, $salt2);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
solves issue #3751 


test.sh (optimized)

```
[ test_1685719318 ] > Init test for hash type 32300.
[ test_1685719318 ] [ Type 32300, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1685719318 ] [ Type 32300, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685719318 ] [ Type 32300, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685719318 ] [ Type 32300, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685719318 ] [ Type 32300, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 1/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1685719318 ] [ Type 32300, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685719318 ] [ Type 32300, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685719318 ] [ Type 32300, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685719318 ] [ Type 32300, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > Warning : 0/7 not found, 0/7 not matched, 1/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685719318 ] [ Type 32300, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```

test.sh (pure)

```
[ test_1685720886 ] > Init test for hash type 32300.
[ test_1685720886 ] [ Type 32300, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1685720886 ] [ Type 32300, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685720886 ] [ Type 32300, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685720886 ] [ Type 32300, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685720886 ] [ Type 32300, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 2/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1685720886 ] [ Type 32300, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685720886 ] [ Type 32300, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685720886 ] [ Type 32300, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1685720886 ] [ Type 32300, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > Warning : 0/7 not found, 0/7 not matched, 2/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1685720886 ] [ Type 32300, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```

benchmark (optimized)

```
-----------------------------------------------
* Hash-Mode 32300 (Empire CMS (Admin password))
-----------------------------------------------

Speed.#1.........:   151.3 MH/s (53.69ms) @ Accel:64 Loops:512 Thr:32 Vec:1

```

benchmark (pure)

```
-----------------------------------------------
* Hash-Mode 32300 (Empire CMS (Admin password))
-----------------------------------------------

Speed.#1.........:   139.5 MH/s (58.42ms) @ Accel:512 Loops:64 Thr:32 Vec:1

```
