### PR TITLE
using hc_IOMasterPortDefault instead of kIOMasterPortDefault/kIOMainPortDefault

### DIFF
--- a/include/ext_iokit.h
+++ b/include/ext_iokit.h
@@ -9,6 +9,9 @@
 #if defined(__APPLE__)
 #include <IOKit/IOKitLib.h>
 
+// kIOMasterPortDefault/kIOMainPortDefault is 0
+static const mach_port_t hc_IOMasterPortDefault = 0;
+
 // Apple SMC Keys
 #define HM_IOKIT_SMC_SENSOR_GRAPHICS_HOT "SGHT"
 #define HM_IOKIT_SMC_CPU_PROXIMITY       "TC0P"

--- a/src/ext_iokit.c
+++ b/src/ext_iokit.c
@@ -48,7 +48,7 @@ kern_return_t hm_IOKIT_SMCOpen (void *hashcat_ctx, io_connect_t *conn)
 
   CFMutableDictionaryRef matchingDictionary = IOServiceMatching ("AppleSMC");
 
-  result = IOServiceGetMatchingServices (kIOMasterPortDefault, matchingDictionary, &iterator);
+  result = IOServiceGetMatchingServices (hc_IOMasterPortDefault, matchingDictionary, &iterator);
 
   if (result != kIOReturnSuccess)
   {
@@ -231,7 +231,7 @@ int hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization)
 
   CFMutableDictionaryRef matching = IOServiceMatching ("IOAccelerator");
 
-  if (IOServiceGetMatchingServices (kIOMasterPortDefault, matching, &iterator) != kIOReturnSuccess)
+  if (IOServiceGetMatchingServices (hc_IOMasterPortDefault, matching, &iterator) != kIOReturnSuccess)
   {
     event_log_error (hashcat_ctx, "IOServiceGetMatchingServices(): failure");
 

--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -47,7 +47,7 @@ static bool iokit_getGPUCore (void *hashcat_ctx, int *gpu_core)
 
   CFMutableDictionaryRef matching = IOServiceMatching ("IOAccelerator");
 
-  io_service_t service = IOServiceGetMatchingService (kIOMasterPortDefault, matching);
+  io_service_t service = IOServiceGetMatchingService (hc_IOMasterPortDefault, matching);
 
   if (!service)
   {


### PR DESCRIPTION
Hi,

kIOMasterPortDefault is deprecated from MacOS 12, replaced with kIOMainPortDefault.
We can use 0, it's the same

Reference:
https://github.com/libusb/hidapi/issues/377#issuecomment-1033293884
