### PR TITLE
fix multiple sprintf build warnings by using snprintf

### DIFF
--- a/src/modules/module_07500.c
+++ b/src/modules/module_07500.c
@@ -225,12 +225,12 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   for (u32 i = 0; i < 36; i++, ptr_data += 2)
   {
-    sprintf (ptr_data, "%02x", ptr_timestamp[i]);
+    snprintf (ptr_data, 3, "%02x", ptr_timestamp[i]);
   }
 
   for (u32 i = 0; i < 16; i++, ptr_data += 2)
   {
-    sprintf (ptr_data, "%02x", ptr_checksum[i]);
+    snprintf (ptr_data, 3, "%02x", ptr_checksum[i]);
   }
 
   *ptr_data = 0;

--- a/src/modules/module_08200.c
+++ b/src/modules/module_08200.c
@@ -237,7 +237,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   for (int i = 0, j = 0; i < 512; i += 1, j += 8)
   {
-    sprintf (data_buf + j, "%08x", cloudkey->data_buf[i]);
+    snprintf (data_buf + j, 9, "%08x", cloudkey->data_buf[i]);
   }
 
   data_buf[cloudkey->data_len * 2] = 0;

--- a/src/modules/module_08800.c
+++ b/src/modules/module_08800.c
@@ -183,7 +183,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   for (u32 i = 0, j = 0; i < 384; i += 1, j += 8)
   {
-    sprintf (tmp + j, "%08x", androidfde->data[i]);
+    snprintf (tmp + j, 9, "%08x", androidfde->data[i]);
   }
 
   tmp[3072] = 0;

--- a/src/modules/module_13100.c
+++ b/src/modules/module_13100.c
@@ -313,7 +313,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_edata2 = (u8 *) krb5tgs->edata2;
 
-    sprintf (data + j, "%02x", ptr_edata2[i]);
+    snprintf (data + j, 3, "%02x", ptr_edata2[i]);
   }
 
   int line_len;

--- a/src/modules/module_13400.c
+++ b/src/modules/module_13400.c
@@ -545,20 +545,17 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   *ptr_data = '*';
   ptr_data++;
 
-  for (u32 i = 0; i < final_random_seed_len; i++, ptr_data += 8)
-    sprintf (ptr_data, "%08x", ptr_final_random_seed[i]);
+  for (u32 i = 0; i < final_random_seed_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_final_random_seed[i]);
 
   *ptr_data = '*';
   ptr_data++;
 
-  for (u32 i = 0; i < transf_random_seed_len; i++, ptr_data += 8)
-    sprintf (ptr_data, "%08x", ptr_transf_random_seed[i]);
+  for (u32 i = 0; i < transf_random_seed_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_transf_random_seed[i]);
 
   *ptr_data = '*';
   ptr_data++;
 
-  for (u32 i = 0; i < enc_iv_len; i++, ptr_data += 8)
-    sprintf (ptr_data, "%08x", ptr_enc_iv[i]);
+  for (u32 i = 0; i < enc_iv_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_enc_iv[i]);
 
   *ptr_data = '*';
   ptr_data++;
@@ -568,8 +565,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     u32  contents_len =         keepass->contents_len;
     u32 *ptr_contents = (u32 *) keepass->contents;
 
-    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_contents_hash[i]);
+    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_contents_hash[i]);
 
     *ptr_data = '*';
     ptr_data++;
@@ -583,31 +579,28 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     char ptr_contents_len[10] = { 0 };
 
-    sprintf ((char*) ptr_contents_len, "%u", contents_len);
+    snprintf ((char*) ptr_contents_len, sizeof (ptr_contents_len), "%u", contents_len);
 
-    sprintf (ptr_data, "%u", contents_len);
+    snprintf (ptr_data, sizeof (ptr_contents_len), "%u", contents_len);
 
     ptr_data += strlen (ptr_contents_len);
 
     *ptr_data = '*';
     ptr_data++;
 
-    for (u32 i = 0; i < contents_len / 4; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_contents[i]);
+    for (u32 i = 0; i < contents_len / 4; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_contents[i]);
   }
   else if (version == 2)
   {
     expected_bytes_len = 8;
     ptr_expected_bytes = (u32 *) keepass->expected_bytes;
 
-    for (u32 i = 0; i < expected_bytes_len; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_expected_bytes[i]);
+    for (u32 i = 0; i < expected_bytes_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_expected_bytes[i]);
 
     *ptr_data = '*';
     ptr_data++;
 
-    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_contents_hash[i]);
+    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_contents_hash[i]);
   }
 
   if (keyfile_len)
@@ -622,15 +615,14 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     *ptr_data = '*';
     ptr_data++;
 
-    sprintf (ptr_data, "%u", keyfile_len * 2);
+    snprintf (ptr_data, 3, "%u", keyfile_len * 2);
 
     ptr_data += 2;
 
     *ptr_data = '*';
     ptr_data++;
 
-    for (u32 i = 0; i < 8; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_keyfile[i]);
+    for (u32 i = 0; i < 8; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_keyfile[i]);
   }
 
   return strlen (line_buf);

--- a/src/modules/module_13500.c
+++ b/src/modules/module_13500.c
@@ -184,7 +184,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     const u8 *ptr = (const u8 *) pstoken->salt_buf;
 
-    sprintf (pstoken_tmp + j, "%02x", ptr[i]);
+    snprintf (pstoken_tmp + j, 3, "%02x", ptr[i]);
   }
 
   const int line_len = snprintf (line_buf, line_size, "%08x%08x%08x%08x%08x%c%s",

--- a/src/modules/module_13600.c
+++ b/src/modules/module_13600.c
@@ -358,7 +358,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     const u8 *ptr = (const u8 *) zip2->salt_buf;
 
-    sprintf (salt_tmp + j, "%02x", ptr[i]);
+    snprintf (salt_tmp + j, 3, "%02x", ptr[i]);
   }
 
   const u32 data_len = zip2->data_len;
@@ -369,7 +369,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     const u8 *ptr = (const u8 *) zip2->data_buf;
 
-    sprintf (data_tmp + j, "%02x", ptr[i]);
+    snprintf (data_tmp + j, 3, "%02x", ptr[i]);
   }
 
   const u32 auth_len = zip2->auth_len;
@@ -380,7 +380,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     const u8 *ptr = (const u8 *) zip2->auth_buf;
 
-    sprintf (auth_tmp + j, "%02x", ptr[i]);
+    snprintf (auth_tmp + j, 3, "%02x", ptr[i]);
   }
 
   const int line_len = snprintf (line_buf, line_size, "%s*%u*%u*%u*%s*%x*%x*%s*%s*%s",

--- a/src/modules/module_13800.c
+++ b/src/modules/module_13800.c
@@ -163,7 +163,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   for (int i = 0, j = 0; i < 32; i += 1, j += 8)
   {
-    sprintf (buf + j, "%08x", esalt->salt_buf[i]);
+    snprintf (buf + j, 9, "%08x", esalt->salt_buf[i]);
   }
 
   const int line_len = snprintf (line_buf, line_size, "%08x%08x%08x%08x%08x%08x%08x%08x%c%s",

--- a/src/modules/module_15500.c
+++ b/src/modules/module_15500.c
@@ -228,7 +228,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   for (u32 i = 0, j = 0; i < jks_sha1->enc_key_len; i += 1, j += 2)
   {
-    sprintf (enc_key + j, "%02X", ptr[i]);
+    snprintf (enc_key + j, 3, "%02X", ptr[i]);
   }
 
   u8 *der = (u8 *) jks_sha1->der;

--- a/src/modules/module_16100.c
+++ b/src/modules/module_16100.c
@@ -166,7 +166,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   for (u32 i = 0, j = 0; i < tacacs_plus->ct_data_len; i += 1, j += 2)
   {
-    sprintf (ct_data + j, "%02x", ct_data_ptr[i]);
+    snprintf (ct_data + j, 3, "%02x", ct_data_ptr[i]);
   }
 
   const u8 *session_ptr  = (const u8 *) tacacs_plus->session_buf;

--- a/src/modules/module_18200.c
+++ b/src/modules/module_18200.c
@@ -283,7 +283,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_edata2 = (u8 *) krb5asrep->edata2;
 
-    sprintf (data + j, "%02x", ptr_edata2[i]);
+    snprintf (data + j, 3, "%02x", ptr_edata2[i]);
   }
 
   int line_len = 0;

--- a/src/modules/module_19600.c
+++ b/src/modules/module_19600.c
@@ -267,7 +267,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_edata2 = (u8 *) krb5tgs->edata2;
 
-    sprintf (data + j, "%02x", ptr_edata2[i]);
+    snprintf (data + j, 3, "%02x", ptr_edata2[i]);
   }
 
   const int line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x$%s",

--- a/src/modules/module_19700.c
+++ b/src/modules/module_19700.c
@@ -267,7 +267,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_edata2 = (u8 *) krb5tgs->edata2;
 
-    sprintf (data + j, "%02x", ptr_edata2[i]);
+    snprintf (data + j, 3, "%02x", ptr_edata2[i]);
   }
 
   const int line_len = snprintf (line_buf, line_size, "%s%s$%s$%08x%08x%08x$%s",

--- a/src/modules/module_19800.c
+++ b/src/modules/module_19800.c
@@ -215,7 +215,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_enc_timestamp = (u8 *) krb5pa->enc_timestamp;
 
-    sprintf (data + j, "%02x", ptr_enc_timestamp[i]);
+    snprintf (data + j, 3, "%02x", ptr_enc_timestamp[i]);
   }
 
   const int line_len = snprintf (line_buf, line_size, "%s%s$%s$%s%08x%08x%08x",

--- a/src/modules/module_19900.c
+++ b/src/modules/module_19900.c
@@ -215,7 +215,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_enc_timestamp = (u8 *) krb5pa->enc_timestamp;
 
-    sprintf (data + j, "%02x", ptr_enc_timestamp[i]);
+    snprintf (data + j, 3, "%02x", ptr_enc_timestamp[i]);
   }
 
   const int line_len = snprintf (line_buf, line_size, "%s%s$%s$%s%08x%08x%08x",

--- a/src/modules/module_29700.c
+++ b/src/modules/module_29700.c
@@ -555,20 +555,17 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   *ptr_data = '*';
   ptr_data++;
 
-  for (u32 i = 0; i < final_random_seed_len; i++, ptr_data += 8)
-    sprintf (ptr_data, "%08x", ptr_final_random_seed[i]);
+  for (u32 i = 0; i < final_random_seed_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_final_random_seed[i]);
 
   *ptr_data = '*';
   ptr_data++;
 
-  for (u32 i = 0; i < transf_random_seed_len; i++, ptr_data += 8)
-    sprintf (ptr_data, "%08x", ptr_transf_random_seed[i]);
+  for (u32 i = 0; i < transf_random_seed_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_transf_random_seed[i]);
 
   *ptr_data = '*';
   ptr_data++;
 
-  for (u32 i = 0; i < enc_iv_len; i++, ptr_data += 8)
-    sprintf (ptr_data, "%08x", ptr_enc_iv[i]);
+  for (u32 i = 0; i < enc_iv_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_enc_iv[i]);
 
   *ptr_data = '*';
   ptr_data++;
@@ -578,8 +575,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     u32  contents_len =         keepass->contents_len;
     u32 *ptr_contents = (u32 *) keepass->contents;
 
-    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_contents_hash[i]);
+    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_contents_hash[i]);
 
     *ptr_data = '*';
     ptr_data++;
@@ -593,31 +589,28 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     char ptr_contents_len[10] = { 0 };
 
-    sprintf ((char*) ptr_contents_len, "%u", contents_len);
+    snprintf ((char*) ptr_contents_len, sizeof (ptr_contents_len), "%u", contents_len);
 
-    sprintf (ptr_data, "%u", contents_len);
+    snprintf (ptr_data, sizeof (ptr_contents_len), "%u", contents_len);
 
     ptr_data += strlen (ptr_contents_len);
 
     *ptr_data = '*';
     ptr_data++;
 
-    for (u32 i = 0; i < contents_len / 4; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_contents[i]);
+    for (u32 i = 0; i < contents_len / 4; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_contents[i]);
   }
   else if (version == 2)
   {
     expected_bytes_len = 8;
     ptr_expected_bytes = (u32 *) keepass->expected_bytes;
 
-    for (u32 i = 0; i < expected_bytes_len; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_expected_bytes[i]);
+    for (u32 i = 0; i < expected_bytes_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_expected_bytes[i]);
 
     *ptr_data = '*';
     ptr_data++;
 
-    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_contents_hash[i]);
+    for (u32 i = 0; i < contents_hash_len; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_contents_hash[i]);
   }
 
   if (keyfile_len)
@@ -632,15 +625,14 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     *ptr_data = '*';
     ptr_data++;
 
-    sprintf (ptr_data, "%u", keyfile_len * 2);
+    snprintf (ptr_data, 3, "%u", keyfile_len * 2);
 
     ptr_data += 2;
 
     *ptr_data = '*';
     ptr_data++;
 
-    for (u32 i = 0; i < 8; i++, ptr_data += 8)
-      sprintf (ptr_data, "%08x", ptr_keyfile[i]);
+    for (u32 i = 0; i < 8; i++, ptr_data += 8) snprintf (ptr_data, 9, "%08x", ptr_keyfile[i]);
   }
 
   return strlen (line_buf);

--- a/src/modules/module_32100.c
+++ b/src/modules/module_32100.c
@@ -309,7 +309,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_edata2 = (u8 *) krb5asrep->edata2;
 
-    sprintf (data + j, "%02x", ptr_edata2[i]);
+    snprintf (data + j, 3, "%02x", ptr_edata2[i]);
   }
 
   int line_len = 0;

--- a/src/modules/module_32200.c
+++ b/src/modules/module_32200.c
@@ -308,7 +308,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   {
     u8 *ptr_edata2 = (u8 *) krb5asrep->edata2;
 
-    sprintf (data + j, "%02x", ptr_edata2[i]);
+    snprintf (data + j, 3, "%02x", ptr_edata2[i]);
   }
 
   int line_len = 0;


### PR DESCRIPTION
example

```
src/modules/module_07500.c:228:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    sprintf (ptr_data, "%02x", ptr_timestamp[i]);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
src/modules/module_07500.c:233:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    sprintf (ptr_data, "%02x", ptr_checksum[i]);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
2 warnings generated.
src/modules/module_07500.c:228:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    sprintf (ptr_data, "%02x", ptr_timestamp[i]);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
src/modules/module_07500.c:233:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    sprintf (ptr_data, "%02x", ptr_checksum[i]);
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
2 warnings generated.

```