### PR TITLE
Fixed a bug in all SCRYPT-based hash modes with Apple Metal

### DIFF
--- a/OpenCL/m08900-pure.cl
+++ b/OpenCL/m08900-pure.cl
@@ -327,6 +327,9 @@ KERNEL_FQ void m08900_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     #if defined IS_CUDA || defined IS_HIP
     const uint4 tmp0 = make_uint4 (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = make_uint4 (digest[4], digest[5], digest[6], digest[7]);
+    #elif defined IS_METAL
+    const uint4 tmp0 = uint4 (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = uint4 (digest[4], digest[5], digest[6], digest[7]);
     #else
     const uint4 tmp0 = (uint4) (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = (uint4) (digest[4], digest[5], digest[6], digest[7]);
@@ -357,6 +360,11 @@ KERNEL_FQ void m08900_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     X[1] = make_uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
     X[2] = make_uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
     X[3] = make_uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
+    #elif defined IS_METAL
+    X[0] = uint4 (T[0].x, T[1].y, T[2].z, T[3].w);
+    X[1] = uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
+    X[2] = uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
+    X[3] = uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
     #else
     X[0] = (uint4) (T[0].x, T[1].y, T[2].z, T[3].w);
     X[1] = (uint4) (T[1].x, T[2].y, T[3].z, T[0].w);
@@ -467,6 +475,11 @@ KERNEL_FQ void m08900_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
     T[1] = make_uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
     T[2] = make_uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
     T[3] = make_uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
+    #elif defined IS_METAL
+    T[0] = uint4 (X[0].x, X[3].y, X[2].z, X[1].w);
+    T[1] = uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
+    T[2] = uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
+    T[3] = uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
     #else
     T[0] = (uint4) (X[0].x, X[3].y, X[2].z, X[1].w);
     T[1] = (uint4) (X[1].x, X[0].y, X[3].z, X[2].w);

--- a/OpenCL/m15700-pure.cl
+++ b/OpenCL/m15700-pure.cl
@@ -463,6 +463,9 @@ KERNEL_FQ void m15700_init (KERN_ATTR_TMPS_ESALT (scrypt_tmp_t, ethereum_scrypt_
     #if defined IS_CUDA || defined IS_HIP
     const uint4 tmp0 = make_uint4 (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = make_uint4 (digest[4], digest[5], digest[6], digest[7]);
+    #elif defined IS_METAL
+    const uint4 tmp0 = uint4 (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = uint4 (digest[4], digest[5], digest[6], digest[7]);
     #else
     const uint4 tmp0 = (uint4) (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = (uint4) (digest[4], digest[5], digest[6], digest[7]);
@@ -493,6 +496,11 @@ KERNEL_FQ void m15700_init (KERN_ATTR_TMPS_ESALT (scrypt_tmp_t, ethereum_scrypt_
     X[1] = make_uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
     X[2] = make_uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
     X[3] = make_uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
+    #elif defined IS_METAL
+    X[0] = uint4 (T[0].x, T[1].y, T[2].z, T[3].w);
+    X[1] = uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
+    X[2] = uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
+    X[3] = uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
     #else
     X[0] = (uint4) (T[0].x, T[1].y, T[2].z, T[3].w);
     X[1] = (uint4) (T[1].x, T[2].y, T[3].z, T[0].w);
@@ -603,6 +611,11 @@ KERNEL_FQ void m15700_comp (KERN_ATTR_TMPS_ESALT (scrypt_tmp_t, ethereum_scrypt_
     T[1] = make_uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
     T[2] = make_uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
     T[3] = make_uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
+    #elif defined IS_METAL
+    T[0] = uint4 (X[0].x, X[3].y, X[2].z, X[1].w);
+    T[1] = uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
+    T[2] = uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
+    T[3] = uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
     #else
     T[0] = (uint4) (X[0].x, X[3].y, X[2].z, X[1].w);
     T[1] = (uint4) (X[1].x, X[0].y, X[3].z, X[2].w);

--- a/OpenCL/m22700-pure.cl
+++ b/OpenCL/m22700-pure.cl
@@ -400,6 +400,9 @@ KERNEL_FQ void m22700_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     #if defined IS_CUDA || defined IS_HIP
     const uint4 tmp0 = make_uint4 (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = make_uint4 (digest[4], digest[5], digest[6], digest[7]);
+    #elif defined IS_METAL
+    const uint4 tmp0 = uint4 (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = uint4 (digest[4], digest[5], digest[6], digest[7]);
     #else
     const uint4 tmp0 = (uint4) (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = (uint4) (digest[4], digest[5], digest[6], digest[7]);
@@ -430,6 +433,11 @@ KERNEL_FQ void m22700_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     X[1] = make_uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
     X[2] = make_uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
     X[3] = make_uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
+    #elif defined IS_METAL
+    X[0] = uint4 (T[0].x, T[1].y, T[2].z, T[3].w);
+    X[1] = uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
+    X[2] = uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
+    X[3] = uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
     #else
     X[0] = (uint4) (T[0].x, T[1].y, T[2].z, T[3].w);
     X[1] = (uint4) (T[1].x, T[2].y, T[3].z, T[0].w);
@@ -605,6 +613,11 @@ KERNEL_FQ void m22700_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
     T[1] = make_uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
     T[2] = make_uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
     T[3] = make_uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
+    #elif defined IS_METAL
+    T[0] = uint4 (X[0].x, X[3].y, X[2].z, X[1].w);
+    T[1] = uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
+    T[2] = uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
+    T[3] = uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
     #else
     T[0] = (uint4) (X[0].x, X[3].y, X[2].z, X[1].w);
     T[1] = (uint4) (X[1].x, X[0].y, X[3].z, X[2].w);

--- a/OpenCL/m27700-pure.cl
+++ b/OpenCL/m27700-pure.cl
@@ -351,6 +351,9 @@ KERNEL_FQ void m27700_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     #if defined IS_CUDA || defined IS_HIP
     const uint4 tmp0 = make_uint4 (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = make_uint4 (digest[4], digest[5], digest[6], digest[7]);
+    #elif defined IS_METAL
+    const uint4 tmp0 = uint4 (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = uint4 (digest[4], digest[5], digest[6], digest[7]);
     #else
     const uint4 tmp0 = (uint4) (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = (uint4) (digest[4], digest[5], digest[6], digest[7]);
@@ -381,6 +384,11 @@ KERNEL_FQ void m27700_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     X[1] = make_uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
     X[2] = make_uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
     X[3] = make_uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
+    #elif defined IS_METAL
+    X[0] = uint4 (T[0].x, T[1].y, T[2].z, T[3].w);
+    X[1] = uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
+    X[2] = uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
+    X[3] = uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
     #else
     X[0] = (uint4) (T[0].x, T[1].y, T[2].z, T[3].w);
     X[1] = (uint4) (T[1].x, T[2].y, T[3].z, T[0].w);
@@ -557,6 +565,11 @@ KERNEL_FQ void m27700_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
     T[1] = make_uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
     T[2] = make_uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
     T[3] = make_uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
+    #elif defined IS_METAL
+    T[0] = uint4 (X[0].x, X[3].y, X[2].z, X[1].w);
+    T[1] = uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
+    T[2] = uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
+    T[3] = uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
     #else
     T[0] = (uint4) (X[0].x, X[3].y, X[2].z, X[1].w);
     T[1] = (uint4) (X[1].x, X[0].y, X[3].z, X[2].w);

--- a/OpenCL/m28200-pure.cl
+++ b/OpenCL/m28200-pure.cl
@@ -337,6 +337,9 @@ KERNEL_FQ void m28200_init (KERN_ATTR_TMPS_ESALT (exodus_tmp_t, exodus_t))
     #if defined IS_CUDA || defined IS_HIP
     const uint4 tmp0 = make_uint4 (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = make_uint4 (digest[4], digest[5], digest[6], digest[7]);
+    #elif defined IS_METAL
+    const uint4 tmp0 = uint4 (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = uint4 (digest[4], digest[5], digest[6], digest[7]);
     #else
     const uint4 tmp0 = (uint4) (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = (uint4) (digest[4], digest[5], digest[6], digest[7]);
@@ -367,6 +370,11 @@ KERNEL_FQ void m28200_init (KERN_ATTR_TMPS_ESALT (exodus_tmp_t, exodus_t))
     X[1] = make_uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
     X[2] = make_uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
     X[3] = make_uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
+    #elif defined IS_METAL
+    X[0] = uint4 (T[0].x, T[1].y, T[2].z, T[3].w);
+    X[1] = uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
+    X[2] = uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
+    X[3] = uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
     #else
     X[0] = (uint4) (T[0].x, T[1].y, T[2].z, T[3].w);
     X[1] = (uint4) (T[1].x, T[2].y, T[3].z, T[0].w);
@@ -525,6 +533,11 @@ KERNEL_FQ void m28200_comp (KERN_ATTR_TMPS_ESALT (exodus_tmp_t, exodus_t))
     T[1] = make_uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
     T[2] = make_uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
     T[3] = make_uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
+    #elif defined IS_METAL
+    T[0] = uint4 (X[0].x, X[3].y, X[2].z, X[1].w);
+    T[1] = uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
+    T[2] = uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
+    T[3] = uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
     #else
     T[0] = (uint4) (X[0].x, X[3].y, X[2].z, X[1].w);
     T[1] = (uint4) (X[1].x, X[0].y, X[3].z, X[2].w);

--- a/OpenCL/m29800-pure.cl
+++ b/OpenCL/m29800-pure.cl
@@ -351,6 +351,9 @@ KERNEL_FQ void m29800_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     #if defined IS_CUDA || defined IS_HIP
     const uint4 tmp0 = make_uint4 (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = make_uint4 (digest[4], digest[5], digest[6], digest[7]);
+    #elif defined IS_METAL
+    const uint4 tmp0 = uint4 (digest[0], digest[1], digest[2], digest[3]);
+    const uint4 tmp1 = uint4 (digest[4], digest[5], digest[6], digest[7]);
     #else
     const uint4 tmp0 = (uint4) (digest[0], digest[1], digest[2], digest[3]);
     const uint4 tmp1 = (uint4) (digest[4], digest[5], digest[6], digest[7]);
@@ -381,6 +384,11 @@ KERNEL_FQ void m29800_init (KERN_ATTR_TMPS (scrypt_tmp_t))
     X[1] = make_uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
     X[2] = make_uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
     X[3] = make_uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
+    #elif defined IS_METAL
+    X[0] = uint4 (T[0].x, T[1].y, T[2].z, T[3].w);
+    X[1] = uint4 (T[1].x, T[2].y, T[3].z, T[0].w);
+    X[2] = uint4 (T[2].x, T[3].y, T[0].z, T[1].w);
+    X[3] = uint4 (T[3].x, T[0].y, T[1].z, T[2].w);
     #else
     X[0] = (uint4) (T[0].x, T[1].y, T[2].z, T[3].w);
     X[1] = (uint4) (T[1].x, T[2].y, T[3].z, T[0].w);
@@ -557,6 +565,11 @@ KERNEL_FQ void m29800_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
     T[1] = make_uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
     T[2] = make_uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
     T[3] = make_uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
+    #elif defined IS_METAL
+    T[0] = uint4 (X[0].x, X[3].y, X[2].z, X[1].w);
+    T[1] = uint4 (X[1].x, X[0].y, X[3].z, X[2].w);
+    T[2] = uint4 (X[2].x, X[1].y, X[0].z, X[3].w);
+    T[3] = uint4 (X[3].x, X[2].y, X[1].z, X[0].w);
     #else
     T[0] = (uint4) (X[0].x, X[3].y, X[2].z, X[1].w);
     T[1] = (uint4) (X[1].x, X[0].y, X[3].z, X[2].w);

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -70,6 +70,7 @@
 - Fixed bug in 29600 module OPTS_TYPE setting
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
+- Fixed a bug in all SCRYPT-based hash modes with Apple Metal
 - Added verification of token buffer length when using TOKEN_ATTR_FIXED_LENGTH
 - Fixed build failed for 4410 with vector width > 1
 - Fixed build failed for 10700 optimized with Apple Metal


### PR DESCRIPTION
Hi,

all hash modes based on SCRYPT did not work on Apple Metal, due to incorrect conversion to uint4.
Example:

```
> Testing hash type 8900 with attack mode 0, markov enabled, single hash, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1.
[ len 1 ] Session..........: hashcat
Status...........: Exhausted
Hash.Mode........: 8900 (scrypt)
Hash.Target......: SCRYPT:16384:8:1:MTc5NDY5MjMwNTEyNA==:2k6p4gDR++pBZ...lh4rI=
Time.Started.....: Wed Jun  7 00:30:16 2023, (1 sec)
Time.Estimated...: Wed Jun  7 00:30:17 2023, (0 secs; Runtime limited: 59 secs)
Kernel.Feature...: Pure Kernel
Guess.Base.......: Pipe
Speed.#1.........:        1 H/s (37.49ms) @ Accel:8 Loops:1024 Thr:32 Vec:1
Recovered........: 0/1 (0.00%) Digests (total), 0/1 (0.00%) Digests (new)
Progress.........: 1
Rejected.........: 0
Restore.Point....: 0
Restore.Sub.#1...: Salt:0 Amplifier:0-1 Iteration:15360-16384
Candidate.Engine.: Device Generator
Candidates.#1....:  -> 
password not found, cmdline : echo  | ./hashcat --quiet --potfile-disable --hwmon-disable --logfile-disable -d 1 -O --runtime 60 -D 2 --force --backend-vector-width 1 -a 0 -m 8900 'SCRYPT:16384:8:1:MTc5NDY5MjMwNTEyNA==:2k6p4gDR++pBZMm9XDE89/4YyqmDVeLlRgpiRzlh4rI='

```


Following the output of test.sh with patches applied

```
bash-3.2$ for a in $(echo 8900 9300 15700 22700 27700 28200 29800); do ./tools/test.sh -m $a -r 60 -f -d 1; done 
[ test_1686091285 ] > Init test for hash type 8900.
[ test_1686091285 ] [ Type 8900, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091285 ] [ Type 8900, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091321 ] > Init test for hash type 9300.
[ test_1686091321 ] [ Type 9300, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091321 ] [ Type 9300, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091339 ] > Init test for hash type 15700.
[ test_1686091339 ] [ Type 15700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091339 ] [ Type 15700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091357 ] > Init test for hash type 22700.
[ test_1686091357 ] [ Type 22700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091357 ] [ Type 22700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091392 ] > Init test for hash type 27700.
[ test_1686091392 ] [ Type 27700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091392 ] [ Type 27700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091428 ] > Init test for hash type 28200.
[ test_1686091428 ] [ Type 28200, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091428 ] [ Type 28200, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091464 ] > Init test for hash type 29800.
[ test_1686091464 ] [ Type 29800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686091464 ] [ Type 29800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

At this point it no longer makes sense to use --force if the Apple Metal runtime version is greater than or equal to 2xx.x
I will open a PR following :)