### PR TITLE
Metal Backend: allow use of devices with Metal if runtime version is >= 200

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -107,6 +107,7 @@
 - MetaMask: update extraction tool to support MetaMask Mobile wallets
 - SecureCRT MasterPassphrase v2: update module, pure kernels and test unit. Add optimized kernels.
 - Metal Backend: added workaround to prevent 'Infinite Loop' bug when build kernels
+- Metal Backend: allow use of devices with Metal if runtime version is >= 200
 - User Options: added --metal-compiler-runtime option
 - Hardware Monitor: avoid sprintf in src/ext_iokit.c
 - Help: show supported hash-modes only with -hh

--- a/src/backend.c
+++ b/src/backend.c
@@ -4543,27 +4543,6 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
 
         mtl_close (hashcat_ctx);
       }
-      else
-      {
-        if (user_options->force == false)
-        {
-          // disable metal < 300
-
-          if (backend_ctx->metal_runtimeVersion < 300)
-          {
-            event_log_warning (hashcat_ctx, "Unsupported Apple Metal runtime version '%s' detected! Falling back to OpenCL...", backend_ctx->metal_runtimeVersionStr);
-            event_log_warning (hashcat_ctx, NULL);
-
-            rc_metal_init = -1;
-
-            backend_ctx->rc_metal_init = rc_metal_init;
-
-            backend_ctx->mtl = NULL;
-
-            mtl_close (hashcat_ctx);
-          }
-        }
-      }
     }
     else
     {


### PR DESCRIPTION
As following of #3758 we can enable Metal running with runtime version >= 200

```
bash-3.2$ ./hashcat -I
hashcat (v6.2.6-571-g890de0bff+) starting in backend information mode

Metal Info:
===========

Metal.Version.: 263.9

Backend Device ID #1 (Alias: #2)
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Apple M1
  Processor(s)...: 8
  Clock..........: N/A
  Memory.Total...: 10922 MB (limited to 4096 MB allocatable in one block)
  Memory.Free....: 5408 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Registry.ID....: 1607
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 0, removable 0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
[...]

bash-3.2$ ./hashcat -b -m 1000 -d 1
hashcat (v6.2.6-571-g890de0bff+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

METAL API (Metal 263.9)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Benchmark relevant options:
===========================
* --backend-devices=1
* --backend-devices-virtual=1
* --optimized-kernel-enable

-----------------------
* Hash-Mode 1000 (NTLM)
-----------------------

Speed.#1.........:  4691.5 MH/s (55.23ms) @ Accel:512 Loops:1024 Thr:64 Vec:1

```