### PR TITLE
do not allow negative kern_type

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -9893,6 +9893,13 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       }
     }
 
+    if ((int) kern_type == -1)
+    {
+      event_log_error (hashcat_ctx, "Invalid hash-mode selected: -1");
+
+      return -1;
+    }
+
     // built options
 
     const size_t build_options_sz = 4096;


### PR DESCRIPTION
Hi,

this is the fix for #3400 

In case of negative kern_type, for example from a call to module_kern_type_dynamic(), hashcat will show an error and exit.

```
bash-3.2$ ./hashcat -m 16500 y --force -d1
hashcat (v6.2.6-574-geb276f12f) starting

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

METAL API (Metal 263.9)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Minimum password length supported by kernel: 0
Maximum password length supported by kernel: 256

Hashes: 1 digests; 1 unique digests, 1 unique salts
Bitmaps: 16 bits, 65536 entries, 0x0000ffff mask, 262144 bytes, 5/13 rotates
Rules: 1

Optimizers applied:
* Zero-Byte
* Not-Iterated
* Single-Hash
* Single-Salt

Watchdog: Temperature abort trigger set to 100c

Invalid hash-mode selected: -1

Started: Wed Jun  7 21:11:34 2023
Stopped: Wed Jun  7 21:11:34 2023
bash-3.2$
```