### PR TITLE
Metal Backend: disable Metal devices only if at least one OpenCL device is active

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -111,6 +111,7 @@
 - SecureCRT MasterPassphrase v2: update module, pure kernels and test unit. Add optimized kernels.
 - Metal Backend: added workaround to prevent 'Infinite Loop' bug when build kernels
 - Metal Backend: allow use of devices with Metal if runtime version is >= 200
+- Metal Backend: disable Metal devices only if at least one OpenCL device is active
 - User Options: added --metal-compiler-runtime option
 - Hardware Monitor: avoid sprintf in src/ext_iokit.c
 - Help: show supported hash-modes only with -hh


### PR DESCRIPTION
Hi,

sometimes on macOS, hashcat fails to select a valid device unless it is selected by the user. Example:

```
% ./hashcat -b -m 0                      
hashcat (v6.2.6-587-g32517211a) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

The device #1 has been disabled as it most likely also exists as an OpenCL device, but it is not possible to automatically map it.
You can use -d 1 to use Metal API instead of OpenCL API. In some rare cases this is more stable.

* Device #2: Outdated or broken Apple OpenCL driver '1.2 1.0' detected!

You are STRONGLY encouraged to use the officially supported driver.
See hashcat.net for officially supported Apple OpenCL drivers.
See also: https://hashcat.net/faq/wrongdriver
You can use --force to override this, but do not report related errors.

No devices found/left.
```

With this patch the Metal devices will be disabled only if at least one OpenCL device is active.

If users do not specify a device by command line and all the OpenCL devices are disabled, will be selected the first Metal device enabled:

```
% ./hashcat -b -m 0                                
hashcat (v6.2.6-587-g32517211a+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

* Device #2: Outdated or broken Apple OpenCL driver '1.2 1.0' detected!

You are STRONGLY encouraged to use the officially supported driver.
See hashcat.net for officially supported Apple OpenCL drivers.
See also: https://hashcat.net/faq/wrongdriver
You can use --force to override this, but do not report related errors.

METAL API (Metal 263.9)
=======================
* Device #1: Apple M1, 5408/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, skipped

Benchmark relevant options:
===========================
* --backend-devices-virtual=1
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#1.........:  2802.4 MH/s (93.95ms) @ Accel:1024 Loops:1024 Thr:32 Vec:1
```

In my case, by using --force the OpenCL device will be enabled, so will be selected by default (instead of another Metal device):

```
% ./hashcat -b -m 0 --force
hashcat (v6.2.6-587-g32517211a+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

You have enabled --force to bypass dangerous warnings and errors!
This can hide serious problems and should only be done when debugging.
Do not report hashcat issues encountered when using --force.

The device #1 has been disabled as it most likely also exists as an OpenCL device, but it is not possible to automatically map it.
You can use -d 1 to use Metal API instead of OpenCL API. In some rare cases this is more stable.

METAL API (Metal 263.9)
=======================
* Device #1: Apple M1, skipped

OpenCL API (OpenCL 1.2 (Aug  8 2022 21:29:55)) - Platform #1 [Apple]
====================================================================
* Device #2: Apple M1, GPU, 960/10922 MB (1024 MB allocatable), 8MCU

Benchmark relevant options:
===========================
* --force
* --backend-devices-virtual=1
* --optimized-kernel-enable

-------------------
* Hash-Mode 0 (MD5)
-------------------

Speed.#2.........:  2805.5 MH/s (2.26ms) @ Accel:1024 Loops:1024 Thr:32 Vec:1
```

Thanks ;)


