### PR TITLE
Added hash-mode: sha512(sha512($pass).$salt)

### DIFF
--- a/OpenCL/m32410_a0-pure.cl
+++ b/OpenCL/m32410_a0-pure.cl
@@ -1,0 +1,369 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m32410_mxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 0
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 8;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+  u32 w4[4];
+  u32 w5[4];
+  u32 w6[4];
+  u32 w7[4];
+
+  COPY_PW (pws[gid]);
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha512_ctx_t ctx0;
+
+    sha512_init (&ctx0);
+
+    sha512_update_swap (&ctx0, tmp.i, tmp.pw_len);
+
+    sha512_final (&ctx0);
+
+    const u64 a = ctx0.h[0];
+    const u64 b = ctx0.h[1];
+    const u64 c = ctx0.h[2];
+    const u64 d = ctx0.h[3];
+    const u64 e = ctx0.h[4];
+    const u64 f = ctx0.h[5];
+    const u64 g = ctx0.h[6];
+    const u64 h = ctx0.h[7];
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 48) & 255) <<  0;
+    w0[1] = uint_to_hex_lower8 ((a >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 32) & 255) <<  0;
+    w0[2] = uint_to_hex_lower8 ((a >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 16) & 255) <<  0;
+    w0[3] = uint_to_hex_lower8 ((a >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((a >>  0) & 255) <<  0;
+    w1[0] = uint_to_hex_lower8 ((b >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 48) & 255) <<  0;
+    w1[1] = uint_to_hex_lower8 ((b >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 32) & 255) <<  0;
+    w1[2] = uint_to_hex_lower8 ((b >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 16) & 255) <<  0;
+    w1[3] = uint_to_hex_lower8 ((b >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((b >>  0) & 255) <<  0;
+    w2[0] = uint_to_hex_lower8 ((c >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 48) & 255) <<  0;
+    w2[1] = uint_to_hex_lower8 ((c >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 32) & 255) <<  0;
+    w2[2] = uint_to_hex_lower8 ((c >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 16) & 255) <<  0;
+    w2[3] = uint_to_hex_lower8 ((c >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((c >>  0) & 255) <<  0;
+    w3[0] = uint_to_hex_lower8 ((d >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 48) & 255) <<  0;
+    w3[1] = uint_to_hex_lower8 ((d >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 32) & 255) <<  0;
+    w3[2] = uint_to_hex_lower8 ((d >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 16) & 255) <<  0;
+    w3[3] = uint_to_hex_lower8 ((d >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((d >>  0) & 255) <<  0;
+    w4[0] = uint_to_hex_lower8 ((e >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 48) & 255) <<  0;
+    w4[1] = uint_to_hex_lower8 ((e >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 32) & 255) <<  0;
+    w4[2] = uint_to_hex_lower8 ((e >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 16) & 255) <<  0;
+    w4[3] = uint_to_hex_lower8 ((e >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((e >>  0) & 255) <<  0;
+    w5[0] = uint_to_hex_lower8 ((f >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 48) & 255) <<  0;
+    w5[1] = uint_to_hex_lower8 ((f >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 32) & 255) <<  0;
+    w5[2] = uint_to_hex_lower8 ((f >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 16) & 255) <<  0;
+    w5[3] = uint_to_hex_lower8 ((f >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((f >>  0) & 255) <<  0;
+    w6[0] = uint_to_hex_lower8 ((g >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 48) & 255) <<  0;
+    w6[1] = uint_to_hex_lower8 ((g >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 32) & 255) <<  0;
+    w6[2] = uint_to_hex_lower8 ((g >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 16) & 255) <<  0;
+    w6[3] = uint_to_hex_lower8 ((g >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((g >>  0) & 255) <<  0;
+    w7[0] = uint_to_hex_lower8 ((h >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 48) & 255) <<  0;
+    w7[1] = uint_to_hex_lower8 ((h >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 32) & 255) <<  0;
+    w7[2] = uint_to_hex_lower8 ((h >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 16) & 255) <<  0;
+    w7[3] = uint_to_hex_lower8 ((h >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((h >>  0) & 255) <<  0;
+
+    sha512_update_128 (&ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    const u32 r0 = l32_from_64_S (ctx.h[7]);
+    const u32 r1 = h32_from_64_S (ctx.h[7]);
+    const u32 r2 = l32_from_64_S (ctx.h[3]);
+    const u32 r3 = h32_from_64_S (ctx.h[3]);
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m32410_sxx (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 0
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 8;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+  u32 w4[4];
+  u32 w5[4];
+  u32 w6[4];
+  u32 w7[4];
+
+  COPY_PW (pws[gid]);
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha512_ctx_t ctx0;
+
+    sha512_init (&ctx0);
+
+    sha512_update_swap (&ctx0, tmp.i, tmp.pw_len);
+
+    sha512_final (&ctx0);
+
+    const u64 a = ctx0.h[0];
+    const u64 b = ctx0.h[1];
+    const u64 c = ctx0.h[2];
+    const u64 d = ctx0.h[3];
+    const u64 e = ctx0.h[4];
+    const u64 f = ctx0.h[5];
+    const u64 g = ctx0.h[6];
+    const u64 h = ctx0.h[7];
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 48) & 255) <<  0;
+    w0[1] = uint_to_hex_lower8 ((a >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 32) & 255) <<  0;
+    w0[2] = uint_to_hex_lower8 ((a >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 16) & 255) <<  0;
+    w0[3] = uint_to_hex_lower8 ((a >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((a >>  0) & 255) <<  0;
+    w1[0] = uint_to_hex_lower8 ((b >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 48) & 255) <<  0;
+    w1[1] = uint_to_hex_lower8 ((b >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 32) & 255) <<  0;
+    w1[2] = uint_to_hex_lower8 ((b >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 16) & 255) <<  0;
+    w1[3] = uint_to_hex_lower8 ((b >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((b >>  0) & 255) <<  0;
+    w2[0] = uint_to_hex_lower8 ((c >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 48) & 255) <<  0;
+    w2[1] = uint_to_hex_lower8 ((c >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 32) & 255) <<  0;
+    w2[2] = uint_to_hex_lower8 ((c >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 16) & 255) <<  0;
+    w2[3] = uint_to_hex_lower8 ((c >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((c >>  0) & 255) <<  0;
+    w3[0] = uint_to_hex_lower8 ((d >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 48) & 255) <<  0;
+    w3[1] = uint_to_hex_lower8 ((d >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 32) & 255) <<  0;
+    w3[2] = uint_to_hex_lower8 ((d >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 16) & 255) <<  0;
+    w3[3] = uint_to_hex_lower8 ((d >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((d >>  0) & 255) <<  0;
+    w4[0] = uint_to_hex_lower8 ((e >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 48) & 255) <<  0;
+    w4[1] = uint_to_hex_lower8 ((e >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 32) & 255) <<  0;
+    w4[2] = uint_to_hex_lower8 ((e >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 16) & 255) <<  0;
+    w4[3] = uint_to_hex_lower8 ((e >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((e >>  0) & 255) <<  0;
+    w5[0] = uint_to_hex_lower8 ((f >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 48) & 255) <<  0;
+    w5[1] = uint_to_hex_lower8 ((f >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 32) & 255) <<  0;
+    w5[2] = uint_to_hex_lower8 ((f >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 16) & 255) <<  0;
+    w5[3] = uint_to_hex_lower8 ((f >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((f >>  0) & 255) <<  0;
+    w6[0] = uint_to_hex_lower8 ((g >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 48) & 255) <<  0;
+    w6[1] = uint_to_hex_lower8 ((g >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 32) & 255) <<  0;
+    w6[2] = uint_to_hex_lower8 ((g >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 16) & 255) <<  0;
+    w6[3] = uint_to_hex_lower8 ((g >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((g >>  0) & 255) <<  0;
+    w7[0] = uint_to_hex_lower8 ((h >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 48) & 255) <<  0;
+    w7[1] = uint_to_hex_lower8 ((h >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 32) & 255) <<  0;
+    w7[2] = uint_to_hex_lower8 ((h >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 16) & 255) <<  0;
+    w7[3] = uint_to_hex_lower8 ((h >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((h >>  0) & 255) <<  0;
+
+    sha512_update_128 (&ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    const u32 r0 = l32_from_64_S (ctx.h[7]);
+    const u32 r1 = h32_from_64_S (ctx.h[7]);
+    const u32 r2 = l32_from_64_S (ctx.h[3]);
+    const u32 r3 = h32_from_64_S (ctx.h[3]);
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m32410_a1-pure.cl
+++ b/OpenCL/m32410_a1-pure.cl
@@ -1,0 +1,363 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m32410_mxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 0
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 8;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+  u32 w4[4];
+  u32 w5[4];
+  u32 w6[4];
+  u32 w7[4];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[idx]);
+  }
+
+  sha512_ctx_t ctx0;
+
+  sha512_init (&ctx0);
+
+  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    sha512_ctx_t ctx1 = ctx0;
+
+    sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha512_final (&ctx1);
+
+    const u64 a = ctx1.h[0];
+    const u64 b = ctx1.h[1];
+    const u64 c = ctx1.h[2];
+    const u64 d = ctx1.h[3];
+    const u64 e = ctx1.h[4];
+    const u64 f = ctx1.h[5];
+    const u64 g = ctx1.h[6];
+    const u64 h = ctx1.h[7];
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 48) & 255) <<  0;
+    w0[1] = uint_to_hex_lower8 ((a >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 32) & 255) <<  0;
+    w0[2] = uint_to_hex_lower8 ((a >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 16) & 255) <<  0;
+    w0[3] = uint_to_hex_lower8 ((a >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((a >>  0) & 255) <<  0;
+    w1[0] = uint_to_hex_lower8 ((b >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 48) & 255) <<  0;
+    w1[1] = uint_to_hex_lower8 ((b >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 32) & 255) <<  0;
+    w1[2] = uint_to_hex_lower8 ((b >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 16) & 255) <<  0;
+    w1[3] = uint_to_hex_lower8 ((b >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((b >>  0) & 255) <<  0;
+    w2[0] = uint_to_hex_lower8 ((c >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 48) & 255) <<  0;
+    w2[1] = uint_to_hex_lower8 ((c >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 32) & 255) <<  0;
+    w2[2] = uint_to_hex_lower8 ((c >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 16) & 255) <<  0;
+    w2[3] = uint_to_hex_lower8 ((c >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((c >>  0) & 255) <<  0;
+    w3[0] = uint_to_hex_lower8 ((d >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 48) & 255) <<  0;
+    w3[1] = uint_to_hex_lower8 ((d >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 32) & 255) <<  0;
+    w3[2] = uint_to_hex_lower8 ((d >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 16) & 255) <<  0;
+    w3[3] = uint_to_hex_lower8 ((d >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((d >>  0) & 255) <<  0;
+    w4[0] = uint_to_hex_lower8 ((e >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 48) & 255) <<  0;
+    w4[1] = uint_to_hex_lower8 ((e >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 32) & 255) <<  0;
+    w4[2] = uint_to_hex_lower8 ((e >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 16) & 255) <<  0;
+    w4[3] = uint_to_hex_lower8 ((e >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((e >>  0) & 255) <<  0;
+    w5[0] = uint_to_hex_lower8 ((f >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 48) & 255) <<  0;
+    w5[1] = uint_to_hex_lower8 ((f >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 32) & 255) <<  0;
+    w5[2] = uint_to_hex_lower8 ((f >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 16) & 255) <<  0;
+    w5[3] = uint_to_hex_lower8 ((f >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((f >>  0) & 255) <<  0;
+    w6[0] = uint_to_hex_lower8 ((g >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 48) & 255) <<  0;
+    w6[1] = uint_to_hex_lower8 ((g >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 32) & 255) <<  0;
+    w6[2] = uint_to_hex_lower8 ((g >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 16) & 255) <<  0;
+    w6[3] = uint_to_hex_lower8 ((g >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((g >>  0) & 255) <<  0;
+    w7[0] = uint_to_hex_lower8 ((h >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 48) & 255) <<  0;
+    w7[1] = uint_to_hex_lower8 ((h >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 32) & 255) <<  0;
+    w7[2] = uint_to_hex_lower8 ((h >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 16) & 255) <<  0;
+    w7[3] = uint_to_hex_lower8 ((h >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((h >>  0) & 255) <<  0;
+
+    sha512_update_128 (&ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    const u32 r0 = l32_from_64_S (ctx.h[7]);
+    const u32 r1 = h32_from_64_S (ctx.h[7]);
+    const u32 r2 = l32_from_64_S (ctx.h[3]);
+    const u32 r3 = h32_from_64_S (ctx.h[3]);
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m32410_sxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 0
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 8;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+  u32 w4[4];
+  u32 w5[4];
+  u32 w6[4];
+  u32 w7[4];
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[idx]);
+  }
+
+  sha512_ctx_t ctx0;
+
+  sha512_init (&ctx0);
+
+  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    sha512_ctx_t ctx1 = ctx0;
+
+    sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    sha512_final (&ctx1);
+
+    const u64 a = ctx1.h[0];
+    const u64 b = ctx1.h[1];
+    const u64 c = ctx1.h[2];
+    const u64 d = ctx1.h[3];
+    const u64 e = ctx1.h[4];
+    const u64 f = ctx1.h[5];
+    const u64 g = ctx1.h[6];
+    const u64 h = ctx1.h[7];
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 48) & 255) <<  0;
+    w0[1] = uint_to_hex_lower8 ((a >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 32) & 255) <<  0;
+    w0[2] = uint_to_hex_lower8 ((a >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 16) & 255) <<  0;
+    w0[3] = uint_to_hex_lower8 ((a >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((a >>  0) & 255) <<  0;
+    w1[0] = uint_to_hex_lower8 ((b >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 48) & 255) <<  0;
+    w1[1] = uint_to_hex_lower8 ((b >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 32) & 255) <<  0;
+    w1[2] = uint_to_hex_lower8 ((b >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 16) & 255) <<  0;
+    w1[3] = uint_to_hex_lower8 ((b >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((b >>  0) & 255) <<  0;
+    w2[0] = uint_to_hex_lower8 ((c >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 48) & 255) <<  0;
+    w2[1] = uint_to_hex_lower8 ((c >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 32) & 255) <<  0;
+    w2[2] = uint_to_hex_lower8 ((c >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 16) & 255) <<  0;
+    w2[3] = uint_to_hex_lower8 ((c >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((c >>  0) & 255) <<  0;
+    w3[0] = uint_to_hex_lower8 ((d >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 48) & 255) <<  0;
+    w3[1] = uint_to_hex_lower8 ((d >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 32) & 255) <<  0;
+    w3[2] = uint_to_hex_lower8 ((d >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 16) & 255) <<  0;
+    w3[3] = uint_to_hex_lower8 ((d >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((d >>  0) & 255) <<  0;
+    w4[0] = uint_to_hex_lower8 ((e >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 48) & 255) <<  0;
+    w4[1] = uint_to_hex_lower8 ((e >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 32) & 255) <<  0;
+    w4[2] = uint_to_hex_lower8 ((e >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 16) & 255) <<  0;
+    w4[3] = uint_to_hex_lower8 ((e >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((e >>  0) & 255) <<  0;
+    w5[0] = uint_to_hex_lower8 ((f >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 48) & 255) <<  0;
+    w5[1] = uint_to_hex_lower8 ((f >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 32) & 255) <<  0;
+    w5[2] = uint_to_hex_lower8 ((f >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 16) & 255) <<  0;
+    w5[3] = uint_to_hex_lower8 ((f >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((f >>  0) & 255) <<  0;
+    w6[0] = uint_to_hex_lower8 ((g >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 48) & 255) <<  0;
+    w6[1] = uint_to_hex_lower8 ((g >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 32) & 255) <<  0;
+    w6[2] = uint_to_hex_lower8 ((g >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 16) & 255) <<  0;
+    w6[3] = uint_to_hex_lower8 ((g >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((g >>  0) & 255) <<  0;
+    w7[0] = uint_to_hex_lower8 ((h >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 48) & 255) <<  0;
+    w7[1] = uint_to_hex_lower8 ((h >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 32) & 255) <<  0;
+    w7[2] = uint_to_hex_lower8 ((h >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 16) & 255) <<  0;
+    w7[3] = uint_to_hex_lower8 ((h >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((h >>  0) & 255) <<  0;
+
+    sha512_update_128 (&ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    const u32 r0 = l32_from_64_S (ctx.h[7]);
+    const u32 r1 = h32_from_64_S (ctx.h[7]);
+    const u32 r2 = l32_from_64_S (ctx.h[3]);
+    const u32 r3 = h32_from_64_S (ctx.h[3]);
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m32410_a3-pure.cl
+++ b/OpenCL/m32410_a3-pure.cl
@@ -1,0 +1,389 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ void m32410_mxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 0
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 8;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  u32x w0[4];
+  u32x w1[4];
+  u32x w2[4];
+  u32x w3[4];
+  u32x w4[4];
+  u32x w5[4];
+  u32x w6[4];
+  u32x w7[4];
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32x s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0_final = w0l | w0r;
+
+    w[0] = w0_final;
+
+    sha512_ctx_vector_t ctx0;
+
+    sha512_init_vector (&ctx0);
+
+    sha512_update_vector (&ctx0, w, pw_len);
+
+    sha512_final_vector (&ctx0);
+
+    const u64x a = ctx0.h[0];
+    const u64x b = ctx0.h[1];
+    const u64x c = ctx0.h[2];
+    const u64x d = ctx0.h[3];
+    const u64x e = ctx0.h[4];
+    const u64x f = ctx0.h[5];
+    const u64x g = ctx0.h[6];
+    const u64x h = ctx0.h[7];
+
+    sha512_ctx_vector_t ctx;
+
+    sha512_init_vector (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 48) & 255) <<  0;
+    w0[1] = uint_to_hex_lower8 ((a >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 32) & 255) <<  0;
+    w0[2] = uint_to_hex_lower8 ((a >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 16) & 255) <<  0;
+    w0[3] = uint_to_hex_lower8 ((a >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((a >>  0) & 255) <<  0;
+    w1[0] = uint_to_hex_lower8 ((b >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 48) & 255) <<  0;
+    w1[1] = uint_to_hex_lower8 ((b >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 32) & 255) <<  0;
+    w1[2] = uint_to_hex_lower8 ((b >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 16) & 255) <<  0;
+    w1[3] = uint_to_hex_lower8 ((b >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((b >>  0) & 255) <<  0;
+    w2[0] = uint_to_hex_lower8 ((c >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 48) & 255) <<  0;
+    w2[1] = uint_to_hex_lower8 ((c >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 32) & 255) <<  0;
+    w2[2] = uint_to_hex_lower8 ((c >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 16) & 255) <<  0;
+    w2[3] = uint_to_hex_lower8 ((c >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((c >>  0) & 255) <<  0;
+    w3[0] = uint_to_hex_lower8 ((d >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 48) & 255) <<  0;
+    w3[1] = uint_to_hex_lower8 ((d >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 32) & 255) <<  0;
+    w3[2] = uint_to_hex_lower8 ((d >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 16) & 255) <<  0;
+    w3[3] = uint_to_hex_lower8 ((d >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((d >>  0) & 255) <<  0;
+    w4[0] = uint_to_hex_lower8 ((e >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 48) & 255) <<  0;
+    w4[1] = uint_to_hex_lower8 ((e >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 32) & 255) <<  0;
+    w4[2] = uint_to_hex_lower8 ((e >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 16) & 255) <<  0;
+    w4[3] = uint_to_hex_lower8 ((e >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((e >>  0) & 255) <<  0;
+    w5[0] = uint_to_hex_lower8 ((f >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 48) & 255) <<  0;
+    w5[1] = uint_to_hex_lower8 ((f >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 32) & 255) <<  0;
+    w5[2] = uint_to_hex_lower8 ((f >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 16) & 255) <<  0;
+    w5[3] = uint_to_hex_lower8 ((f >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((f >>  0) & 255) <<  0;
+    w6[0] = uint_to_hex_lower8 ((g >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 48) & 255) <<  0;
+    w6[1] = uint_to_hex_lower8 ((g >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 32) & 255) <<  0;
+    w6[2] = uint_to_hex_lower8 ((g >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 16) & 255) <<  0;
+    w6[3] = uint_to_hex_lower8 ((g >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((g >>  0) & 255) <<  0;
+    w7[0] = uint_to_hex_lower8 ((h >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 48) & 255) <<  0;
+    w7[1] = uint_to_hex_lower8 ((h >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 32) & 255) <<  0;
+    w7[2] = uint_to_hex_lower8 ((h >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 16) & 255) <<  0;
+    w7[3] = uint_to_hex_lower8 ((h >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((h >>  0) & 255) <<  0;
+
+    sha512_update_vector_128 (&ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
+
+    sha512_update_vector (&ctx, s, salt_len);
+
+    sha512_final_vector (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.h[7]);
+    const u32x r1 = h32_from_64 (ctx.h[7]);
+    const u32x r2 = l32_from_64 (ctx.h[3]);
+    const u32x r3 = h32_from_64 (ctx.h[3]);
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m32410_sxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 0
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 8;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  u32x w0[4];
+  u32x w1[4];
+  u32x w2[4];
+  u32x w3[4];
+  u32x w4[4];
+  u32x w5[4];
+  u32x w6[4];
+  u32x w7[4];
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32x s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0_final = w0l | w0r;
+
+    w[0] = w0_final;
+
+    sha512_ctx_vector_t ctx0;
+
+    sha512_init_vector (&ctx0);
+
+    sha512_update_vector (&ctx0, w, pw_len);
+
+    sha512_final_vector (&ctx0);
+
+    const u64x a = ctx0.h[0];
+    const u64x b = ctx0.h[1];
+    const u64x c = ctx0.h[2];
+    const u64x d = ctx0.h[3];
+    const u64x e = ctx0.h[4];
+    const u64x f = ctx0.h[5];
+    const u64x g = ctx0.h[6];
+    const u64x h = ctx0.h[7];
+
+    sha512_ctx_vector_t ctx;
+
+    sha512_init_vector (&ctx);
+
+    w0[0] = uint_to_hex_lower8 ((a >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 48) & 255) <<  0;
+    w0[1] = uint_to_hex_lower8 ((a >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 32) & 255) <<  0;
+    w0[2] = uint_to_hex_lower8 ((a >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((a >> 16) & 255) <<  0;
+    w0[3] = uint_to_hex_lower8 ((a >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((a >>  0) & 255) <<  0;
+    w1[0] = uint_to_hex_lower8 ((b >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 48) & 255) <<  0;
+    w1[1] = uint_to_hex_lower8 ((b >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 32) & 255) <<  0;
+    w1[2] = uint_to_hex_lower8 ((b >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((b >> 16) & 255) <<  0;
+    w1[3] = uint_to_hex_lower8 ((b >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((b >>  0) & 255) <<  0;
+    w2[0] = uint_to_hex_lower8 ((c >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 48) & 255) <<  0;
+    w2[1] = uint_to_hex_lower8 ((c >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 32) & 255) <<  0;
+    w2[2] = uint_to_hex_lower8 ((c >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((c >> 16) & 255) <<  0;
+    w2[3] = uint_to_hex_lower8 ((c >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((c >>  0) & 255) <<  0;
+    w3[0] = uint_to_hex_lower8 ((d >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 48) & 255) <<  0;
+    w3[1] = uint_to_hex_lower8 ((d >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 32) & 255) <<  0;
+    w3[2] = uint_to_hex_lower8 ((d >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((d >> 16) & 255) <<  0;
+    w3[3] = uint_to_hex_lower8 ((d >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((d >>  0) & 255) <<  0;
+    w4[0] = uint_to_hex_lower8 ((e >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 48) & 255) <<  0;
+    w4[1] = uint_to_hex_lower8 ((e >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 32) & 255) <<  0;
+    w4[2] = uint_to_hex_lower8 ((e >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((e >> 16) & 255) <<  0;
+    w4[3] = uint_to_hex_lower8 ((e >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((e >>  0) & 255) <<  0;
+    w5[0] = uint_to_hex_lower8 ((f >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 48) & 255) <<  0;
+    w5[1] = uint_to_hex_lower8 ((f >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 32) & 255) <<  0;
+    w5[2] = uint_to_hex_lower8 ((f >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((f >> 16) & 255) <<  0;
+    w5[3] = uint_to_hex_lower8 ((f >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((f >>  0) & 255) <<  0;
+    w6[0] = uint_to_hex_lower8 ((g >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 48) & 255) <<  0;
+    w6[1] = uint_to_hex_lower8 ((g >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 32) & 255) <<  0;
+    w6[2] = uint_to_hex_lower8 ((g >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((g >> 16) & 255) <<  0;
+    w6[3] = uint_to_hex_lower8 ((g >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((g >>  0) & 255) <<  0;
+    w7[0] = uint_to_hex_lower8 ((h >> 56) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 48) & 255) <<  0;
+    w7[1] = uint_to_hex_lower8 ((h >> 40) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 32) & 255) <<  0;
+    w7[2] = uint_to_hex_lower8 ((h >> 24) & 255) << 16
+          | uint_to_hex_lower8 ((h >> 16) & 255) <<  0;
+    w7[3] = uint_to_hex_lower8 ((h >>  8) & 255) << 16
+          | uint_to_hex_lower8 ((h >>  0) & 255) <<  0;
+
+    sha512_update_vector_128 (&ctx, w0, w1, w2, w3, w4, w5, w6, w7, 128);
+
+    sha512_update_vector (&ctx, s, salt_len);
+
+    sha512_final_vector (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.h[7]);
+    const u32x r1 = h32_from_64 (ctx.h[7]);
+    const u32x r2 = l32_from_64 (ctx.h[3]);
+    const u32x r3 = h32_from_64 (ctx.h[3]);
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -43,6 +43,7 @@
 - Added hash-mode: md5(md5($salt).md5(md5($pass)))
 - Added hash-mode: md5(md5(md5($pass).$salt1).$salt2)
 - Added hash-mode: md5(md5(md5($pass)).$salt)
+- Added hash-mode: sha512(sha512($pass).$salt)
 
 ##
 ## Features

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -130,6 +130,7 @@ NVIDIA GPUs require "NVIDIA Driver" (440.64 or later) and "CUDA Toolkit" (9.0 or
 - sha512($pass.$salt)
 - sha512($salt.$pass)
 - sha512($salt.utf16le($pass))
+- sha512(sha512($pass).$salt)
 - sha512(utf16le($pass).$salt)
 - HMAC-MD5 (key = $pass)
 - HMAC-MD5 (key = $salt)

--- a/src/modules/module_32410.c
+++ b/src/modules/module_32410.c
@@ -1,0 +1,271 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 14;
+static const u32   DGST_POS1      = 15;
+static const u32   DGST_POS2      = 6;
+static const u32   DGST_POS3      = 7;
+static const u32   DGST_SIZE      = DGST_SIZE_8_8;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_RAW_HASH_SALTED;
+static const char *HASH_NAME      = "sha512(sha512($pass).$salt)";
+static const u64   KERN_TYPE      = 32410;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_EARLY_SKIP
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_APPENDED_SALT
+                                  | OPTI_TYPE_USES_BITS_64
+                                  | OPTI_TYPE_RAW_HASH;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_ST_ADD80
+                                  | OPTS_TYPE_ST_ADDBITS15;
+static const u32   SALT_TYPE      = SALT_TYPE_GENERIC;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "25d509824028a999f4ee851b5de404bb316b78ae8e974874376484018f58520e082747a7ce9f769bcaccb5f63878356c780f602e23393f12b650a6931e4b9338:21881837027919828109608";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  char *jit_build_options = NULL;
+
+  // Extra treatment for Apple systems
+  if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
+  {
+    // Metal
+    if (device_param->is_metal == true)
+    {
+      hc_asprintf (&jit_build_options, "-D _unroll");
+    }
+
+    return jit_build_options;
+  }
+
+  // HIP
+  if (device_param->opencl_device_vendor_id == VENDOR_ID_AMD_USE_HIP)
+  {
+    hc_asprintf (&jit_build_options, "-D _unroll");
+  }
+
+  // ROCM
+  if ((device_param->opencl_device_vendor_id == VENDOR_ID_AMD) && (device_param->has_vperm == true))
+  {
+    hc_asprintf (&jit_build_options, "-D _unroll");
+  }
+
+  return jit_build_options;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u64 *digest = (u64 *) digest_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 2;
+
+  token.sep[0]     = hashconfig->separator;
+  token.len[0]     = 128;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.len_min[1] = SALT_MIN;
+  token.len_max[1] = SALT_MAX;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  if (hashconfig->opts_type & OPTS_TYPE_ST_HEX)
+  {
+    token.len_min[1] *= 2;
+    token.len_max[1] *= 2;
+
+    token.attr[1] |= TOKEN_ATTR_VERIFY_HEX;
+  }
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *hash_pos = token.buf[0];
+
+  digest[0] = hex_to_u64 (hash_pos +   0);
+  digest[1] = hex_to_u64 (hash_pos +  16);
+  digest[2] = hex_to_u64 (hash_pos +  32);
+  digest[3] = hex_to_u64 (hash_pos +  48);
+  digest[4] = hex_to_u64 (hash_pos +  64);
+  digest[5] = hex_to_u64 (hash_pos +  80);
+  digest[6] = hex_to_u64 (hash_pos +  96);
+  digest[7] = hex_to_u64 (hash_pos + 112);
+
+  digest[0] = byte_swap_64 (digest[0]);
+  digest[1] = byte_swap_64 (digest[1]);
+  digest[2] = byte_swap_64 (digest[2]);
+  digest[3] = byte_swap_64 (digest[3]);
+  digest[4] = byte_swap_64 (digest[4]);
+  digest[5] = byte_swap_64 (digest[5]);
+  digest[6] = byte_swap_64 (digest[6]);
+  digest[7] = byte_swap_64 (digest[7]);
+
+  const u8 *salt_pos = token.buf[1];
+  const int salt_len = token.len[1];
+
+  const bool parse_rc = generic_salt_decode (hashconfig, salt_pos, salt_len, (u8 *) salt->salt_buf, (int *) &salt->salt_len);
+
+  if (parse_rc == false) return (PARSER_SALT_LENGTH);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u64 *digest = (const u64 *) digest_buf;
+
+  // we can not change anything in the original buffer, otherwise destroying sorting
+  // therefore create some local buffer
+
+  u64 tmp[8];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = digest[2];
+  tmp[3] = digest[3];
+  tmp[4] = digest[4];
+  tmp[5] = digest[5];
+  tmp[6] = digest[6];
+  tmp[7] = digest[7];
+
+  tmp[0] = byte_swap_64 (tmp[0]);
+  tmp[1] = byte_swap_64 (tmp[1]);
+  tmp[2] = byte_swap_64 (tmp[2]);
+  tmp[3] = byte_swap_64 (tmp[3]);
+  tmp[4] = byte_swap_64 (tmp[4]);
+  tmp[5] = byte_swap_64 (tmp[5]);
+  tmp[6] = byte_swap_64 (tmp[6]);
+  tmp[7] = byte_swap_64 (tmp[7]);
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  int out_len = 0;
+
+  u64_to_hex (tmp[0], out_buf + out_len); out_len += 16;
+  u64_to_hex (tmp[1], out_buf + out_len); out_len += 16;
+  u64_to_hex (tmp[2], out_buf + out_len); out_len += 16;
+  u64_to_hex (tmp[3], out_buf + out_len); out_len += 16;
+  u64_to_hex (tmp[4], out_buf + out_len); out_len += 16;
+  u64_to_hex (tmp[5], out_buf + out_len); out_len += 16;
+  u64_to_hex (tmp[6], out_buf + out_len); out_len += 16;
+  u64_to_hex (tmp[7], out_buf + out_len); out_len += 16;
+
+  out_buf[out_len] = hashconfig->separator;
+
+  out_len += 1;
+
+  out_len += generic_salt_encode (hashconfig, (const u8 *) salt->salt_buf, (const int) salt->salt_len, out_buf + out_len);
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m32410.pm
+++ b/tools/test_modules/m32410.pm
@@ -1,0 +1,44 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha512_hex);
+
+sub module_constraints { [[0, 256], [0, 256], [0, 55], [0, 55], [0, 55]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $digest = sha512_hex (sha512_hex ($word) . $salt);
+
+  my $hash = sprintf ("%s:%s", $digest, $salt);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $salt, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $salt;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Added missing algo from #235

```
[ test_1686776121 ] > Init test for hash type 32410.
[ test_1686776121 ] [ Type 32410, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686776121 ] [ Type 32410, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1686776121 ] [ Type 32410, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1686776121 ] [ Type 32410, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1686776121 ] [ Type 32410, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 2/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1686776121 ] [ Type 32410, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1686776121 ] [ Type 32410, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1686776121 ] [ Type 32410, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1686776121 ] [ Type 32410, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > Warning : 0/7 not found, 0/7 not matched, 2/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1686776121 ] [ Type 32410, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```

Thanks