### PR TITLE
Fixed stray comma in JSON output when selecting a device other than t…

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1899,14 +1899,18 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
   printf (" \"rejected\": %" PRIu64 ",", hashcat_status->progress_rejected);
   printf (" \"devices\": [");
 
-  for (int device_id = 0; device_id < hashcat_status->device_info_cnt; device_id++)
+  for (int device_id = 0, first_dev = 1; device_id < hashcat_status->device_info_cnt; device_id++)
   {
     const device_info_t *device_info = hashcat_status->device_info_buf + device_id;
 
     if (device_info->skipped_dev == true) continue;
     if (device_info->skipped_warning_dev == true) continue;
 
-    if (device_id != 0)
+    if (first_dev)
+    {
+      first_dev = 0;
+    }
+    else
     {
       printf (",");
     }


### PR DESCRIPTION
…he first.

Current handling of JSON output when using -d > 1 causes stray commas to be inserted.

`"devices": [, { "device_id": 3, "device_name": "NVIDIA GeForce RTX 3080",`

As the device is not 0, but is also the only device specified, invalid JSON is output. This patch accounts for this condition. There may be a more elegant way to handle this, but this quick hack seems to do the trick.