### PR TITLE
Added path to HIP RTC DLL provided in HIP SDK (ROCm 5.5.0) for Windows

### DIFF
--- a/src/ext_hiprtc.c
+++ b/src/ext_hiprtc.c
@@ -41,14 +41,14 @@ int hiprtc_init (void *hashcat_ctx)
   #if   defined (_WIN)
   hiprtc->lib = hc_dlopen ("hiprtc.dll");
 
-  if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("contrib/bin/win64/hiprtc0503.dll");
+  if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("C:/Program Files/AMD/ROCm/5.5/bin/hiprtc0505.dll");
   if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("amdhip64.dll");
   #elif defined (__APPLE__)
   hiprtc->lib = hc_dlopen ("fixme.dylib");
   #elif defined (__CYGWIN__)
   hiprtc->lib = hc_dlopen ("hiprtc.dll");
 
-  if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("contrib/bin/win64/hiprtc0503.dll");
+  if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("C:/Program Files/AMD/ROCm/5.5/bin/hiprtc0505.dll");
   if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("amdhip64.dll");
   #else
   hiprtc->lib = hc_dlopen ("libhiprtc.so");


### PR DESCRIPTION
AMD released HIP SDK for the Windows operating system as a part of ROCm 5.5.0 release. HIP SDK provides the missing HIP RTC libraries which were removed from AMD Adrenaline Software/Drivers after the release of mid-2022 (Last known version Adrenalin 22.5.1).

With including this patch, Adrenaline drivers can be updated to the latest version, alongside working HIP RTC functionalities. 

The Windows build is now working as intended and allows `hashcat` to use the HIP Backend on Windows OS.

AMD HIP SDK can be obtained from: [https://www.amd.com/en/developer/rocm-hub/hip-sdk.html](https://www.amd.com/en/developer/rocm-hub/hip-sdk.html)

The default installation path is `C:\Program Files\AMD\ROCm\5.5\`.


Currently works with Windows 10, 11, and Windows Server 2022

- Output of `hashcat.exe -I`

```
.\hashcat.exe -I
hashcat (v6.2.6-667-g5e3222ec3+) starting in backend information mode

HIP Info:
=========

HIP.Version.: 5.5.0

Backend Device ID #1 (Alias: #3)
  Name...........: AMD Radeon RX 6900 XT
  Processor(s)...: 40
  Clock..........: 2375
  Memory.Total...: 16368 MB
  Memory.Free....: 16240 MB
  Local.Memory...: 64 KB
  PCI.Addr.BDFe..: 0000:0d:00.0

Backend Device ID #2 (Alias: #4)
  Name...........: AMD Radeon RX 6900 XT
  Processor(s)...: 40
  Clock..........: 2255
  Memory.Total...: 16368 MB
  Memory.Free....: 16240 MB
  Local.Memory...: 64 KB
  PCI.Addr.BDFe..: 0000:10:00.0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Advanced Micro Devices, Inc.
  Name....: AMD Accelerated Parallel Processing
  Version.: OpenCL 2.1 AMD-APP (3570.0)

  Backend Device ID #3 (Alias: #1)
    Type...........: GPU
    Vendor.ID......: 1
    Vendor.........: Advanced Micro Devices, Inc.
    Name...........: AMD Radeon RX 6900 XT
    Version........: OpenCL 2.0 AMD-APP (3570.0)
    Processor(s)...: 40
    Clock..........: 2375
    Memory.Total...: 16368 MB (limited to 13912 MB allocatable in one block)
    Memory.Free....: 16256 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 2.0
    Driver.Version.: 3570.0 (PAL,LC)
    PCI.Addr.BDF...: 0d:00.0

  Backend Device ID #4 (Alias: #2)
    Type...........: GPU
    Vendor.ID......: 1
    Vendor.........: Advanced Micro Devices, Inc.
    Name...........: AMD Radeon RX 6900 XT
    Version........: OpenCL 2.0 AMD-APP (3570.0)
    Processor(s)...: 40
    Clock..........: 2255
    Memory.Total...: 16368 MB (limited to 13912 MB allocatable in one block)
    Memory.Free....: 16256 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 2.0
    Driver.Version.: 3570.0 (PAL,LC)
    PCI.Addr.BDF...: 10:00.0

```



