### PR TITLE
Fix a wrong expression in rp.c (static analysis)

### DIFF
--- a/src/rp.c
+++ b/src/rp.c
@@ -770,7 +770,7 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
     {
       rule_len = (u32) fgetl (&fp, rule_buf, HCBUFSIZ_LARGE);
 
-      if (rule_line == (u32) -1)
+      if (rule_len == (u32) -1)
       {
         event_log_error (hashcat_ctx, "Unsupported number of lines in rule file %s.", rp_file);
 


### PR DESCRIPTION
During analysis of hashcat with PVS-Studio a bug was found:
```
rp.c (773) | V1051 | Consider checking for misprints. It's possible that the 'rule_len' should be checked here.
```

The manual reviewing has confirmed that a misprint was indeed present.