### PR TITLE
clang-tidy: align and pack structs

### DIFF
--- a/OpenCL/inc_ecc_secp256k1.h
+++ b/OpenCL/inc_ecc_secp256k1.h
@@ -216,7 +216,7 @@ typedef struct secp256k1
 {
   u32 xy[SECP256K1_PRE_COMPUTED_XY_SIZE]; // pre-computed points: (x1,y1,-y1),(x3,y3,-y3),(x5,y5,-y5),(x7,y7,-y7)
 
-} secp256k1_t;
+} __attribute__((aligned(128))) secp256k1_t;
 
 
 DECLSPEC u32  transform_public (PRIVATE_AS secp256k1_t *r, PRIVATE_AS const u32 *x, const u32 first_byte);

--- a/OpenCL/inc_hash_md4.h
+++ b/OpenCL/inc_hash_md4.h
@@ -53,14 +53,14 @@ typedef struct md4_ctx
 
   int len;
 
-} md4_ctx_t;
+} __attribute__((aligned(128))) md4_ctx_t;
 
 typedef struct md4_hmac_ctx
 {
   md4_ctx_t ipad;
   md4_ctx_t opad;
 
-} md4_hmac_ctx_t;
+} __attribute__((aligned(256))) md4_hmac_ctx_t;
 
 typedef struct md4_ctx_vector
 {
@@ -73,14 +73,14 @@ typedef struct md4_ctx_vector
 
   int  len;
 
-} md4_ctx_vector_t;
+} __attribute__((aligned(128))) md4_ctx_vector_t;
 
 typedef struct md4_hmac_ctx_vector
 {
   md4_ctx_vector_t ipad;
   md4_ctx_vector_t opad;
 
-} md4_hmac_ctx_vector_t;
+} __attribute__((aligned(256))) md4_hmac_ctx_vector_t;
 
 DECLSPEC void md4_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest);
 DECLSPEC void md4_init (PRIVATE_AS md4_ctx_t *ctx);

--- a/OpenCL/inc_hash_md5.h
+++ b/OpenCL/inc_hash_md5.h
@@ -60,14 +60,14 @@ typedef struct md5_ctx
 
   int len;
 
-} md5_ctx_t;
+} __attribute__((aligned(128))) md5_ctx_t;
 
 typedef struct md5_hmac_ctx
 {
   md5_ctx_t ipad;
   md5_ctx_t opad;
 
-} md5_hmac_ctx_t;
+} __attribute__((aligned(256))) md5_hmac_ctx_t;
 
 typedef struct md5_ctx_vector
 {
@@ -80,14 +80,14 @@ typedef struct md5_ctx_vector
 
   int  len;
 
-} md5_ctx_vector_t;
+} __attribute__((aligned(128))) md5_ctx_vector_t;
 
 typedef struct md5_hmac_ctx_vector
 {
   md5_ctx_vector_t ipad;
   md5_ctx_vector_t opad;
 
-} md5_hmac_ctx_vector_t;
+} __attribute__((aligned(256))) md5_hmac_ctx_vector_t;
 
 DECLSPEC void md5_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest);
 DECLSPEC void md5_init (PRIVATE_AS md5_ctx_t *ctx);

--- a/OpenCL/inc_hash_ripemd160.h
+++ b/OpenCL/inc_hash_ripemd160.h
@@ -73,14 +73,14 @@ typedef struct ripemd160_ctx
 
   int len;
 
-} ripemd160_ctx_t;
+} __attribute__((aligned(128))) ripemd160_ctx_t;
 
 typedef struct ripemd160_hmac_ctx
 {
   ripemd160_ctx_t ipad;
   ripemd160_ctx_t opad;
 
-} ripemd160_hmac_ctx_t;
+} __attribute__((aligned(256))) ripemd160_hmac_ctx_t;
 
 typedef struct ripemd160_ctx_vector
 {
@@ -93,14 +93,14 @@ typedef struct ripemd160_ctx_vector
 
   int  len;
 
-} ripemd160_ctx_vector_t;
+} __attribute__((aligned(128))) ripemd160_ctx_vector_t;
 
 typedef struct ripemd160_hmac_ctx_vector
 {
   ripemd160_ctx_vector_t ipad;
   ripemd160_ctx_vector_t opad;
 
-} ripemd160_hmac_ctx_vector_t;
+} __attribute__((aligned(256))) ripemd160_hmac_ctx_vector_t;
 
 DECLSPEC void ripemd160_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest);
 DECLSPEC void ripemd160_init (PRIVATE_AS ripemd160_ctx_t *ctx);

--- a/OpenCL/inc_hash_sha1.h
+++ b/OpenCL/inc_hash_sha1.h
@@ -61,14 +61,14 @@ typedef struct sha1_ctx
 
   int len;
 
-} sha1_ctx_t;
+} __attribute__((aligned(128))) sha1_ctx_t;
 
 typedef struct sha1_hmac_ctx
 {
   sha1_ctx_t ipad;
   sha1_ctx_t opad;
 
-} sha1_hmac_ctx_t;
+} __attribute__((aligned(256))) sha1_hmac_ctx_t;
 
 typedef struct sha1_ctx_vector
 {
@@ -81,14 +81,14 @@ typedef struct sha1_ctx_vector
 
   int  len;
 
-} sha1_ctx_vector_t;
+} __attribute__((aligned(128))) sha1_ctx_vector_t;
 
 typedef struct sha1_hmac_ctx_vector
 {
   sha1_ctx_vector_t ipad;
   sha1_ctx_vector_t opad;
 
-} sha1_hmac_ctx_vector_t;
+} __attribute__((aligned(256))) sha1_hmac_ctx_vector_t;
 
 DECLSPEC void sha1_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest);
 DECLSPEC void sha1_init (PRIVATE_AS sha1_ctx_t *ctx);

--- a/OpenCL/inc_hash_sha224.h
+++ b/OpenCL/inc_hash_sha224.h
@@ -60,14 +60,14 @@ typedef struct sha224_ctx
 
   int len;
 
-} sha224_ctx_t;
+} __attribute__((aligned(128))) sha224_ctx_t;
 
 typedef struct sha224_hmac_ctx
 {
   sha224_ctx_t ipad;
   sha224_ctx_t opad;
 
-} sha224_hmac_ctx_t;
+} __attribute__((aligned(256))) sha224_hmac_ctx_t;
 
 typedef struct sha224_ctx_vector
 {
@@ -80,14 +80,14 @@ typedef struct sha224_ctx_vector
 
   int  len;
 
-} sha224_ctx_vector_t;
+} __attribute__((aligned(128))) sha224_ctx_vector_t;
 
 typedef struct sha224_hmac_ctx_vector
 {
   sha224_ctx_vector_t ipad;
   sha224_ctx_vector_t opad;
 
-} sha224_hmac_ctx_vector_t;
+} __attribute__((aligned(256))) sha224_hmac_ctx_vector_t;
 
 DECLSPEC void sha224_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest);
 DECLSPEC void sha224_init (PRIVATE_AS sha224_ctx_t *ctx);

--- a/OpenCL/inc_hash_sha256.h
+++ b/OpenCL/inc_hash_sha256.h
@@ -60,14 +60,14 @@ typedef struct sha256_ctx
 
   int len;
 
-} sha256_ctx_t;
+} __attribute__((aligned(128))) sha256_ctx_t;
 
 typedef struct sha256_hmac_ctx
 {
   sha256_ctx_t ipad;
   sha256_ctx_t opad;
 
-} sha256_hmac_ctx_t;
+} __attribute__((aligned(256))) sha256_hmac_ctx_t;
 
 typedef struct sha256_ctx_vector
 {
@@ -80,14 +80,14 @@ typedef struct sha256_ctx_vector
 
   int  len;
 
-} sha256_ctx_vector_t;
+} __attribute__((aligned(128))) sha256_ctx_vector_t;
 
 typedef struct sha256_hmac_ctx_vector
 {
   sha256_ctx_vector_t ipad;
   sha256_ctx_vector_t opad;
 
-} sha256_hmac_ctx_vector_t;
+} __attribute__((aligned(256))) sha256_hmac_ctx_vector_t;
 
 DECLSPEC void sha256_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest);
 DECLSPEC void sha256_init (PRIVATE_AS sha256_ctx_t *ctx);

--- a/OpenCL/inc_hash_sha384.h
+++ b/OpenCL/inc_hash_sha384.h
@@ -70,14 +70,14 @@ typedef struct sha384_ctx
 
   int len;
 
-} sha384_ctx_t;
+} __attribute__((aligned(128))) __attribute__((packed)) sha384_ctx_t;
 
 typedef struct sha384_hmac_ctx
 {
   sha384_ctx_t ipad;
   sha384_ctx_t opad;
 
-} sha384_hmac_ctx_t;
+} __attribute__((aligned(512))) sha384_hmac_ctx_t;
 
 typedef struct sha384_ctx_vector
 {
@@ -94,14 +94,14 @@ typedef struct sha384_ctx_vector
 
   int  len;
 
-} sha384_ctx_vector_t;
+} __attribute__((aligned(128))) __attribute__((packed)) sha384_ctx_vector_t;
 
 typedef struct sha384_hmac_ctx_vector
 {
   sha384_ctx_vector_t ipad;
   sha384_ctx_vector_t opad;
 
-} sha384_hmac_ctx_vector_t;
+} __attribute__((aligned(512))) sha384_hmac_ctx_vector_t;
 
 DECLSPEC void sha384_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS const u32 *w4, PRIVATE_AS const u32 *w5, PRIVATE_AS const u32 *w6, PRIVATE_AS const u32 *w7, PRIVATE_AS u64 *digest);
 DECLSPEC void sha384_init (PRIVATE_AS sha384_ctx_t *ctx);

--- a/OpenCL/inc_hash_sha512.h
+++ b/OpenCL/inc_hash_sha512.h
@@ -70,14 +70,14 @@ typedef struct sha512_ctx
 
   int len;
 
-} sha512_ctx_t;
+} __attribute__((aligned(128))) __attribute__((packed)) sha512_ctx_t;
 
 typedef struct sha512_hmac_ctx
 {
   sha512_ctx_t ipad;
   sha512_ctx_t opad;
 
-} sha512_hmac_ctx_t;
+} __attribute__((aligned(512))) sha512_hmac_ctx_t;
 
 typedef struct sha512_ctx_vector
 {
@@ -94,14 +94,14 @@ typedef struct sha512_ctx_vector
 
   int  len;
 
-} sha512_ctx_vector_t;
+} __attribute__((aligned(128))) __attribute__((packed)) sha512_ctx_vector_t;
 
 typedef struct sha512_hmac_ctx_vector
 {
   sha512_ctx_vector_t ipad;
   sha512_ctx_vector_t opad;
 
-} sha512_hmac_ctx_vector_t;
+} __attribute__((aligned(512))) sha512_hmac_ctx_vector_t;
 
 DECLSPEC void sha512_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS const u32 *w4, PRIVATE_AS const u32 *w5, PRIVATE_AS const u32 *w6, PRIVATE_AS const u32 *w7, PRIVATE_AS u64 *digest);
 DECLSPEC void sha512_init (PRIVATE_AS sha512_ctx_t *ctx);

--- a/OpenCL/inc_hash_streebog256.h
+++ b/OpenCL/inc_hash_streebog256.h
@@ -51,14 +51,14 @@ typedef struct streebog256_ctx
 
   SHM_TYPE u64a (*s_sbob_sl64)[256];
 
-} streebog256_ctx_t;
+} __attribute__((aligned(128))) __attribute__((packed)) streebog256_ctx_t;
 
 typedef struct streebog256_hmac_ctx
 {
   streebog256_ctx_t ipad;
   streebog256_ctx_t opad;
 
-} streebog256_hmac_ctx_t;
+} __attribute__((aligned(128))) streebog256_hmac_ctx_t;
 
 typedef struct streebog256_ctx_vector
 {
@@ -77,14 +77,14 @@ typedef struct streebog256_ctx_vector
 
   SHM_TYPE u64a (*s_sbob_sl64)[256];
 
-} streebog256_ctx_vector_t;
+} __attribute__((aligned(128))) __attribute__((packed)) streebog256_ctx_vector_t;
 
 typedef struct streebog256_hmac_ctx_vector
 {
   streebog256_ctx_vector_t ipad;
   streebog256_ctx_vector_t opad;
 
-} streebog256_hmac_ctx_vector_t;
+} __attribute__((aligned(128))) streebog256_hmac_ctx_vector_t;
 
 DECLSPEC void streebog256_init (PRIVATE_AS streebog256_ctx_t *ctx, SHM_TYPE u64a (*s_sbob_sl64)[256]);
 DECLSPEC void streebog256_add (PRIVATE_AS u64 *x, PRIVATE_AS const u64 *y);

--- a/OpenCL/inc_hash_streebog512.h
+++ b/OpenCL/inc_hash_streebog512.h
@@ -63,14 +63,14 @@ typedef struct streebog512_ctx
 
   SHM_TYPE u64a (*s_sbob_sl64)[256];
 
-} streebog512_ctx_t;
+} __attribute__((aligned(128))) __attribute__((packed)) streebog512_ctx_t;
 
 typedef struct streebog512_hmac_ctx
 {
   streebog512_ctx_t ipad;
   streebog512_ctx_t opad;
 
-} streebog512_hmac_ctx_t;
+} __attribute__((aligned(128))) streebog512_hmac_ctx_t;
 
 typedef struct streebog512_ctx_vector
 {
@@ -89,14 +89,14 @@ typedef struct streebog512_ctx_vector
 
   SHM_TYPE u64a (*s_sbob_sl64)[256];
 
-} streebog512_ctx_vector_t;
+} __attribute__((aligned(128))) __attribute__((packed)) streebog512_ctx_vector_t;
 
 typedef struct streebog512_hmac_ctx_vector
 {
   streebog512_ctx_vector_t ipad;
   streebog512_ctx_vector_t opad;
 
-} streebog512_hmac_ctx_vector_t;
+} __attribute__((aligned(128))) streebog512_hmac_ctx_vector_t;
 
 DECLSPEC void streebog512_init (PRIVATE_AS streebog512_ctx_t *ctx, SHM_TYPE u64a (*s_sbob_sl64)[256]);
 DECLSPEC void streebog512_add (PRIVATE_AS u64 *x, PRIVATE_AS const u64 *y);

--- a/OpenCL/inc_hash_whirlpool.h
+++ b/OpenCL/inc_hash_whirlpool.h
@@ -46,14 +46,14 @@ typedef struct whirlpool_ctx
   SHM_TYPE u64 *s_MT6;
   SHM_TYPE u64 *s_MT7;
 
-} whirlpool_ctx_t;
+} __attribute__((aligned(128))) __attribute__((packed)) whirlpool_ctx_t;
 
 typedef struct whirlpool_hmac_ctx
 {
   whirlpool_ctx_t ipad;
   whirlpool_ctx_t opad;
 
-} whirlpool_hmac_ctx_t;
+} __attribute__((aligned(512))) whirlpool_hmac_ctx_t;
 
 typedef struct whirlpool_ctx_vector
 {
@@ -75,14 +75,14 @@ typedef struct whirlpool_ctx_vector
   SHM_TYPE u64 *s_MT6;
   SHM_TYPE u64 *s_MT7;
 
-} whirlpool_ctx_vector_t;
+} __attribute__((aligned(128))) __attribute__((packed)) whirlpool_ctx_vector_t;
 
 typedef struct whirlpool_hmac_ctx_vector
 {
   whirlpool_ctx_vector_t ipad;
   whirlpool_ctx_vector_t opad;
 
-} whirlpool_hmac_ctx_vector_t;
+} __attribute__((aligned(512))) whirlpool_hmac_ctx_vector_t;
 
 DECLSPEC void whirlpool_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest, SHM_TYPE u64 *s_MT0, SHM_TYPE u64 *s_MT1, SHM_TYPE u64 *s_MT2, SHM_TYPE u64 *s_MT3, SHM_TYPE u64 *s_MT4, SHM_TYPE u64 *s_MT5, SHM_TYPE u64 *s_MT6, SHM_TYPE u64 *s_MT7);
 DECLSPEC void whirlpool_init (PRIVATE_AS whirlpool_ctx_t *ctx, SHM_TYPE u64 *s_MT0, SHM_TYPE u64 *s_MT1, SHM_TYPE u64 *s_MT2, SHM_TYPE u64 *s_MT3, SHM_TYPE u64 *s_MT4, SHM_TYPE u64 *s_MT5, SHM_TYPE u64 *s_MT6, SHM_TYPE u64 *s_MT7);

--- a/OpenCL/inc_types.h
+++ b/OpenCL/inc_types.h
@@ -907,7 +907,7 @@ typedef union vconv32
     u16 a;
     u16 b;
 
-  } v16;
+  } __attribute__((aligned(4))) v16;
 
   struct
   {
@@ -916,7 +916,7 @@ typedef union vconv32
     u8 c;
     u8 d;
 
-  } v8;
+  } __attribute__((aligned(4))) v8;
 
 } vconv32_t;
 
@@ -929,7 +929,7 @@ typedef union vconv64
     u32 a;
     u32 b;
 
-  } v32;
+  } __attribute__((aligned(8))) v32;
 
   struct
   {
@@ -938,7 +938,7 @@ typedef union vconv64
     u16 c;
     u16 d;
 
-  } v16;
+  } __attribute__((aligned(8))) v16;
 
   struct
   {
@@ -951,7 +951,7 @@ typedef union vconv64
     u8 g;
     u8 h;
 
-  } v8;
+  } __attribute__((aligned(8))) v8;
 
 } vconv64_t;
 
@@ -1801,7 +1801,7 @@ typedef struct kernel_param
   u64 pws_pos;              // 35
   u64 gid_max;              // 36
 
-} kernel_param_t;
+} __attribute__((aligned(64))) kernel_param_t;
 
 typedef struct salt
 {
@@ -1826,27 +1826,27 @@ typedef struct salt
   u32 scrypt_r;
   u32 scrypt_p;
 
-} salt_t;
+} __attribute__((aligned(128))) salt_t;
 
 typedef struct
 {
   u32 key;
   u64 val;
 
-} hcstat_table_t;
+} __attribute__((aligned(16))) hcstat_table_t;
 
 typedef struct
 {
   u32 cs_buf[0x100];
   u32 cs_len;
 
-} cs_t;
+} __attribute__((aligned(128))) cs_t;
 
 typedef struct
 {
   u32 cmds[32];
 
-} kernel_rule_t;
+} __attribute__((aligned(128))) kernel_rule_t;
 
 typedef struct pw
 {
@@ -1854,7 +1854,7 @@ typedef struct pw
 
   u32 pw_len;
 
-} pw_t;
+} __attribute__((aligned(128))) pw_t __attribute__((aligned(128)));
 
 typedef struct pw_idx
 {
@@ -1862,7 +1862,7 @@ typedef struct pw_idx
   u32 cnt;
   u32 len;
 
-} pw_idx_t;
+} __attribute__((aligned(16))) pw_idx_t;
 
 typedef struct bf
 {
@@ -1874,7 +1874,7 @@ typedef struct bs_word
 {
   u32  b[32];
 
-} bs_word_t;
+} __attribute__((aligned(128))) bs_word_t;
 
 typedef struct plain
 {
@@ -1886,7 +1886,7 @@ typedef struct plain
   u32  extra1;
   u32  extra2;
 
-} plain_t;
+} __attribute__((aligned(32))) plain_t;
 
 typedef struct keyboard_layout_mapping
 {
@@ -1895,7 +1895,7 @@ typedef struct keyboard_layout_mapping
   u32 dst_char;
   int dst_len;
 
-} keyboard_layout_mapping_t;
+} __attribute__((aligned(16))) keyboard_layout_mapping_t;
 
 typedef struct hc_enc
 {
@@ -1904,6 +1904,6 @@ typedef struct hc_enc
   u32  cbuf;  // carry buffer
   int  clen;  // carry length
 
-} hc_enc_t;
+} __attribute__((aligned(16))) hc_enc_t;
 
 #endif

--- a/OpenCL/m02500-pure.cl
+++ b/OpenCL/m02500-pure.cl
@@ -50,7 +50,7 @@ typedef struct wpa_eapol
   int  detected_le;
   int  detected_be;
 
-} wpa_eapol_t;
+} __attribute__((aligned(128))) __attribute__((packed)) wpa_eapol_t;
 
 typedef struct wpa_pbkdf2_tmp
 {
@@ -60,7 +60,7 @@ typedef struct wpa_pbkdf2_tmp
   u32 dgst[10];
   u32 out[10];
 
-} wpa_pbkdf2_tmp_t;
+} __attribute__((aligned(128))) wpa_pbkdf2_tmp_t;
 
 DECLSPEC void make_kn (PRIVATE_AS u32 *k)
 {

--- a/OpenCL/m02501-pure.cl
+++ b/OpenCL/m02501-pure.cl
@@ -31,7 +31,7 @@ typedef struct wpa_pmk_tmp
 {
   u32 out[8];
 
-} wpa_pmk_tmp_t;
+} __attribute__((aligned(32))) wpa_pmk_tmp_t;
 
 typedef struct wpa_eapol
 {
@@ -53,7 +53,7 @@ typedef struct wpa_eapol
   int  detected_le;
   int  detected_be;
 
-} wpa_eapol_t;
+} __attribute__((aligned(128))) __attribute__((packed)) wpa_eapol_t;
 
 #ifdef KERNEL_STATIC
 DECLSPEC u8 hex_convert (const u8 c)

--- a/OpenCL/m16800-pure.cl
+++ b/OpenCL/m16800-pure.cl
@@ -32,7 +32,7 @@ typedef struct wpa_pbkdf2_tmp
   u32 dgst[10];
   u32 out[10];
 
-} wpa_pbkdf2_tmp_t;
+} __attribute__((aligned(128))) wpa_pbkdf2_tmp_t;
 
 typedef struct wpa_pmkid
 {
@@ -43,7 +43,7 @@ typedef struct wpa_pmkid
   u8   essid_len;
   u32  essid_buf[16];
 
-} wpa_pmkid_t;
+} __attribute__((aligned(128))) __attribute__((packed)) wpa_pmkid_t;
 
 DECLSPEC void hmac_sha1_run_V (u32x *w0, u32x *w1, u32x *w2, u32x *w3, u32x *ipad, u32x *opad, u32x *digest)
 {

--- a/OpenCL/m16801-pure.cl
+++ b/OpenCL/m16801-pure.cl
@@ -28,7 +28,7 @@ typedef struct wpa_pmk_tmp
 {
   u32 out[8];
 
-} wpa_pmk_tmp_t;
+} __attribute__((aligned(32))) wpa_pmk_tmp_t;
 
 typedef struct wpa_pmkid
 {
@@ -39,7 +39,7 @@ typedef struct wpa_pmkid
   u8   essid_len;
   u32  essid_buf[16];
 
-} wpa_pmkid_t;
+} __attribute__((aligned(128))) __attribute__((packed)) wpa_pmkid_t;
 
 #ifdef KERNEL_STATIC
 DECLSPEC u8 hex_convert (const u8 c)

--- a/OpenCL/m22000-pure.cl
+++ b/OpenCL/m22000-pure.cl
@@ -38,7 +38,7 @@ typedef struct wpa_pbkdf2_tmp
   u32 dgst[10];
   u32 out[10];
 
-} wpa_pbkdf2_tmp_t;
+} __attribute__((aligned(128))) wpa_pbkdf2_tmp_t;
 
 typedef struct wpa
 {
@@ -77,7 +77,7 @@ typedef struct wpa
   int  detected_le;
   int  detected_be;
 
-} wpa_t;
+} __attribute__((aligned(128))) wpa_t;
 
 DECLSPEC void make_kn (PRIVATE_AS u32 *k)
 {

--- a/OpenCL/m22001-pure.cl
+++ b/OpenCL/m22001-pure.cl
@@ -34,7 +34,7 @@ typedef struct wpa_pmk_tmp
 {
   u32 out[8];
 
-} wpa_pmk_tmp_t;
+} __attribute__((aligned(32))) wpa_pmk_tmp_t;
 
 typedef struct wpa
 {
@@ -73,7 +73,7 @@ typedef struct wpa
   int  detected_le;
   int  detected_be;
 
-} wpa_t;
+} __attribute__((aligned(128))) wpa_t;
 
 #ifdef KERNEL_STATIC
 DECLSPEC u8 hex_convert (const u8 c)


### PR DESCRIPTION
Found with: altera-struct-pack-align