### PR TITLE
Add -m 99999 to Modules_default.hctune

### DIFF
--- a/tunings/Modules_default.hctune
+++ b/tunings/Modules_default.hctune
@@ -45,6 +45,7 @@ ALIAS_nv_real_simd                              3       11100   2       A       
 ALIAS_nv_real_simd                              3       11900   2       A       A
 ALIAS_nv_real_simd                              3       13300   4       A       A
 ALIAS_nv_real_simd                              3       18700   8       A       A
+ALIAS_nv_real_simd                              3       99999   4       A       A
 
 ALIAS_nv_sm50_or_higher                         3       0       8       A       A
 ALIAS_nv_sm50_or_higher                         3       10      8       A       A
@@ -68,6 +69,7 @@ ALIAS_nv_sm50_or_higher                         3       5500    2       A       
 ALIAS_nv_sm50_or_higher                         3       9900    4       A       A
 ALIAS_nv_sm50_or_higher                         3       16400   8       A       A
 ALIAS_nv_sm50_or_higher                         3       18700   8       A       A
+ALIAS_nv_sm50_or_higher                         3       99999   8       A       A
 
 ##
 ## CryptoAPI


### PR DESCRIPTION
Add -m 99999 to match -m 900's tunings. Around 9% speed increase for my hardware on `-m 99999 -b`

Post-tuning:
```
Speed.#1.........: 72433.7 MH/s (20.83ms) @ Accel:128 Loops:1024 Thr:256 Vec:8
```
Pre-tuning:
```
Speed.#1.........: 66719.8 MH/s (45.58ms) @ Accel:128 Loops:1024 Thr:512 Vec:1
```