### PR TITLE
verify test fix for -m 13400/-m 29700

### DIFF
--- a/tools/test_modules/m13400.pm
+++ b/tools/test_modules/m13400.pm
@@ -239,14 +239,32 @@ sub module_generate_hash
     $final_algorithm = "Crypt::Rijndael";
   }
 
-  my $cipher = Crypt::CBC->new ({
+  my $cipher;
+
+  if ($version == 1)
+  {
+    $cipher = Crypt::CBC->new ({
                  key         => $final_key,
                  cipher      => $final_algorithm,
                  iv          => $enc_iv,
                  literal_key => 1,
                  header      => "none",
+                 padding     => "standard",
                  keysize     => 32
                });
+  }
+  else
+  {
+    $cipher = Crypt::CBC->new ({
+                 key         => $final_key,
+                 cipher      => $final_algorithm,
+                 iv          => $enc_iv,
+                 literal_key => 1,
+                 header      => "none",
+                 padding     => "none",
+                 keysize     => 32
+               });
+  }
 
   my $hash;
 

--- a/tools/test_modules/m29700.pm
+++ b/tools/test_modules/m29700.pm
@@ -243,14 +243,32 @@ sub module_generate_hash
     $final_algorithm = "Crypt::Rijndael";
   }
 
-  my $cipher = Crypt::CBC->new ({
+  my $cipher;
+
+  if ($version == 1)
+  {
+    $cipher = Crypt::CBC->new ({
                  key         => $final_key,
                  cipher      => $final_algorithm,
                  iv          => $enc_iv,
                  literal_key => 1,
                  header      => "none",
+                 padding     => "standard",
                  keysize     => 32
                });
+  }
+  else
+  {
+    $cipher = Crypt::CBC->new ({
+                 key         => $final_key,
+                 cipher      => $final_algorithm,
+                 iv          => $enc_iv,
+                 literal_key => 1,
+                 header      => "none",
+                 padding     => "none",
+                 keysize     => 32
+               });
+  }
 
   my $hash;
 


### PR DESCRIPTION
This is just some minor test.pl `verify` test fix that I have found accidentially (during preparation for CMIYC):
in the unit tests for -m 13400 and -m 29700 we didn't specify the padding used for the decryption algorithms and therefore the `verify` invocation failed (it didn't even work for me with the example hashes).

This should fix the underlying problem.

It's interesting to see that between version 1 and version 2 we have different padding types, but only this way the "verify" worked for me, therefore everything should be okay with this fix.

Thanks