### PR TITLE
verify test fix for -m 3730 = md5($s1.uc(md5($s2.$p)))

### DIFF
--- a/tools/test_modules/m03730.pm
+++ b/tools/test_modules/m03730.pm
@@ -29,15 +29,16 @@ sub module_verify_hash
 {
   my $line = shift;
 
-  my ($hash, $salt, $word) = split (':', $line);
+  my ($hash, $salt1, $salt2, $word) = split (':', $line);
 
   return unless defined $hash;
-  return unless defined $salt;
+  return unless defined $salt1;
+  return unless defined $salt2;
   return unless defined $word;
 
   my $word_packed = pack_if_HEX_notation ($word);
 
-  my $new_hash = module_generate_hash ($word_packed, $salt);
+  my $new_hash = module_generate_hash ($word_packed, $salt1, $salt2);
 
   return ($new_hash, $word);
 }


### PR DESCRIPTION
This is a minor `verify` fix that I have accidentially found during preparation for CMIYC:
In -m 3730 = `md5($salt1.strtoupper(md5($salt2.$pass)))` the `verify` function of the unit tests, didn't correclty extract both salts and therefore until now the tests could not work at all.

This minor fix extracts the "crack" lines correctly and is able to pass both salts to the hash generation function.

Thank you!