### PR TITLE
verify test fix for -m 30700 = Anope IRC Services

### DIFF
--- a/tools/test_modules/m30700.pm
+++ b/tools/test_modules/m30700.pm
@@ -52,11 +52,14 @@ sub module_verify_hash
 {
   my $line = shift;
 
-  my ($hash, $salt, $word) = split (':', $line);
+  my ($signature, $digest, $salt, $word) = split (':', $line);
 
-  return unless defined $hash;
+  return unless defined $signature;
+  return unless defined $digest;
   return unless defined $salt;
   return unless defined $word;
+
+  return unless ($signature eq "sha256");
 
   my $word_packed = pack_if_HEX_notation ($word);
 


### PR DESCRIPTION
This is just some minor test.pl `verify` test fix that I have found accidentially (during preparation for CMIYC):
The verify function of -m 30700 = `Anope IRC Services (enc_sha256)` had a minor bug which made the `verify` part non-functional for this specific hash type.

With this minor fix included, we are able to parse the hash-password lines (cracks) correctly and therefore `verify` should start working for -m 30700.

Thx