### PR TITLE
verify test fix for -m 31900 = MetaMask Mobile Wallet

### DIFF
--- a/tools/test_modules/m31900.pm
+++ b/tools/test_modules/m31900.pm
@@ -44,7 +44,25 @@ sub module_generate_hash
     padding     => "none"
   });
 
-  my $pt = "[{\"type\":\"HD Key Tree\",\"data\":{\"mnemonic\":\"ocean hidden kidney famous rich season gloom husband spring convince attitude boy\",\"numberOfAccounts\":1,\"hdPath\":\"m/44'/60'/0'/0\"}}]";
+  my $pt = "";
+
+  if (! defined ($ct))
+  {
+    $pt = "[{\"type\":\"HD Key Tree\",\"data\":{\"mnemonic\":\"ocean hidden kidney famous rich season gloom husband spring convince attitude boy\",\"numberOfAccounts\":1,\"hdPath\":\"m/44'/60'/0'/0\"}}]";
+  }
+  else
+  {
+    $pt = $cipher->decrypt (pack ("H*", $ct));
+
+    if ($pt =~ m/^[ -~]*$/) # is_valid_printable_32 ()
+    {
+      # ok
+    }
+    else
+    {
+      $pt = ""; # fake
+    }
+  }
 
   my $ct1 = substr ($cipher->encrypt ($pt), 0, 16);
 


### PR DESCRIPTION
This is just some minor test.pl `verify` test fix that I have found accidentially (during preparation for CMIYC):
In this specific case, for -m 31900 = MetaMask Wallet (short hash, plaintext check) the current code didn't make any distinction between a hash generation and verification invocation and therefore didn't handle the input buffer ($ct, i.e. the encrypted data, ciphertext).

The problem and implication with this incorrect (or missing) handling was that the verification only worked if we had a (our) constant strings/buffer ("[{\"type\":\"HD Key Tree\",\"data\":{\"mnemonic\":\"ocean hidden kidney famous ri...."), but verify didn't work AT ALL with any slightly different (but still correct) buffer/data.

This should definitely fix the underlying problem

Thank you very much
