### PR TITLE
verify fix for -m 32100=Kerberos 5,etype 17,AS-REP

### DIFF
--- a/tools/test_modules/m32100.pm
+++ b/tools/test_modules/m32100.pm
@@ -98,9 +98,9 @@ sub module_generate_hash
 
     my $truncated_ticket_decrypted = byte2hex ($b_truncated_ticket_decrypted);
 
-    my $check_correct  = ((substr ($truncated_ticket_decrypted, 16, 4) eq "7981" || substr ($truncated_ticket_decrypted, 16, 4) eq "7a81") && (substr ($truncated_ticket_decrypted, 22, 2) eq "30")) ||
-                         ((substr ($truncated_ticket_decrypted, 16, 2) eq "79" || substr ($truncated_ticket_decrypted, 16, 2) eq "7a") && (substr ($truncated_ticket_decrypted, 20, 2) eq "30")) ||
-                         ((substr ($truncated_ticket_decrypted, 16, 4) eq "7982" || substr ($truncated_ticket_decrypted, 16, 4) eq "7a82")  && (substr ($truncated_ticket_decrypted, 24, 2) eq "30"));
+    my $check_correct  = ((substr ($truncated_ticket_decrypted, 32, 4) eq "7981" || substr ($truncated_ticket_decrypted, 32, 4) eq "7a81") && (substr ($truncated_ticket_decrypted, 38, 2) eq "30")) ||
+ -                       ((substr ($truncated_ticket_decrypted, 32, 2) eq "79" || substr ($truncated_ticket_decrypted, 32, 2) eq "7a") && (substr ($truncated_ticket_decrypted, 36, 2) eq "30")) ||
+ -                       ((substr ($truncated_ticket_decrypted, 32, 4) eq "7982" || substr ($truncated_ticket_decrypted, 32, 4) eq "7a82")  && (substr ($truncated_ticket_decrypted, 40, 2) eq "30"));
 
     if ($check_correct == 1)
     {
@@ -138,7 +138,7 @@ sub module_generate_hash
   }
   else
   {
-    if (!defined $edata2)
+    if (! defined $edata2)
     {
       my $nonce = unpack ("H*", random_bytes (16));
 


### PR DESCRIPTION
This is a minor `verify` fix that I have accidentially found during preparation for CMIYC:

For -m 32100 = `Kerberos 5, etype 17, AS-REP` we didn't use the correct offsets/checks that were needed for the `verify` invocation of `test.pl` and therefore `verify` did never work together with -m 32100 (until now).

Even the test hashes didn't work (to verify).

This fix should fix the underlying problem of offsets (that of course depend on the prepended data and hex conversation etc... i.e. the offset "just" needs to be the correct one and afterwards everything starts working).

Thank you very, very much