### PR TITLE
unit tests Crypt::Digest::BLAKE2s_256 dependency

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -22,6 +22,7 @@ cpan install Authen::Passphrase::LANManager \
              Crypt::CBC                     \
              Crypt::DES                     \
              Crypt::DES_EDE3                \
+             Crypt::Digest::BLAKE2s_256     \
              Crypt::Digest::RIPEMD160       \
              Crypt::Digest::Whirlpool       \
              Crypt::ECB                     \


### PR DESCRIPTION
A minor test.pl `verify` fix that I have found accidentially (during CMIYC 2023 preparation):

There is a missing perl unit tests (`test.pl` / i.e. `tools/install_modules.sh`) dependency for the perl module `Crypt::Digest::BLAKE2s_256` that we currently use in -m 31000 = `BLAKE2s-256`. Without installing this dependency the tests script could fail.

Thank you