### PR TITLE
Adding new rule, increment all numeric values

### DIFF
--- a/OpenCL/inc_rp.cl
+++ b/OpenCL/inc_rp.cl
@@ -298,6 +298,28 @@ DECLSPEC int mangle_toggle_at_sep (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const 
   return (len);
 }
 
+DECLSPEC int mangle_num_incr (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u8 *buf, const int len)
+{
+  for (int pos = 0; pos < len; pos++)
+  {
+    const u8 byte = buf[pos];
+
+    if ((byte <= '9') && (byte >= '0'))
+    {
+      if (byte == '9')
+      {
+        buf[pos] = '0';
+      }
+      else
+      {
+        buf[pos]++;
+      }
+    }
+  }
+
+  return (len);
+}
+
 DECLSPEC int mangle_reverse (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u32 *buf, const int len)
 {
   for (int l = 0; l < len / 2; l++)
@@ -789,6 +811,7 @@ DECLSPEC int apply_rule (const u32 name, MAYBE_UNUSED const u8 p0, MAYBE_UNUSED 
     case RULE_OP_MANGLE_DUPEBLOCK_LAST:   out_len = mangle_dupeblock_last   (p0, p1, (PRIVATE_AS u8 *) buf, out_len); break;
     case RULE_OP_MANGLE_TITLE_SEP:        out_len = mangle_title_sep        (p0, p1,        buf, out_len); break;
     case RULE_OP_MANGLE_TITLE:            out_len = mangle_title_sep        (' ', p1,       buf, out_len); break;
+    case RULE_OP_MANGLE_NUM_INCR:         out_len = mangle_num_incr         (p0, p1, (PRIVATE_AS u8 *) buf, out_len); break;
   }
 
   return out_len;

--- a/OpenCL/inc_rp.h
+++ b/OpenCL/inc_rp.h
@@ -68,6 +68,7 @@
 #define RULE_OP_MANGLE_DUPEBLOCK_FIRST  'y'
 #define RULE_OP_MANGLE_DUPEBLOCK_LAST   'Y'
 #define RULE_OP_MANGLE_TITLE            'E'
+#define RULE_OP_MANGLE_NUM_INCR         '#'
 
 #define RP_PASSWORD_SIZE 256
 
@@ -118,6 +119,7 @@ DECLSPEC int mangle_replace_nm1 (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8
 DECLSPEC int mangle_dupeblock_first (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u8 *buf, const int len);
 DECLSPEC int mangle_dupeblock_last (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u8 *buf, const int len);
 DECLSPEC int mangle_title_sep (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u32 *buf, const int len);
+DECLSPEC int mangle_num_incr  (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u8 *buf, const int len);
 DECLSPEC int apply_rule (const u32 name, MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u32 *buf, const int in_len);
 DECLSPEC int apply_rules (CONSTANT_AS const u32 *cmds, PRIVATE_AS u32 *buf, const int in_len);
 

--- a/OpenCL/inc_rp.h
+++ b/OpenCL/inc_rp.h
@@ -68,7 +68,7 @@
 #define RULE_OP_MANGLE_DUPEBLOCK_FIRST  'y'
 #define RULE_OP_MANGLE_DUPEBLOCK_LAST   'Y'
 #define RULE_OP_MANGLE_TITLE            'E'
-#define RULE_OP_MANGLE_NUM_INCR         '#'
+#define RULE_OP_MANGLE_NUM_INCR         'F'
 
 #define RP_PASSWORD_SIZE 256
 

--- a/OpenCL/inc_rp_optimized.cl
+++ b/OpenCL/inc_rp_optimized.cl
@@ -1239,6 +1239,50 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at_sep (MAYBE_UNUSED const u32 p
   return in_len;
 }
 
+DECLSPEC HC_INLINE_RP u32 rule_op_mangle_num_incr (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len)
+{
+  u32 t[8];
+
+  t[0] = buf0[0];
+  t[1] = buf0[1];
+  t[2] = buf0[2];
+  t[3] = buf0[3];
+  t[4] = buf1[0];
+  t[5] = buf1[1];
+  t[6] = buf1[2];
+  t[7] = buf1[3];
+
+  PRIVATE_AS u8 *ptr = (PRIVATE_AS u8 *) t;
+
+  for (int pos = 0; pos < 32; pos++)
+  {
+    const u8 byte = ptr[pos];
+
+    if ((byte <= '9') && (byte >= '0'))
+    {
+      if (byte == '9')
+      {
+        ptr[pos] = '0';
+      }
+      else
+      {
+        ptr[pos]++;
+      }
+    }
+  }
+
+  buf0[0] = t[0];
+  buf0[1] = t[1];
+  buf0[2] = t[2];
+  buf0[3] = t[3];
+  buf1[0] = t[4];
+  buf1[1] = t[5];
+  buf1[2] = t[6];
+  buf1[3] = t[7];
+
+  return in_len;
+}
+
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_reverse (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len)
 {
   reverse_block_optimized (buf0, buf1, buf0, buf1, in_len);
@@ -2397,6 +2441,8 @@ DECLSPEC u32 apply_rule_optimized (const u32 name, const u32 p0, const u32 p1, P
     case RULE_OP_MANGLE_DUPEBLOCK_LAST:   out_len = rule_op_mangle_dupeblock_last   (p0, p1, buf0, buf1, out_len); break;
     case RULE_OP_MANGLE_TITLE_SEP:        out_len = rule_op_mangle_title_sep        (p0, p1, buf0, buf1, out_len); break;
     case RULE_OP_MANGLE_TITLE:            out_len = rule_op_mangle_title_sep        (' ', p1, buf0, buf1, out_len); break;
+    case RULE_OP_MANGLE_NUM_INCR:         out_len = rule_op_mangle_num_incr         (p0, p1, buf0, buf1, out_len); break;
+
   }
 
   return out_len;

--- a/OpenCL/inc_rp_optimized.h
+++ b/OpenCL/inc_rp_optimized.h
@@ -74,6 +74,7 @@
 #define RULE_OP_MANGLE_DUPEBLOCK_FIRST  'y'
 #define RULE_OP_MANGLE_DUPEBLOCK_LAST   'Y'
 #define RULE_OP_MANGLE_TITLE            'E'
+#define RULE_OP_MANGLE_NUM_INCR         '#'
 
 DECLSPEC u32 generate_cmask_optimized (const u32 value);
 DECLSPEC void truncate_right_optimized (PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 offset);
@@ -127,6 +128,7 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_replace_np1 (MAYBE_UNUSED const u32 p0,
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_replace_nm1 (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_dupeblock_first (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_dupeblock_last (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
+DECLSPEC HC_INLINE_RP u32 rule_op_mangle_num_incr (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC u32 toggle_on_register (const u32 in, const u32 r);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_title_sep (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC u32 apply_rule_optimized (const u32 name, const u32 p0, const u32 p1, PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 in_len);

--- a/OpenCL/inc_rp_optimized.h
+++ b/OpenCL/inc_rp_optimized.h
@@ -74,7 +74,7 @@
 #define RULE_OP_MANGLE_DUPEBLOCK_FIRST  'y'
 #define RULE_OP_MANGLE_DUPEBLOCK_LAST   'Y'
 #define RULE_OP_MANGLE_TITLE            'E'
-#define RULE_OP_MANGLE_NUM_INCR         '#'
+#define RULE_OP_MANGLE_NUM_INCR         'F'
 
 DECLSPEC u32 generate_cmask_optimized (const u32 value);
 DECLSPEC void truncate_right_optimized (PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 offset);

--- a/include/types.h
+++ b/include/types.h
@@ -366,7 +366,7 @@ typedef enum rule_functions
   RULE_OP_MANGLE_DUPEBLOCK_FIRST = 'y',
   RULE_OP_MANGLE_DUPEBLOCK_LAST  = 'Y',
   RULE_OP_MANGLE_TITLE           = 'E',
-  RULE_OP_MANGLE_NUM_INCR        = '#',
+  RULE_OP_MANGLE_NUM_INCR        = 'F',
 
 } rule_functions_t;
 

--- a/include/types.h
+++ b/include/types.h
@@ -366,6 +366,7 @@ typedef enum rule_functions
   RULE_OP_MANGLE_DUPEBLOCK_FIRST = 'y',
   RULE_OP_MANGLE_DUPEBLOCK_LAST  = 'Y',
   RULE_OP_MANGLE_TITLE           = 'E',
+  RULE_OP_MANGLE_NUM_INCR        = '#',
 
 } rule_functions_t;
 

--- a/src/rp.c
+++ b/src/rp.c
@@ -31,6 +31,7 @@ static const char grp_op_nop[] =
   RULE_OP_MANGLE_SWITCH_LAST,
   RULE_OP_MANGLE_DUPECHAR_ALL,
   RULE_OP_MANGLE_TITLE,
+  RULE_OP_MANGLE_NUM_INCR,
 };
 
 static const char grp_op_pos_p0[] =
@@ -281,6 +282,10 @@ int cpu_rule_to_kernel_rule (char *rule_buf, u32 rule_len, kernel_rule_t *rule)
         break;
 
       case RULE_OP_MANGLE_TREST:
+        SET_NAME (rule, rule_buf[rule_pos]);
+        break;
+
+      case RULE_OP_MANGLE_NUM_INCR:
         SET_NAME (rule, rule_buf[rule_pos]);
         break;
 

--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -127,7 +127,7 @@ static int mangle_num_incr (char arr[RP_PASSWORD_SIZE], int arr_len)
 {
   for (int pos = 0; pos < arr_len; pos++)
   {
-    const u8 byte = arr[pos];
+    const char byte = arr[pos];
 
     if ((byte <= '9') && (byte >= '0'))
     {

--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -123,6 +123,28 @@ static int mangle_reverse (char arr[RP_PASSWORD_SIZE], int arr_len)
   return (arr_len);
 }
 
+static int mangle_num_incr (char arr[RP_PASSWORD_SIZE], int arr_len)
+{
+  for (int pos = 0; pos < arr_len; pos++)
+  {
+    const u8 byte = arr[pos];
+
+    if ((byte <= '9') && (byte >= '0'))
+    {
+      if (byte == '9')
+      {
+        arr[pos] = '0';
+      }
+      else
+      {
+        arr[pos]++;
+      }
+    }
+  }
+
+  return (arr_len);
+}
+
 static int mangle_double (char arr[RP_PASSWORD_SIZE], int arr_len)
 {
   if ((arr_len * 2) >= RP_PASSWORD_SIZE) return (arr_len);
@@ -590,6 +612,10 @@ int _old_apply_rule (const char *rule, int rule_len, char in[RP_PASSWORD_SIZE], 
 
       case RULE_OP_MANGLE_TREST:
         out_len = mangle_trest (out, out_len);
+        break;
+
+      case RULE_OP_MANGLE_NUM_INCR:
+        out_len = mangle_num_incr (out, out_len);
         break;
 
       case RULE_OP_MANGLE_TOGGLE_AT:


### PR DESCRIPTION
This is a draft since it's only a prototype code.

Expected input:
```
01
012
0123
01234
012345
0123456
01234567
012345678
0123456789

9876543210
```

Expected output:
```
12
123
1234
12345
123456
1234567
12345678
123456789
1234567890

0987654321
```

I am open to any ideas and suggestions, including bitwise optimizations for OpenCL kernels.