### PR TITLE
Mode 17230: Remove lower bound restriction for hash count

### DIFF
--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -220,7 +220,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // check here that the hash_count is valid for the attack type
   if (pkzip->hash_count > 8) return PARSER_HASH_VALUE;
-  if (pkzip->hash_count < 3) return PARSER_HASH_VALUE;
 
   p = strtok_r (NULL, "*", &saveptr);
   if (p == NULL) return PARSER_HASH_LENGTH;


### PR DESCRIPTION
I was able to create zip archive with one file, extracted hash (-c, checksum only) and cracked it (dict attack) with hashcat + this patch.