### PR TITLE
Remove unused variable warning

### DIFF
--- a/src/potfile.c
+++ b/src/potfile.c
@@ -249,7 +249,6 @@ void potfile_write_close (hashcat_ctx_t *hashcat_ctx)
 void potfile_write_append (hashcat_ctx_t *hashcat_ctx, const char *out_buf, const int out_len, u8 *plain_ptr, unsigned int plain_len)
 {
   const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
-  const user_options_t *user_options = hashcat_ctx->user_options;
         potfile_ctx_t  *potfile_ctx  = hashcat_ctx->potfile_ctx;
 
   if (potfile_ctx->enabled == false) return;


### PR DESCRIPTION
As title, to avoid a compiler unused variable warning by removing user_options from potfile.c caused by https://github.com/hashcat/hashcat/commit/50e7d9d56c18cb544d3e113bb91fca667ec9adb4
```
src/potfile.c: In function ‘potfile_write_append’:
src/potfile.c:252:25: warning: unused variable ‘user_options’ [-Wunused-variable]
  252 |   const user_options_t *user_options = hashcat_ctx->user_options;
      |
```