### PR TITLE
Correctly check -j and -k when creating dictstat

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -2316,6 +2316,8 @@ typedef struct user_options
   bool         limit_chgd;
   bool         scrypt_tmto_chgd;
   bool         separator_chgd;
+  bool         rule_buf_l_chgd;
+  bool         rule_buf_r_chgd;
 
   bool         advice_disable;
   bool         benchmark;

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -192,8 +192,8 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
 
   if (hashconfig->dictstat_disable == true) return 0;
 
-  if (user_options->rule_buf_l_chgd == true) return 0 ;
-  if (user_options->rule_buf_r_chgd == true) return 0 ;
+  if (user_options->rule_buf_l_chgd == true) return 0;
+  if (user_options->rule_buf_r_chgd == true) return 0;
 
   HCFILE fp;
 

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -100,8 +100,8 @@ void dictstat_read (hashcat_ctx_t *hashcat_ctx)
 
   if (hashconfig->dictstat_disable == true) return;
 
-  if (*user_options->rule_buf_l != ':') return;
-  if (*user_options->rule_buf_r != ':') return;
+  if (user_options->rule_buf_l_chgd == true) return;
+  if (user_options->rule_buf_r_chgd == true) return;
 
   HCFILE fp;
 
@@ -192,8 +192,8 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
 
   if (hashconfig->dictstat_disable == true) return 0;
 
-  if (*user_options->rule_buf_l != ':') return 0;
-  if (*user_options->rule_buf_r != ':') return 0;
+  if (user_options->rule_buf_l_chgd == true) return 0 ;
+  if (user_options->rule_buf_r_chgd == true) return 0 ;
 
   HCFILE fp;
 

--- a/src/dictstat.c
+++ b/src/dictstat.c
@@ -100,8 +100,8 @@ void dictstat_read (hashcat_ctx_t *hashcat_ctx)
 
   if (hashconfig->dictstat_disable == true) return;
 
-  if (user_options->rule_buf_l != NULL) return;
-  if (user_options->rule_buf_r != NULL) return;
+  if (*user_options->rule_buf_l != ':') return;
+  if (*user_options->rule_buf_r != ':') return;
 
   HCFILE fp;
 
@@ -192,8 +192,8 @@ int dictstat_write (hashcat_ctx_t *hashcat_ctx)
 
   if (hashconfig->dictstat_disable == true) return 0;
 
-  if (user_options->rule_buf_l != NULL) return 0;
-  if (user_options->rule_buf_r != NULL) return 0;
+  if (*user_options->rule_buf_l != ':') return 0;
+  if (*user_options->rule_buf_r != ':') return 0;
 
   HCFILE fp;
 

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -450,8 +450,10 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_RP_GEN_FUNC_SEL:           user_options->rp_gen_func_sel           = optarg;                          break;
       case IDX_RP_GEN_SEED:               user_options->rp_gen_seed               = hc_strtoul (optarg, NULL, 10);
                                           user_options->rp_gen_seed_chgd          = true;                            break;
-      case IDX_RULE_BUF_L:                user_options->rule_buf_l                = optarg;                          break;
-      case IDX_RULE_BUF_R:                user_options->rule_buf_r                = optarg;                          break;
+      case IDX_RULE_BUF_L:                user_options->rule_buf_l                = optarg;
+                                          user_options->rule_buf_l_chgd           = true;                            break;
+      case IDX_RULE_BUF_R:                user_options->rule_buf_r                = optarg;
+                                          user_options->rule_buf_r_chgd           = true;                            break;
       case IDX_MARKOV_DISABLE:            user_options->markov_disable            = true;                            break;
       case IDX_MARKOV_CLASSIC:            user_options->markov_classic            = true;                            break;
       case IDX_MARKOV_INVERSE:            user_options->markov_inverse            = true;                            break;


### PR DESCRIPTION
Check `-j` / `-k` values as ':' instead of NULL when deciding to build dictstat cache or not, as : is the default value of rule_buf_l and rule_buf_r, courtsey of @Chick3nman's [comment](https://github.com/hashcat/hashcat/commit/734b4350280b572ec863cec05d576cb05b84a7f4#commitcomment-125448793) on https://github.com/hashcat/hashcat/commit/734b4350280b572ec863cec05d576cb05b84a7f4