### PR TITLE
Raise Flask Session Cookie (-m 29100) max data length to 120 chars.

### DIFF
--- a/OpenCL/m29100_a0-pure.cl
+++ b/OpenCL/m29100_a0-pure.cl
@@ -34,13 +34,13 @@ KERNEL_FQ void m29100_mxx (KERN_ATTR_RULES ())
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
-  u32 s[16] = { 0 };
+  u32 s[32] = { 0 };
 
   #pragma unroll
-  for (u32 id = 0; id < 16; id++)
+  for (u32 id = 0; id < 32; id++)
   {
     s[id] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[id]);
-  };
+  }
 
   /**
    * base
@@ -129,13 +129,13 @@ KERNEL_FQ void m29100_sxx (KERN_ATTR_RULES ())
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
-  u32 s[16] = { 0 };
+  u32 s[32] = { 0 };
 
   #pragma unroll
-  for (u32 id = 0; id < 16; id++)
+  for (u32 id = 0; id < 32; id++)
   {
     s[id] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[id]);
-  };
+  }
 
   /**
    * base

--- a/OpenCL/m29100_a1-pure.cl
+++ b/OpenCL/m29100_a1-pure.cl
@@ -42,13 +42,13 @@ KERNEL_FQ void m29100_mxx (KERN_ATTR_BASIC ())
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
-  u32 s[16] = { 0 };
+  u32 s[32] = { 0 };
 
   #pragma unroll
-  for (u32 id = 0; id < 16; id++)
+  for (u32 id = 0; id < 32; id++)
   {
     s[id] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[id]);
-  };
+  }
 
   /**
    * loop
@@ -164,13 +164,13 @@ KERNEL_FQ void m29100_sxx (KERN_ATTR_BASIC ())
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
-  u32 s[16] = { 0 };
+  u32 s[32] = { 0 };
 
   #pragma unroll
-  for (u32 id = 0; id < 16; id++)
+  for (u32 id = 0; id < 32; id++)
   {
     s[id] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[id]);
-  };
+  }
 
   /**
    * loop

--- a/OpenCL/m29100_a3-pure.cl
+++ b/OpenCL/m29100_a3-pure.cl
@@ -41,13 +41,13 @@ KERNEL_FQ void m29100_mxx (KERN_ATTR_BASIC ())
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
-  u32 s[16] = { 0 };
+  u32 s[32] = { 0 };
 
   #pragma unroll
-  for (u32 id = 0; id < 16; id++)
+  for (u32 id = 0; id < 32; id++)
   {
     s[id] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[id]);
-  };
+  }
 
   /**
    * loop
@@ -149,13 +149,13 @@ KERNEL_FQ void m29100_sxx (KERN_ATTR_BASIC ())
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
-  u32 s[16] = { 0 };
+  u32 s[32] = { 0 };
 
   #pragma unroll
-  for (u32 id = 0; id < 16; id++)
+  for (u32 id = 0; id < 32; id++)
   {
     s[id] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[id]);
-  };
+  }
 
   /**
    * loop

--- a/src/modules/module_29100.c
+++ b/src/modules/module_29100.c
@@ -64,7 +64,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[0]     = '.';
   token.len_min[0] =  0;
-  token.len_max[0] = 56;
+  token.len_max[0] = 120;
   token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_BASE64C;
 
@@ -96,6 +96,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   if (parse_rc == false) return (PARSER_SALT_LENGTH);
 
   memcpy (salt->salt_buf, line_buf, salt_len);
+  salt->salt_buf[salt_len] = '\0';
 
   u8 tmp_buf[100] = { 0 };
 
@@ -120,8 +121,6 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 {
   const u32 *digest32 = (const u32 *) digest_buf;
 
-  char tmp_buf[128] = { 0 };
-
   char ptr_plain[128];
 
   u32 tmp[5];
@@ -132,9 +131,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   tmp[3] = byte_swap_32 (digest32[3]);
   tmp[4] = byte_swap_32 (digest32[4]);
 
-  memcpy (tmp_buf, tmp, 20);
-
-  base64_encode (int_to_base64url, (const u8 *) tmp_buf, 48, (u8 *) ptr_plain);
+  base64_encode (int_to_base64url, (const u8 *) tmp, 20, (u8 *) ptr_plain);
 
   ptr_plain[27] = 0;
 


### PR DESCRIPTION
Before this the data was limited to mere 56 characters which made the mode only useful with small cookies. This change raises the limit to 120 (128 - 1 - 6 - 1) chars, making the mode useful with wider range of session cookies.

Related to #3440 / #3441.