### PR TITLE
Add faq link to potfile advice

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -466,6 +466,7 @@ static void main_potfile_all_cracked (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, M
   if (user_options->quiet == true) return;
 
   event_log_info (hashcat_ctx, "INFO: All hashes found as potfile and/or empty entries! Use --show to display them.");
+  event_log_info (hashcat_ctx, "For more information, see https://hashcat.net/faq/potfile");
   event_log_info (hashcat_ctx, NULL);
 }
 


### PR DESCRIPTION
Add the FAQ link to the potfile advice as this seems to trip a lot of beginners up, "Yeah, but what actually is a potfile? And why are my hashes in it?"

(Thanks to @roycewilliams for the shortened link!)