### PR TITLE
Fix RAM usage for Intel iGPUs

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -8029,7 +8029,7 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
         device_param->device_available_mem = device_param->device_global_mem - MAX_ALLOC_CHECKS_SIZE;
 
-        if (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU)
+        if ((device_param->opencl_device_type & CL_DEVICE_TYPE_GPU) && ((device_param->opencl_platform_vendor_id != VENDOR_ID_INTEL_SDK) || (device_param->device_host_unified_memory == 0)))
         {
           // OK, so the problem here is the following:
           // There's just CL_DEVICE_GLOBAL_MEM_SIZE to ask OpenCL about the total memory on the device,


### PR DESCRIPTION
It fixes #3426.
Basically it should return pre-v6.2.4 behavior for Intel iGPUs by reverting a part of 76e388e.
Intel ARC dGPUs should not be affected by this change (they have `device_host_unified_memory=0` according to [clinfo](https://bbs.archlinux.org/viewtopic.php?pid=2070516#p2070516) )