### PR TITLE
Increase virtual backend limit

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -131,7 +131,7 @@ but this is needed for VS compiler which doesn't have inline keyword but has __i
 
 #define CPT_CACHE           0x20000
 #define PARAMCNT            64
-#define DEVICES_MAX         128
+#define DEVICES_MAX         256
 #define EXEC_CACHE          128
 #define SPEED_CACHE         4096
 #define SPEED_MAXAGE        4096

--- a/include/types.h
+++ b/include/types.h
@@ -1901,7 +1901,7 @@ typedef struct backend_ctx
   int                 opencl_devices_cnt;
   int                 opencl_devices_active;
 
-  u64                 backend_devices_filter;
+  bool                backend_devices_filter[DEVICES_MAX + 1];
 
   hc_device_param_t  *devices_param;
 


### PR DESCRIPTION
This change increases the maximum device limit to 256, which is particularly useful when using the new 'virtual backend device' functionality of upcoming Hashcat 7.

The backend_devices_filter is changed to a boolean array where each index refers to a specific virtual backend device. The last place in the array ( DEVICES_MAX + 1) is reserved to determine if filtering is needed. If this value is true, then no filter was specified and all (virtual) devices are enabled.

Let us know what you think and if any changes are needed. 

Kind regards

(Pelle & Ewald)