### PR TITLE
Flush debug-file more often

### DIFF
--- a/src/debugfile.c
+++ b/src/debugfile.c
@@ -173,8 +173,6 @@ void debugfile_destroy (hashcat_ctx_t *hashcat_ctx)
 
   if (debugfile_ctx->filename)
   {
-    hc_unlockfile (&debugfile_ctx->fp);
-
     hc_fclose (&debugfile_ctx->fp);
   }
 


### PR DESCRIPTION
Instead of only flushing/unlocking the debug file at the end of Hashcat, flush after each write, aligning it with the outfile and potfile's behaviour