### PR TITLE
Remove unused variable

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -7674,8 +7674,6 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
   if (!backend_ctx->backend_devices_filter[DEVICES_MAX])
   {
-    const u64 backend_devices_cnt_mask = ~(((u64) -1 >> backend_ctx->backend_devices_cnt) << backend_ctx->backend_devices_cnt);
-
     for (int i = backend_ctx->backend_devices_cnt; i < DEVICES_MAX; i++)
     {
       if (backend_ctx->backend_devices_filter[i])


### PR DESCRIPTION
Remove unused variable debris from: https://github.com/hashcat/hashcat/commit/c1a10518fd98535e3ef573d9cd5f8bab292c4609

```
src/backend.c:7677:15: warning: unused variable ‘backend_devices_cnt_mask’ [-Wunused-variable]
```
<br />
Truly saving lives with this PR, I'm sure.