### PR TITLE
Hip rtc windows env implementation & LLVMBitcode compilation fix 

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -8755,7 +8755,7 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
       */
 
       hiprtc_options[1] = "-nocudainc";
-      hiprtc_options[2] = "-nocudalib";
+      hiprtc_options[2] = "";
       hiprtc_options[3] = "";
       hiprtc_options[4] = "";
 

--- a/src/ext_hiprtc.c
+++ b/src/ext_hiprtc.c
@@ -11,6 +11,42 @@
 
 #include "dynloader.h"
 
+
+char* hiprtcDllPath(char* hipSDKPath)
+{
+  /*
+      AMD HIP RTC DLLs is stored at "C:\Program Files\ROCm\X.Y\bin\hiprtc0X0Y.dll"
+      Tried using regex to simplify, but had compilation issues on mingw64 (linker
+      had troubles with pcre.h)
+
+      This function can return complete dll path based on major release version
+      X.Y parsed from the ENV variable HIP_PATH.
+  */
+
+    // Identifying major release version X.Y
+    char* majorVersion = malloc(strlen("X.Y")+1);
+    memcpy(majorVersion, hipSDKPath + (strlen(hipSDKPath) - 4), 3);
+    memcpy(majorVersion+0x3, "\0", 1);
+
+    // Preparing DLL name "hiprtc0X0Y.dll"
+    char* hiprtcDllName = malloc(strlen("hiprtcXXXX.dll")+1);
+    memcpy(hiprtcDllName, "hiprtc0", strlen("hiprtc0"));
+ 
+    memcpy(hiprtcDllName + 0x7, majorVersion, 1);
+    memcpy(hiprtcDllName + 0x8, "0", 1);
+    memcpy(hiprtcDllName + 0x9, majorVersion + 2, 1);
+    memcpy(hiprtcDllName + 0xa, ".dll\0", 5);
+
+    // Preparing complete path as "C:\Program Files\ROCm\X.Y\bin\hiprtc0X0Y.dll" to 
+    // return to the caller.
+    char* hiprtcDllPath = malloc(strlen(hipSDKPath) + strlen("bin/") + strlen("hiprtcXXXX.dll") + 1);
+    strcpy(hiprtcDllPath, hipSDKPath);
+    strcat(hiprtcDllPath, "bin\\");
+    strcat(hiprtcDllPath, hiprtcDllName);
+    return(hiprtcDllPath);   
+}
+
+
 int hiprtc_make_options_array_from_string (char *string, char **options)
 {
   char *saveptr = NULL;
@@ -41,14 +77,23 @@ int hiprtc_init (void *hashcat_ctx)
   #if   defined (_WIN)
   hiprtc->lib = hc_dlopen ("hiprtc.dll");
 
-  if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("C:/Program Files/AMD/ROCm/5.5/bin/hiprtc0505.dll");
+  // Check for HIP SDK installation from ENV
+  const char* hipSDKPath = getenv("HIP_PATH");
+  if (hipSDKPath != NULL && hiprtc->lib == NULL) 
+  {
+    hiprtc->lib = hc_dlopen (hiprtcDllPath(hipSDKPath));
+  }
   if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("amdhip64.dll");
   #elif defined (__APPLE__)
   hiprtc->lib = hc_dlopen ("fixme.dylib");
   #elif defined (__CYGWIN__)
   hiprtc->lib = hc_dlopen ("hiprtc.dll");
-
-  if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("C:/Program Files/AMD/ROCm/5.5/bin/hiprtc0505.dll");
+  // Check for HIP SDK installation from ENV
+  const char* hipSDKPath = getenv("HIP_PATH");
+  if (hipSDKPath != NULL && hiprtc->lib == NULL) 
+  {
+    hiprtc->lib = hc_dlopen (hiprtcDllPath(hipSDKPath));
+  }
   if (hiprtc->lib == NULL) hiprtc->lib = hc_dlopen ("amdhip64.dll");
   #else
   hiprtc->lib = hc_dlopen ("libhiprtc.so");


### PR DESCRIPTION
Since the release of HIP SDK on Windows, the HIP SDK installer provided by AMD sets the ENV variable "HIP_PATH" on Windows.

That can be used to parse the latest release version which can be used to load the latest HIP RTC DLL for the HIP backend to work.

This also fixes a bug that was due to the presence of `-nocudalib` under HIP RTC compile options, resulting in a kernel compilation error.
More details [here](https://github.com/ROCm/HIP/issues/3410)
