### PR TITLE
Improve performance of scrypt-based algorithms by code reordering.

### DIFF
--- a/OpenCL/m08900-pure.cl
+++ b/OpenCL/m08900-pure.cl
@@ -128,6 +128,36 @@ DECLSPEC uint4 hc_swap32_4 (uint4 v)
 
 DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
 {
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4 / 2];
+
+  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TT[dst_off + 0] = TI[src_off + 0];
+    TT[dst_off + 1] = TI[src_off + 1];
+    TT[dst_off + 2] = TI[src_off + 2];
+    TT[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TI[dst_off + 0] = TI[src_off + 0];
+    TI[dst_off + 1] = TI[src_off + 1];
+    TI[dst_off + 2] = TI[src_off + 2];
+    TI[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
+  {
+    TI[dst_off + 0] = TT[src_off + 0];
+    TI[dst_off + 1] = TT[src_off + 1];
+    TI[dst_off + 2] = TT[src_off + 2];
+    TI[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
+
   uint4 R0 = TI[STATE_CNT4 - 4];
   uint4 R1 = TI[STATE_CNT4 - 3];
   uint4 R2 = TI[STATE_CNT4 - 2];
@@ -165,36 +195,6 @@ DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
     TI[i + 2] = R2;
     TI[i + 3] = R3;
   }
-
-  #if SCRYPT_R > 1
-
-  uint4 TT[STATE_CNT4 / 2];
-
-  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TT[dst_off + 0] = TI[src_off + 0];
-    TT[dst_off + 1] = TI[src_off + 1];
-    TT[dst_off + 2] = TI[src_off + 2];
-    TT[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TI[dst_off + 0] = TI[src_off + 0];
-    TI[dst_off + 1] = TI[src_off + 1];
-    TI[dst_off + 2] = TI[src_off + 2];
-    TI[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
-  {
-    TI[dst_off + 0] = TT[src_off + 0];
-    TI[dst_off + 1] = TT[src_off + 1];
-    TI[dst_off + 2] = TT[src_off + 2];
-    TI[dst_off + 3] = TT[src_off + 3];
-  }
-
-  #endif
 }
 
 DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
@@ -216,6 +216,30 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
     case 2: V = V2; break;
     case 3: V = V3; break;
   }
+
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4];
+
+  for (int z = 0; z < zSIZE; z++) TT[z] = X[z];
+
+  for (int dst_off = 8, src_off = 4; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = zSIZE / 2; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
 
   for (u32 y = 0; y < ySIZE; y++)
   {
@@ -459,9 +483,13 @@ KERNEL_FQ void m08900_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   sha256_hmac_init_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
 
-  for (u32 l = 0; l < SCRYPT_CNT4; l += 4)
+  for (u32 i = 0; i < SCRYPT_CNT4; i += STATE_CNT4)
   {
+   for (u32 j = 0; j < (STATE_CNT4 * 2); j += 8)
+   {
     uint4 X[4];
+
+    const u32 l =  i + j + ((j >= STATE_CNT4) ? (4 - STATE_CNT4) : 0);
 
     X[0] = tmps[gid].P[l + 0];
     X[1] = tmps[gid].P[l + 1];
@@ -510,6 +538,7 @@ KERNEL_FQ void m08900_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
     w3[3] = T[3].w;
 
     sha256_hmac_update_64 (&ctx, w0, w1, w2, w3, 64);
+   }
   }
 
   w0[0] = 1;

--- a/OpenCL/m22700-pure.cl
+++ b/OpenCL/m22700-pure.cl
@@ -176,6 +176,36 @@ DECLSPEC uint4 hc_swap32_4 (uint4 v)
 
 DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
 {
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4 / 2];
+
+  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TT[dst_off + 0] = TI[src_off + 0];
+    TT[dst_off + 1] = TI[src_off + 1];
+    TT[dst_off + 2] = TI[src_off + 2];
+    TT[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TI[dst_off + 0] = TI[src_off + 0];
+    TI[dst_off + 1] = TI[src_off + 1];
+    TI[dst_off + 2] = TI[src_off + 2];
+    TI[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
+  {
+    TI[dst_off + 0] = TT[src_off + 0];
+    TI[dst_off + 1] = TT[src_off + 1];
+    TI[dst_off + 2] = TT[src_off + 2];
+    TI[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
+
   uint4 R0 = TI[STATE_CNT4 - 4];
   uint4 R1 = TI[STATE_CNT4 - 3];
   uint4 R2 = TI[STATE_CNT4 - 2];
@@ -213,36 +243,6 @@ DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
     TI[i + 2] = R2;
     TI[i + 3] = R3;
   }
-
-  #if SCRYPT_R > 1
-
-  uint4 TT[STATE_CNT4 / 2];
-
-  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TT[dst_off + 0] = TI[src_off + 0];
-    TT[dst_off + 1] = TI[src_off + 1];
-    TT[dst_off + 2] = TI[src_off + 2];
-    TT[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TI[dst_off + 0] = TI[src_off + 0];
-    TI[dst_off + 1] = TI[src_off + 1];
-    TI[dst_off + 2] = TI[src_off + 2];
-    TI[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
-  {
-    TI[dst_off + 0] = TT[src_off + 0];
-    TI[dst_off + 1] = TT[src_off + 1];
-    TI[dst_off + 2] = TT[src_off + 2];
-    TI[dst_off + 3] = TT[src_off + 3];
-  }
-
-  #endif
 }
 
 DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
@@ -264,6 +264,30 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
     case 2: V = V2; break;
     case 3: V = V3; break;
   }
+
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4];
+
+  for (int z = 0; z < zSIZE; z++) TT[z] = X[z];
+
+  for (int dst_off = 8, src_off = 4; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = zSIZE / 2; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
 
   for (u32 y = 0; y < ySIZE; y++)
   {
@@ -597,9 +621,13 @@ KERNEL_FQ void m22700_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
   u32 w2[4];
   u32 w3[4];
 
-  for (u32 l = 0; l < SCRYPT_CNT4; l += 4)
+  for (u32 i = 0; i < SCRYPT_CNT4; i += STATE_CNT4)
   {
+   for (u32 j = 0; j < (STATE_CNT4 * 2); j += 8)
+   {
     uint4 X[4];
+
+    const u32 l =  i + j + ((j >= STATE_CNT4) ? (4 - STATE_CNT4) : 0);
 
     X[0] = tmps[gid].P[l + 0];
     X[1] = tmps[gid].P[l + 1];
@@ -648,6 +676,7 @@ KERNEL_FQ void m22700_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
     w3[3] = T[3].w;
 
     sha256_hmac_update_64 (&ctx, w0, w1, w2, w3, 64);
+   }
   }
 
   w0[0] = 1;

--- a/OpenCL/m27700-pure.cl
+++ b/OpenCL/m27700-pure.cl
@@ -126,6 +126,36 @@ DECLSPEC uint4 hc_swap32_4 (uint4 v)
 
 DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
 {
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4 / 2];
+
+  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TT[dst_off + 0] = TI[src_off + 0];
+    TT[dst_off + 1] = TI[src_off + 1];
+    TT[dst_off + 2] = TI[src_off + 2];
+    TT[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TI[dst_off + 0] = TI[src_off + 0];
+    TI[dst_off + 1] = TI[src_off + 1];
+    TI[dst_off + 2] = TI[src_off + 2];
+    TI[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
+  {
+    TI[dst_off + 0] = TT[src_off + 0];
+    TI[dst_off + 1] = TT[src_off + 1];
+    TI[dst_off + 2] = TT[src_off + 2];
+    TI[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
+
   uint4 R0 = TI[STATE_CNT4 - 4];
   uint4 R1 = TI[STATE_CNT4 - 3];
   uint4 R2 = TI[STATE_CNT4 - 2];
@@ -163,36 +193,6 @@ DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
     TI[i + 2] = R2;
     TI[i + 3] = R3;
   }
-
-  #if SCRYPT_R > 1
-
-  uint4 TT[STATE_CNT4 / 2];
-
-  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TT[dst_off + 0] = TI[src_off + 0];
-    TT[dst_off + 1] = TI[src_off + 1];
-    TT[dst_off + 2] = TI[src_off + 2];
-    TT[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TI[dst_off + 0] = TI[src_off + 0];
-    TI[dst_off + 1] = TI[src_off + 1];
-    TI[dst_off + 2] = TI[src_off + 2];
-    TI[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
-  {
-    TI[dst_off + 0] = TT[src_off + 0];
-    TI[dst_off + 1] = TT[src_off + 1];
-    TI[dst_off + 2] = TT[src_off + 2];
-    TI[dst_off + 3] = TT[src_off + 3];
-  }
-
-  #endif
 }
 
 DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
@@ -214,6 +214,30 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
     case 2: V = V2; break;
     case 3: V = V3; break;
   }
+
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4];
+
+  for (int z = 0; z < zSIZE; z++) TT[z] = X[z];
+
+  for (int dst_off = 8, src_off = 4; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = zSIZE / 2; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
 
   for (u32 y = 0; y < ySIZE; y++)
   {
@@ -549,9 +573,13 @@ KERNEL_FQ void m27700_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
   u32 w2[4];
   u32 w3[4];
 
-  for (u32 l = 0; l < SCRYPT_CNT4; l += 4)
+  for (u32 i = 0; i < SCRYPT_CNT4; i += STATE_CNT4)
   {
+   for (u32 j = 0; j < (STATE_CNT4 * 2); j += 8)
+   {
     uint4 X[4];
+
+    const u32 l =  i + j + ((j >= STATE_CNT4) ? (4 - STATE_CNT4) : 0);
 
     X[0] = tmps[gid].P[l + 0];
     X[1] = tmps[gid].P[l + 1];
@@ -600,6 +628,7 @@ KERNEL_FQ void m27700_comp (KERN_ATTR_TMPS (scrypt_tmp_t))
     w3[3] = T[3].w;
 
     sha256_hmac_update_64 (&ctx, w0, w1, w2, w3, 64);
+   }
   }
 
   w0[0] = 1;

--- a/OpenCL/m28200-pure.cl
+++ b/OpenCL/m28200-pure.cl
@@ -138,6 +138,36 @@ DECLSPEC uint4 hc_swap32_4 (uint4 v)
 
 DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
 {
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4 / 2];
+
+  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TT[dst_off + 0] = TI[src_off + 0];
+    TT[dst_off + 1] = TI[src_off + 1];
+    TT[dst_off + 2] = TI[src_off + 2];
+    TT[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
+  {
+    TI[dst_off + 0] = TI[src_off + 0];
+    TI[dst_off + 1] = TI[src_off + 1];
+    TI[dst_off + 2] = TI[src_off + 2];
+    TI[dst_off + 3] = TI[src_off + 3];
+  }
+
+  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
+  {
+    TI[dst_off + 0] = TT[src_off + 0];
+    TI[dst_off + 1] = TT[src_off + 1];
+    TI[dst_off + 2] = TT[src_off + 2];
+    TI[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
+
   uint4 R0 = TI[STATE_CNT4 - 4];
   uint4 R1 = TI[STATE_CNT4 - 3];
   uint4 R2 = TI[STATE_CNT4 - 2];
@@ -175,37 +205,8 @@ DECLSPEC void salsa_r (PRIVATE_AS uint4 *TI)
     TI[i + 2] = R2;
     TI[i + 3] = R3;
   }
-
-  #if SCRYPT_R > 1
-
-  uint4 TT[STATE_CNT4 / 2];
-
-  for (int dst_off = 0, src_off = 4; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TT[dst_off + 0] = TI[src_off + 0];
-    TT[dst_off + 1] = TI[src_off + 1];
-    TT[dst_off + 2] = TI[src_off + 2];
-    TT[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = 4, src_off = 8; src_off < STATE_CNT4; dst_off += 4, src_off += 8)
-  {
-    TI[dst_off + 0] = TI[src_off + 0];
-    TI[dst_off + 1] = TI[src_off + 1];
-    TI[dst_off + 2] = TI[src_off + 2];
-    TI[dst_off + 3] = TI[src_off + 3];
-  }
-
-  for (int dst_off = STATE_CNT4 / 2, src_off = 0; dst_off < STATE_CNT4; dst_off += 4, src_off += 4)
-  {
-    TI[dst_off + 0] = TT[src_off + 0];
-    TI[dst_off + 1] = TT[src_off + 1];
-    TI[dst_off + 2] = TT[src_off + 2];
-    TI[dst_off + 3] = TT[src_off + 3];
-  }
-
-  #endif
 }
+
 
 DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
 {
@@ -226,6 +227,30 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
     case 2: V = V2; break;
     case 3: V = V3; break;
   }
+
+  #if SCRYPT_R > 1
+
+  uint4 TT[STATE_CNT4];
+
+  for (int z = 0; z < zSIZE; z++) TT[z] = X[z];
+
+  for (int dst_off = 8, src_off = 4; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  for (int dst_off = 4, src_off = zSIZE / 2; dst_off < zSIZE; dst_off += 8, src_off += 4)
+  {
+    X[dst_off + 0] = TT[src_off + 0];
+    X[dst_off + 1] = TT[src_off + 1];
+    X[dst_off + 2] = TT[src_off + 2];
+    X[dst_off + 3] = TT[src_off + 3];
+  }
+
+  #endif
 
   for (u32 y = 0; y < ySIZE; y++)
   {
@@ -517,9 +542,13 @@ KERNEL_FQ void m28200_comp (KERN_ATTR_TMPS_ESALT (exodus_tmp_t, exodus_t))
 
   sha256_hmac_init_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
 
-  for (u32 l = 0; l < SCRYPT_CNT4; l += 4)
+  for (u32 i = 0; i < SCRYPT_CNT4; i += STATE_CNT4)
   {
+   for (u32 j = 0; j < (STATE_CNT4 * 2); j += 8)
+   {
     uint4 X[4];
+
+    const u32 l =  i + j + ((j >= STATE_CNT4) ? (4 - STATE_CNT4) : 0);
 
     X[0] = tmps[gid].P[l + 0];
     X[1] = tmps[gid].P[l + 1];
@@ -568,6 +597,7 @@ KERNEL_FQ void m28200_comp (KERN_ATTR_TMPS_ESALT (exodus_tmp_t, exodus_t))
     w3[3] = T[3].w;
 
     sha256_hmac_update_64 (&ctx, w0, w1, w2, w3, 64);
+   }
   }
 
   w0[0] = 1;


### PR DESCRIPTION
Performance improvements to scrypt-based algorithms. In particular for `scrypt_mix_init()` and `salsa_r()`. Part of these methods is the reordering (demultiplexing) of elements in `X[]` and `TI[]`. By changing the moment of reordering, the GPU (or compiler) seems to be more efficient which improves performance.

Tested with the self-test hash on the following device: `Device #1: NVIDIA GeForce RTX 3070, 7113/8191 MB, 46MCU`
Core was: `1725 MHz`
 
| Plugin | Speed Before | Speed After |
| ------- | ------- | ------- |
| 8900|    1660 H/s|   1863 H/s|
|15700|       8 H/s|      9 H/s|
|22700|    1676 H/s|   1889 H/s|
|27700|    1667 H/s|   1898 H/s|
|28200|    1651 H/s|   1865 H/s|