### PR TITLE
Update token lenght in module_20711.c (AuthMe)

### DIFF
--- a/src/modules/module_20711.c
+++ b/src/modules/module_20711.c
@@ -82,8 +82,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_SIGNATURE;
 
   token.sep[1]     = '$';
-  token.len[1]     = 16;
-  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
+  token.len_min[1] = 16;
+  token.len_max[1] = 20;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_OPTIONAL_ROUNDS;
 
   token.sep[2]     = '$';
   token.len[2]     = 64;

--- a/src/modules/module_20711.c
+++ b/src/modules/module_20711.c
@@ -84,8 +84,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.sep[1]     = '$';
   token.len_min[1] = 16;
   token.len_max[1] = 20;
-  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_OPTIONAL_ROUNDS;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   token.sep[2]     = '$';
   token.len[2]     = 64;


### PR DESCRIPTION
$SHA$i41fyk8i8zcn1wadetlf$279d613079e5c9d810b38b2db1adbff63d90283923c4f10814a1ccdf3ee07fa7 = AuthMe(123456)
I changed the length required for the 2nd token in AuthMe hashes since it can vary from 16 to 20 characters as seen in the example above.
