### PR TITLE
Improving performance of --show #1

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -67,6 +67,7 @@
 ##
 
 - DEScrypt Kernel (1500): Improved performance from 950MH/s to 2200MH/s (RX6900XT) on HIP backend by workaround invalid compile time optimizer
+- Performance of --show feature has been improved by removing unnecessary memset calls in potfile_remove_parse function.
 
 ##
 ## Bugs

--- a/src/potfile.c
+++ b/src/potfile.c
@@ -535,21 +535,6 @@ int potfile_remove_parse (hashcat_ctx_t *hashcat_ctx)
 
     if (line_hash_len == 0) continue;
 
-    if (hash_buf.salt)
-    {
-      memset (hash_buf.salt, 0, sizeof (salt_t));
-    }
-
-    if (hash_buf.esalt)
-    {
-      memset (hash_buf.esalt, 0, hashconfig->esalt_size);
-    }
-
-    if (hash_buf.hook_salt)
-    {
-      memset (hash_buf.hook_salt, 0, hashconfig->hook_salt_size);
-    }
-
     if (module_ctx->module_hash_decode_potfile != MODULE_DEFAULT)
     {
       if (module_ctx->module_potfile_custom_check != MODULE_DEFAULT)


### PR DESCRIPTION
Related: https://github.com/hashcat/hashcat/issues/3988

Let's take a look into `src/hashcat.c` file:
```C
    while (!hc_feof (&fp))
    {
      const size_t line_len = fgetl (&fp, line_buf, HCBUFSIZ_LARGE);

      if (line_len == 0) continue;

      char *hash_buf = NULL;
      int   hash_len = 0;

      hlfmt_hash (hashcat_ctx, hashlist_format, line_buf, line_len, &hash_buf, &hash_len);

      bool hash_fmt_error = false;

      if (hash_len < 1)     hash_fmt_error = true;
      if (hash_buf == NULL) hash_fmt_error = true;

      if (hash_fmt_error) continue;

      int parser_status = module_ctx->module_hash_decode (hashconfig, digest, salt, esalt, hook_salt, hash_info, hash_buf, hash_len);
```

This code uses module_hash_decode in a loop and doesn't memset `salt`, `esalt`, or `hook_salt`. Therefore, we can conclude that it's safe to use module_hash_decode without memsetting the buffers.