### PR TITLE
Improving performance of --show #2

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -67,6 +67,7 @@
 ##
 
 - DEScrypt Kernel (1500): Improved performance from 950MH/s to 2200MH/s (RX6900XT) on HIP backend by workaround invalid compile time optimizer
+- Added a redundant signature check to modules 01711, 02100, 07500, 13100, 13400, 18200, 19600, 19700, 19800, 19900, 20200, 20300, 20400, 28800, 28900, and 29700 to improve potfile reading performance
 
 ##
 ## Bugs

--- a/src/modules/module_01711.c
+++ b/src/modules/module_01711.c
@@ -88,6 +88,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (line_len < 64) return (PARSER_SALT_LENGTH);
+
+  if (strncmp(line_buf, SIGNATURE_SHA512B64S, strlen (SIGNATURE_SHA512B64S))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.token_cnt  = 2;

--- a/src/modules/module_02100.c
+++ b/src/modules/module_02100.c
@@ -78,6 +78,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (line_len < 41) return (PARSER_SALT_LENGTH);
+
+  if (strncmp(line_buf, SIGNATURE_DCC2, strlen (SIGNATURE_DCC2))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.token_cnt  = 4;

--- a/src/modules/module_07500.c
+++ b/src/modules/module_07500.c
@@ -104,6 +104,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 46) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5PA, strlen (SIGNATURE_KRB5PA))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.token_cnt  = 6;

--- a/src/modules/module_13100.c
+++ b/src/modules/module_13100.c
@@ -105,6 +105,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 46) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5TGS, strlen (SIGNATURE_KRB5TGS))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;
@@ -122,8 +132,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    * jtr
    * format 3: $krb5tgs$spn:checksum$edata2
    */
-
-  if (line_len < (int) strlen (SIGNATURE_KRB5TGS)) return (PARSER_SALT_LENGTH);
 
   memset (krb5tgs, 0, sizeof (krb5tgs_t));
 

--- a/src/modules/module_13400.c
+++ b/src/modules/module_13400.c
@@ -106,6 +106,14 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (line_len < 128) return (PARSER_SALT_LENGTH);
 
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KEEPASS, strlen (SIGNATURE_KEEPASS))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   if ((line_buf[line_len - (64 + 1 + 2 + 1 + 2)] == '*')
    && (line_buf[line_len - (64 + 1 + 2 + 1 + 1)] == '1')
    && (line_buf[line_len - (64 + 1 + 2 + 1 + 0)] == '*')) is_keyfile_present = true;

--- a/src/modules/module_18200.c
+++ b/src/modules/module_18200.c
@@ -104,6 +104,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 46) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5ASREP, strlen (SIGNATURE_KRB5ASREP))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;
@@ -120,8 +130,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    * jtr
    * format 2: $krb5asrep$user_principal_name:checksum$edata2
    */
-
-  if (line_len < (int) strlen (SIGNATURE_KRB5ASREP)) return (PARSER_SALT_LENGTH);
 
   memset (krb5asrep, 0, sizeof (krb5asrep_t));
 

--- a/src/modules/module_19600.c
+++ b/src/modules/module_19600.c
@@ -89,6 +89,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 46) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5TGS, strlen (SIGNATURE_KRB5TGS))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;
@@ -102,9 +112,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    * $krb5tgs$17$*user*realm*$checksum$edata2
    * $krb5tgs$17$*user*realm*spn*$checksum$edata2
    */
-
-  // assume no signature found
-  if (line_len < 12) return (PARSER_SALT_LENGTH);
 
   char *spn_info_start  = strchr (line_buf + 12 + 1, '*');
 

--- a/src/modules/module_19700.c
+++ b/src/modules/module_19700.c
@@ -89,6 +89,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 46) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5TGS, strlen (SIGNATURE_KRB5TGS))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;

--- a/src/modules/module_19800.c
+++ b/src/modules/module_19800.c
@@ -1,3 +1,4 @@
+
 /**
  * Author......: See docs/credits.txt
  * License.....: MIT
@@ -89,6 +90,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 46) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5PA, strlen (SIGNATURE_KRB5PA))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;
@@ -101,9 +112,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   /**
    * $krb5pa$17$*user*realm*$enc_timestamp+checksum
    */
-
-  // assume no signature found
-  if (line_len < 11) return (PARSER_SALT_LENGTH);
 
   // assume $krb5pa$17$user$realm$enc_timestamp+checksum
   token.token_cnt  = 4;

--- a/src/modules/module_19900.c
+++ b/src/modules/module_19900.c
@@ -89,6 +89,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 46) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5PA, strlen (SIGNATURE_KRB5PA))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;
@@ -101,9 +111,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   /**
    * $krb5pa$18$*user*realm*$enc_timestamp+checksum
    */
-
-  // assume no signature found
-  if (line_len < 11) return (PARSER_SALT_LENGTH);
 
   // assume $krb5pa$18$user$realm$enc_timestamp+checksum
   token.token_cnt  = 4;

--- a/src/modules/module_20200.c
+++ b/src/modules/module_20200.c
@@ -93,6 +93,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (line_len < 52) return (PARSER_SALT_LENGTH);
+
+  if (strncmp(line_buf, SIGNATURE_PASSLIB_PBKDF2_SHA512, strlen (SIGNATURE_PASSLIB_PBKDF2_SHA512))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.token_cnt  = 5;

--- a/src/modules/module_20300.c
+++ b/src/modules/module_20300.c
@@ -92,6 +92,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (line_len < 52) return (PARSER_SALT_LENGTH);
+
+  if (strncmp(line_buf, SIGNATURE_PASSLIB_PBKDF2_SHA256, strlen (SIGNATURE_PASSLIB_PBKDF2_SHA256))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.token_cnt  = 5;

--- a/src/modules/module_20400.c
+++ b/src/modules/module_20400.c
@@ -92,6 +92,15 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  /**
+   * Checking the signature for performance optimization
+   */
+  if (line_len < 52) return (PARSER_SALT_LENGTH);
+
+  if (strncmp(line_buf, SIGNATURE_PASSLIB_PBKDF2_SHA1, strlen (SIGNATURE_PASSLIB_PBKDF2_SHA1))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.token_cnt  = 5;

--- a/src/modules/module_28800.c
+++ b/src/modules/module_28800.c
@@ -99,6 +99,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 11) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5DB, strlen (SIGNATURE_KRB5DB))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;
@@ -112,9 +122,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    * $krb5db$17$user$realm$hash
    * $krb5db$17$user$realm$*spn*$hash
    */
-
-  // assume no signature found
-  if (line_len < 11) return (PARSER_SALT_LENGTH);
 
   char *spn_info_start  = strchr (line_buf + 11 + 1, '*');
 

--- a/src/modules/module_28900.c
+++ b/src/modules/module_28900.c
@@ -99,6 +99,16 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   hc_token_t token;
 
+  if (line_len < 11) return (PARSER_SALT_LENGTH);
+
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KRB5DB, strlen (SIGNATURE_KRB5DB))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   memset (&token, 0, sizeof (hc_token_t));
 
   token.signatures_cnt    = 1;
@@ -112,9 +122,6 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    * $krb5db$18$user$realm$hash
    * $krb5db$18$user$realm$*spn*$hash
    */
-
-  // assume no signature found
-  if (line_len < 11) return (PARSER_SALT_LENGTH);
 
   char *spn_info_start  = strchr (line_buf + 11 + 1, '*');
 

--- a/src/modules/module_29700.c
+++ b/src/modules/module_29700.c
@@ -116,6 +116,14 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (line_len < 128) return (PARSER_SALT_LENGTH);
 
+  /**
+   * Checking the signature for performance optimization
+   */
+
+  if (strncmp(line_buf, SIGNATURE_KEEPASS, strlen (SIGNATURE_KEEPASS))) {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
   if ((line_buf[line_len - (64 + 1 + 2 + 1 + 2)] == '*')
    && (line_buf[line_len - (64 + 1 + 2 + 1 + 1)] == '1')
    && (line_buf[line_len - (64 + 1 + 2 + 1 + 0)] == '*')) is_keyfile_present = true;


### PR DESCRIPTION
Related: https://github.com/hashcat/hashcat/issues/3988

This PR adds a redundant signature check to modules 01711, 02100, 07500, 13100, 13400, 18200, 19600, 19700, 19800, 19900, 20200, 20300, 20400, 28800, 28900, and 29700 to enhance potfile reading performance.

These algorithms are the ones most commonly used in penetration testing. Enhancing them should improve the user experience.

Regarding magic constants in the code:
```C
  /**
   * Checking the signature for performance optimization
   */

  if (line_len < 64) return (PARSER_SALT_LENGTH);

  if (strncmp(line_buf, SIGNATURE_SHA512B64S, strlen (SIGNATURE_SHA512B64S))) {
    return (PARSER_SIGNATURE_UNMATCHED);
  }
```

It wasn't initially introduced by me. I just increased the already existed constants:
```C
  // assume no signature found
  if (line_len < 12) return (PARSER_SALT_LENGTH);
```

If you would like to change something, I'm ready to hear your suggestions.