### PR TITLE
Show all autotune setting changes in -b

### DIFF
--- a/src/user_options.c
+++ b/src/user_options.c
@@ -2155,20 +2155,20 @@ void user_options_info (hashcat_ctx_t *hashcat_ctx)
     {
       event_log_info (hashcat_ctx, "* --kernel-accel=%u", user_options->kernel_accel);
     }
-    else if (user_options->kernel_loops_chgd == true)
+
+    if (user_options->kernel_loops_chgd == true)
     {
       event_log_info (hashcat_ctx, "* --kernel-loops=%u", user_options->kernel_loops);
     }
-    else if (user_options->kernel_threads_chgd == true)
+
+    if (user_options->kernel_threads_chgd == true)
     {
       event_log_info (hashcat_ctx, "* --kernel-threads=%u", user_options->kernel_threads);
     }
-    else
+
+    if (user_options->workload_profile_chgd == true)
     {
-      if (user_options->workload_profile_chgd == true)
-      {
-        event_log_info (hashcat_ctx, "* --workload-profile=%u", user_options->workload_profile);
-      }
+      event_log_info (hashcat_ctx, "* --workload-profile=%u", user_options->workload_profile);
     }
 
     event_log_info (hashcat_ctx, NULL);
@@ -2219,20 +2219,20 @@ void user_options_info (hashcat_ctx_t *hashcat_ctx)
     {
       event_log_info (hashcat_ctx, "# option: --kernel-accel=%u", user_options->kernel_accel);
     }
-    else if (user_options->kernel_loops_chgd == true)
+
+    if (user_options->kernel_loops_chgd == true)
     {
       event_log_info (hashcat_ctx, "# option: --kernel-loops=%u", user_options->kernel_loops);
     }
-    else if (user_options->kernel_threads_chgd == true)
+
+    if (user_options->kernel_threads_chgd == true)
     {
       event_log_info (hashcat_ctx, "# option: --kernel-threads=%u", user_options->kernel_threads);
     }
-    else
+    
+    if (user_options->workload_profile_chgd == true)
     {
-      if (user_options->workload_profile_chgd == true)
-      {
-        event_log_info (hashcat_ctx, "# option: --workload-profile=%u", user_options->workload_profile);
-      }
+      event_log_info (hashcat_ctx, "# option: --workload-profile=%u", user_options->workload_profile);
     }
   }
 }


### PR DESCRIPTION
Previous behaviour was to only show the first autotune setting, this change makes it so it shows everything if it's changed as there's no reason to hide it and is safer to show everything that's changed.
Command:
```
$ ./hashcat.exe -m 0 -b -n 1 -u 1 -T 1 -w 4 --force
```
Previous behaviour:
```
Benchmark relevant options:
===========================
* --force
* --backend-devices-virtual=1
* --kernel-accel=1
```
This PR's behaviour:
```
Benchmark relevant options:
===========================
* --force
* --backend-devices-virtual=1
* --kernel-accel=1
* --kernel-loops=1
* --kernel-threads=1
* --workload-profile=4
```