### PR TITLE
Fix hash encoding in WinZip format

### DIFF
--- a/src/modules/module_13600.c
+++ b/src/modules/module_13600.c
@@ -383,7 +383,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     snprintf (auth_tmp + j, 3, "%02x", ptr[i]);
   }
 
-  const int line_len = snprintf (line_buf, line_size, "%s*%u*%u*%u*%s*%x*%x*%s*%s*%s",
+  const int line_len = snprintf (line_buf, line_size, "%s*%u*%u*%u*%s*%04x*%x*%s*%s*%s",
     SIGNATURE_ZIP2_START,
     zip2->type,
     zip2->mode,


### PR DESCRIPTION
Tiny improvement to easier match input and hit pair.

Before this change the following string

```
$zip2$*0*3*0*6390eadd596ee4cc9926f85f0732f64c*0e9e*31*86fcd34a933839e16f866bc3fa994d49d171cd090ef64cb8cd42c705cf1117*8439adea7f6094ef41ba*$/zip2$
```

will be encoded to

```
$zip2$*0*3*0*6390eadd596ee4cc9926f85f0732f64c*e9e*31*86fcd34a933839e16f866bc3fa994d49d171cd090ef64cb8cd42c705cf1117*8439adea7f6094ef41ba*$/zip2$
```

Due to known size of `verify_bytes` it should be prefixed with leading zeros.