### PR TITLE
Added m10510 for PDF 1.3 - 1.6 using RC4-40

### DIFF
--- a/OpenCL/m10510-pure.cl
+++ b/OpenCL/m10510-pure.cl
@@ -1,0 +1,360 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct pdf
+{
+  int V;
+  int R;
+  int P;
+
+  int enc_md;
+
+  u32 id_buf[8];
+  u32 u_buf[32];
+  u32 o_buf[32];
+
+  int id_len;
+  int o_len;
+  int u_len;
+
+  u32 rc4key[2];
+  u32 rc4data[2];
+
+  int P_minus;
+
+} pdf_t;
+
+typedef struct pdf14_tmp
+{
+  u32 digest[4];
+  u32 out[4];
+
+} pdf14_tmp_t;
+
+KERNEL_FQ void m10510_init (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  //const u64 lid = get_local_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  /**
+   * U_buf
+   */
+
+  u32 o_buf[8];
+
+  o_buf[0] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[0];
+  o_buf[1] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[1];
+  o_buf[2] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[2];
+  o_buf[3] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[3];
+  o_buf[4] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[4];
+  o_buf[5] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[5];
+  o_buf[6] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[6];
+  o_buf[7] = esalt_bufs[DIGESTS_OFFSET_HOST].o_buf[7];
+
+  u32 P = esalt_bufs[DIGESTS_OFFSET_HOST].P;
+
+  u32 id_buf[12];
+
+  id_buf[ 0] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[0];
+  id_buf[ 1] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[1];
+  id_buf[ 2] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[2];
+  id_buf[ 3] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[3];
+
+  id_buf[ 4] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[4];
+  id_buf[ 5] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[5];
+  id_buf[ 6] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[6];
+  id_buf[ 7] = esalt_bufs[DIGESTS_OFFSET_HOST].id_buf[7];
+
+  id_buf[ 8] = 0;
+  id_buf[ 9] = 0;
+  id_buf[10] = 0;
+  id_buf[11] = 0;
+
+  u32 id_len  = esalt_bufs[DIGESTS_OFFSET_HOST].id_len;
+  u32 id_len4 = id_len / 4;
+
+  u32 rc4data[2];
+
+  rc4data[0] = esalt_bufs[DIGESTS_OFFSET_HOST].rc4data[0];
+  rc4data[1] = esalt_bufs[DIGESTS_OFFSET_HOST].rc4data[1];
+
+  u32 final_length = 68 + id_len;
+
+  u32 w11 = 0x80;
+  u32 w12 = 0;
+
+  if (esalt_bufs[DIGESTS_OFFSET_HOST].enc_md != 1)
+  {
+    w11 = 0xffffffff;
+    w12 = 0x80;
+
+    final_length += 4;
+  }
+
+  id_buf[id_len4 + 0] = w11;
+  id_buf[id_len4 + 1] = w12;
+
+  /**
+   * main init
+   */
+
+  u32 w0_t[4];
+  u32 w1_t[4];
+  u32 w2_t[4];
+  u32 w3_t[4];
+
+  // max length supported by pdf11 is 32
+
+  const u32 padding[8] =
+  {
+    0x5e4ebf28,
+    0x418a754e,
+    0x564e0064,
+    0x0801faff,
+    0xb6002e2e,
+    0x803e68d0,
+    0xfea90c2f,
+    0x7a695364
+  };
+
+  w0_t[0] = padding[0];
+  w0_t[1] = padding[1];
+  w0_t[2] = padding[2];
+  w0_t[3] = padding[3];
+  w1_t[0] = padding[4];
+  w1_t[1] = padding[5];
+  w1_t[2] = padding[6];
+  w1_t[3] = padding[7];
+  w2_t[0] = 0;
+  w2_t[1] = 0;
+  w2_t[2] = 0;
+  w2_t[3] = 0;
+  w3_t[0] = 0;
+  w3_t[1] = 0;
+  w3_t[2] = 0;
+  w3_t[3] = 0;
+
+  switch_buffer_by_offset_le (w0_t, w1_t, w2_t, w3_t, pw_len);
+
+  // add password
+  // truncate at 32 is wanted, not a bug!
+  // add o_buf
+
+  w0_t[0] |= w0[0];
+  w0_t[1] |= w0[1];
+  w0_t[2] |= w0[2];
+  w0_t[3] |= w0[3];
+  w1_t[0] |= w1[0];
+  w1_t[1] |= w1[1];
+  w1_t[2] |= w1[2];
+  w1_t[3] |= w1[3];
+  w2_t[0]  = o_buf[0];
+  w2_t[1]  = o_buf[1];
+  w2_t[2]  = o_buf[2];
+  w2_t[3]  = o_buf[3];
+  w3_t[0]  = o_buf[4];
+  w3_t[1]  = o_buf[5];
+  w3_t[2]  = o_buf[6];
+  w3_t[3]  = o_buf[7];
+
+  u32 digest[4];
+
+  digest[0] = MD5M_A;
+  digest[1] = MD5M_B;
+  digest[2] = MD5M_C;
+  digest[3] = MD5M_D;
+
+  md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
+
+  w0_t[0] = P;
+  w0_t[1] = id_buf[ 0];
+  w0_t[2] = id_buf[ 1];
+  w0_t[3] = id_buf[ 2];
+  w1_t[0] = id_buf[ 3];
+  w1_t[1] = id_buf[ 4];
+  w1_t[2] = id_buf[ 5];
+  w1_t[3] = id_buf[ 6];
+  w2_t[0] = id_buf[ 7];
+  w2_t[1] = id_buf[ 8];
+  w2_t[2] = id_buf[ 9];
+  w2_t[3] = id_buf[10];
+  w3_t[0] = id_buf[11];
+  w3_t[1] = 0;
+  w3_t[2] = final_length * 8;
+  w3_t[3] = 0;
+
+  md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
+
+  tmps[gid].digest[0] = digest[0];
+  tmps[gid].digest[1] = digest[1];
+  tmps[gid].digest[2] = digest[2];
+  tmps[gid].digest[3] = digest[3];
+
+  tmps[gid].out[0] = rc4data[0];
+  tmps[gid].out[1] = rc4data[1];
+  tmps[gid].out[2] = 0;
+  tmps[gid].out[3] = 0;
+}
+
+KERNEL_FQ void m10510_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * shared
+   */
+
+  LOCAL_VK u32 S[64 * FIXED_LOCAL_SIZE];
+
+  /**
+   * loop
+   */
+
+  u32 digest[4];
+
+  digest[0] = tmps[gid].digest[0];
+  digest[1] = tmps[gid].digest[1];
+  digest[2] = tmps[gid].digest[2];
+  digest[3] = tmps[gid].digest[3];
+
+  u32 out[4];
+
+  out[0] = tmps[gid].out[0];
+  out[1] = tmps[gid].out[1];
+  out[2] = tmps[gid].out[2];
+  out[3] = tmps[gid].out[3];
+
+  for (u32 i = 0, j = LOOP_POS; i < LOOP_CNT; i++, j++)
+  {
+    if (j < 50)
+    {
+      u32 w0_t[4];
+      u32 w1_t[4];
+      u32 w2_t[4];
+      u32 w3_t[4];
+
+      w0_t[0] = digest[0];
+      w0_t[1] = 0x8000 + (digest[1] & 0xff);
+      w0_t[2] = 0;
+      w0_t[3] = 0;
+      w1_t[0] = 0;
+      w1_t[1] = 0;
+      w1_t[2] = 0;
+      w1_t[3] = 0;
+      w2_t[0] = 0;
+      w2_t[1] = 0;
+      w2_t[2] = 0;
+      w2_t[3] = 0;
+      w3_t[0] = 0;
+      w3_t[1] = 0;
+      w3_t[2] = 40;
+      w3_t[3] = 0;
+
+      digest[0] = MD5M_A;
+      digest[1] = MD5M_B;
+      digest[2] = MD5M_C;
+      digest[3] = MD5M_D;
+
+      md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
+    }
+    else
+    {
+      const u32 x = j - 50;
+
+      const u32 xv = x <<  0
+                   | x <<  8
+                   | x << 16
+                   | x << 24;
+
+      u32 tmp[2];
+
+      tmp[0] = digest[0] ^ xv;
+      tmp[1] = (digest[1] ^ xv) & 0xff;
+
+      rc4_init_40 (S, tmp, lid);
+
+      rc4_next_16 (S, 0, 0, out, out, lid);
+    }
+  }
+
+  tmps[gid].digest[0] = digest[0];
+  tmps[gid].digest[1] = digest[1] & 0xff;
+  tmps[gid].digest[2] = 0;
+  tmps[gid].digest[3] = 0;
+
+  tmps[gid].out[0] = out[0];
+  tmps[gid].out[1] = out[1];
+  tmps[gid].out[2] = out[2];
+  tmps[gid].out[3] = out[3];
+}
+
+KERNEL_FQ void m10510_comp (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * digest
+   */
+
+  const u32 r0 = tmps[gid].out[0];
+  const u32 r1 = tmps[gid].out[1];
+  const u32 r2 = 0;
+  const u32 r3 = 0;
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/OpenCL/m10510-pure.cl
+++ b/OpenCL/m10510-pure.cl
@@ -45,7 +45,7 @@ typedef struct pdf14_tmp
 
 } pdf14_tmp_t;
 
-KERNEL_FQ void m10510_init (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
+KERNEL_FQ KERNEL_FA void m10510_init (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
 {
   /**
    * base
@@ -232,7 +232,7 @@ KERNEL_FQ void m10510_init (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
   tmps[gid].out[3] = 0;
 }
 
-KERNEL_FQ void m10510_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
+KERNEL_FQ KERNEL_FA void m10510_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
 {
   /**
    * base
@@ -331,7 +331,7 @@ KERNEL_FQ void m10510_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
   tmps[gid].out[3] = out[3];
 }
 
-KERNEL_FQ void m10510_comp (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
+KERNEL_FQ KERNEL_FA void m10510_comp (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
 {
   /**
    * modifier

--- a/src/modules/module_10510.c
+++ b/src/modules/module_10510.c
@@ -1,0 +1,539 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "emu_inc_hash_md5.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_DOCUMENTS;
+static const char *HASH_NAME      = "PDF 1.3 - 1.6 (Acrobat 4 - 8) w/ RC4-40";
+static const u64   KERN_TYPE      = 10510;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$pdf$1*3*40*-4*1*16*5e1f73575e1f73575e1f73575e1f7357*32*c0be424bef466277092f2a1ba0fbe506ebabe5c01db100dedc0ffeebabe5c01d*32*0ff1cedeadce110ff1cedeadce110ff1cedeadce110ff1cedeadce11babebabe";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct pdf
+{
+  int V;
+  int R;
+  int P;
+
+  int enc_md;
+
+  u32 id_buf[8];
+  u32 u_buf[32];
+  u32 o_buf[32];
+
+  int id_len;
+  int o_len;
+  int u_len;
+
+  u32 rc4key[2];
+  u32 rc4data[2];
+
+  int P_minus;
+
+} pdf_t;
+
+typedef struct pdf14_tmp
+{
+  u32 digest[4];
+  u32 out[4];
+
+} pdf14_tmp_t;
+
+static const char *SIGNATURE_PDF = "$pdf$";
+
+static void md5_complete_no_limit (u32 digest[4], const u32 *plain, const u32 plain_len)
+{
+  // plain = u32 tmp_md5_buf[64] so this is compatible
+
+  md5_ctx_t md5_ctx;
+
+  md5_init (&md5_ctx);
+  md5_update (&md5_ctx, plain, plain_len);
+  md5_final (&md5_ctx);
+
+  digest[0] = md5_ctx.h[0];
+  digest[1] = md5_ctx.h[1];
+  digest[2] = md5_ctx.h[2];
+  digest[3] = md5_ctx.h[3];
+}
+
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  char *jit_build_options = NULL;
+
+  u32 native_threads = 0;
+
+  if (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU)
+  {
+    native_threads = 1;
+  }
+  else if (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU)
+  {
+    #if defined (__APPLE__)
+
+    native_threads = 32;
+
+    #else
+
+    if (device_param->device_local_mem_size < 49152)
+    {
+      native_threads = MIN (device_param->kernel_preferred_wgs_multiple, 32); // We can't just set 32, because Intel GPU need 8
+    }
+    else
+    {
+      native_threads = device_param->kernel_preferred_wgs_multiple;
+    }
+
+    #endif
+  }
+
+  hc_asprintf (&jit_build_options, "-D FIXED_LOCAL_SIZE=%u -D _unroll", native_threads);
+
+  return jit_build_options;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (pdf_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (pdf14_tmp_t);
+
+  return tmp_size;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 pw_max = 32; // https://www.pdflib.com/knowledge-base/pdf-password-security/encryption/
+
+  return pw_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  pdf_t *pdf = (pdf_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 12;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_PDF;
+
+  token.len[0]     = 5;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '*';
+  token.len[1]     = 1;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[2]     = '*';
+  token.len[2]     = 1;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[3]     = '*';
+  token.len[3]     = 2;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[4]     = '*';
+  token.len_min[4] = 1;
+  token.len_max[4] = 11;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  token.sep[5]     = '*';
+  token.len[5]     = 1;
+  token.attr[5]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[6]     = '*';
+  token.len[6]     = 2;
+  token.attr[6]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[7]     = '*';
+  token.len_min[7] = 32;
+  token.len_max[7] = 64;
+  token.attr[7]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[8]     = '*';
+  token.len[8]     = 2;
+  token.attr[8]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[9]     = '*';
+  token.len[9]     = 64;
+  token.attr[9]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[10]    = '*';
+  token.len[10]    = 2;
+  token.attr[10]   = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[11]    = '*';
+  token.len[11]    = 64;
+  token.attr[11]   = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *V_pos      = token.buf[1];
+  const u8 *R_pos      = token.buf[2];
+  const u8 *bits_pos   = token.buf[3];
+  const u8 *P_pos      = token.buf[4];
+  const u8 *enc_md_pos = token.buf[5];
+  const u8 *id_len_pos = token.buf[6];
+  const u8 *id_buf_pos = token.buf[7];
+  const u8 *u_len_pos  = token.buf[8];
+  const u8 *u_buf_pos  = token.buf[9];
+  const u8 *o_len_pos  = token.buf[10];
+  const u8 *o_buf_pos  = token.buf[11];
+
+  // validate data
+
+  pdf->P_minus = 0;
+
+  if (P_pos[0] == 0x2d) pdf->P_minus = 1;
+
+  const int V = strtol ((const char *) V_pos, NULL, 10);
+  const int R = strtol ((const char *) R_pos, NULL, 10);
+  const int P = strtol ((const char *) P_pos, NULL, 10);
+
+  int vr_ok = 0;
+
+  if ((V == 1 || V == 2) && (R == 3)) vr_ok = 1;
+  if ((V == 4) && (R == 4)) vr_ok = 1;
+
+  if (vr_ok == 0) return (PARSER_SALT_VALUE);
+
+  const int id_len = strtol ((const char *) id_len_pos, NULL, 10);
+  const int u_len  = strtol ((const char *) u_len_pos,  NULL, 10);
+  const int o_len  = strtol ((const char *) o_len_pos,  NULL, 10);
+
+  if ((id_len != 16) && (id_len != 32)) return (PARSER_SALT_VALUE);
+
+  if (u_len != 32) return (PARSER_SALT_VALUE);
+  if (o_len != 32) return (PARSER_SALT_VALUE);
+
+  const int bits = strtol ((const char *) bits_pos, NULL, 10);
+
+  if (bits != 40) return (PARSER_SALT_VALUE);
+
+  int enc_md = 1;
+
+  if (R >= 4)
+  {
+    enc_md = strtol ((const char *) enc_md_pos, NULL, 10);
+  }
+
+  // copy data to esalt
+
+  pdf->V = V;
+  pdf->R = R;
+  pdf->P = P;
+
+  pdf->enc_md = enc_md;
+
+  pdf->id_buf[0] = hex_to_u32 (id_buf_pos +  0);
+  pdf->id_buf[1] = hex_to_u32 (id_buf_pos +  8);
+  pdf->id_buf[2] = hex_to_u32 (id_buf_pos + 16);
+  pdf->id_buf[3] = hex_to_u32 (id_buf_pos + 24);
+
+  if (id_len == 32)
+  {
+    pdf->id_buf[4] = hex_to_u32 (id_buf_pos + 32);
+    pdf->id_buf[5] = hex_to_u32 (id_buf_pos + 40);
+    pdf->id_buf[6] = hex_to_u32 (id_buf_pos + 48);
+    pdf->id_buf[7] = hex_to_u32 (id_buf_pos + 56);
+  }
+
+  pdf->id_len = id_len;
+
+  pdf->u_buf[0]  = hex_to_u32 (u_buf_pos +  0);
+  pdf->u_buf[1]  = hex_to_u32 (u_buf_pos +  8);
+  pdf->u_buf[2]  = hex_to_u32 (u_buf_pos + 16);
+  pdf->u_buf[3]  = hex_to_u32 (u_buf_pos + 24);
+  pdf->u_buf[4]  = hex_to_u32 (u_buf_pos + 32);
+  pdf->u_buf[5]  = hex_to_u32 (u_buf_pos + 40);
+  pdf->u_buf[6]  = hex_to_u32 (u_buf_pos + 48);
+  pdf->u_buf[7]  = hex_to_u32 (u_buf_pos + 56);
+  pdf->u_len     = u_len;
+
+  pdf->o_buf[0]  = hex_to_u32 (o_buf_pos +  0);
+  pdf->o_buf[1]  = hex_to_u32 (o_buf_pos +  8);
+  pdf->o_buf[2]  = hex_to_u32 (o_buf_pos + 16);
+  pdf->o_buf[3]  = hex_to_u32 (o_buf_pos + 24);
+  pdf->o_buf[4]  = hex_to_u32 (o_buf_pos + 32);
+  pdf->o_buf[5]  = hex_to_u32 (o_buf_pos + 40);
+  pdf->o_buf[6]  = hex_to_u32 (o_buf_pos + 48);
+  pdf->o_buf[7]  = hex_to_u32 (o_buf_pos + 56);
+  pdf->o_len     = o_len;
+
+  // precompute rc4 data for later use
+
+  u32 padding[8] =
+  {
+    0x5e4ebf28,
+    0x418a754e,
+    0x564e0064,
+    0x0801faff,
+    0xb6002e2e,
+    0x803e68d0,
+    0xfea90c2f,
+    0x7a695364
+  };
+
+  // md5
+
+  u32 salt_pc_block[32] = { 0 };
+
+  u8 *salt_pc_ptr = (u8 *) salt_pc_block;
+
+  memcpy (salt_pc_ptr, padding, 32);
+  memcpy (salt_pc_ptr + 32, pdf->id_buf, pdf->id_len);
+
+  u32 salt_pc_digest[4] = { 0 };
+
+  md5_complete_no_limit (salt_pc_digest, salt_pc_block, 32 + pdf->id_len);
+
+  pdf->rc4data[0] = salt_pc_digest[0];
+  pdf->rc4data[1] = salt_pc_digest[1];
+
+  // we use ID for salt, maybe needs to change, we will see...
+
+  salt->salt_buf[0] = pdf->id_buf[0];
+  salt->salt_buf[1] = pdf->id_buf[1];
+  salt->salt_buf[2] = pdf->id_buf[2];
+  salt->salt_buf[3] = pdf->id_buf[3];
+  salt->salt_buf[4] = pdf->u_buf[0];
+  salt->salt_buf[5] = pdf->u_buf[1];
+  salt->salt_buf[6] = pdf->o_buf[0];
+  salt->salt_buf[7] = pdf->o_buf[1];
+  salt->salt_len    = pdf->id_len + 16;
+
+  salt->salt_iter   = (50 + 20);
+
+  digest[0] = pdf->u_buf[0];
+  digest[1] = pdf->u_buf[1];
+  digest[2] = 0;
+  digest[3] = 0;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const pdf_t *pdf = (const pdf_t *) esalt_buf;
+
+  int line_len = 0;
+
+  if (pdf->id_len == 32)
+  {
+    const char *line_format = "$pdf$%d*%d*%d*%u*%d*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x";
+
+    if (pdf->P_minus == 1) line_format = "$pdf$%d*%d*%d*%d*%d*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x";
+
+    line_len = snprintf (line_buf, line_size, line_format,
+      pdf->V,
+      pdf->R,
+      40,
+      pdf->P,
+      pdf->enc_md,
+      pdf->id_len,
+      byte_swap_32 (pdf->id_buf[0]),
+      byte_swap_32 (pdf->id_buf[1]),
+      byte_swap_32 (pdf->id_buf[2]),
+      byte_swap_32 (pdf->id_buf[3]),
+      byte_swap_32 (pdf->id_buf[4]),
+      byte_swap_32 (pdf->id_buf[5]),
+      byte_swap_32 (pdf->id_buf[6]),
+      byte_swap_32 (pdf->id_buf[7]),
+      pdf->u_len,
+      byte_swap_32 (pdf->u_buf[0]),
+      byte_swap_32 (pdf->u_buf[1]),
+      byte_swap_32 (pdf->u_buf[2]),
+      byte_swap_32 (pdf->u_buf[3]),
+      byte_swap_32 (pdf->u_buf[4]),
+      byte_swap_32 (pdf->u_buf[5]),
+      byte_swap_32 (pdf->u_buf[6]),
+      byte_swap_32 (pdf->u_buf[7]),
+      pdf->o_len,
+      byte_swap_32 (pdf->o_buf[0]),
+      byte_swap_32 (pdf->o_buf[1]),
+      byte_swap_32 (pdf->o_buf[2]),
+      byte_swap_32 (pdf->o_buf[3]),
+      byte_swap_32 (pdf->o_buf[4]),
+      byte_swap_32 (pdf->o_buf[5]),
+      byte_swap_32 (pdf->o_buf[6]),
+      byte_swap_32 (pdf->o_buf[7])
+    );
+  }
+  else
+  {
+    const char *line_format = "$pdf$%d*%d*%d*%u*%d*%d*%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x";
+
+    if (pdf->P_minus == 1) line_format = "$pdf$%d*%d*%d*%d*%d*%d*%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x%08x%08x%08x%08x";
+
+    line_len = snprintf (line_buf, line_size, line_format,
+      pdf->V,
+      pdf->R,
+      40,
+      pdf->P,
+      pdf->enc_md,
+      pdf->id_len,
+      byte_swap_32 (pdf->id_buf[0]),
+      byte_swap_32 (pdf->id_buf[1]),
+      byte_swap_32 (pdf->id_buf[2]),
+      byte_swap_32 (pdf->id_buf[3]),
+      pdf->u_len,
+      byte_swap_32 (pdf->u_buf[0]),
+      byte_swap_32 (pdf->u_buf[1]),
+      byte_swap_32 (pdf->u_buf[2]),
+      byte_swap_32 (pdf->u_buf[3]),
+      byte_swap_32 (pdf->u_buf[4]),
+      byte_swap_32 (pdf->u_buf[5]),
+      byte_swap_32 (pdf->u_buf[6]),
+      byte_swap_32 (pdf->u_buf[7]),
+      pdf->o_len,
+      byte_swap_32 (pdf->o_buf[0]),
+      byte_swap_32 (pdf->o_buf[1]),
+      byte_swap_32 (pdf->o_buf[2]),
+      byte_swap_32 (pdf->o_buf[3]),
+      byte_swap_32 (pdf->o_buf[4]),
+      byte_swap_32 (pdf->o_buf[5]),
+      byte_swap_32 (pdf->o_buf[6]),
+      byte_swap_32 (pdf->o_buf[7])
+    );
+  }
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_10510.c
+++ b/src/modules/module_10510.c
@@ -469,6 +469,8 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
   module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
   module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;  
   module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
   module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
   module_ctx->module_deprecated_notice        = MODULE_DEFAULT;


### PR DESCRIPTION
Fixes #4047 

<s>Note: Self-test missing because I couldn't find nor produce a PDF for making one.</s>The posted test vector is a mockup but the format is tested on a real '`$pdf$1*3*40*`' document and cracked it just fine. 

This is based on 10500 (diffing against its files shows the changes are minimal).