### PR TITLE
Added Node Express cookie-session middleware module

### DIFF
--- a/OpenCL/m90901_a0-pure.cl
+++ b/OpenCL/m90901_a0-pure.cl
@@ -1,0 +1,126 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90901_mxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha256_hmac_ctx_t ctx;
+
+    sha256_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha256_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha256_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90901_sxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha256_hmac_ctx_t ctx;
+
+    sha256_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha256_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha256_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90901_a1-pure.cl
+++ b/OpenCL/m90901_a1-pure.cl
@@ -1,0 +1,174 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90901_mxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha256_hmac_ctx_t ctx;
+
+    sha256_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha256_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha256_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90901_sxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha256_hmac_ctx_t ctx;
+
+    sha256_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha256_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha256_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90901_a3-pure.cl
+++ b/OpenCL/m90901_a3-pure.cl
@@ -1,0 +1,146 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90901_mxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha256_hmac_ctx_t ctx;
+
+    sha256_hmac_init (&ctx, w, pw_len);
+
+    sha256_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha256_hmac_final (&ctx);
+
+    const u32x r0 = ctx.opad.h[DGST_R0];
+    const u32x r1 = ctx.opad.h[DGST_R1];
+    const u32x r2 = ctx.opad.h[DGST_R2];
+    const u32x r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90901_sxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha256_hmac_ctx_t ctx;
+
+    sha256_hmac_init (&ctx, w, pw_len);
+
+    sha256_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha256_hmac_final (&ctx);
+
+    const u32x r0 = ctx.opad.h[DGST_R0];
+    const u32x r1 = ctx.opad.h[DGST_R1];
+    const u32x r2 = ctx.opad.h[DGST_R2];
+    const u32x r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90902_a0-pure.cl
+++ b/OpenCL/m90902_a0-pure.cl
@@ -1,0 +1,126 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha384.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90902_mxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha384_hmac_ctx_t ctx;
+
+    sha384_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha384_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha384_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90902_sxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha384_hmac_ctx_t ctx;
+
+    sha384_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha384_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha384_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90902_a1-pure.cl
+++ b/OpenCL/m90902_a1-pure.cl
@@ -1,0 +1,174 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha384.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90902_mxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha384_hmac_ctx_t ctx;
+
+    sha384_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha384_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha384_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90902_sxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha384_hmac_ctx_t ctx;
+
+    sha384_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha384_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha384_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90902_a3-pure.cl
+++ b/OpenCL/m90902_a3-pure.cl
@@ -1,0 +1,146 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha384.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90902_mxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha384_hmac_ctx_t ctx;
+
+    sha384_hmac_init (&ctx, w, pw_len);
+
+    sha384_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha384_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90902_sxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha384_hmac_ctx_t ctx;
+
+    sha384_hmac_init (&ctx, w, pw_len);
+
+    sha384_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha384_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90903_a0-pure.cl
+++ b/OpenCL/m90903_a0-pure.cl
@@ -1,0 +1,126 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90903_mxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha512_hmac_ctx_t ctx;
+
+    sha512_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha512_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha512_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90903_sxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha512_hmac_ctx_t ctx;
+
+    sha512_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha512_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha512_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90903_a1-pure.cl
+++ b/OpenCL/m90903_a1-pure.cl
@@ -1,0 +1,174 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90903_mxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha512_hmac_ctx_t ctx;
+
+    sha512_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha512_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha512_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90903_sxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha512_hmac_ctx_t ctx;
+
+    sha512_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha512_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha512_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90903_a3-pure.cl
+++ b/OpenCL/m90903_a3-pure.cl
@@ -1,0 +1,146 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90903_mxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha512_hmac_ctx_t ctx;
+
+    sha512_hmac_init (&ctx, w, pw_len);
+
+    sha512_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha512_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90903_sxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha512_hmac_ctx_t ctx;
+
+    sha512_hmac_init (&ctx, w, pw_len);
+
+    sha512_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha512_hmac_final (&ctx);
+
+    const u32x r0 = l32_from_64 (ctx.opad.h[0]);
+    const u32x r1 = h32_from_64 (ctx.opad.h[0]);
+    const u32x r2 = l32_from_64 (ctx.opad.h[1]);
+    const u32x r3 = h32_from_64 (ctx.opad.h[1]);
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90904_a0-pure.cl
+++ b/OpenCL/m90904_a0-pure.cl
@@ -1,0 +1,126 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha224.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90904_mxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha224_hmac_ctx ctx;
+
+    sha224_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha224_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha224_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90904_sxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha224_hmac_ctx_t ctx;
+
+    sha224_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha224_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha224_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90904_a1-pure.cl
+++ b/OpenCL/m90904_a1-pure.cl
@@ -1,0 +1,174 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha224.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90904_mxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha224_hmac_ctx_t ctx;
+
+    sha224_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha224_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha224_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90904_sxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha224_hmac_ctx_t ctx;
+
+    sha224_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha224_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha224_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90904_a3-pure.cl
+++ b/OpenCL/m90904_a3-pure.cl
@@ -1,0 +1,146 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha224.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90904_mxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha224_hmac_ctx_t ctx;
+
+    sha224_hmac_init (&ctx, w, pw_len);
+
+    sha224_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha224_hmac_final (&ctx);
+
+    const u32x r0 = ctx.opad.h[DGST_R0];
+    const u32x r1 = ctx.opad.h[DGST_R1];
+    const u32x r2 = ctx.opad.h[DGST_R2];
+    const u32x r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90904_sxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha224_hmac_ctx_t ctx;
+
+    sha224_hmac_init (&ctx, w, pw_len);
+
+    sha224_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha224_hmac_final (&ctx);
+
+    const u32x r0 = ctx.opad.h[DGST_R0];
+    const u32x r1 = ctx.opad.h[DGST_R1];
+    const u32x r2 = ctx.opad.h[DGST_R2];
+    const u32x r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90905_a0-pure.cl
+++ b/OpenCL/m90905_a0-pure.cl
@@ -1,0 +1,126 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90905_mxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_hmac_ctx_t ctx;
+
+    sha1_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha1_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90905_sxx (KERN_ATTR_RULES_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    sha1_hmac_ctx_t ctx;
+
+    sha1_hmac_init_swap (&ctx, tmp.i, tmp.pw_len);
+
+    sha1_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha1_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90905_a1-pure.cl
+++ b/OpenCL/m90905_a1-pure.cl
@@ -1,0 +1,174 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90905_mxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha1_hmac_ctx_t ctx;
+
+    sha1_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha1_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha1_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90905_sxx (KERN_ATTR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (pws[gid].i[idx]);
+  }
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+
+    u32 c[64];
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int idx = 0; idx < 64; idx++)
+    {
+      c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
+    }
+
+    switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+    #ifdef _unroll
+    #pragma unroll
+    #endif
+    for (int i = 0; i < 64; i++)
+    {
+      c[i] |= w[i];
+    }
+
+    sha1_hmac_ctx_t ctx;
+
+    sha1_hmac_init (&ctx, c, pw_len + comb_len);
+
+    sha1_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha1_hmac_final (&ctx);
+
+    const u32 r0 = ctx.opad.h[DGST_R0];
+    const u32 r1 = ctx.opad.h[DGST_R1];
+    const u32 r2 = ctx.opad.h[DGST_R2];
+    const u32 r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m90905_a3-pure.cl
+++ b/OpenCL/m90905_a3-pure.cl
@@ -1,0 +1,146 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+KERNEL_FQ void m90905_mxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_hmac_ctx_t ctx;
+
+    sha1_hmac_init (&ctx, w, pw_len);
+
+    sha1_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha1_hmac_final (&ctx);
+
+    const u32x r0 = ctx.opad.h[DGST_R0];
+    const u32x r1 = ctx.opad.h[DGST_R1];
+    const u32x r2 = ctx.opad.h[DGST_R2];
+    const u32x r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m90905_sxx (KERN_ATTR_VECTOR_ESALT (express_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    sha1_hmac_ctx_t ctx;
+
+    sha1_hmac_init (&ctx, w, pw_len);
+
+    sha1_hmac_update_global_swap (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+    sha1_hmac_final (&ctx);
+
+    const u32x r0 = ctx.opad.h[DGST_R0];
+    const u32x r1 = ctx.opad.h[DGST_R1];
+    const u32x r2 = ctx.opad.h[DGST_R2];
+    const u32x r3 = ctx.opad.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/src/modules/module_90909.c
+++ b/src/modules/module_90909.c
@@ -1,0 +1,471 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "emu_inc_hash_md5.h"
+#include "memory.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_16;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "ExpressJS";
+static const u64   KERN_TYPE      = 90901;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_BE
+                                  | OPTS_TYPE_SELF_TEST_DISABLE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "session=eyJjc3JmU2VjcmV0IjoidHdVWklTdDZIWUJRTjlrdEdCQmdfWnVaIiwiZmxhc2giOnt9fQ==$5LgP0U6ix4Bt1zT6NfmfVFknlyk";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct express
+{
+  u32 salt_buf[1024];
+  u32 salt_len;
+
+  u32 signature_len;
+
+} express_t;
+
+typedef enum kern_type_express
+{
+  KERN_TYPE_EXPRESS_HS256 = 90901,
+  KERN_TYPE_EXPRESS_HS384 = 90902,
+  KERN_TYPE_EXPRESS_HS512 = 90903,
+  KERN_TYPE_EXPRESS_HS224 = 90904,
+  KERN_TYPE_EXPRESS_HS1 = 90905,
+
+} kern_type_express_t;
+
+salt_t *module_benchmark_salt (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  salt_t *salt = (salt_t *) hcmalloc (sizeof (salt_t));
+
+  salt->salt_iter = 1;
+  salt->salt_len  = 16;
+
+  return salt;
+}
+
+void *module_benchmark_esalt (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  express_t *express = (express_t *) hcmalloc (sizeof (express_t));
+
+  express->signature_len = 27;
+  express->salt_len      = 32;
+
+  return express;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (express_t);
+
+  return esalt_size;
+}
+
+u64 module_kern_type_dynamic (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info)
+{
+  const express_t *express = (const express_t *) esalt_buf;
+
+  u64 kern_type = -1;
+
+  if (express->signature_len == 27)
+  {
+    kern_type = KERN_TYPE_EXPRESS_HS1;
+  }
+  else if (express->signature_len == 38)
+  {
+    kern_type = KERN_TYPE_EXPRESS_HS224;
+  }
+  else if (express->signature_len == 43)
+  {
+    kern_type = KERN_TYPE_EXPRESS_HS256;
+  }
+  else if (express->signature_len == 64)
+  {
+    kern_type = KERN_TYPE_EXPRESS_HS384;
+  }
+  else if (express->signature_len == 86)
+  {
+    kern_type = KERN_TYPE_EXPRESS_HS512;
+  }
+  else
+  {
+    return (PARSER_HASH_LENGTH);
+  }
+
+  return kern_type;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  express_t *express = (express_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 2;
+
+  token.sep[0]     = '$';
+  token.len_min[0] = 1;
+  token.len_max[0] = 2047;
+  token.attr[0]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  token.sep[1]     = '$';
+  token.len_min[1] = 27;
+  token.len_max[1] = 86;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64C;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // payload
+
+  const int payload_len = token.len[0];
+
+  // signature
+
+  const u8 *signature_pos = token.buf[1];
+  const int signature_len = token.len[1];
+
+  express->signature_len = signature_len;
+
+  // esalt
+
+  const int esalt_len = payload_len;
+
+  if (esalt_len > 4096) return (PARSER_SALT_LENGTH);
+
+  memcpy (express->salt_buf, line_buf, esalt_len);
+
+  express->salt_len = esalt_len;
+
+  // salt
+  //
+  // Create a hash of the esalt because esalt buffer can change somewhere behind salt->salt_buf size
+  // Not a regular MD5 but good enough
+
+  u32 hash[4];
+
+  hash[0] = 0;
+  hash[1] = 1;
+  hash[2] = 2;
+  hash[3] = 3;
+
+  u32 block[16];
+
+  memset (block, 0, sizeof (block));
+
+  for (int i = 0; i < 1024; i += 16)
+  {
+    for (int j = 0; j < 16; j++)
+    {
+      block[j] = express->salt_buf[i + j];
+
+      md5_transform (block + 0, block + 4, block + 8, block + 12, hash);
+    }
+  }
+
+  salt->salt_buf[0] = hash[0];
+  salt->salt_buf[1] = hash[1];
+  salt->salt_buf[2] = hash[2];
+  salt->salt_buf[3] = hash[3];
+
+  salt->salt_len = 16;
+
+  // hash
+
+  u8 tmp_buf[100] = { 0 };
+
+  base64_decode (base64url_to_int, signature_pos, signature_len, tmp_buf);
+
+  if (signature_len == 27)
+  {
+    memcpy (digest_buf, tmp_buf, 20);
+
+    u32 *digest = (u32 *) digest_buf;
+
+    digest[0] = byte_swap_32 (digest[0]);
+    digest[1] = byte_swap_32 (digest[1]);
+    digest[2] = byte_swap_32 (digest[2]);
+    digest[3] = byte_swap_32 (digest[3]);
+    digest[4] = byte_swap_32 (digest[4]);
+  }
+  else if (signature_len == 38)
+  {
+    memcpy (digest_buf, tmp_buf, 32);
+
+    u32 *digest = (u32 *) digest_buf;
+
+    digest[0] = byte_swap_32 (digest[0]);
+    digest[1] = byte_swap_32 (digest[1]);
+    digest[2] = byte_swap_32 (digest[2]);
+    digest[3] = byte_swap_32 (digest[3]);
+    digest[4] = byte_swap_32 (digest[4]);
+    digest[5] = byte_swap_32 (digest[5]);
+    digest[6] = byte_swap_32 (digest[6]);
+  }
+  else if (signature_len == 43)
+  {
+    memcpy (digest_buf, tmp_buf, 32);
+
+    u32 *digest = (u32 *) digest_buf;
+
+    digest[0] = byte_swap_32 (digest[0]);
+    digest[1] = byte_swap_32 (digest[1]);
+    digest[2] = byte_swap_32 (digest[2]);
+    digest[3] = byte_swap_32 (digest[3]);
+    digest[4] = byte_swap_32 (digest[4]);
+    digest[5] = byte_swap_32 (digest[5]);
+    digest[6] = byte_swap_32 (digest[6]);
+    digest[7] = byte_swap_32 (digest[7]);
+  }
+  else if (signature_len == 64)
+  {
+    memcpy (digest_buf, tmp_buf, 48);
+
+    u64 *digest = (u64 *) digest_buf;
+
+    digest[0] = byte_swap_64 (digest[0]);
+    digest[1] = byte_swap_64 (digest[1]);
+    digest[2] = byte_swap_64 (digest[2]);
+    digest[3] = byte_swap_64 (digest[3]);
+    digest[4] = byte_swap_64 (digest[4]);
+    digest[5] = byte_swap_64 (digest[5]);
+  }
+  else if (signature_len == 86)
+  {
+    memcpy (digest_buf, tmp_buf, 64);
+
+    u64 *digest = (u64 *) digest_buf;
+
+    digest[0] = byte_swap_64 (digest[0]);
+    digest[1] = byte_swap_64 (digest[1]);
+    digest[2] = byte_swap_64 (digest[2]);
+    digest[3] = byte_swap_64 (digest[3]);
+    digest[4] = byte_swap_64 (digest[4]);
+    digest[5] = byte_swap_64 (digest[5]);
+    digest[6] = byte_swap_64 (digest[6]);
+    digest[7] = byte_swap_64 (digest[7]);
+  }
+
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const express_t *express = (const express_t *) esalt_buf;
+
+  const u32 *digest32 = (const u32 *) digest_buf;
+  const u64 *digest64 = (const u64 *) digest_buf;
+
+  char tmp_buf[128] = { 0 };
+
+  char ptr_plain[128];
+
+  if (express->signature_len == 27)
+  {
+    u32 tmp[5];
+
+    tmp[0] = byte_swap_32 (digest32[0]);
+    tmp[1] = byte_swap_32 (digest32[1]);
+    tmp[2] = byte_swap_32 (digest32[2]);
+    tmp[3] = byte_swap_32 (digest32[3]);
+    tmp[4] = byte_swap_32 (digest32[4]);
+
+    memcpy (tmp_buf, tmp, 20);
+
+    base64_encode (int_to_base64url, (const u8 *) tmp_buf, 20, (u8 *) ptr_plain);
+
+    ptr_plain[27] = 0;
+  }
+  else if (express->signature_len == 38)
+  {
+    u32 tmp[7];
+
+    tmp[0] = byte_swap_32 (digest32[0]);
+    tmp[1] = byte_swap_32 (digest32[1]);
+    tmp[2] = byte_swap_32 (digest32[2]);
+    tmp[3] = byte_swap_32 (digest32[3]);
+    tmp[4] = byte_swap_32 (digest32[4]);
+    tmp[5] = byte_swap_32 (digest32[5]);
+    tmp[6] = byte_swap_32 (digest32[6]);
+
+    memcpy (tmp_buf, tmp, 28);
+
+    base64_encode (int_to_base64url, (const u8 *) tmp_buf, 32, (u8 *) ptr_plain);
+
+    ptr_plain[38] = 0;
+  }
+  else if (express->signature_len == 43)
+  {
+    u32 tmp[8];
+
+    tmp[0] = byte_swap_32 (digest32[0]);
+    tmp[1] = byte_swap_32 (digest32[1]);
+    tmp[2] = byte_swap_32 (digest32[2]);
+    tmp[3] = byte_swap_32 (digest32[3]);
+    tmp[4] = byte_swap_32 (digest32[4]);
+    tmp[5] = byte_swap_32 (digest32[5]);
+    tmp[6] = byte_swap_32 (digest32[6]);
+    tmp[7] = byte_swap_32 (digest32[7]);
+
+    memcpy (tmp_buf, tmp, 32);
+
+    base64_encode (int_to_base64url, (const u8 *) tmp_buf, 32, (u8 *) ptr_plain);
+
+    ptr_plain[43] = 0;
+  }
+  else if (express->signature_len == 64)
+  {
+    u64 tmp[6];
+
+    tmp[0] = byte_swap_64 (digest64[0]);
+    tmp[1] = byte_swap_64 (digest64[1]);
+    tmp[2] = byte_swap_64 (digest64[2]);
+    tmp[3] = byte_swap_64 (digest64[3]);
+    tmp[4] = byte_swap_64 (digest64[4]);
+    tmp[5] = byte_swap_64 (digest64[5]);
+
+    memcpy (tmp_buf, tmp, 48);
+
+    base64_encode (int_to_base64url, (const u8 *) tmp_buf, 48, (u8 *) ptr_plain);
+
+    ptr_plain[64] = 0;
+  }
+  else if (express->signature_len == 86)
+  {
+    u64 tmp[8];
+
+    tmp[0] = byte_swap_64 (digest64[0]);
+    tmp[1] = byte_swap_64 (digest64[1]);
+    tmp[2] = byte_swap_64 (digest64[2]);
+    tmp[3] = byte_swap_64 (digest64[3]);
+    tmp[4] = byte_swap_64 (digest64[4]);
+    tmp[5] = byte_swap_64 (digest64[5]);
+    tmp[6] = byte_swap_64 (digest64[6]);
+    tmp[7] = byte_swap_64 (digest64[7]);
+
+    memcpy (tmp_buf, tmp, 64);
+
+    base64_encode (int_to_base64url, (const u8 *) tmp_buf, 64, (u8 *) ptr_plain);
+
+    ptr_plain[86] = 0;
+  }
+
+  const int line_len = snprintf (line_buf, line_size, "%s.%s", (const char *) express->salt_buf, (const char *) ptr_plain);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = module_benchmark_esalt;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = module_benchmark_salt;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = module_kern_type_dynamic;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m90909.pm
+++ b/tools/test_modules/m90909.pm
@@ -47,7 +47,7 @@ sub module_generate_hash
     die "not supported hash\n";
   }
 
-  my $hash = sprintf ("%s$%s", $payload, encode_base64url ($digest, ""));
+  my $hash = sprintf("%s\$%s", $payload, encode_base64url($digest));
 
   return $hash;
 }

--- a/tools/test_modules/m90909.pm
+++ b/tools/test_modules/m90909.pm
@@ -1,0 +1,114 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA  qw (sha256 sha384 sha512);
+use Digest::HMAC qw (hmac);
+use MIME::Base64 qw (encode_base64url decode_base64url);
+use JSON         qw (encode_json decode_json);
+
+sub module_constraints { [[0, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift || get_random_express_salt ();
+
+  my ($header_base64, $payload) = split (/\./, $salt);
+
+  my $header_express = decode_base64url ($header_base64);
+
+  my $header = decode_json ($header_express);
+
+  my $alg = $header->{"alg"};
+
+  my $digest;
+
+  if ($alg eq "HS256")
+  {
+    $digest = hmac ($payload, $word, \&sha256, 64);
+  }
+  elsif ($alg eq "HS384")
+  {
+    $digest = hmac ($payload, $word, \&sha384, 128);
+  }
+  elsif ($alg eq "HS512")
+  {
+    $digest = hmac ($payload, $word, \&sha512, 128);
+  }
+  else
+  {
+    die "not supported hash\n";
+  }
+
+  my $hash = sprintf ("%s$%s", $payload, encode_base64url ($digest, ""));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @data = split (/\$/, $hash);
+
+  return unless scalar @data == 2;
+
+  my ($salt, $signature) = @data;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt);
+
+  return ($new_hash, $word);
+}
+
+sub get_random_express_salt
+{
+    my @hashes =
+  (
+    "HS256",
+    "HS384", 
+    "HS512", 
+  );
+
+  my $rnd = random_number (0, scalar @hashes - 1);
+
+  my $hash = $hashes[$rnd];
+
+  my $header =
+  {
+    "alg" => $hash
+  };
+
+  my $random_key = random_number (1, 100000000);
+  my $random_val = random_number (1, 100000000);
+
+  my $payload =
+  {
+    $random_key => $random_val
+  };
+
+  my $header_json    = encode_json ($header);
+  my $header_base64  = encode_base64url ($header_json, "");
+
+  my $cookie         = "session";
+  my $payload_json   = encode_json ($payload);
+
+  my $payload_base64 = encode_base64url ($payload_json, "");
+
+  return $header_base64 . "." . $cookie . "=" . $payload_base64;
+}
+
+1;


### PR DESCRIPTION
Hello!

This PR is for the Node js Express cookie-session middleware (keygrip). Functionally is same as JWT with extra support of the SHA-1 and SHA-224 hmac functions. Since the hash is stored separately from the message, I used the $ char as a separator, although you can use any symbol not included in base64.

 I've never written in Perl before but if its something thats required on my end just let me know and I'll see what I can do!

Cheers