### PR TITLE
Fixed memory leaks in tuning_db_init in tuningdb.c

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -95,6 +95,7 @@
 - Fixed keys extraction in luks2hashcat - now extracts all active keys
 - Fixed maximum password length in module/test_module of hash-mode 2400
 - Fixed maximum password length in module/test_module of hash-mode 2410
+- Fixed memory leaks in tuning_db_init in tuningdb.c
 - Fixed minimum password length in module of hash-mode 28200
 - Fixed minimum password length in module of hash-mode 29800
 - Fixed out-of-boundary read when a fast hash defines a kernel_loops_min value higher than the amplifiers provided by the user

--- a/src/tuningdb.c
+++ b/src/tuningdb.c
@@ -72,6 +72,8 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
   char **tuning_db_files = scan_directory (tuning_db_folder);
 
+  hcfree (tuning_db_folder);
+
   for (int i = 0; tuning_db_files[i] != NULL; i++)
   {
     char *tuning_db_file = tuning_db_files[i];
@@ -80,15 +82,27 @@ int tuning_db_init (hashcat_ctx_t *hashcat_ctx)
 
     const size_t dblen = strlen (tuning_db_file);
 
-    if (dblen < suflen) continue; // make sure to not do any out-of-boundary reads
+    if (dblen < suflen)
+    {
+      hcfree (tuning_db_file);
 
-    if (memcmp (tuning_db_file + dblen - suflen, TUNING_DB_SUFFIX, suflen) != 0) continue;
+      continue; // make sure to not do any out-of-boundary reads
+    }
+
+    if (memcmp (tuning_db_file + dblen - suflen, TUNING_DB_SUFFIX, suflen) != 0)
+    {
+      hcfree (tuning_db_file);
+
+      continue;
+    }
 
     HCFILE fp;
 
     if (hc_fopen (&fp, tuning_db_file, "rb") == false)
     {
       event_log_error (hashcat_ctx, "%s: %s", tuning_db_file, strerror (errno));
+
+      for (int j = 0; tuning_db_files[j] != NULL; j++) hcfree (tuning_db_files[j]);
 
       return -1;
     }


### PR DESCRIPTION
```
==211926== 33 bytes in 1 blocks are definitely lost in loss record 372 of 2,004
==211926==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==211926==    by 0x49EE937: __vasprintf_internal (vasprintf.c:116)
==211926==    by 0x12D50B: vasprintf (stdio2.h:169)
==211926==    by 0x12D50B: hc_asprintf (shared.c:281)
==211926==    by 0x13891B: tuning_db_init (tuningdb.c:71)
==211926==    by 0x112292: hashcat_session_init (hashcat.c:1242)
==211926==    by 0x11127D: main (main.c:1323)
==211926== 
==211926== 43 bytes in 1 blocks are definitely lost in loss record 1,167 of 2,004
==211926==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==211926==    by 0x49EE937: __vasprintf_internal (vasprintf.c:116)
==211926==    by 0x12D50B: vasprintf (stdio2.h:169)
==211926==    by 0x12D50B: hc_asprintf (shared.c:281)
==211926==    by 0x18C1AF: scan_directory (folder.c:260)
==211926==    by 0x138925: tuning_db_init (tuningdb.c:73)
==211926==    by 0x112292: hashcat_session_init (hashcat.c:1242)
==211926==    by 0x11127D: main (main.c:1323)
```