### PR TITLE
Update backend.c: Fixes hiprtcCompileProgram(): HIPRTC_ERROR_COMPILATION on AMD 6900XT.

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -8754,8 +8754,8 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
       hiprtc_options[5] = "-I";
       */
 
-      hiprtc_options[1] = "-nocudainc";
-      hiprtc_options[2] = "-nocudalib";
+      hiprtc_options[1] = "";
+      hiprtc_options[2] = "";
       hiprtc_options[3] = "";
       hiprtc_options[4] = "";
 


### PR DESCRIPTION
Fixes hiprtcCompileProgram(): HIPRTC_ERROR_COMPILATION on AMD 6900XT.

```bash
hiprtcCompileProgram(): HIPRTC_ERROR_COMPILATION

ld.lld: error: undefined hidden symbol: __ockl_get_group_id
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_decompress)
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_decompress)
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_memset)
>>> referenced 7 more times

ld.lld: error: undefined hidden symbol: __ockl_get_local_size
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_decompress)
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_decompress)
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_memset)
>>> referenced 7 more times

ld.lld: error: undefined hidden symbol: __ockl_get_local_id
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_decompress)
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_decompress)
>>> referenced by /home/mathias/.local/share/hashcat/comgr-69ec34/input/shared_kernel.o:(gpu_memset)
>>> referenced 7 more times

* Device #1: Kernel /usr/local/share/hashcat/OpenCL/shared.cl build failed.

* Device #1: Kernel /usr/local/share/hashcat/OpenCL/shared.cl build failed.
```



```bash
lsb_release -a                                                                                                      ✘ INT
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.1 LTS
Release:        24.04
Codename:       noble
```



```bash
uname -a 
Linux mathias-ubuntu-desktop-pc 6.8.0-47-generic #47-Ubuntu SMP PREEMPT_DYNAMIC Fri Sep 27 21:40:26 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```



```bash
sudo lshw -C display

  *-display                 
       description: VGA compatible controller
       product: Navi 21 [Radeon RX 6800/6800 XT / 6900 XT]
       vendor: Advanced Micro Devices, Inc. [AMD/ATI]
       physical id: 0
       bus info: pci@0000:03:00.0
       logical name: /dev/fb0
       version: c0
       width: 64 bits
       clock: 33MHz
       capabilities: pm pciexpress msi vga_controller bus_master cap_list rom fb
       configuration: depth=32 driver=amdgpu latency=0 resolution=2560,1440
       resources: irq:163 memory:90000000-9fffffff memory:a0000000-a01fffff ioport:3000(size=256) memory:a0a00000-a0afffff memory:a0b00000-a0b1ffff
```



```bash
apt show rocm-libs -a

Package: rocm-libs
Version: 6.2.2.60202-116~24.04
Priority: optional
Section: devel
Maintainer: ROCm Dev Support <rocm-dev.support@amd.com>
Installed-Size: 13,3 kB
Depends: hipblas (= 2.2.0.60202-116~24.04), hipblaslt (= 0.8.0.60202-116~24.04), hipfft (= 1.0.15.60202-116~24.04), hipsolver (= 2.2.0.60202-116~24.04), hipsparse (= 3.1.1.60202-116~24.04), hiptensor (= 1.3.0.60202-116~24.04), miopen-hip (= 3.2.0.60202-116~24.04), half (= 1.12.0.60202-116~24.04), rccl (= 2.20.5.60202-116~24.04), rocalution (= 3.2.0.60202-116~24.04), rocblas (= 4.2.1.60202-116~24.04), rocfft (= 1.0.29.60202-116~24.04), rocrand (= 3.1.0.60202-116~24.04), hiprand (= 2.11.0.60202-116~24.04), rocsolver (= 3.26.0.60202-116~24.04), rocsparse (= 3.2.0.60202-116~24.04), rocm-core (= 6.2.2.60202-116~24.04), hipsparselt (= 0.2.1.60202-116~24.04), composablekernel-dev (= 1.1.0.60202-116~24.04), hipblas-dev (= 2.2.0.60202-116~24.04), hipblaslt-dev (= 0.8.0.60202-116~24.04), hipcub-dev (= 3.2.0.60202-116~24.04), hipfft-dev (= 1.0.15.60202-116~24.04), hipsolver-dev (= 2.2.0.60202-116~24.04), hipsparse-dev (= 3.1.1.60202-116~24.04), hiptensor-dev (= 1.3.0.60202-116~24.04), miopen-hip-dev (= 3.2.0.60202-116~24.04), rccl-dev (= 2.20.5.60202-116~24.04), rocalution-dev (= 3.2.0.60202-116~24.04), rocblas-dev (= 4.2.1.60202-116~24.04), rocfft-dev (= 1.0.29.60202-116~24.04), rocprim-dev (= 3.2.0.60202-116~24.04), rocrand-dev (= 3.1.0.60202-116~24.04), hiprand-dev (= 2.11.0.60202-116~24.04), rocsolver-dev (= 3.26.0.60202-116~24.04), rocsparse-dev (= 3.2.0.60202-116~24.04), rocthrust-dev (= 3.1.0.60202-116~24.04), rocwmma-dev (= 1.5.0.60202-116~24.04), hipsparselt-dev (= 0.2.1.60202-116~24.04)
Homepage: https://github.com/RadeonOpenCompute/ROCm
Download-Size: 1.060 B
APT-Sources: https://repo.radeon.com/rocm/apt/6.2.2 noble/main amd64 Packages
Description: Radeon Open Compute (ROCm) Runtime software stack
```




```bash
apt show rocm -a          

Package: rocm
Version: 6.2.2.60202-116~24.04
Priority: optional
Section: devel
Maintainer: ROCm dev support <rocm-dev.support@amd.com>
Installed-Size: 13,3 kB
Depends: rocm-utils (= 6.2.2.60202-116~24.04), rocm-developer-tools (= 6.2.2.60202-116~24.04), rocm-openmp-sdk (= 6.2.2.60202-116~24.04), rocm-opencl-sdk (= 6.2.2.60202-116~24.04), rocm-ml-sdk (= 6.2.2.60202-116~24.04), mivisionx (= 3.0.0.60202-116~24.04), migraphx (= 2.10.0.60202-116~24.04), rpp (= 1.8.0.60202-116~24.04), rocm-core (= 6.2.2.60202-116~24.04), migraphx-dev (= 2.10.0.60202-116~24.04), mivisionx-dev (= 3.0.0.60202-116~24.04), rpp-dev (= 1.8.0.60202-116~24.04)
Homepage: https://github.com/RadeonOpenCompute/ROCm
Download-Size: 2.066 B
APT-Manual-Installed: yes
APT-Sources: https://repo.radeon.com/rocm/apt/6.2.2 noble/main amd64 Packages
Description: Radeon Open Compute (ROCm) software stack meta package
```



```bash
apt show amdgpu -a

Package: amdgpu
Version: 1:6.2.60202-2041575.24.04
Priority: optional
Section: metapackages
Maintainer: Advanced Micro Devices (AMD) <slava.grigorev@amd.com>
Installed-Size: 9.216 B
Depends: amdgpu-dkms, amdgpu-lib (= 1:6.2.60202-2041575.24.04)
Download-Size: 1.684 B
APT-Sources: https://repo.radeon.com/amdgpu/6.2.2/ubuntu noble/main amd64 Packages
Description: Meta package to install amdgpu components.
```



```bash
apt show amdgpu-install -a

Package: amdgpu-install
Version: 6.2.60202-2041575.24.04
Priority: optional
Section: graphics
Maintainer: Advanced Micro Devices (AMD) <gpudriverdevsupport@amd.com>
Installed-Size: 74,8 kB
Depends: rsync
Recommends: dialog
Homepage: http://www.amd.com
Download-Size: 16,9 kB
APT-Manual-Installed: yes
APT-Sources: https://repo.radeon.com/amdgpu/6.2.2/ubuntu noble/main amd64 Packages
Description: AMDGPU driver repository and installer
```