### PR TITLE
Kernel: Renamed multiple defines in CAST cipher to fit expected naming convention of the C++ language standard

### DIFF
--- a/OpenCL/inc_cipher_cast.cl
+++ b/OpenCL/inc_cipher_cast.cl
@@ -569,22 +569,22 @@ DECLSPEC void Cast5Encrypt (PRIVATE_AS const u8 *inBlock, PRIVATE_AS u8 *outBloc
 	u32 t;
 
 	/* Do the work */
-	_CAST_F1(l, r,  0, 16);
-	_CAST_F2(r, l,  1, 16);
-	_CAST_F3(l, r,  2, 16);
-	_CAST_F1(r, l,  3, 16);
-	_CAST_F2(l, r,  4, 16);
-	_CAST_F3(r, l,  5, 16);
-	_CAST_F1(l, r,  6, 16);
-	_CAST_F2(r, l,  7, 16);
-	_CAST_F3(l, r,  8, 16);
-	_CAST_F1(r, l,  9, 16);
-	_CAST_F2(l, r, 10, 16);
-	_CAST_F3(r, l, 11, 16);
-	_CAST_F1(l, r, 12, 16);
-	_CAST_F2(r, l, 13, 16);
-	_CAST_F3(l, r, 14, 16);
-	_CAST_F1(r, l, 15, 16);
+	CAST_F1(l, r,  0, 16);
+	CAST_F2(r, l,  1, 16);
+	CAST_F3(l, r,  2, 16);
+	CAST_F1(r, l,  3, 16);
+	CAST_F2(l, r,  4, 16);
+	CAST_F3(r, l,  5, 16);
+	CAST_F1(l, r,  6, 16);
+	CAST_F2(r, l,  7, 16);
+	CAST_F3(l, r,  8, 16);
+	CAST_F1(r, l,  9, 16);
+	CAST_F2(l, r, 10, 16);
+	CAST_F3(r, l, 11, 16);
+	CAST_F1(l, r, 12, 16);
+	CAST_F2(r, l, 13, 16);
+	CAST_F3(l, r, 14, 16);
+	CAST_F1(r, l, 15, 16);
 
 	/* Put l,r into outblock */
 	PUT_UINT32BE(r, outBlock, 0);
@@ -599,22 +599,22 @@ DECLSPEC void Cast5Decrypt (PRIVATE_AS const u8 *inBlock, PRIVATE_AS u8 *outBloc
 	u32 t;
 
 	/* Only do full 16 rounds if key length > 80 bits */
-	_CAST_F1(r, l, 15, 16);
-	_CAST_F3(l, r, 14, 16);
-	_CAST_F2(r, l, 13, 16);
-	_CAST_F1(l, r, 12, 16);
-	_CAST_F3(r, l, 11, 16);
-	_CAST_F2(l, r, 10, 16);
-	_CAST_F1(r, l,  9, 16);
-	_CAST_F3(l, r,  8, 16);
-	_CAST_F2(r, l,  7, 16);
-	_CAST_F1(l, r,  6, 16);
-	_CAST_F3(r, l,  5, 16);
-	_CAST_F2(l, r,  4, 16);
-	_CAST_F1(r, l,  3, 16);
-	_CAST_F3(l, r,  2, 16);
-	_CAST_F2(r, l,  1, 16);
-	_CAST_F1(l, r,  0, 16);
+	CAST_F1(r, l, 15, 16);
+	CAST_F3(l, r, 14, 16);
+	CAST_F2(r, l, 13, 16);
+	CAST_F1(l, r, 12, 16);
+	CAST_F3(r, l, 11, 16);
+	CAST_F2(l, r, 10, 16);
+	CAST_F1(r, l,  9, 16);
+	CAST_F3(l, r,  8, 16);
+	CAST_F2(r, l,  7, 16);
+	CAST_F1(l, r,  6, 16);
+	CAST_F3(r, l,  5, 16);
+	CAST_F2(l, r,  4, 16);
+	CAST_F1(r, l,  3, 16);
+	CAST_F3(l, r,  2, 16);
+	CAST_F2(r, l,  1, 16);
+	CAST_F1(l, r,  0, 16);
 	/* Put l,r into outblock */
 	PUT_UINT32BE(r, outBlock, 0);
 	PUT_UINT32BE(l, outBlock, 4);
@@ -633,8 +633,8 @@ DECLSPEC void Cast5SetKey (PRIVATE_AS CAST_KEY *key, u32 keylength, PRIVATE_AS c
 	GET_UINT32BE(X[2], userKey, 8);
 	GET_UINT32BE(X[3], userKey, 12);
 
-  #define x(i) GETBYTE(X[i/4], 3-i%4)
-  #define z(i) GETBYTE(Z[i/4], 3-i%4)
+	#define x(i) GETBYTE(X[i/4], 3-i%4)
+	#define z(i) GETBYTE(Z[i/4], 3-i%4)
 
 	for (i=0; i<=16; i+=16) {
 		// this part is copied directly from RFC 2144 (with some search and replace) by Wei Dai
@@ -673,11 +673,11 @@ DECLSPEC void Cast5SetKey (PRIVATE_AS CAST_KEY *key, u32 keylength, PRIVATE_AS c
 	}
 
 	u32 data[32];
-    for (i = 0; i < 16; i++) {
-        data[i * 2] = K[i];
-        data[i * 2 + 1] = ((K[i + 16]) + 16) & 0x1f; // here only the lowest 5 bits are set..
-    }
 
-	for (i=16; i<32; i++)
-		K[i] &= 0x1f;
+	for (i = 0; i < 16; i++) {
+		data[i * 2] = K[i];
+		data[i * 2 + 1] = ((K[i + 16]) + 16) & 0x1f; // here only the lowest 5 bits are set..
+	}
+
+	for (i=16; i<32; i++) K[i] &= 0x1f;
 }

--- a/OpenCL/inc_cipher_cast.h
+++ b/OpenCL/inc_cipher_cast.h
@@ -1,7 +1,5 @@
-
-
-#ifndef _OPENCL_CAST_H
-#define _OPENCL_CAST_H
+#ifndef INC_CIPHER_CAST_H
+#define INC_CIPHER_CAST_H
 
 // #include "opencl_misc.h"
 #define GET_UINT32BE(n, b, i)	  \
@@ -32,28 +30,26 @@ typedef struct {
 #define U8d(x) GETBYTE(x,0)
 
 /* CAST uses three different round functions */
-#define _CAST_f1(l, r, km, kr) \
+#define CAST_f1(l, r, km, kr) \
 	t = hc_rotl32_S(km + r, kr); \
 	l ^= ((s_S[0][U8a(t)] ^ s_S[1][U8b(t)]) - \
 	 s_S[2][U8c(t)]) + s_S[3][U8d(t)];
-#define _CAST_f2(l, r, km, kr) \
+#define CAST_f2(l, r, km, kr) \
 	t = hc_rotl32_S(km ^ r, kr); \
 	l ^= ((s_S[0][U8a(t)] - s_S[1][U8b(t)]) + \
 	 s_S[2][U8c(t)]) ^ s_S[3][U8d(t)];
-#define _CAST_f3(l, r, km, kr) \
+#define CAST_f3(l, r, km, kr) \
 	t = hc_rotl32_S(km - r, kr); \
 	l ^= ((s_S[0][U8a(t)] + s_S[1][U8b(t)]) ^ \
 	 s_S[2][U8c(t)]) - s_S[3][U8d(t)];
 
-#define _CAST_F1(l, r, i, j) _CAST_f1(l, r, K[i], K[i+j])
-#define _CAST_F2(l, r, i, j) _CAST_f2(l, r, K[i], K[i+j])
-#define _CAST_F3(l, r, i, j) _CAST_f3(l, r, K[i], K[i+j])
-
+#define CAST_F1(l, r, i, j) CAST_f1(l, r, K[i], K[i+j])
+#define CAST_F2(l, r, i, j) CAST_f2(l, r, K[i], K[i+j])
+#define CAST_F3(l, r, i, j) CAST_f3(l, r, K[i], K[i+j])
 
 /* OpenSSL API compatibility */
 #define CAST_set_key(ckey, len, key)     Cast5SetKey(ckey, len, key)
 #define CAST_ecb_encrypt(in, out, ckey)  Cast5Encrypt(in, out, ckey)
 #define CAST_ecb_decrypt(in, out, ckey)  Cast5Decrypt(in, out, ckey)
 
-
-#endif /* _OPENCL_CAST_H */
+#endif /* INC_CIPHER_CAST_H */

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -134,6 +134,7 @@
 - Help: show supported hash-modes only with -hh
 - Makefile: prevent make failure with Apple Silicon in case of partial rebuild
 - Rules: Rename best64.rule to best66.rule and remove the unknown section from it
+- Kernel: Renamed multiple defines in CAST cipher to fit expected naming convention of the C++ language standard
 
 * changes v6.2.5 -> v6.2.6
 


### PR DESCRIPTION
Fix #3569

```
$ ./hashcat -b -m 17040 -D1 --quiet
--------------------------------------------------------------
* Hash-Mode 17040 (GPG (CAST5 (SHA-1($pass)))) [Iterations: 8]
--------------------------------------------------------------

Speed.#1.........:  1729.7 kH/s (0.25ms) @ Accel:512 Loops:65536 Thr:1 Vec:4
```