### PR TITLE
Add [b] [c] and [f] functionality in pause state

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -35,6 +35,8 @@ static const char *const  ST_0013 = "Error";
 static const char *const  ST_0014 = "Aborted (Finish)";
 static const char *const  ST_0015 = "Running (Quit after attack requested)";
 static const char *const  ST_0016 = "Autodetect";
+static const char *const  ST_0017 = "Paused (Checkpoint Quit requested)";
+static const char *const  ST_0018 = "Paused (Quit after attack requested)";
 static const char *const  ST_9999 = "Unknown! Bug!";
 
 static const char UNITS[7] = { ' ', 'k', 'M', 'G', 'T', 'P', 'E' };
@@ -262,8 +264,6 @@ const char *status_get_status_string (const hashcat_ctx_t *hashcat_ctx)
 
   const int devices_status = status_ctx->devices_status;
 
-  // special case: running but checkpoint quit requested
-
   if (devices_status == STATUS_RUNNING)
   {
     if (status_ctx->checkpoint_shutdown == true)
@@ -274,6 +274,18 @@ const char *status_get_status_string (const hashcat_ctx_t *hashcat_ctx)
     if (status_ctx->finish_shutdown == true)
     {
       return ST_0015;
+    }
+  }
+  else if (devices_status == STATUS_PAUSED)
+  {
+    if (status_ctx->checkpoint_shutdown == true)
+    {
+      return ST_0017;
+    }
+
+    if (status_ctx->finish_shutdown == true)
+    {
+      return ST_0018;
     }
   }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -214,8 +214,6 @@ int bypass (hashcat_ctx_t *hashcat_ctx)
 {
   status_ctx_t *status_ctx = hashcat_ctx->status_ctx;
 
-  if (status_ctx->devices_status != STATUS_RUNNING) return -1;
-
   status_ctx->devices_status = STATUS_BYPASS;
 
   status_ctx->run_main_level1   = true;
@@ -262,8 +260,6 @@ int stop_at_checkpoint (hashcat_ctx_t *hashcat_ctx)
 {
   status_ctx_t *status_ctx = hashcat_ctx->status_ctx;
 
-  if (status_ctx->devices_status != STATUS_RUNNING) return -1;
-
   // this feature only makes sense if --restore-disable was not specified
 
   restore_ctx_t *restore_ctx = hashcat_ctx->restore_ctx;
@@ -304,8 +300,6 @@ int stop_at_checkpoint (hashcat_ctx_t *hashcat_ctx)
 int finish_after_attack (hashcat_ctx_t *hashcat_ctx)
 {
   status_ctx_t *status_ctx = hashcat_ctx->status_ctx;
-
-  if (status_ctx->devices_status != STATUS_RUNNING) return -1;
 
   // Enable or Disable
 


### PR DESCRIPTION
Add the ability to [b]ypass, [c]heckpoint and [f]inish an attack while paused. I'm not too sure why it was limited to only [r]unning states but have not found any bugs in testing, the limit was implemented in https://github.com/hashcat/hashcat/commit/2545ec6bf9665ad15fcff74d0daa6e7311d69b92, 8 years ago so it may just be that Hashcat's resilience has increased since then or it was an oversight while refactoring.

Previous behaviour (pressing c while paused):
```
Paused at Wed Dec 04 19:21:53 2024

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>

Checkpoint disabled. Restore-point updates will no longer be monitored.

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>

Checkpoint disabled. Restore-point updates will no longer be monitored.

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>

Checkpoint disabled. Restore-point updates will no longer be monitored.

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>
```

New behaviour (pressing c while paused):
```
[s]tatus [p]ause [b]ypass [c]heckpoint [f]inish [q]uit =>

Paused at Fri Dec 06 05:55:04 2024

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>

Checkpoint enabled. Will quit at next restore-point update.

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>

Checkpoint disabled. Restore-point updates will no longer be monitored.

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>

Checkpoint enabled. Will quit at next restore-point update.

[s]tatus [r]esume [b]ypass [c]heckpoint [f]inish [q]uit =>
```