### PR TITLE
Gracefully handle corrupt .gz archives

### DIFF
--- a/src/combinator.c
+++ b/src/combinator.c
@@ -96,6 +96,16 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         return -1;
       }
 
+      if (rc1 == -2)
+      {
+        event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile1);
+
+        hc_fclose (&fp1);
+        hc_fclose (&fp2);
+
+        return -1;
+      }
+
       if (words1_cnt == 0)
       {
         event_log_error (hashcat_ctx, "%s: empty file.", dictfile1);
@@ -118,6 +128,13 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
       if (rc2 == -1)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile2);
+
+        return -1;
+      }
+
+      if (rc2 == -2)
+      {
+        event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile2);
 
         return -1;
       }
@@ -199,6 +216,16 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
           return -1;
         }
 
+        if (rc1 == -2)
+        {
+          event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile1);
+
+          hc_fclose (&fp1);
+          hc_fclose (&fp2);
+
+          return -1;
+        }
+
         if (words1_cnt == 0)
         {
           event_log_error (hashcat_ctx, "%s: empty file.", dictfile1);
@@ -221,6 +248,13 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         if (rc2 == -1)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile2);
+
+          return -1;
+        }
+
+        if (rc2 == -2)
+        {
+          event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile2);
 
           return -1;
         }
@@ -330,6 +364,16 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
           return -1;
         }
 
+        if (rc1 == -2)
+        {
+          event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile1);
+
+          hc_fclose (&fp1);
+          hc_fclose (&fp2);
+
+          return -1;
+        }
+
         if (words1_cnt == 0)
         {
           event_log_error (hashcat_ctx, "%s: empty file.", dictfile1);
@@ -352,6 +396,13 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         if (rc2 == -1)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile2);
+
+          return -1;
+        }
+
+        if (rc2 == -2)
+        {
+          event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile2);
 
           return -1;
         }
@@ -408,6 +459,13 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         if (rc == -1)
         {
           event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile);
+
+          return -1;
+        }
+
+        if (rc == -2)
+        {
+          event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile);
 
           return -1;
         }

--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -410,6 +410,17 @@ size_t hc_fread (void *ptr, size_t size, size_t nmemb, HCFILE *fp)
   else if (fp->gfp)
   {
     n = gzfread (ptr, size, nmemb, fp->gfp);
+
+    // Double check to make sure that it successfully read 0 bytes instead of erroring
+    if (n == 0)
+    {
+      int errnum;
+      gzerror (fp->gfp, &errnum);
+      if (errnum != Z_OK)
+      {
+        return (size_t) -1;
+      }
+    }
   }
   else if (fp->ufp)
   {

--- a/src/straight.c
+++ b/src/straight.c
@@ -91,6 +91,13 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
         return -1;
       }
 
+      if (rc == -2)
+      {
+        event_log_error (hashcat_ctx, "Error reading wordlist: %s", straight_ctx->dict);
+
+        return -1;
+      }
+
       if (status_ctx->words_cnt == 0)
       {
         logfile_sub_msg ("STOP");
@@ -125,6 +132,13 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
 
         return -1;
       }
+      
+      if (rc == -2)
+      {
+        event_log_error (hashcat_ctx, "Error reading wordlist: %s", combinator_ctx->dict1);
+
+        return -1;
+      }
     }
     else if (combinator_ctx->combs_mode == COMBINATOR_MODE_BASE_RIGHT)
     {
@@ -144,6 +158,13 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
       if (rc == -1)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", combinator_ctx->dict2);
+
+        return -1;
+      }
+
+      if (rc == -2)
+      {
+        event_log_error (hashcat_ctx, "Error reading wordlist: %s", combinator_ctx->dict2);
 
         return -1;
       }
@@ -194,6 +215,13 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
       return -1;
     }
 
+    if (rc == -2)
+    {
+      event_log_error (hashcat_ctx, "Error reading wordlist: %s", straight_ctx->dict);
+
+      return -1;
+    }
+
     if (status_ctx->words_cnt == 0)
     {
       logfile_sub_msg ("STOP");
@@ -230,6 +258,13 @@ int straight_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
       if (rc == -1)
       {
         event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", straight_ctx->dict);
+
+        return -1;
+      }
+
+      if (rc == -2)
+      {
+        event_log_error (hashcat_ctx, "Error reading wordlist: %s", straight_ctx->dict);
 
         return -1;
       }


### PR DESCRIPTION
When a .gz wordlist is corrupt, Hashcat will enter an infinite loop state of reading 0 bytes and never escape while building dictionary cache. This change ensures that when 0 bytes are read, it is because there are 0 bytes left to read instead of an error occurring. I'd also encourage similar changes be made to the .zip filehandling.c code if applicable.

Previous behaviour (hang):
```
Dictionary cache building test.gz: 0 bytes (0.00%)
```
New behaviour:
```
Error reading wordlist: test.gz
```

Thanks to @Shooter3k for reporting this.