### PR TITLE
Improve salt length reporting in hashconfig

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -996,7 +996,7 @@ static void main_hashconfig_post (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE
 
   if (hashconfig->is_salted == true)
   {
-    if (hashconfig->opti_type & OPTI_TYPE_RAW_HASH)
+    if (hashconfig->opti_type & OPTI_TYPE_RAW_HASH || hashconfig->salt_type & SALT_TYPE_GENERIC)
     {
       event_log_info (hashcat_ctx, "Minimum salt length supported by kernel: %u", hashconfig->salt_min);
       event_log_info (hashcat_ctx, "Maximum salt length supported by kernel: %u", hashconfig->salt_max);


### PR DESCRIPTION
This increases the amount of hash modes that will have their salt min/max length showed when it uses SALT_TYPE_GENERIC. A lot of salted algorithms (all listed below) don't show the min/max length of the salts (most notably vBulletin 2611/2711 and MyBB), whereas other modes like -m 10/20 do have their salt length limitations shown; bit weird for UX. This commit just widens the scope of which algorithms show their limits.

Recreation commands:
Normal:
```
> ./hashcat -m 20 00000000000000000000000000000000:00 -a 3 penguin
...
Minimum password length supported by kernel: 0
Maximum password length supported by kernel: 256
Minimim salt length supported by kernel: 0
Maximum salt length supported by kernel: 256
```
Affected:
```
> ./hashcat -m 2611 00000000000000000000000000000000:00 -a 3 penguin
...
Minimum password length supported by kernel: 0
Maximum password length supported by kernel: 256
```
All affected hash modes:
```
mode  algorithm name
00050 HMAC-MD5 (key = $pass)
00060 HMAC-MD5 (key = $salt)
00150 HMAC-SHA1 (key = $pass)
00160 HMAC-SHA1 (key = $salt)
01100 Domain Cached Credentials (DCC), MS Cache
01450 HMAC-SHA256 (key = $pass)
01460 HMAC-SHA256 (key = $salt)
01750 HMAC-SHA512 (key = $pass)
01760 HMAC-SHA512 (key = $salt)
02410 Cisco-ASA MD5
02611 vBulletin < v3.8.5
02711 vBulletin >= v3.8.5
02811 MyBB 1.2+, IPB2+ (Invision Power Board)
03100 Oracle H: Type (Oracle 7+)
03610 md5(md5(md5($pass)).$salt)
03710 md5($salt.md5($pass))
03730 md5($salt1.strtoupper(md5($salt2.$pass)))
03910 md5(md5($pass).md5($salt))
04010 md5($salt.md5($salt.$pass))
04110 md5($salt.md5($pass.$salt))
04520 sha1($salt.sha1($pass))
04521 Redmine
04522 PunBB
04900 sha1($salt.$pass.$salt)
05000 sha1(sha1($salt.$pass.$salt))
05800 Samsung Android Password/PIN
06050 HMAC-RIPEMD160 (key = $pass)
06060 HMAC-RIPEMD160 (key = $salt)
07350 IPMI2 RAKP HMAC-MD5
08400 WBB3 (Woltlab Burning Board)
11000 PrestaShop
11750 HMAC-Streebog-256 (key = $pass), big-endian
11760 HMAC-Streebog-256 (key = $salt), big-endian
11850 HMAC-Streebog-512 (key = $pass), big-endian
11860 HMAC-Streebog-512 (key = $salt), big-endian
12600 ColdFusion 10+
13900 OpenCart
14400 sha1(CX)
24300 sha1($salt.sha1($pass.$salt))
30000 Python Werkzeug MD5 (HMAC-MD5 (key = $salt))
30120 Python Werkzeug SHA256 (HMAC-SHA256 (key = $salt))
30500 md5(md5($salt).md5(md5($pass)))
31300 MS SNTP
31500 Domain Cached Credentials (DCC), MS Cache (NT)
31700 md5(md5(md5($pass).$salt1).$salt2)
```