### PR TITLE
Recommend --keep-guessing on -m 20510

### DIFF
--- a/src/modules/module_20510.c
+++ b/src/modules/module_20510.c
@@ -81,7 +81,8 @@ static const u32   OPTI_TYPE      = 0;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_COPY_TMPS
                                   | OPTS_TYPE_MAXIMUM_THREADS
-                                  | OPTS_TYPE_AUTODETECT_DISABLE;
+                                  | OPTS_TYPE_AUTODETECT_DISABLE
+                                  | OPTS_TYPE_SUGGEST_KG;
 static const u32   SALT_TYPE      = SALT_TYPE_NONE;
 static const char *ST_PASS        = "t"; // actually "hashcat"
 static const char *ST_HASH        = "f1eff5c0368d10311dcfc419";


### PR DESCRIPTION
Due to -m 20510 being stupendously fast with the 6-byte optimisation, collisions are trivial to generate on such short 24-hex keys, something that isn't fixable through Hashcat so only a simple warning is possible.

Collision rate = `(24hex) / (4090-hashrate * 6-byte-optimisation)`
Collision rate = `(16^24) / (130,000,000,000 * 256^6)` = 2,165 seconds
2,165 seconds / 36 minutes per collision, per 4090. 

Example collisions:
```
6f857085416a79741d7478e8:$HEX[cc0beb7f61e26d617a6728616d7767]
6f857085416a79741d7478e8:$HEX[746defd6d1ad496e6b6f777772363339]
6f857085416a79741d7478e8:$HEX[fa4179ccb2ec36383431343270676b6161]
6f857085416a79741d7478e8:$HEX[75b64d35e58f746c71666f696d706f3132]
6f857085416a79741d7478e8:$HEX[148cff9de3326265796272797866673933]
6f857085416a79741d7478e8:$HEX[f0f166a82848796968677a61786d6b3338]
6f857085416a79741d7478e8:$HEX[4b5dc7cce9d16b776567716871706a7d]
6f857085416a79741d7478e8:$HEX[0811f5daf9ab76776c63616379636b656c]
6f857085416a79741d7478e8:$HEX[dd1c6f239fd562706270636968695c36]
6f857085416a79741d7478e8:$HEX[c43144b55980323232307864726d737677]
6f857085416a79741d7478e8:$HEX[4f48004dd52072787171787738387867]
```