### PR TITLE
Allow flexible current directories on Windows

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -41,6 +41,8 @@ u64 mydivc64 (const u64 dividend, const u64 divisor);
 
 char *filename_from_filepath (char *filepath);
 
+int utf8_to_widechar (const char *utf8, wchar_t **wide_out);
+
 void naive_replace (char *s, const char key_char, const char replace_char);
 void naive_escape (char *s, size_t s_max, const char key_char, const char escape_char);
 
@@ -57,6 +59,7 @@ bool hc_path_is_file (const char *path);
 bool hc_path_is_directory (const char *path);
 bool hc_path_is_fifo (const char *path);
 bool hc_path_is_empty (const char *path);
+bool hc_access (const char *path, const int mode);
 bool hc_path_exist (const char *path);
 bool hc_path_read (const char *path);
 bool hc_path_write (const char *path);
@@ -72,6 +75,8 @@ void hc_string_trim_leading (char *s);
 int hc_get_processor_count (void);
 
 bool hc_same_files (char *file1, char *file2);
+
+int hc_stat (const char* path, struct stat *buf);
 
 u32 hc_strtoul  (const char *nptr, char **endptr, int base);
 u64 hc_strtoull (const char *nptr, char **endptr, int base);

--- a/src/backend.c
+++ b/src/backend.c
@@ -8504,12 +8504,7 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
       hc_asprintf (&nvrtc_options[3], "compute_%d%d", device_param->sm_major, device_param->sm_minor);
 
-      // untested on windows, but it should work
-      #if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
-      hc_asprintf (&nvrtc_options[4], "-D INCLUDE_PATH=%s", "OpenCL");
-      #else
       hc_asprintf (&nvrtc_options[4], "-D INCLUDE_PATH=%s", folder_config->cpath_real);
-      #endif
 
       hc_asprintf (&nvrtc_options[5], "-D XM2S(x)=#x");
       hc_asprintf (&nvrtc_options[6], "-D M2S(x)=XM2S(x)");

--- a/src/backend.c
+++ b/src/backend.c
@@ -539,7 +539,7 @@ bool read_kernel_binary (hashcat_ctx_t *hashcat_ctx, const char *kernel_file, si
   {
     struct stat st;
 
-    if (stat (kernel_file, &st))
+    if (hc_stat (kernel_file, &st))
     {
       hc_fclose (&fp);
 

--- a/src/brain.c
+++ b/src/brain.c
@@ -1631,7 +1631,7 @@ bool brain_server_read_hash_dump (brain_server_db_hash_t *brain_server_db_hash, 
 
   memset (&sb, 0, sizeof (struct stat));
 
-  if (stat (file, &sb) == -1)
+  if (hc_stat (file, &sb) == -1)
   {
     brain_logging (stderr, 0, "%s: %s\n", file, strerror (errno));
 
@@ -1723,7 +1723,7 @@ bool brain_server_write_hash_dump (brain_server_db_hash_t *brain_server_db_hash,
 
   memset (&sb, 0, sizeof (struct stat));
 
-  if (stat (file, &sb) == -1)
+  if (hc_stat (file, &sb) == -1)
   {
     brain_logging (stderr, 0, "%s: %s\n", file, strerror (errno));
 
@@ -1830,7 +1830,7 @@ bool brain_server_read_attack_dump (brain_server_db_attack_t *brain_server_db_at
 
   memset (&sb, 0, sizeof (struct stat));
 
-  if (stat (file, &sb) == -1)
+  if (hc_stat (file, &sb) == -1)
   {
     brain_logging (stderr, 0, "%s: %s\n", file, strerror (errno));
 
@@ -1924,7 +1924,7 @@ bool brain_server_write_attack_dump (brain_server_db_attack_t *brain_server_db_a
 
   memset (&sb, 0, sizeof (struct stat));
 
-  if (stat (file, &sb) == -1)
+  if (hc_stat (file, &sb) == -1)
   {
     brain_logging (stderr, 0, "%s: %s\n", file, strerror (errno));
 

--- a/src/dynloader.c
+++ b/src/dynloader.c
@@ -6,12 +6,22 @@
 #include "common.h"
 #include "types.h"
 #include "dynloader.h"
+#include "shared.h"
 
 #ifdef _WIN
 
-hc_dynlib_t hc_dlopen (LPCSTR lpLibFileName)
+hc_dynlib_t hc_dlopen (const char *lpLibFileName)
 {
-  return LoadLibraryA (lpLibFileName);
+  wchar_t *wpath = NULL;
+  if (utf8_to_widechar (lpLibFileName, &wpath) == 0)
+  {
+    hc_dynlib_t lib = LoadLibraryW(wpath);
+    return lib;
+  }
+  else
+  {
+    return LoadLibraryA (lpLibFileName);
+ }
 }
 
 BOOL hc_dlclose (hc_dynlib_t hLibModule)
@@ -28,6 +38,7 @@ hc_dynfunc_t hc_dlsym (hc_dynlib_t hModule, LPCSTR lpProcName)
 
 hc_dynlib_t hc_dlopen (const char *filename)
 {
+  
   return dlopen (filename, RTLD_NOW);
 }
 

--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -16,6 +16,15 @@
 #include <Xz.h>
 #include <XzCrc64.h>
 
+
+#if defined (_WIN)
+#include <fcntl.h>
+#include <io.h>
+#include <stdio.h>
+#include <wchar.h>
+#include <locale.h>
+#endif
+
 /* Maybe _LZMA_NO_SYSTEM_SIZE_T defined? */
 #if defined (__clang__) || defined (__GNUC__)
 #include <assert.h>
@@ -144,14 +153,30 @@ bool hc_fopen (HCFILE *fp, const char *path, const char *mode)
     }
   }
 
-  if (fmode == -1)
-  {
-    fp->fd = open (path, oflag);
-  }
-  else
-  {
-    fp->fd = open (path, oflag, fmode);
-  }
+  #if defined (_WIN)
+    wchar_t *wpath = NULL;
+    if(utf8_to_widechar (path, &wpath) == -1) return false;
+
+    // Use _wopen to open the file safer on Windows
+    if (fmode == -1)
+    {
+      fp->fd = _wopen(wpath, oflag);
+    }
+    else
+    {
+      fp->fd = _wopen(wpath, oflag, fmode);
+    }
+
+  #else
+    if (fmode == -1)
+    {
+      fp->fd = open (path, oflag);
+    }
+    else
+    {
+      fp->fd = open (path, oflag, fmode);
+    }
+  #endif
 
   if (fp->fd == -1) return false;
 
@@ -340,14 +365,30 @@ bool hc_fopen_raw (HCFILE *fp, const char *path, const char *mode)
     return false;
   }
 
-  if (fmode == -1)
-  {
-    fp->fd = open (path, oflag);
-  }
-  else
-  {
-    fp->fd = open (path, oflag, fmode);
-  }
+  #if defined (_WIN)
+    wchar_t *wpath = NULL;
+    if(utf8_to_widechar (path, &wpath) == -1) return false;
+
+    // Use _wopen to open the file safer on Windows
+    if (fmode == -1)
+    {
+      fp->fd = _wopen(wpath, oflag);
+    }
+    else
+    {
+      fp->fd = _wopen(wpath, oflag, fmode);
+    }
+
+  #else
+    if (fmode == -1)
+    {
+      fp->fd = open (path, oflag);
+    }
+    else
+    {
+      fp->fd = open (path, oflag, fmode);
+    }
+  #endif
 
   if (fp->fd == -1) return false;
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -101,8 +101,35 @@ static void get_install_dir (char *install_dir, const char *exec_path)
   }
   else
   {
+    #if defined (_WIN)
+
+    static char path[MAX_PATH];
+
+    // Get full path of executable
+    int length = GetModuleFileName (NULL, path, MAX_PATH);
+    if (length == 0 || length >= MAX_PATH)
+    {
+      // Failed to get folder path, fall back to current directory
+      install_dir[0] = '.';
+      install_dir[1] = 0;
+      return;
+    }
+    
+    naive_replace (path, '\\', '/');
+
+    char *last_slash = NULL;
+    
+    // Find last backslash and overwrite with \0 to keep only the directory
+    if ((last_slash = strrchr (path, '/')) != NULL)
+    {
+      *last_slash = 0;
+    }
+    
+    strncpy (install_dir, path, HCBUFSIZ_TINY - 1);
+    #else
     install_dir[0] = '.';
     install_dir[1] = 0;
+    #endif
   }
 }
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -34,9 +34,23 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   #elif defined (_WIN)
 
-  memset (exec_path, 0, exec_path_sz);
+  static char path[MAX_PATH];
 
-  const int len = 0;
+  // Get full path of executable
+  int length = GetModuleFileName (NULL, path, MAX_PATH);
+  if (length == 0 || length >= MAX_PATH)
+  {
+    // Failed to get folder path, fall back to current directory
+    exec_path[0] = '.';
+    exec_path[1] = 0;
+    return;
+  }
+  
+  naive_replace (path, '\\', '/');
+  
+  strncpy (exec_path, path, exec_path_sz);
+
+  const size_t len = strlen (exec_path);
 
   #elif defined (__APPLE__)
 
@@ -101,35 +115,8 @@ static void get_install_dir (char *install_dir, const char *exec_path)
   }
   else
   {
-    #if defined (_WIN)
-
-    static char path[MAX_PATH];
-
-    // Get full path of executable
-    int length = GetModuleFileName (NULL, path, MAX_PATH);
-    if (length == 0 || length >= MAX_PATH)
-    {
-      // Failed to get folder path, fall back to current directory
-      install_dir[0] = '.';
-      install_dir[1] = 0;
-      return;
-    }
-    
-    naive_replace (path, '\\', '/');
-
-    char *last_slash = NULL;
-    
-    // Find last backslash and overwrite with \0 to keep only the directory
-    if ((last_slash = strrchr (path, '/')) != NULL)
-    {
-      *last_slash = 0;
-    }
-    
-    strncpy (install_dir, path, HCBUFSIZ_TINY - 1);
-    #else
     install_dir[0] = '.';
     install_dir[1] = 0;
-    #endif
   }
 }
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -34,21 +34,24 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   #elif defined (_WIN)
 
-  static char path[MAX_PATH];
+  wchar_t wpath[MAX_PATH];
+  DWORD length = GetModuleFileNameW(NULL, wpath, MAX_PATH);
+  if (length == 0 || length >= MAX_PATH) {
+      exec_path[0] = '.';
+      exec_path[1] = 0;
+      return 0;
+  }
 
-  // Get full path of executable
-  int length = GetModuleFileName (NULL, path, MAX_PATH);
-  if (length == 0 || length >= MAX_PATH)
-  {
-    // Failed to get folder path, fall back to current directory
+  utf8_to_widechar (wpath, &exec_path);
+
+  
+  if (converted == 0) {
     exec_path[0] = '.';
     exec_path[1] = 0;
-    return;
+    return 0;
   }
   
-  naive_replace (path, '\\', '/');
-  
-  strncpy (exec_path, path, exec_path_sz);
+  naive_replace (exec_path, '\\', '/');
 
   const size_t len = strlen (exec_path);
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -34,24 +34,33 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   #elif defined (_WIN)
 
-  wchar_t wpath[MAX_PATH];
-  DWORD length = GetModuleFileNameW(NULL, wpath, MAX_PATH);
-  if (length == 0 || length >= MAX_PATH) {
+    wchar_t wpath[MAX_PATH];
+    DWORD length = GetModuleFileNameW(NULL, wpath, MAX_PATH);
+    if (length == 0 || length >= MAX_PATH) {
+        exec_path[0] = '.';
+        exec_path[1] = 0;
+        return 0;
+    }
+
+    // Convert UTF-16 to UTF-8 directly
+    int converted = WideCharToMultiByte(
+        CP_UTF8,             // Code page
+        0,                   // Flags
+        wpath,               // Wide-char input
+        -1,                  // Null-terminated input
+        exec_path,           // Output buffer
+        (int)exec_path_sz,   // Output buffer size
+        NULL, NULL           // No default char / no used default char flag
+    );
+
+    
+    if (converted == 0) {
       exec_path[0] = '.';
       exec_path[1] = 0;
       return 0;
-  }
-
-  utf8_to_widechar (wpath, &exec_path);
-
-  
-  if (converted == 0) {
-    exec_path[0] = '.';
-    exec_path[1] = 0;
-    return 0;
-  }
-  
-  naive_replace (exec_path, '\\', '/');
+    }
+    
+    naive_replace (exec_path, '\\', '/');
 
   const size_t len = strlen (exec_path);
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -955,7 +955,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
     {
       struct stat st;
 
-      if (stat (hashes->hashfile, &st) == -1)
+      if (hc_stat (hashes->hashfile, &st) == -1)
       {
         event_log_error (hashcat_ctx, "%s: %s", hashes->hashfile, strerror (errno));
 

--- a/src/induct.c
+++ b/src/induct.c
@@ -19,8 +19,8 @@ static int sort_by_mtime (const void *p1, const void *p2)
   struct stat s1;
   struct stat s2;
 
-  const int rc1 = stat (*f1, &s1);
-  const int rc2 = stat (*f2, &s2);
+  const int rc1 = hc_stat (*f1, &s1);
+  const int rc2 = hc_stat (*f2, &s2);
 
   if (rc1 < rc2) return  1;
   if (rc1 > rc2) return -1;

--- a/src/interface.c
+++ b/src/interface.c
@@ -41,7 +41,7 @@ bool module_load (hashcat_ctx_t *hashcat_ctx, module_ctx_t *module_ctx, const u3
 
   memset (&s, 0, sizeof (struct stat));
 
-  if (stat (module_file, &s) == -1)
+  if (hc_stat (module_file, &s) == -1)
   {
     event_log_warning (hashcat_ctx, "Either the specified hash mode does not exist in the official repository,");
     event_log_warning (hashcat_ctx, "or the file(s) could not be found. Please check that the hash mode number is");

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -712,7 +712,7 @@ static int sp_setup_tbl (hashcat_ctx_t *hashcat_ctx)
 
   struct stat s;
 
-  if (stat (hcstat, &s) == -1)
+  if (hc_stat (hcstat, &s) == -1)
   {
     event_log_error (hashcat_ctx, "%s: %s", hcstat, strerror (errno));
 

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -99,7 +99,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
     struct stat outfile_check_stat;
 
-    if (stat (root_directory, &outfile_check_stat) == -1)
+    if (hc_stat (root_directory, &outfile_check_stat) == -1)
     {
       event_log_error (hashcat_ctx, "%s: %s", root_directory, strerror (errno));
 
@@ -133,7 +133,7 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
             struct stat outfile_stat;
 
-            if (stat (out_info_new[i].file_name, &outfile_stat) != 0) continue;
+            if (hc_stat (out_info_new[i].file_name, &outfile_stat) != 0) continue;
 
             if (outfile_stat.st_ctime != out_info[j].ctime) continue;
 


### PR DESCRIPTION
This PR allows Hashcat to be run from any directory, not requiring Hashcat to be the current directory. This issue only affects Windows, Linux already appears to work by default so this just restores a little feature parity.

Considerations:
I have tested this personally a fair amount but because Hashcat uses thousands of paths, I can't test every them all and I encourage people to try many different varied attacks, on many compilers to ensure this is a safe change.

Fixes https://github.com/hashcat/hashcat/issues/1539 and others