### PR TITLE
Fixing BUILD_WSL.md

### DIFF
--- a/BUILD_WSL.md
+++ b/BUILD_WSL.md
@@ -12,10 +12,11 @@ Enable WSL.
 
 Press the win + r key on your keyboard simultaneously and in the "Run" popup window type bash and make sure to install additional dependencies necessary for hashcat compilation
 ```
-sudo apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 make git
+sudo apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 make git unzip
 git clone https://github.com/hashcat/hashcat
-git clone https://github.com/win-iconv/win-iconv
-cd win-iconv/
+wget https://github.com/win-iconv/win-iconv/archive/refs/tags/v0.0.8.zip -O win-iconv.zip
+unzip win-iconv.zip
+cd ./win-iconv-0.0.8/
 patch < ../hashcat/tools/win-iconv-64.diff
 sudo make install
 cd ../

--- a/BUILD_WSL.md
+++ b/BUILD_WSL.md
@@ -16,6 +16,7 @@ sudo apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 make git unzip
 git clone https://github.com/hashcat/hashcat
 wget https://github.com/win-iconv/win-iconv/archive/refs/tags/v0.0.8.zip -O win-iconv.zip
 unzip win-iconv.zip
+rm win-iconv.zip
 cd ./win-iconv-0.0.8/
 patch < ../hashcat/tools/win-iconv-64.diff
 sudo make install


### PR DESCRIPTION
The win-iconv GitHub repo does not contain the Makefile (anymore?).
You need to download the release archiv instead.