### PR TITLE
Update WSL docs to use cmake for win-iconv

### DIFF
--- a/BUILD_WSL.md
+++ b/BUILD_WSL.md
@@ -11,12 +11,12 @@ Make sure to have the system upgraded after install (otherwise it will fail to f
 Enable WSL.
 
 Press the win + r key on your keyboard simultaneously and in the "Run" popup window type bash and make sure to install additional dependencies necessary for hashcat compilation
-```
+```bash
 sudo apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 make git
 git clone https://github.com/hashcat/hashcat
 git clone https://github.com/win-iconv/win-iconv
 cd win-iconv/
-patch < ../hashcat/tools/win-iconv-64.diff
+cmake -D WIN_ICONV_BUILD_EXECUTABLE=OFF -D CMAKE_INSTALL_PREFIX=/opt/win-iconv-64 -D CMAKE_CXX_COMPILER=$(which x86_64-w64-mingw32-g++) -D CMAKE_C_COMPILER=$(which x86_64-w64-mingw32-gcc)
 sudo make install
 cd ../
 ```


### PR DESCRIPTION
Update BUILD_WSL to use cmake to build `win-iconv`.

More than likely, this fix also applies to BUILD_macOS.md, however I don't have a mac to confirm.

Fixes #4192 
Supersedes #4183 

Confirmed working today, win-iconv 9d16924a97cffcda415dc28569c15d34a6dbf1d5 (v0.0.10) and hashcat 6716447dfce969ddde42a9abe0681500bee0df48