### PR TITLE
Added options --benchmark-min and --benchmark-max to set a hash-mode range to be used during the benchmark

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -61,6 +61,7 @@
 ##
 
 - Added new feature (-Y) that creates N virtual instances for each device in your system at the cost of N times the device memory consumption
+- Added options --benchmark-min and --benchmark-max to set a hash-mode range to be used during the benchmark
 
 ##
 ## Performance

--- a/include/types.h
+++ b/include/types.h
@@ -626,6 +626,8 @@ typedef enum user_options_defaults
   AUTODETECT               = false,
   BACKEND_DEVICES_VIRTUAL  = 1,
   BENCHMARK_ALL            = false,
+  BENCHMARK_MAX            = 99999,
+  BENCHMARK_MIN            = 0,
   BENCHMARK                = false,
   BITMAP_MAX               = 18,
   BITMAP_MIN               = 16,
@@ -736,6 +738,8 @@ typedef enum user_options_map
   IDX_BACKEND_INFO              = 'I',
   IDX_BACKEND_VECTOR_WIDTH      = 0xff05,
   IDX_BENCHMARK_ALL             = 0xff06,
+  IDX_BENCHMARK_MAX             = 0xff56,
+  IDX_BENCHMARK_MIN             = 0xff57,
   IDX_BENCHMARK                 = 'b',
   IDX_BITMAP_MAX                = 0xff07,
   IDX_BITMAP_MIN                = 0xff08,
@@ -2418,6 +2422,8 @@ typedef struct user_options
   u32          attack_mode;
   u32          backend_devices_virtual;
   u32          backend_info;
+  u32          benchmark_max;
+  u32          benchmark_min;
   u32          bitmap_max;
   u32          bitmap_min;
   #ifdef WITH_BRAIN

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -1771,6 +1771,9 @@ int hashcat_session_execute (hashcat_ctx_t *hashcat_ctx)
 
       while ((hash_mode = benchmark_next (hashcat_ctx)) != -1)
       {
+        if ((u32) hash_mode < user_options->benchmark_min) continue;
+        if ((u32) hash_mode > user_options->benchmark_max) continue;
+
         user_options->hash_mode = hash_mode;
 
         rc_final = outer_loop (hashcat_ctx);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -56,6 +56,15 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
         event_log_advice (hashcat_ctx, "To disable the optimized kernel code in benchmark mode, use the -w option.");
         event_log_advice (hashcat_ctx, NULL);
       }
+
+      if (user_options->benchmark_min != BENCHMARK_MIN || user_options->benchmark_max != BENCHMARK_MAX)
+      {
+        if (user_options->hash_mode_chgd == true)
+        {
+          event_log_advice (hashcat_ctx, "Benchmark min/max is ignored because --hash-type is set.");
+          event_log_advice (hashcat_ctx, NULL);
+        }
+      }
     }
     else
     {

--- a/src/usage.c
+++ b/src/usage.c
@@ -87,6 +87,8 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   "     --veracrypt-pim-stop       | Num  | VeraCrypt personal iterations multiplier stop        | --veracrypt-pim-stop=500",
   " -b, --benchmark                |      | Run benchmark of selected hash-modes                 |",
   "     --benchmark-all            |      | Run benchmark of all hash-modes (requires -b)        |",
+  "     --benchmark-min            |      | Set benchmark min hash-mode (requires -b)            | --benchmark-min=100",
+  "     --benchmark-max            |      | Set benchmark max hash-mode (requires -b)            | --benchmark-max=1000",
   "     --speed-only               |      | Return expected speed of the attack, then quit       |",
   "     --progress-only            |      | Return ideal progress step size and time to process  |",
   " -c, --segment-size             | Num  | Sets size in MB to cache from the wordfile to X      | -c 32",


### PR DESCRIPTION
Hi,

added two new options as the title, useful if you want to benchmark only a range of hash-modes.
If both are set, --benchmark-all is also automatically enabled.

```
$ ./hashcat -b --benchmark-min 10 --benchmark-max 20 -d1
hashcat (v6.2.6-852-g120e758be) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

CUDA API (CUDA 12.5)
====================
* Device #1: NVIDIA GeForce RTX 4080, 15736/15981 MB, 76MCU

[...]

Benchmark relevant options:
===========================
* --benchmark-all
* --benchmark-max=20
* --benchmark-min=10
* --backend-devices=1
* --backend-devices-virtual=1
* --optimized-kernel-enable

---------------------------------
* Hash-Mode 10 (md5($pass.$salt))
---------------------------------

Speed.#1.........: 95135.7 MH/s (26.39ms) @ Accel:256 Loops:1024 Thr:128 Vec:8

--------------------------------
* Hash-Mode 11 (Joomla < 2.5.18)
--------------------------------

Speed.#1.........: 92362.4 MH/s (27.17ms) @ Accel:128 Loops:1024 Thr:256 Vec:8

---------------------------
* Hash-Mode 12 (PostgreSQL)
---------------------------

Speed.#1.........: 92380.1 MH/s (27.17ms) @ Accel:128 Loops:1024 Thr:256 Vec:8

---------------------------------
* Hash-Mode 20 (md5($salt.$pass))
---------------------------------

Speed.#1.........: 49023.0 MH/s (51.51ms) @ Accel:1024 Loops:1024 Thr:32 Vec:4

Started: Wed May  7 18:53:35 2025
Stopped: Wed May  7 18:53:59 2025

```

Thanks