### PR TITLE
Syntax error from vmwarevmx2hashcat

### DIFF
--- a/tools/vmwarevmx2hashcat.py
+++ b/tools/vmwarevmx2hashcat.py
@@ -14,7 +14,7 @@ from binascii import hexlify
 import re
 import base64
 
-ks_re = '.+phrase/(.*?)/pass2key=(.*?):cipher=(.*?):rounds=(.*?):salt=(.*?),(.*?),(.*?)\)'
+ks_re = '.+phrase/(.*?)/pass2key=(.*?):cipher=(.*?):rounds=(.*?):salt=(.*?),(.*?),(.*?)\\)'
 
 ks_struct = {
     'password_hash': None,


### PR DESCRIPTION
The vmwarevmx2hashcat script presents a syntax error when executed:

vmwarevmx2hashcat.py:17: SyntaxWarning: invalid escape sequence '\)'
  ks_re = '.+phrase/(.*?)/pass2key=(.*?):cipher=(.*?):rounds=(.*?):salt=(.*?),(.*?),(.*?)\)'

This fixes that error. Tested in Python 3.12.3 with a valid vmx file.