### PR TITLE
add -std=c++14 for UNRAR only on MacOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -214,7 +214,7 @@ endif
 ## because UNRAR
 ifeq ($(ENABLE_UNRAR),1)
 ifeq ($(USE_SYSTEM_UNRAR),0)
-CFLAGS_UNRAR            += -std=c++14
+#CFLAGS_UNRAR            += -std=c++14
 ifneq ($(CC),clang)
 CFLAGS_UNRAR            += -Wno-class-memaccess
 CFLAGS_UNRAR            += -Wno-misleading-indentation

--- a/src/Makefile
+++ b/src/Makefile
@@ -214,7 +214,9 @@ endif
 ## because UNRAR
 ifeq ($(ENABLE_UNRAR),1)
 ifeq ($(USE_SYSTEM_UNRAR),0)
-#CFLAGS_UNRAR            += -std=c++14
+ifeq ($(UNAME),Darwin)
+CFLAGS_UNRAR            += -std=c++14
+endif
 ifneq ($(CC),clang)
 CFLAGS_UNRAR            += -Wno-class-memaccess
 CFLAGS_UNRAR            += -Wno-misleading-indentation


### PR DESCRIPTION
@jsteube, so it doesn't give error. Even using clang/clang++ on linux works