### PR TITLE
fix salsa_r() for Apple Metal

### DIFF
--- a/OpenCL/m08900-pure.cl
+++ b/OpenCL/m08900-pure.cl
@@ -221,7 +221,7 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
   {
     for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
 
-    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 
@@ -259,11 +259,11 @@ DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
 
     for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
 
-    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
+    for (u32 i = 0; i < km; i++) salsa_r ((PRIVATE_AS u32 *) T);
 
     for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
 
-    salsa_r ((u32 *) X);
+    salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 

--- a/OpenCL/m15700-pure.cl
+++ b/OpenCL/m15700-pure.cl
@@ -252,7 +252,7 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
   {
     for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
 
-    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 
@@ -290,11 +290,11 @@ DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
 
     for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
 
-    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
+    for (u32 i = 0; i < km; i++) salsa_r ((PRIVATE_AS u32 *) T);
 
     for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
 
-    salsa_r ((u32 *) X);
+    salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 

--- a/OpenCL/m22700-pure.cl
+++ b/OpenCL/m22700-pure.cl
@@ -269,7 +269,7 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
   {
     for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
 
-    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 
@@ -307,11 +307,11 @@ DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
 
     for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
 
-    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
+    for (u32 i = 0; i < km; i++) salsa_r ((PRIVATE_AS u32 *) T);
 
     for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
 
-    salsa_r ((u32 *) X);
+    salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 

--- a/OpenCL/m24000-pure.cl
+++ b/OpenCL/m24000-pure.cl
@@ -257,7 +257,7 @@ DECLSPEC void scrypt_smix (PRIVATE_AS uint4 *X, PRIVATE_AS uint4 *T, GLOBAL_AS u
   {
     for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
 
-    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((PRIVATE_AS u32 *) X);
   }
 
   for (u32 i = 0; i < SCRYPT_N; i++)
@@ -270,11 +270,11 @@ DECLSPEC void scrypt_smix (PRIVATE_AS uint4 *X, PRIVATE_AS uint4 *T, GLOBAL_AS u
 
     for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
 
-    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
+    for (u32 i = 0; i < km; i++) salsa_r ((PRIVATE_AS u32 *) T);
 
     for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
 
-    salsa_r ((u32 *) X);
+    salsa_r ((PRIVATE_AS u32 *) X);
   }
 
   #ifdef _unroll

--- a/OpenCL/m27700-pure.cl
+++ b/OpenCL/m27700-pure.cl
@@ -219,7 +219,7 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
   {
     for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
 
-    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 
@@ -257,11 +257,11 @@ DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
 
     for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
 
-    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
+    for (u32 i = 0; i < km; i++) salsa_r ((PRIVATE_AS u32 *) T);
 
     for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
 
-    salsa_r ((u32 *) X);
+    salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 

--- a/OpenCL/m28200-pure.cl
+++ b/OpenCL/m28200-pure.cl
@@ -231,7 +231,7 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
   {
     for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
 
-    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 
@@ -269,11 +269,11 @@ DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
 
     for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
 
-    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
+    for (u32 i = 0; i < km; i++) salsa_r ((PRIVATE_AS u32 *) T);
 
     for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
 
-    salsa_r ((u32 *) X);
+    salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 

--- a/OpenCL/m29800-pure.cl
+++ b/OpenCL/m29800-pure.cl
@@ -219,7 +219,7 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
   {
     for (u32 z = 0; z < zSIZE; z++) V[CO] = X[z];
 
-    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
+    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 
@@ -257,11 +257,11 @@ DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
 
     for (u32 z = 0; z < zSIZE; z++) T[z] = V[CO];
 
-    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
+    for (u32 i = 0; i < km; i++) salsa_r ((PRIVATE_AS u32 *) T);
 
     for (u32 z = 0; z < zSIZE; z++) X[z] ^= T[z];
 
-    salsa_r ((u32 *) X);
+    salsa_r ((PRIVATE_AS u32 *) X);
   }
 }
 


### PR DESCRIPTION
fix build errors with Metal

```
hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:272:57: error: pointer type must have explicit address space qualifier
    for (u32 i = 0; i < SCRYPT_TMTO; i++) salsa_r ((u32 *) X);
                                                        ^
program_source:310:48: error: pointer type must have explicit address space qualifier
    for (u32 i = 0; i < km; i++) salsa_r ((u32 *) T);
                                               ^
program_source:314:19: error: pointer type must have explicit address space qualifier
    salsa_r ((u32 *) X);
                  ^

```