### PR TITLE
Metal Backend: added workaround to set the true Processor value in Metal devices on Apple Intel

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -137,6 +137,7 @@
 - MetaMask: update extraction tool to support MetaMask Mobile wallets
 - SecureCRT MasterPassphrase v2: update module, pure kernels and test unit. Add optimized kernels.
 - Metal Backend: added workaround to prevent 'Infinite Loop' bug when build kernels
+- Metal Backend: added workaround to set the true Processor value in Metal devices on Apple Intel
 - Metal Backend: allow use of devices with Metal if runtime version is >= 200
 - Metal Backend: disable Metal devices only if at least one OpenCL device is active
 - Modules: Check UnpackSize to raise false positive with hc_decompress_rar

--- a/src/backend.c
+++ b/src/backend.c
@@ -6838,6 +6838,33 @@ int backend_ctx_devices_init (hashcat_ctx_t *hashcat_ctx, const int comptime)
 
         device_param->device_processors = device_processors;
 
+        #if defined (__APPLE__)
+        if (device_param->opencl_device_type & CL_DEVICE_TYPE_GPU)
+        {
+          if (backend_ctx->metal_devices_cnt > 0 && backend_ctx->metal_devices_active > 0)
+          {
+            for (int metal_devices_idx = 0; metal_devices_idx < backend_ctx->metal_devices_cnt; metal_devices_idx++)
+            {
+              const int tmp_backend_devices_idx = backend_ctx->backend_device_from_metal[metal_devices_idx];
+
+              hc_device_param_t *tmp_device_param = backend_ctx->devices_param + tmp_backend_devices_idx;
+
+              if (strstr (device_param->device_name, tmp_device_param->device_name) || strstr (tmp_device_param->device_name, device_param->device_name))
+              {
+                // can't detect the actual value of device_processors on macOS Intel with Metal
+                // set the value of Metal device_processor from OpenCL to solve the issue
+                if (tmp_device_param->device_processors != device_param->device_processors)
+                {
+                  tmp_device_param->device_processors = device_param->device_processors;
+
+                  break;
+                }
+              }
+            }
+          }
+        }
+        #endif // __APPLE__
+
         // device_host_unified_memory
 
         cl_bool device_host_unified_memory = false;


### PR DESCRIPTION
Hi,

with Metal on Apple Intel cannot identify the number of compute units in the device. As a result, it has been set to 8 by default until now.

```
$ ./hashcat -I
hashcat (v6.2.6-928-g70825ebac+) starting in backend information mode

Metal Info:
===========

Metal.Version.: 244.303

Backend Device ID #01
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Intel Iris Graphics
  Processor(s)...: 8 <------------------------------------------------------ this
  Clock..........: N/A
  Memory.Total...: 1536 MB (limited to 576 MB allocatable in one block)
  Memory.Free....: 704 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Registry.ID....: 1067
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 1, removable 0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Aug 29 2022 02:56:50)

[...]

  Backend Device ID #03
    Type...........: GPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Iris
    Version........: OpenCL 1.2 
    Processor(s)...: 40 <------------------------------------------------------ this
    Clock..........: 1200
    Memory.Total...: 1536 MB (limited to 192 MB allocatable in one block)
    Memory.Free....: 704 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2(Jul  6 2023 23:30:43)
```

With this patch the value is updated if a matching device is found on OpenCL. Following the new output:

```
$ ./hashcat -I
hashcat (v6.2.6-949-g5dd91af03+) starting in backend information mode

Metal Info:
===========

Metal.Version.: 244.303

Backend Device ID #01 (Alias: #03)
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Intel Iris Graphics
  Processor(s)...: 40
  Clock..........: N/A
  Memory.Total...: 1536 MB (limited to 576 MB allocatable in one block)
  Memory.Free....: 614 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Registry.ID....: 1067
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 1, removable 0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Aug 29 2022 02:56:50)

[...]

  Backend Device ID #03 (Alias: #01)
    Type...........: GPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Iris
    Version........: OpenCL 1.2 
    Processor(s)...: 40
    Clock..........: 1200
    Memory.Total...: 1536 MB (limited to 192 MB allocatable in one block)
    Memory.Free....: 614 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2(Jul  6 2023 23:30:43)

```

Must be tested on Apple Intel with other GPU version/type (like AMD)

Thanks

