### PR TITLE
OpenCL Backend: added workaround to set device_available_memory from CUDA/HIP alias device

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -130,6 +130,7 @@
 - Modules: Added support for non-zero IVs for -m 6800 (Lastpass). Also added `tools/lastpass2hashcat.py`
 - Modules: Updated module_unstable_warning
 - Open Document Format: Added support for small documents with content length < 1024
+- OpenCL Backend: added workaround to set device_available_memory from CUDA/HIP alias device
 - Status Code: Add specific return code for self-test fail (-11)
 - Scrypt: Increase buffer sizes in module for hash mode 8900 to allow longer scrypt digests
 - Unicode: Update UTF-8 to UTF-16 conversion to match RFC 3629


### PR DESCRIPTION
Hi,

since the value of device_available_mem identified by the OpenCL engine is not accurate:
in the case where an alias device is present on CUDA/HIP the value is retrieved from it, otherwise we proceed with the strategy adopted so far.

Tested on linux with AMD Radeon RX 6900 XT and NVIDIA GeForce RTX 4080 GPUs. Following the POC:

```
$ ./hashcat -I
hashcat (v6.2.6-954-g2af580b44+) starting in backend information mode

CUDA Info:
==========

CUDA.Version.: 12.5

Backend Device ID #01 (Alias: #03)
  Name...........: NVIDIA GeForce RTX 4080
  Processor(s)...: 76
  Clock..........: 2505
  Memory.Total...: 15981 MB
  Memory.Free....: 12589 MB
  Local.Memory...: 99 KB
  PCI.Addr.BDFe..: 0000:01:00.0

HIP Info:
=========

HIP.Version.: 6.3.42134

Backend Device ID #02 (Alias: #05)
  Name...........: AMD Radeon RX 6900 XT
  Processor(s)...: 40
  Clock..........: 2660
  Memory.Total...: 16368 MB
  Memory.Free....: 13073 MB
  Local.Memory...: 64 KB
  PCI.Addr.BDFe..: 0000:04:00.0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: NVIDIA Corporation
  Name....: NVIDIA CUDA
  Version.: OpenCL 3.0 CUDA 12.5.51

  Backend Device ID #03 (Alias: #01)
    Type...........: GPU
    Vendor.ID......: 32
    Vendor.........: NVIDIA Corporation
    Name...........: NVIDIA GeForce RTX 4080
    Version........: OpenCL 3.0 CUDA
    Processor(s)...: 76
    Clock..........: 2505
    Memory.Total...: 15981 MB (limited to 3995 MB allocatable in one block)
    Memory.Free....: 12589 MB
    Local.Memory...: 48 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 555.42.06
    PCI.Addr.BDF...: 01:00.0

OpenCL Platform ID #2
  Vendor..: Intel(R) Corporation
  Name....: Intel(R) OpenCL
  Version.: OpenCL 3.0 LINUX

  Backend Device ID #04
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel(R) Corporation
    Name...........: 12th Gen Intel(R) Core(TM) i7-12700K
    Version........: OpenCL 3.0 (Build 0)
    Processor(s)...: 20
    Clock..........: 0
    Memory.Total...: 64077 MB (limited to 16019 MB allocatable in one block)
    Memory.Free....: 25631 MB
    Local.Memory...: 256 KB
    OpenCL.Version.: OpenCL C 3.0 
    Driver.Version.: 2025.19.4.0.18_160000.xmain-hotfix

OpenCL Platform ID #3
  Vendor..: Advanced Micro Devices, Inc.
  Name....: AMD Accelerated Parallel Processing
  Version.: OpenCL 2.1 AMD-APP (3635.0)

  Backend Device ID #05 (Alias: #02)
    Type...........: GPU
    Vendor.ID......: 1
    Vendor.........: Advanced Micro Devices, Inc.
    Name...........: AMD Radeon RX 6900 XT
    Version........: OpenCL 2.0 
    Processor(s)...: 40
    Clock..........: 2660
    Memory.Total...: 16368 MB (limited to 13912 MB allocatable in one block)
    Memory.Free....: 13073 MB
    Local.Memory...: 64 KB
    OpenCL.Version.: OpenCL C 2.0 
    Driver.Version.: 3635.0 (HSA1.1,LC)
    PCI.Addr.BDF...: 04:00.0


```

Thanks