### PR TITLE
update BUILD_MSYS2: add python3 to dependencies

### DIFF
--- a/BUILD_MSYS2.md
+++ b/BUILD_MSYS2.md
@@ -13,6 +13,7 @@ $ pacman -S git
 $ pacman -S make
 $ pacman -S gcc
 $ pacman -S libiconv-devel
+$ pacman -S python3
 ```
 
 ### Building ###


### PR DESCRIPTION
Tested on Win10, python-3.12.7-1 will be installed