### PR TITLE
update BUILD_CYGWIN: add python3.12 to dependencies

### DIFF
--- a/BUILD_CYGWIN.md
+++ b/BUILD_CYGWIN.md
@@ -14,6 +14,8 @@ gcc-core
 gcc-g++
 make
 git
+python312
+python312-devel
 ```
 
 ### Building ###


### PR DESCRIPTION
Tested on Win10, python-3.12.7 will be installed