### PR TITLE
fix DEFAULT_SOURCE_FILENAME with CYGWIN

### DIFF
--- a/src/bridges/bridge_python_generic_hash_mp.c
+++ b/src/bridges/bridge_python_generic_hash_mp.c
@@ -188,7 +188,7 @@ typedef struct
 
 } python_interpreter_t;
 
-#if defined (_WIN) || defined (__APPLE__)
+#if defined (_WIN) || defined (__CYGWIN__) || defined (__APPLE__)
 static char *DEFAULT_SOURCE_FILENAME = "generic_hash_sp";
 #else
 static char *DEFAULT_SOURCE_FILENAME = "generic_hash_mp";

--- a/src/bridges/bridge_python_generic_hash_mp.c
+++ b/src/bridges/bridge_python_generic_hash_mp.c
@@ -714,7 +714,7 @@ void *platform_init (user_options_t *user_options)
 
   unit_t *unit_buf = &python_interpreter->units_buf[0];
 
-  #if defined (_WIN) || defined (__APPLE__)
+  #if defined (_WIN) || defined (__CYGWIN__) || defined (__APPLE__)
   fprintf (stderr, "Attention!!! Falling back to single-threaded mode.\n");
   fprintf (stderr, " Windows and MacOS ds not support multiprocessing module cleanly!\n");
   fprintf (stderr, " For multithreading on Windows and MacOS, please use -m 72000 instead.\n\n");

--- a/src/bridges/bridge_python_generic_hash_sp.c
+++ b/src/bridges/bridge_python_generic_hash_sp.c
@@ -532,7 +532,7 @@ static bool init_python (hc_python_lib_t *python)
     printf ("Loaded python library from: %s\n\n", pythondll_path);
   }
 
-  #if defined (_WIN) || defined (__APPLE__)
+  #if defined (_WIN) || defined (__CYGWIN__) || defined (__APPLE__)
 
   #else
   fprintf (stderr, "Attention!!! The 'free-threaded' python library has some major downsides.\n");


### PR DESCRIPTION
Hi,

by compiling with cygwin and run on cygwin terminal, hashcat trying to use "generic_hash_mp" and print a lot of message like:

`The specified parameter cannot use 'from multiprocessing.spawn [...]' as a value - must be a number.`

Thanks

