### PR TITLE
Alias Devices: Prevents hashcat, when started with x86_64 emulation on Apple Silicon, from showing the Apple M1 OpenCL CPU as an alias for the Apple M1 Metal GPU

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -117,6 +117,7 @@
 ##
 
 - AMD Driver: Updated requirements for AMD Windows drivers to "AMD Adrenalin Edition" (23.7.2 or later) and "AMD HIP SDK" (23.Q3 or later)
+- Alias Devices: Prevents hashcat, when started with x86_64 emulation on Apple Silicon, from showing the Apple M1 OpenCL CPU as an alias for the Apple M1 Metal GPU
 - Apple Driver: Automatically enable GPU support on Apple OpenCL instead of CPU support
 - Apple Driver: Updated requirements to use Apple OpenCL API to macOS 13.0 - use
 - Backend Checks: Describe workaround in error message when detecting more than 64 backend devices

--- a/src/backend.c
+++ b/src/backend.c
@@ -70,6 +70,15 @@ static bool is_same_device (const hc_device_param_t *src, const hc_device_param_
   // Metal can't have aliases
 
   if ((src->is_metal == true) && (dst->is_metal == true)) return false;
+
+  // But Metal and OpenCL can have aliases
+
+  if ((src->is_metal == true) && (dst->is_opencl == true))
+  {
+    // Prevents hashcat, when started with x86_64 emulation on Apple Silicon, from showing the Apple M1 OpenCL CPU as an alias for the Apple M1 Metal GPU
+
+    if (src->opencl_device_type != dst->opencl_device_type) return false;
+  }
   #endif
 
   // But OpenCL can have aliases


### PR DESCRIPTION
Hi,

with Apple Silicon, when hashcat is started with x86_64 emulation, show wrong alias device indication.
This patch prevent this error.

POC:

Start /bin/bash with x86_64 emulation before

```
$ arch -arch x86_64 /bin/bash
```

Before the patch

```
$ ./hashcat -I
hashcat (v6.2.6-971-g6aeb188b4) starting in backend information mode

Metal Info:
===========

Metal.Version.: 368.12

Backend Device ID #01 (Alias: #02)
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Apple M1
  Processor(s)...: 8
  Clock..........: N/A
  Memory.Total...: 10922 MB (limited to 4096 MB allocatable in one block)
  Memory.Free....: 5461 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Registry.ID....: 2021
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 0, removable 0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Apr 18 2025 21:45:30)

  Backend Device ID #02 (Alias: #01)
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 2400
    Memory.Total...: 16384 MB (limited to 2048 MB allocatable in one block)
    Memory.Free....: 8192 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.1

  Backend Device ID #03 (Alias: #01)
    Type...........: GPU
    Vendor.ID......: 2
    Vendor.........: Apple
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 1000
    Memory.Total...: 10922 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 5461 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2 1.0
```

After the patch

```
$ ./hashcat -I
hashcat (v6.2.6-971-g6aeb188b4+) starting in backend information mode

Metal Info:
===========

Metal.Version.: 368.12

Backend Device ID #01 (Alias: #03)
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Apple M1
  Processor(s)...: 8
  Clock..........: N/A
  Memory.Total...: 10922 MB (limited to 4096 MB allocatable in one block)
  Memory.Free....: 5461 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Registry.ID....: 2021
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 0, removable 0

OpenCL Info:
============

OpenCL Platform ID #1
  Vendor..: Apple
  Name....: Apple
  Version.: OpenCL 1.2 (Apr 18 2025 21:45:30)

  Backend Device ID #02
    Type...........: CPU
    Vendor.ID......: 8
    Vendor.........: Intel
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 2400
    Memory.Total...: 16384 MB (limited to 2048 MB allocatable in one block)
    Memory.Free....: 8192 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.1

  Backend Device ID #03 (Alias: #01)
    Type...........: GPU
    Vendor.ID......: 2
    Vendor.........: Apple
    Name...........: Apple M1
    Version........: OpenCL 1.2 
    Processor(s)...: 8
    Clock..........: 1000
    Memory.Total...: 10922 MB (limited to 1024 MB allocatable in one block)
    Memory.Free....: 5461 MB
    Local.Memory...: 32 KB
    OpenCL.Version.: OpenCL C 1.2 
    Driver.Version.: 1.2 1.0
```

Thanks
