### PR TITLE
Modules: Updated module_unstable_warning for hash-mode 1500, 3000, 14000, 19200

### DIFF
--- a/src/modules/module_01500.c
+++ b/src/modules/module_01500.c
@@ -60,6 +60,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
       return false;
     }
 
+    if (device_param->opencl_platform_vendor_id != VENDOR_ID_INTEL_SDK)
+    {
+      // works on Linux/POCL
+      return false;
+    }
+
     // skip by default for now
     return true;
   }

--- a/src/modules/module_01500.c
+++ b/src/modules/module_01500.c
@@ -46,9 +46,21 @@ const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {
-  // Intel(R) Xeon(R) W-3223 CPU @ 3.50GHz; OpenCL C 1.2; 11.3.1; 20E241
-  if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE || device_param->opencl_platform_vendor_id == VENDOR_ID_INTEL_SDK) && (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU))
+  if (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU)
   {
+    if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
+    {
+      // works on Apple Intel: Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz
+      return false;
+    }
+
+    if (strncmp (device_param->device_name, "AMD EPYC", 8) == 0)
+    {
+      // works on Linux: AMD EPYC 7642 48-Core Processor, OpenCL 2.1 (Build 0)
+      return false;
+    }
+
+    // skip by default for now
     return true;
   }
 

--- a/src/modules/module_03000.c
+++ b/src/modules/module_03000.c
@@ -54,6 +54,15 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // Intel(R) Xeon(R) W-3223 CPU @ 3.50GHz; OpenCL C 1.2; 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE || device_param->opencl_platform_vendor_id == VENDOR_ID_INTEL_SDK) && (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU))
   {
+    if (strncmp (device_param->device_name, "AMD EPYC", 8) == 0)
+    {
+      // works on: AMD EPYC 7642 48-Core Processor, OpenCL 2.1 (Build 0)
+      return false;
+    }
+
+    // fail also on Apple Intel
+
+    // skip by default for now
     return true;
   }
 

--- a/src/modules/module_14000.c
+++ b/src/modules/module_14000.c
@@ -49,6 +49,15 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   // Intel(R) Xeon(R) W-3223 CPU @ 3.50GHz; OpenCL C 1.2; 11.3.1; 20E241
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE || device_param->opencl_platform_vendor_id == VENDOR_ID_INTEL_SDK) && (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU))
   {
+    if (strncmp (device_param->device_name, "AMD EPYC", 8) == 0)
+    {
+      // works on: AMD EPYC 7642 48-Core Processor, OpenCL 2.1 (Build 0)
+      return false;
+    }
+
+    // fail also on Apple Intel
+
+    // skip by default for now
     return true;
   }
 

--- a/src/modules/module_19200.c
+++ b/src/modules/module_19200.c
@@ -58,6 +58,12 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
 {
   if ((device_param->opencl_platform_vendor_id == VENDOR_ID_INTEL_SDK) && (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU))
   {
+    if (strncmp (device_param->device_name, "AMD EPYC", 8) == 0)
+    {
+      // works on Linux: AMD EPYC 7642 48-Core Processor, OpenCL 2.1 (Build 0)
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Hi,

summary:

1500: works on Apple Intel CPU, Linux AMD EPYC CPU OpenCL and POCL
3000: works on Linux AMD EPYC CPU
14000: works on Linux AMD EPYC CPU
19200: works on Linux AMD EPYC CPU


Tested on:
- Apple, Intel(R) Core(TM) i7-4578U CPU @ 3.00GHz, OpenCL 1.2
- Linux, 12th Gen Intel(R) Core(TM) i7-12700K, OpenCL 3.0 (Build 0)
- Linux, 12th Gen Intel(R) Core(TM) i7-12700K, POCL
- Linux, AMD EPYC 7642 48-Core Processor (thanks to @roycewilliams)


Thanks