### PR TITLE
Fix incorrect comparison result in sort_pot_orig_line()

### DIFF
--- a/src/potfile.c
+++ b/src/potfile.c
@@ -81,7 +81,10 @@ int sort_pot_orig_line (const void *v1, const void *v2)
   const pot_orig_line_entry_t *t1 = (const pot_orig_line_entry_t *) v1;
   const pot_orig_line_entry_t *t2 = (const pot_orig_line_entry_t *) v2;
 
-  return t1->line_pos > t2->line_pos;
+  if (t1->line_pos > t2->line_pos) return 1;
+  if (t1->line_pos < t2->line_pos) return -1;
+
+  return 0;
 }
 
 // the problem with the GNU tdestroy () function is that it doesn't work with mingw etc


### PR DESCRIPTION
The original sort_pot_orig_line() function returned 0 even when a < b, violating the C standard requirements for qsort() comparison functions. Specifically, it broke antisymmetry and transitivity, which can result in undefined behavior.

In some versions of glibc, this leads not only to incorrect sorting but also potential memory corruption[1].

Fix the issue by returning -1 when a < b, restoring compliance with the standard.

Link: https://www.qualys.com/2024/01/30/qsort.txt [1]
Fixes: 6adc217ba ("Keep output of --show and --left in the original ordering of the input hash file")