### PR TITLE
Fix incorrect comparison result in sort_by_src_len()

### DIFF
--- a/src/keyboard_layout.c
+++ b/src/keyboard_layout.c
@@ -15,7 +15,10 @@ static int sort_by_src_len (const void *p1, const void *p2)
   const keyboard_layout_mapping_t *k1 = (const keyboard_layout_mapping_t *) p1;
   const keyboard_layout_mapping_t *k2 = (const keyboard_layout_mapping_t *) p2;
 
-  return k1->src_len < k2->src_len;
+  if (k1->src_len < k2->src_len) return 1;
+  if (k1->src_len > k2->src_len) return -1;
+
+  return 0;
 }
 
 bool initialize_keyboard_layout_mapping (const char *filename, keyboard_layout_mapping_t *keyboard_layout_mapping, int *keyboard_layout_mapping_cnt)


### PR DESCRIPTION
The original sort_by_src_len() function returned 0 even when a > b, violating the C standard requirements for qsort() comparison functions. Specifically, it broke antisymmetry and transitivity, which can result in undefined behavior.

In some versions of glibc, this leads not only to incorrect sorting but also potential memory corruption[1].

Fix the issue by returning -1 when a > b, restoring compliance with the standard.

Link: https://www.qualys.com/2024/01/30/qsort.txt [1]
Fixes: 8eb2558a7 ("Add -m 6211 module and moved some code around")