### PR TITLE
porting the new scrypt engine to Apple Metal

### DIFF
--- a/OpenCL/inc_common.h
+++ b/OpenCL/inc_common.h
@@ -126,7 +126,8 @@
 #define KERN_ATTR_MAIN_PARAMS                       \
   uint hc_gid [[ thread_position_in_grid ]],        \
   uint hc_lid [[ thread_position_in_threadgroup ]], \
-  uint hc_lsz [[ threads_per_threadgroup ]]
+  uint hc_lsz [[ threads_per_threadgroup ]],        \
+  uint hc_bid [[ threadgroup_position_in_grid ]]
 #endif // IS_METAL
 
 /*

--- a/OpenCL/inc_hash_scrypt.cl
+++ b/OpenCL/inc_hash_scrypt.cl
@@ -286,17 +286,13 @@ DECLSPEC void salsa_r_p (PRIVATE_AS u32 *TI)
 }
 
 #ifdef IS_HIP
-DECLSPEC void scrypt_smix_init (LOCAL_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
+DECLSPEC void scrypt_smix_init (LOCAL_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid, const u64 lid, const u64 lsz, const u64 bid)
 #else
-DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
+DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid, const u64 lid, const u64 lsz, const u64 bid)
 #endif
 {
   const u32 ySIZE = SCRYPT_N >> SCRYPT_TMTO;
   const u32 zSIZE = STATE_CNT4;
-
-  const u64 bid = get_group_id(0);
-  const u64 lsz = get_local_size(0);
-  const u64 lid = get_local_id(0);
 
   const u32 xd4 = bid / 4;
   const u32 xm4 = bid & 3;
@@ -324,17 +320,13 @@ DECLSPEC void scrypt_smix_init (PRIVATE_AS uint4 *X, GLOBAL_AS uint4 *V0, GLOBAL
 }
 
 #ifdef IS_HIP
-DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, LOCAL_AS uint4 *T, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
+DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, LOCAL_AS uint4 *T, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid, const u64 lid, const u64 lsz, const u64 bid)
 #else
-DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, PRIVATE_AS uint4 *T, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid)
+DECLSPEC void scrypt_smix_loop (PRIVATE_AS uint4 *X, PRIVATE_AS uint4 *T, GLOBAL_AS uint4 *V0, GLOBAL_AS uint4 *V1, GLOBAL_AS uint4 *V2, GLOBAL_AS uint4 *V3, const u64 gid, const u64 lid, const u64 lsz, const u64 bid)
 #endif
 {
   const u32 ySIZE = SCRYPT_N >> SCRYPT_TMTO;
   const u32 zSIZE = STATE_CNT4;
-
-  const u64 bid = get_group_id(0);
-  const u64 lsz = get_local_size(0);
-  const u64 lid = get_local_id(0);
 
   const u32 xd4 = bid / 4;
   const u32 xm4 = bid & 3;

--- a/OpenCL/inc_platform.h
+++ b/OpenCL/inc_platform.h
@@ -74,6 +74,7 @@ DECLSPEC u32 hc_atomic_or  (volatile GLOBAL_AS u32 *p, volatile const u32 val);
 #define get_global_id(param) hc_gid
 #define get_local_id(param) hc_lid
 #define get_local_size(param) hc_lsz
+#define get_group_id(param) hc_bid
 
 DECLSPEC u32x rotl32   (const u32x a, const int n);
 DECLSPEC u32x rotr32   (const u32x a, const int n);

--- a/OpenCL/m08900-pure.cl
+++ b/OpenCL/m08900-pure.cl
@@ -40,6 +40,8 @@ KERNEL_FQ void HC_ATTR_SEQ m08900_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -61,7 +63,7 @@ KERNEL_FQ void HC_ATTR_SEQ m08900_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }
@@ -70,6 +72,8 @@ KERNEL_FQ void HC_ATTR_SEQ m08900_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -93,7 +97,7 @@ KERNEL_FQ void HC_ATTR_SEQ m08900_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }

--- a/OpenCL/m15700-pure.cl
+++ b/OpenCL/m15700-pure.cl
@@ -176,6 +176,8 @@ KERNEL_FQ void HC_ATTR_SEQ m15700_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -197,7 +199,7 @@ KERNEL_FQ void HC_ATTR_SEQ m15700_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }
@@ -206,6 +208,8 @@ KERNEL_FQ void HC_ATTR_SEQ m15700_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -229,7 +233,7 @@ KERNEL_FQ void HC_ATTR_SEQ m15700_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }

--- a/OpenCL/m22700-pure.cl
+++ b/OpenCL/m22700-pure.cl
@@ -119,6 +119,8 @@ KERNEL_FQ void HC_ATTR_SEQ m22700_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -140,7 +142,7 @@ KERNEL_FQ void HC_ATTR_SEQ m22700_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }
@@ -149,6 +151,8 @@ KERNEL_FQ void HC_ATTR_SEQ m22700_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -172,7 +176,7 @@ KERNEL_FQ void HC_ATTR_SEQ m22700_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }

--- a/OpenCL/m24000-pure.cl
+++ b/OpenCL/m24000-pure.cl
@@ -184,6 +184,8 @@ KERNEL_FQ void HC_ATTR_SEQ m24000_loop_prepare (KERN_ATTR_TMPS_ESALT (scrypt_tmp
 
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -202,7 +204,7 @@ KERNEL_FQ void HC_ATTR_SEQ m24000_loop_prepare (KERN_ATTR_TMPS_ESALT (scrypt_tmp
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }
@@ -211,6 +213,8 @@ KERNEL_FQ void HC_ATTR_SEQ m24000_loop (KERN_ATTR_TMPS_ESALT (scrypt_tmp_t, best
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -234,7 +238,7 @@ KERNEL_FQ void HC_ATTR_SEQ m24000_loop (KERN_ATTR_TMPS_ESALT (scrypt_tmp_t, best
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }

--- a/OpenCL/m27700-pure.cl
+++ b/OpenCL/m27700-pure.cl
@@ -69,6 +69,8 @@ KERNEL_FQ void HC_ATTR_SEQ m27700_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -90,7 +92,7 @@ KERNEL_FQ void HC_ATTR_SEQ m27700_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }
@@ -99,6 +101,8 @@ KERNEL_FQ void HC_ATTR_SEQ m27700_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -122,7 +126,7 @@ KERNEL_FQ void HC_ATTR_SEQ m27700_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }

--- a/OpenCL/m28200-pure.cl
+++ b/OpenCL/m28200-pure.cl
@@ -50,6 +50,8 @@ KERNEL_FQ void HC_ATTR_SEQ m28200_loop_prepare (KERN_ATTR_TMPS_ESALT (exodus_tmp
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -71,7 +73,7 @@ KERNEL_FQ void HC_ATTR_SEQ m28200_loop_prepare (KERN_ATTR_TMPS_ESALT (exodus_tmp
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }
@@ -80,6 +82,8 @@ KERNEL_FQ void HC_ATTR_SEQ m28200_loop (KERN_ATTR_TMPS_ESALT (exodus_tmp_t, exod
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -103,7 +107,7 @@ KERNEL_FQ void HC_ATTR_SEQ m28200_loop (KERN_ATTR_TMPS_ESALT (exodus_tmp_t, exod
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }

--- a/OpenCL/m29800-pure.cl
+++ b/OpenCL/m29800-pure.cl
@@ -69,6 +69,8 @@ KERNEL_FQ void HC_ATTR_SEQ m29800_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -90,7 +92,7 @@ KERNEL_FQ void HC_ATTR_SEQ m29800_loop_prepare (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_init (X, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }
@@ -99,6 +101,8 @@ KERNEL_FQ void HC_ATTR_SEQ m29800_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+  const u64 bid = get_group_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -122,7 +126,7 @@ KERNEL_FQ void HC_ATTR_SEQ m29800_loop (KERN_ATTR_TMPS (scrypt_tmp_t))
 
   for (int z = 0; z < STATE_CNT4; z++) X[z] = P[z];
 
-  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid);
+  scrypt_smix_loop (X, T, d_scrypt0_buf, d_scrypt1_buf, d_scrypt2_buf, d_scrypt3_buf, gid, lid, lsz, bid);
 
   for (int z = 0; z < STATE_CNT4; z++) P[z] = X[z];
 }


### PR DESCRIPTION
Hi,

added the equivalent of get_group_id() for Apple Metal and rewrote the new scrypt engine to make it work with it. Following the POC with hash-mode 8900

```
$ ./hashcat -b -d 1 -m 8900
hashcat (v6.2.6-998-g7fe091f4a) starting in benchmark mode

[...]

METAL API (Metal 368.12)
========================
* Device #01: Apple M1, 5461/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Apr 18 2025 21:46:03)) - Platform #1 [Apple]
====================================================================
* Device #02: Apple M1, skipped

Benchmark relevant options:
===========================
* --backend-devices=1
* --backend-devices-virtmulti=1
* --backend-devices-virthost=1
* --optimized-kernel-enable

---------------------------------------------
* Hash-Mode 8900 (scrypt) [Iterations: 16384]
---------------------------------------------

* Device #1: This system does not offer any reliable method to query actual free memory. Estimated base: 5726625792
             Assuming normal desktop activity, reducing estimate by 20%: 4581300633
             This can hurt performance drastically, especially on memory-heavy algorithms.
             You can adjust this percentage using --backend-devices-keepfree

Speed.#01........:      171 H/s (109.95ms) @ Accel:8 Loops:2048 Thr:32 Vec:1

Started: Tue Jun 17 22:24:05 2025
Stopped: Tue Jun 17 22:24:09 2025
```

Thanks ;)