### PR TITLE
fix is_autotune checks on Apple Metal

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -2660,12 +2660,15 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
     const size_t global_work_size[3] = { num_elements,   1, 1 };
     const size_t local_work_size[3]  = { kernel_threads, 1, 1 };
 
+    double ms = 0;
+
     if (is_autotune == true)
     {
       hc_mtlEncodeComputeCommand (hashcat_ctx, metal_command_encoder, metal_command_buffer, global_work_size[0], local_work_size[0], &ms);
-    }
 
-    double ms = 0;
+      // hc_mtlEncodeComputeCommand_pre() must be called before every hc_mtlEncodeComputeCommand()
+      if (hc_mtlEncodeComputeCommand_pre (hashcat_ctx, metal_pipeline, device_param->metal_command_queue, &metal_command_buffer, &metal_command_encoder) == -1) return -1;
+    }
 
     const int rc_cc = hc_mtlEncodeComputeCommand (hashcat_ctx, metal_command_encoder, metal_command_buffer, global_work_size[0], local_work_size[0], &ms);
 


### PR DESCRIPTION
Hi,

fixed build and runtime error with Apple Metal:

```
src/backend.c:2665:135: error: use of undeclared identifier 'ms'
 2665 |       hc_mtlEncodeComputeCommand (hashcat_ctx, metal_command_encoder, metal_command_buffer, global_work_size[0], local_work_size[0], &ms);
      |                                                                                                                                       ^
1 error generated.
make: *** [obj/backend.NATIVE.o] Error 1
make: *** Waiting for unfinished jobs....

```

```
$ ./hashcat -m 8900 -b -d 1
hashcat (v6.2.6-1022-g13f48e563+) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

[...]

METAL API (Metal 368.12)
========================
* Device #01: Apple M1, 5461/10922 MB, 8MCU

OpenCL API (OpenCL 1.2 (Apr 18 2025 21:46:03)) - Platform #1 [Apple]
====================================================================
* Device #02: Apple M1, skipped

Benchmark relevant options:
===========================
* --backend-devices=1
* --backend-devices-virtmulti=1
* --backend-devices-virthost=1
* --optimized-kernel-enable

---------------------------------------------
* Hash-Mode 8900 (scrypt) [Iterations: 16384]
---------------------------------------------

* Device #1: This system does not offer any reliable method to query actual free memory. Estimated base: 5726625792
             Assuming normal desktop activity, reducing estimate by 20%: 4581300633
             This can hurt performance drastically, especially on memory-heavy algorithms.
             You can adjust this percentage using --backend-devices-keepfree

Segmentation fault: 11
```

Thanks
