### PR TITLE
fix memory leaks

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -8636,6 +8636,11 @@ void backend_ctx_devices_destroy (hashcat_ctx_t *hashcat_ctx)
       hcfree (device_param->opencl_device_c_version);
       hcfree (device_param->opencl_device_vendor);
     }
+
+    if (device_param->is_hip == true)
+    {
+      hcfree (device_param->gcnArchName);
+    }
   }
 
   backend_ctx->backend_devices_cnt    = 0;

--- a/src/backend.c
+++ b/src/backend.c
@@ -5168,6 +5168,8 @@ int backend_ctx_init (hashcat_ctx_t *hashcat_ctx)
     event_log_warning (hashcat_ctx, "  \"CUDA Toolkit\" (9.0 or later)");
     event_log_warning (hashcat_ctx, NULL);
 
+    hcfree (backend_ctx->devices_param);
+
     return -1;
   }
 

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -324,6 +324,11 @@ void user_options_destroy (hashcat_ctx_t *hashcat_ctx)
 
   hcfree (user_options->rp_files);
 
+  if (user_options->backend_info > 0)
+  {
+    hcfree (user_options->opencl_device_types);
+  }
+
   //do not reset this, it might be used from main.c
   //memset (user_options, 0, sizeof (user_options_t));
 }


### PR DESCRIPTION
```
Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7e73c70fd340 in calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x5fd5673e4229 in hccalloc src/memory.c:12
    #2 0x5fd5673e4291 in hcmalloc src/memory.c:27
    #3 0x5fd5673e43a9 in hcstrdup src/memory.c:52
    #4 0x5fd5674358a2 in user_options_preprocess src/user_options.c:2044
    #5 0x5fd5673b9e34 in hashcat_session_init src/hashcat.c:1206
    #6 0x5fd5673b754f in main src/main.c:1363
    #7 0x7e73c682a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #8 0x7e73c682a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #9 0x5fd5673b2964 in _start ([redacted]/hashcat/hashcat+0x37964) (BuildId: 94ac558d46faaa0ed3d634469c797c34e5c7c1b2)
	
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7e73c70f74e8 in strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:578
    #1 0x5fd5674c0d61 in backend_ctx_devices_init src/backend.c:5809
    #2 0x5fd5673b9ffc in hashcat_session_init src/hashcat.c:1347
    #3 0x5fd5673b754f in main src/main.c:1363
    #4 0x7e73c682a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #5 0x7e73c682a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #6 0x5fd5673b2964 in _start ([redacted]/hashcat/hashcat+0x37964) (BuildId: 94ac558d46faaa0ed3d634469c797c34e5c7c1b2)
	
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x74e4738fd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x74e47308f947 in __vasprintf_internal libio/vasprintf.c:116
    #2 0x55fc0b44bd1f in vasprintf /usr/include/x86_64-linux-gnu/bits/stdio2.h:169
    #3 0x55fc0b44bd1f in hc_asprintf src/shared.c:290
    #4 0x55fc0b5611e2 in hm_SYSFS_CPU_get_syspath_hwmon src/ext_sysfs_cpu.c:73
    #5 0x55fc0b5613b8 in hm_SYSFS_CPU_get_temperature_current src/ext_sysfs_cpu.c:90
    #6 0x55fc0b411754 in hm_get_temperature_with_devices_idx src/hwmon.c:265
    #7 0x55fc0b4194b7 in hwmon_ctx_init src/hwmon.c:1987
    #8 0x55fc0b3fa009 in hashcat_session_init src/hashcat.c:1353
    #9 0x55fc0b3f754f in main src/main.c:1363
    #10 0x74e47302a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x74e47302a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #12 0x55fc0b3f2964 in _start ([redacted]/hashcat/hashcat+0x37964) (BuildId: b194102add02e09e8d0f0558afa12bd71f5abf57)

```