### PR TITLE
Fix socket leak in brain_server()

### DIFF
--- a/src/brain.c
+++ b/src/brain.c
@@ -3052,6 +3052,8 @@ int brain_server (const char *listen_host, const int listen_port, const char *br
   {
     brain_logging (stderr, 0, "setsockopt: %s\n", strerror (errno));
 
+    close(server_fd);
+
     if (brain_password == NULL) hcfree (auth_password);
 
     return -1;
@@ -3060,6 +3062,8 @@ int brain_server (const char *listen_host, const int listen_port, const char *br
   if (setsockopt (server_fd, SOL_TCP, TCP_NODELAY, &one, sizeof (one)) == -1)
   {
     brain_logging (stderr, 0, "setsockopt: %s\n", strerror (errno));
+
+    close(server_fd);
 
     if (brain_password == NULL) hcfree (auth_password);
 
@@ -3104,6 +3108,8 @@ int brain_server (const char *listen_host, const int listen_port, const char *br
     {
       brain_logging (stderr, 0, "%s: %s\n", listen_host, gai_strerror (rc_getaddrinfo));
 
+      close(server_fd);
+
       if (brain_password == NULL) hcfree (auth_password);
 
       return -1;
@@ -3114,6 +3120,8 @@ int brain_server (const char *listen_host, const int listen_port, const char *br
   {
     brain_logging (stderr, 0, "bind: %s\n", strerror (errno));
 
+    close(server_fd);
+
     if (brain_password == NULL) hcfree (auth_password);
 
     return -1;
@@ -3122,6 +3130,8 @@ int brain_server (const char *listen_host, const int listen_port, const char *br
   if (listen (server_fd, 5) == -1)
   {
     brain_logging (stderr, 0, "listen: %s\n", strerror (errno));
+
+    close(server_fd);
 
     if (brain_password == NULL) hcfree (auth_password);
 


### PR DESCRIPTION
**Describe**

Hi,

Fixes a resource leak in the `brain_server()` function by ensuring the socket file descriptor (`server_fd`) is properly closed when an error occurs after `socket()` is successfully created but before the server is fully initialized.

**Expected Behavior**

When `setsockopt()`, `getaddrinfo()`, `bind()`, or `listen()` fails, the `server_fd` should be closed to avoid file descriptor leaks.

**Actual Behavior**

Previously, if any of those operations failed, the `server_fd` remained open, causing a resource leak.

This patch prevents a subtle file descriptor leak with minimal changes, improving the server’s stability in real-world use.

Thanks for reviewing.