### PR TITLE
do not allow --benchmark and --backend-info

### DIFF
--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1387,6 +1387,13 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
       return -1;
     }
 
+    if (user_options->backend_info > 0)
+    {
+      event_log_error (hashcat_ctx, "Use of --backend-info is not allowed in benchmark mode.");
+
+      return -1;
+    }
+
     if (user_options->spin_damp_chgd == true)
     {
       event_log_error (hashcat_ctx, "Can't change --spin-damp in benchmark mode.");


### PR DESCRIPTION
```
$ ./hashcat -I -b
hashcat (v6.2.6-1043-ga5e472c12) starting in benchmark mode

Benchmarking uses hand-optimized kernel code by default.
You can use it in your cracking session by setting the -O option.
Note: Using optimized kernel code limits the maximum supported password length.
To disable the optimized kernel code in benchmark mode, use the -w option.

Metal Info:
===========

Metal.Version.: 244.303

Backend Device ID #01 (Alias: #03)
  Type...........: GPU
  Vendor.ID......: 2
  Vendor.........: Apple
  Name...........: Intel Iris Graphics
  Processor(s)...: 40
  Clock..........: N/A
  Memory.Total...: 1536 MB (limited to 576 MB allocatable in one block)
  Memory.Free....: 768 MB
  Local.Memory...: 32 KB
  Phys.Location..: built-in
  Registry.ID....: 1082
  Max.TX.Rate....: N/A
  GPU.Properties.: headless 0, low-power 1, removable 0

[...]
```