### PR TITLE
workaround for HIP bug and avoiding a potential same bug on CUDA

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -15948,6 +15948,12 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       {
         u32 threads_per_block_with_regs = (floor) ((float) device_param->regsPerBlock / num_regs);
 
+        if (threads_per_block_with_regs == 0)
+        {
+          // prevent threads_per_block from resulting in 0 due to a bug on the runtime
+          threads_per_block_with_regs = threads_per_block;
+        }
+
         if (threads_per_block_with_regs > device_param->kernel_preferred_wgs_multiple) threads_per_block_with_regs -= threads_per_block_with_regs % device_param->kernel_preferred_wgs_multiple;
 
         threads_per_block = MIN (threads_per_block, threads_per_block_with_regs);
@@ -15966,6 +15972,14 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (num_regs)
       {
         u32 threads_per_block_with_regs = (floor) ((float) device_param->regsPerBlock / num_regs);
+
+        if (threads_per_block_with_regs == 0)
+        {
+          // https://rocm.docs.amd.com/projects/HIP/en/docs-develop/doxygen/html/bug.html
+          // HIP-Clang always returns 0 for regsPerBlock due to a known bug
+          // prevent threads_per_block from resulting in 0, otherwise hashcat crashes
+          threads_per_block_with_regs = threads_per_block;
+        }
 
         if (threads_per_block_with_regs > device_param->kernel_preferred_wgs_multiple) threads_per_block_with_regs -= threads_per_block_with_regs % device_param->kernel_preferred_wgs_multiple;
 


### PR DESCRIPTION
found a bug on HIP, documented here https://rocm.docs.amd.com/projects/HIP/en/docs-develop/doxygen/html/bug.html

```
HIP-Clang always returns 0 for regsPerBlock
```

Added a workaround and a safe check also on CUDA

POC on windows

<img width="1060" alt="Screenshot 2025-06-28 at 21 18 21" src="https://github.com/user-attachments/assets/87403211-1db9-4158-bae0-8d88f100ff9b" />

