### PR TITLE
Fixed race condition in selftest_init on OpenCL with non-blocking write

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -92,6 +92,7 @@
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
 - Fixed bug in --stdout that caused certain rules to malfunction
+- Fixed race condition in selftest_init on OpenCL with non-blocking write
 - Fixed build failed for 10700 optimized with Apple Metal
 - Fixed build failed for 13772 and 13773 with Apple Metal
 - Fixed build failed for 18400 with Apple Metal


### PR DESCRIPTION
Preventing selftest failure on Linux using OpenCL