### PR TITLE
[FIX] Prevent NULL dereference in read_restore() via hcmalloc

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -89,6 +89,14 @@ static int read_restore (hashcat_ctx_t *hashcat_ctx)
 
   char *buf = (char *) hcmalloc (HCBUFSIZ_LARGE);
 
+  if (buf == NULL)
+  {
+    event_log_error(hashcat_ctx, "hcmalloc: %s", strerror(errno));
+    hc_fclose(&fp);
+    hcfree(rd->argv);
+    return -1;
+  }
+
   for (u32 i = 0; i < rd->argc; i++)
   {
     if (hc_fgets (buf, HCBUFSIZ_LARGE - 1, &fp) == NULL)


### PR DESCRIPTION
Describe the bug

In restore.c, the function init_restore() allocates a large buffer using the hcmalloc() function:

char *buf = (char *) hcmalloc(HCBUFSIZ_LARGE);

However, this allocation is not followed by a NULL check. Although hcmalloc() is expected to wrap standard memory allocation, in scenarios where allocation fails (e.g., low-memory systems), it may return NULL. This would cause the program to dereference a NULL pointer when accessing buf, leading to undefined behavior or a segmentation fault.

File

src/restore.c

Vulnerable code

char *buf = (char *) hcmalloc(HCBUFSIZ_LARGE);
// potential NULL dereference here if hcmalloc fails

Line number

Line 151 (based on latest master)

Expected behavior

If memory allocation fails, the code should handle this gracefully by checking for NULL, freeing any already-allocated memory, and returning a failure code, rather than proceeding with dereferencing the buffer.

Actual behavior

No NULL check is performed after memory allocation. This could result in undefined behavior on memory exhaustion.

Proposed Fix

We added a NULL check after the hcmalloc() call to ensure the buffer was allocated successfully. If allocation fails, we log the error, release previously allocated resources (rd->argv), close the file descriptor, and return an error code (-1):

char *buf = (char *) hcmalloc(HCBUFSIZ_LARGE);
if (buf == NULL)
{
    event_log_error(hashcat_ctx, "hcmalloc: %s", strerror(errno));
    hc_fclose(&fp);
    hcfree(rd->argv);
    return -1;
}

How to Reproduce

Force memory exhaustion in the environment and trigger a restore-read operation by executing hashcat with restore enabled. This may cause a segmentation fault due to NULL dereference.

Additional context

This patch improves the robustness of the restore mechanism in hashcat by ensuring safe memory handling. We verified that this change does not affect normal functionality and only adds a safety guard for rare error conditions.