### PR TITLE
skip non-machine preamble if --backend_info and --machine

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -88,8 +88,11 @@ void welcome_screen (hashcat_ctx_t *hashcat_ctx, const char *version_tag)
   }
   else if (user_options->backend_info > 0)
   {
-    event_log_info (hashcat_ctx, "%s (%s) starting in backend information mode", PROGNAME, version_tag);
-    event_log_info (hashcat_ctx, NULL);
+    if (user_options->machine_readable == false)
+    {
+      event_log_info (hashcat_ctx, "%s (%s) starting in backend information mode", PROGNAME, version_tag);
+      event_log_info (hashcat_ctx, NULL);
+    }
   }
   else if (user_options->hash_mode_chgd == false)
   {


### PR DESCRIPTION
By skipping non-JSON output, this allows JSON output to be piped directly into something else without modification.