### PR TITLE
Support for Argon2id on NVIDIA CUDA GPUs

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -1947,6 +1947,19 @@ DECLSPEC u32 hc_lop_0x96_S (const u32 a, const u32 b, const u32 c)
 #endif
 
 /**
+ * arithmetic operations
+ */
+
+DECLSPEC u32 hc_umulhi (const u32 x, const u32 y)
+{
+#if defined IS_CUDA
+  return __umulhi (x, y);
+#else
+  return h32_from_64_S ((u64) x * (u64) y);
+#endif
+}
+
+/**
  * pure scalar functions
  */
 
@@ -41963,6 +41976,76 @@ DECLSPEC void switch_buffer_by_offset_8x4_le_S (PRIVATE_AS u32 *w0, PRIVATE_AS u
       w4[1] = hc_byte_perm_S (w0[1], w0[2], selector);
       w4[0] = hc_byte_perm_S (w0[0], w0[1], selector);
       w3[3] = hc_byte_perm_S (    0, w0[0], selector);
+      w3[2] = 0;
+      w3[1] = 0;
+      w3[0] = 0;
+      w2[3] = 0;
+      w2[2] = 0;
+      w2[1] = 0;
+      w2[0] = 0;
+      w1[3] = 0;
+      w1[2] = 0;
+      w1[1] = 0;
+      w1[0] = 0;
+      w0[3] = 0;
+      w0[2] = 0;
+      w0[1] = 0;
+      w0[0] = 0;
+      break;
+
+    case 16:
+      w7[3] = hc_byte_perm_S (w3[2], w3[3], selector);
+      w7[2] = hc_byte_perm_S (w3[1], w3[2], selector);
+      w7[1] = hc_byte_perm_S (w3[0], w3[1], selector);
+      w7[0] = hc_byte_perm_S (w2[3], w3[0], selector);
+      w6[3] = hc_byte_perm_S (w2[2], w2[3], selector);
+      w6[2] = hc_byte_perm_S (w2[1], w2[2], selector);
+      w6[1] = hc_byte_perm_S (w2[0], w2[1], selector);
+      w6[0] = hc_byte_perm_S (w1[3], w2[0], selector);
+      w5[3] = hc_byte_perm_S (w1[2], w1[3], selector);
+      w5[2] = hc_byte_perm_S (w1[1], w1[2], selector);
+      w5[1] = hc_byte_perm_S (w1[0], w1[1], selector);
+      w5[0] = hc_byte_perm_S (w0[3], w1[0], selector);
+      w4[3] = hc_byte_perm_S (w0[2], w0[3], selector);
+      w4[2] = hc_byte_perm_S (w0[1], w0[2], selector);
+      w4[1] = hc_byte_perm_S (w0[0], w0[1], selector);
+      w4[0] = hc_byte_perm_S (    0, w0[0], selector);
+      w3[3] = 0;
+      w3[2] = 0;
+      w3[1] = 0;
+      w3[0] = 0;
+      w2[3] = 0;
+      w2[2] = 0;
+      w2[1] = 0;
+      w2[0] = 0;
+      w1[3] = 0;
+      w1[2] = 0;
+      w1[1] = 0;
+      w1[0] = 0;
+      w0[3] = 0;
+      w0[2] = 0;
+      w0[1] = 0;
+      w0[0] = 0;
+      break;
+
+    case 17:
+      w7[3] = hc_byte_perm_S (w3[1], w3[2], selector);
+      w7[2] = hc_byte_perm_S (w3[0], w3[1], selector);
+      w7[1] = hc_byte_perm_S (w2[3], w3[0], selector);
+      w7[0] = hc_byte_perm_S (w2[2], w2[3], selector);
+      w6[3] = hc_byte_perm_S (w2[1], w2[2], selector);
+      w6[2] = hc_byte_perm_S (w2[0], w2[1], selector);
+      w6[1] = hc_byte_perm_S (w1[3], w2[0], selector);
+      w6[0] = hc_byte_perm_S (w1[2], w1[3], selector);
+      w5[3] = hc_byte_perm_S (w1[1], w1[2], selector);
+      w5[2] = hc_byte_perm_S (w1[0], w1[1], selector);
+      w5[1] = hc_byte_perm_S (w0[3], w1[0], selector);
+      w5[0] = hc_byte_perm_S (w0[2], w0[3], selector);
+      w4[3] = hc_byte_perm_S (w0[1], w0[2], selector);
+      w4[2] = hc_byte_perm_S (w0[0], w0[1], selector);
+      w4[1] = hc_byte_perm_S (    0, w0[0], selector);
+      w4[0] = 0;
+      w3[3] = 0;
       w3[2] = 0;
       w3[1] = 0;
       w3[0] = 0;

--- a/OpenCL/inc_common.h
+++ b/OpenCL/inc_common.h
@@ -284,6 +284,10 @@ DECLSPEC u32  hc_bfe_S          (const u32  a, const u32  b, const u32  c);
 DECLSPEC u32x hc_lop_0x96       (const u32x a, const u32x b, const u32x c);
 DECLSPEC u32  hc_lop_0x96_S     (const u32  a, const u32  b, const u32  c);
 
+// arithmetic operations
+
+DECLSPEC u32  hc_umulhi (const u32 x, const u32 y);
+
 // legacy common code
 
 DECLSPEC int ffz (const u32 v);

--- a/OpenCL/inc_hash_argon2.cl
+++ b/OpenCL/inc_hash_argon2.cl
@@ -1,0 +1,383 @@
+/**
+ * Author......: Netherlands Forensic Institute
+ * License.....: MIT
+ *
+ * Warp code based on original work by Ondrej Mosnáček
+ */
+
+#include "inc_vendor.h"
+#include "inc_types.h"
+#include "inc_platform.h"
+#include "inc_common.h"
+#include "inc_hash_blake2b.h"
+#include "inc_hash_argon2.h"
+
+DECLSPEC void argon2_initial_block (const u32 *in, const u32 lane, const u32 blocknum, const u32 parallelism, GLOBAL_AS argon2_block_t *blocks)
+{
+  blake2b_ctx_t ctx;
+
+  blake2b_init (&ctx);
+
+  u64 blake_buf[16] = { 0 };
+
+  blake_buf[0] = sizeof(argon2_block_t);
+
+  blake2b_update (&ctx, (u32 *) blake_buf, 4);
+  blake2b_update (&ctx, in, 64);
+
+  blake_buf[0] = hl32_to_64 (lane, blocknum);
+
+  blake2b_update (&ctx, (u32 *) blake_buf, 8);
+
+  blake2b_final (&ctx);
+
+  u64 *out = blocks[(blocknum * parallelism) + lane].values;
+
+  out[0] = ctx.h[0];
+  out[1] = ctx.h[1];
+  out[2] = ctx.h[2];
+  out[3] = ctx.h[3];
+
+  for (u32 off = 4; off < 124; off += 4)
+  {
+    for (u32 idx = 0; idx < 8; idx++) blake_buf[idx] = ctx.h[idx];
+
+    blake2b_init (&ctx);
+    blake2b_transform (ctx.h, blake_buf, 64, BLAKE2B_FINAL);
+
+    out[off + 0] = ctx.h[0];
+    out[off + 1] = ctx.h[1];
+    out[off + 2] = ctx.h[2];
+    out[off + 3] = ctx.h[3];
+  }
+
+  out[124] = ctx.h[4];
+  out[125] = ctx.h[5];
+  out[126] = ctx.h[6];
+  out[127] = ctx.h[7];
+}
+
+DECLSPEC void argon2_initial_hash (GLOBAL_AS const pw_t *pw, GLOBAL_AS const salt_t *salt, const argon2_options_t *options, u64 *blockhash)
+{
+  blake2b_ctx_t ctx;
+  blake2b_init (&ctx);
+
+  u32 option_input[32] = { 0 };
+
+  option_input[0] = options->parallelism;
+  option_input[1] = options->digest_len;
+  option_input[2] = options->memory_usage_in_kib;
+  option_input[3] = options->iterations;
+  option_input[4] = options->version;
+  option_input[5] = options->type;
+
+  blake2b_update (&ctx, option_input, 24);
+
+  u32 len_input[32] = { 0 };
+
+  len_input[0] = pw->pw_len;
+
+  blake2b_update (&ctx, len_input, 4);
+  blake2b_update_global (&ctx, pw->i, pw->pw_len);
+
+  len_input[0] = salt->salt_len;
+
+  blake2b_update (&ctx, len_input, 4);
+  blake2b_update_global (&ctx, salt->salt_buf, salt->salt_len);
+
+  len_input[0] = 0;
+
+  blake2b_update (&ctx, len_input, 4); // secret (K)
+  blake2b_update (&ctx, len_input, 4); // associated data (X)
+
+  blake2b_final (&ctx);
+
+  for (u32 idx = 0; idx < 8; idx++) blockhash[idx] = ctx.h[idx];
+}
+
+DECLSPEC void argon2_init (GLOBAL_AS const pw_t *pw, GLOBAL_AS const salt_t *salt,
+                           const argon2_options_t *options, GLOBAL_AS argon2_block_t *out)
+{
+  u64 blockhash[16] = { 0 };
+
+  argon2_initial_hash (pw, salt, options, blockhash);
+
+  // Generate the first two blocks of each lane
+  for (u32 lane = 0; lane < options->parallelism; lane++)
+  {
+    argon2_initial_block ((u32 *) blockhash, lane, 0, options->parallelism, out);
+    argon2_initial_block ((u32 *) blockhash, lane, 1, options->parallelism, out);
+  }
+}
+
+DECLSPEC u64 trunc_mul (u64 x, u64 y)
+{
+  const u32 xlo = (u32) x;
+  const u32 ylo = (u32) y;
+  return hl32_to_64_S (hc_umulhi (xlo, ylo), (u32) (xlo * ylo));
+}
+
+DECLSPEC inline u32 argon2_ref_address (const argon2_options_t *options, const argon2_pos_t *pos, u32 index, u64 pseudo_random)
+{
+  u32 ref_lane;
+  u32 ref_area;
+  u32 ref_index;
+
+  if ((pos->pass == 0) && (pos->slice == 0))
+  {
+    ref_lane = pos->lane;
+  }
+  else
+  {
+    ref_lane = h32_from_64_S (pseudo_random) % options->parallelism;
+  }
+
+  ref_area  = (pos->pass == 0) ? pos->slice : (ARGON2_SYNC_POINTS - 1);
+  ref_area *= options->segment_length;
+
+  if ((ref_lane == pos->lane) || (index == 0))
+  {
+      ref_area += (index - 1);
+  }
+
+  const u32 j1 = l32_from_64_S (pseudo_random);
+  ref_index = (ref_area - 1 - hc_umulhi (ref_area, hc_umulhi (j1, j1)));
+
+  if (pos->pass > 0)
+  {
+    ref_index += (pos->slice + 1) * options->segment_length;
+
+    if (ref_index >= options->lane_length)
+    {
+      ref_index -= options->lane_length;
+    }
+  }
+
+  return (options->parallelism * ref_index) + ref_lane;
+}
+
+DECLSPEC void swap_u64 (u64 *x, u64 *y)
+{
+  u64 tmp = *x;
+  *x = *y;
+  *y = tmp;
+}
+
+DECLSPEC void transpose_permute_block (u64 R[4], int thread)
+{
+  if (thread & 0x08)
+  {
+    swap_u64 (&R[0], &R[2]);
+    swap_u64 (&R[1], &R[3]);
+  }
+  if (thread & 0x04)
+  {
+    swap_u64 (&R[0], &R[1]);
+    swap_u64 (&R[2], &R[3]);
+  }
+}
+
+DECLSPEC int argon2_shift (int idx, int thread)
+{
+  const int delta = ((idx & 0x02) << 3) + (idx & 0x01);
+  return (thread & 0x0e) | (((thread & 0x11) + delta + 0x0e) & 0x11);
+}
+
+DECLSPEC void argon2_hash_block (u64 R[4], int thread)
+{
+  for (u32 idx = 1; idx < 4; idx++) R[idx] = __shfl_sync (FULL_MASK, R[idx], thread ^ (idx << 2));
+
+  transpose_permute_block (R, thread);
+
+  for (u32 idx = 1; idx < 4; idx++) R[idx] = __shfl_sync (FULL_MASK, R[idx], thread ^ (idx << 2));
+
+  ARGON2_G(R[0], R[1], R[2], R[3]);
+
+  for (u32 idx = 1; idx < 4; idx++) R[idx] = __shfl_sync (FULL_MASK, R[idx],  (thread & 0x1c) | ((thread + idx) & 0x03));
+
+  ARGON2_G(R[0], R[1], R[2], R[3]);
+
+  for (u32 idx = 1; idx < 4; idx++) R[idx] = __shfl_sync (FULL_MASK, R[idx], ((thread & 0x1c) | ((thread - idx) & 0x03)) ^ (idx << 2));
+
+  transpose_permute_block (R, thread);
+
+  for (u32 idx = 1; idx < 4; idx++) R[idx] = __shfl_sync (FULL_MASK, R[idx], thread ^ (idx << 2));
+
+  ARGON2_G(R[0], R[1], R[2], R[3]);
+
+  for (u32 idx = 1; idx < 4; idx++) R[idx] = __shfl_sync (FULL_MASK, R[idx], argon2_shift (idx, thread));
+
+  ARGON2_G(R[0], R[1], R[2], R[3]);
+
+  for (u32 idx = 1; idx < 4; idx++) R[idx] = __shfl_sync (FULL_MASK, R[idx], argon2_shift ((4 - idx), thread));
+}
+
+DECLSPEC void argon2_next_addresses (const argon2_options_t *options, const argon2_pos_t *pos, u32 *addresses, u32 start_index, u32 thread)
+{
+  u64 Z[4] = { 0 };
+  u64 tmp[4];
+
+  switch (thread)
+  {
+    case 0:  Z[0] = pos->pass;                   break;
+    case 1:  Z[0] = pos->lane;                   break;
+    case 2:  Z[0] = pos->slice;                  break;
+    case 3:  Z[0] = options->memory_block_count; break;
+    case 4:  Z[0] = options->iterations;         break;
+    case 5:  Z[0] = options->type;               break;
+    case 6:  Z[0] = (start_index / 128) + 1;     break;
+    default: Z[0] = 0;                           break;
+  }
+
+  tmp[0] = Z[0];
+
+  argon2_hash_block (Z, thread);
+
+  Z[0]  ^= tmp[0];
+
+  for (u32 idx = 0; idx < 4; idx++) tmp[idx] = Z[idx];
+
+  argon2_hash_block (Z, thread);
+
+  for (u32 idx = 0; idx < 4; idx++) Z[idx]  ^= tmp[idx];
+
+  for (u32 i = 0, index = (start_index + thread); i < 4; i++, index += THREADS_PER_LANE)
+  {
+    addresses[i] = argon2_ref_address (options, pos, index, Z[i]);
+  }
+}
+
+DECLSPEC u32 index_u32x4 (const u32 array[4], u32 index)
+{
+  switch (index)
+  {
+    case 0:
+      return array[0];
+    case 1:
+      return array[1];
+    case 2:
+      return array[2];
+    case 3:
+      return array[3];
+  }
+}
+
+DECLSPEC GLOBAL_AS argon2_block_t *argon2_get_current_block (GLOBAL_AS argon2_block_t *blocks, const argon2_options_t *options, u32 lane, u32 index_in_lane, u64 R[4], u32 thread)
+{
+  // Apply wrap-around to previous block index if the current block is the first block in the lane
+  const u32 prev_in_lane = (index_in_lane == 0) ? (options->lane_length - 1) : (index_in_lane - 1);
+
+  argon2_block_t *prev_block = &blocks[(prev_in_lane * options->parallelism) + lane];
+
+  for (u32 idx = 0; idx < 4; idx++) R[idx] = prev_block->values[(idx * THREADS_PER_LANE) + thread];
+
+  return &blocks[(index_in_lane * options->parallelism) + lane];
+}
+
+DECLSPEC void argon2_fill_subsegment (GLOBAL_AS argon2_block_t *blocks, const argon2_options_t *options, const argon2_pos_t *pos, bool indep_addr, const u32 addresses[4],
+                                      u32 start_index, u32 end_index, GLOBAL_AS argon2_block_t *cur_block, u64 R[4], u32 thread)
+{
+  for (u32 index = start_index; index < end_index; index++, cur_block += options->parallelism)
+  {
+    u32 ref_address;
+
+    if (indep_addr)
+    {
+      ref_address = index_u32x4 (addresses, (index / THREADS_PER_LANE) % ARGON2_SYNC_POINTS);
+      ref_address = __shfl_sync (FULL_MASK, ref_address, index);
+    }
+    else
+    {
+      ref_address = argon2_ref_address (options, pos, index, R[0]);
+      ref_address = __shfl_sync (FULL_MASK, ref_address, 0);
+    }
+
+    GLOBAL_AS const argon2_block_t *ref_block = &blocks[ref_address];
+
+    u64 tmp[4] = { 0 };
+
+    // First pass is overwrite, next passes are XOR with previous
+    if ((pos->pass > 0) && (options->version != ARGON2_VERSION_10))
+    {
+      for (u32 idx = 0; idx < 4; idx++) tmp[idx]  = cur_block->values[(idx * THREADS_PER_LANE) + thread];
+    }
+
+    for (u32 idx = 0; idx < 4; idx++) R[idx]   ^= ref_block->values[(idx * THREADS_PER_LANE) + thread];
+
+    for (u32 idx = 0; idx < 4; idx++) tmp[idx] ^= R[idx];
+
+    argon2_hash_block (R, thread);
+
+    for (u32 idx = 0; idx < 4; idx++) R[idx]   ^= tmp[idx];
+
+    for (u32 idx = 0; idx < 4; idx++) cur_block->values[(idx * THREADS_PER_LANE) + thread] = R[idx];
+  }
+}
+
+DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, const argon2_options_t *options, const argon2_pos_t *pos)
+{
+  const u32  thread       = get_local_id(0);
+
+  // We have already generated the first two blocks of each lane (for the first pass)
+  const u32 skip_blocks   = (pos->pass == 0) && (pos->slice == 0) ? 2 : 0;
+  const u32 index_in_lane = (pos->slice * options->segment_length) + skip_blocks;
+
+  u64 R[4];
+
+  GLOBAL_AS argon2_block_t *cur_block = argon2_get_current_block (blocks, options, pos->lane, index_in_lane, R, thread);
+
+  if ((options->type == TYPE_I) || ((options->type == TYPE_ID) && (pos->pass == 0) && (pos->slice <= 1)))
+  {
+    for (u32 block_index = 0; block_index < options->segment_length; block_index += 128)
+    {
+      const u32 start_index = (block_index == 0) ? skip_blocks : block_index;
+      const u32 end_index   = MIN(((start_index | 127) + 1), options->segment_length);
+
+      u32 addresses[4];
+
+      argon2_next_addresses (options, pos, addresses, block_index, thread);
+      argon2_fill_subsegment (blocks, options, pos, true, addresses, start_index, end_index, cur_block, R, thread);
+
+      cur_block += (end_index - start_index) * options->parallelism;
+    }
+  }
+  else
+  {
+    u32 addresses[4] = { 0 };
+
+    argon2_fill_subsegment (blocks, options, pos, false, addresses, skip_blocks, options->segment_length, cur_block, R, thread);
+  }
+}
+
+DECLSPEC void argon2_final (GLOBAL_AS argon2_block_t *blocks, const argon2_options_t *options, u32 *out)
+{
+  const u32 lane_length = options->lane_length;
+  const u32 lanes = options->parallelism;
+
+  argon2_block_t final_block = { };
+
+  for (u32 l = 0; l < lanes; l++)
+  {
+    for (u32 idx = 0; idx < 128; idx++) final_block.values[idx] ^= blocks[((lane_length - 1) * lanes) + l].values[idx];
+  }
+
+  u32 output_len [32] = {0};
+  output_len [0] = options->digest_len;
+
+  blake2b_ctx_t ctx;
+  blake2b_init (&ctx);
+
+  // Override default (0x40) value in BLAKE2b
+  ctx.h[0] ^= 0x40 ^ options->digest_len; 
+
+  blake2b_update (&ctx, output_len, 4);
+  blake2b_update (&ctx, (u32 *) final_block.values, sizeof(final_block));
+
+  blake2b_final (&ctx);
+
+  for (int i = 0, idx = 0; i < (options->digest_len / 4); i += 2, idx += 1)
+  {
+    out [i + 0] = l32_from_64_S (ctx.h[idx]);
+    out [i + 1] = h32_from_64_S (ctx.h[idx]);
+  }
+}

--- a/OpenCL/inc_hash_argon2.h
+++ b/OpenCL/inc_hash_argon2.h
@@ -1,0 +1,84 @@
+/**
+ * Author......: Netherlands Forensic Institute
+ * License.....: MIT
+ */
+
+#ifndef INC_HASH_ARGON2_H
+#define INC_HASH_ARGON2_H
+
+#define MIN(a,b) (((a) < (b)) ? (a) : (b))
+
+#define ARGON2_VERSION_10 0x10
+#define ARGON2_VERSION_13 0x13
+
+#define THREADS_PER_LANE 32
+#define FULL_MASK 0xffffffff
+
+#define BLAKE2B_OUTBYTES 64
+#define ARGON2_SYNC_POINTS 4
+#define ARGON2_ADDRESSES_IN_BLOCK 128
+
+#define TYPE_D  0
+#define TYPE_I  1
+#define TYPE_ID 2
+
+#define ARGON2_G(a,b,c,d)                \
+{                                        \
+  a = a + b + 2 * trunc_mul(a, b);       \
+  d = blake2b_rot32_S (d ^ a);           \
+  c = c + d + 2 * trunc_mul(c, d);       \
+  b = blake2b_rot24_S (b ^ c);           \
+  a = a + b + 2 * trunc_mul(a, b);       \
+  d = blake2b_rot16_S (d ^ a);           \
+  c = c + d + 2 * trunc_mul(c, d);       \
+  b = hc_rotr64_S (b ^ c, 63);           \
+}
+
+#define ARGON2_P()                       \
+{                                        \
+  ARGON2_G(v[0], v[4], v[8], v[12]);     \
+  ARGON2_G(v[1], v[5], v[9], v[13]);     \
+  ARGON2_G(v[2], v[6], v[10], v[14]);    \
+  ARGON2_G(v[3], v[7], v[11], v[15]);    \
+                                         \
+  ARGON2_G(v[0], v[5], v[10], v[15]);    \
+  ARGON2_G(v[1], v[6], v[11], v[12]);    \
+  ARGON2_G(v[2], v[7], v[8], v[13]);     \
+  ARGON2_G(v[3], v[4], v[9], v[14]);     \
+}
+
+typedef struct argon2_block
+{
+  u64 values[128];
+
+} argon2_block_t;
+
+typedef struct argon2_options
+{
+  u32 type;
+  u32 version;
+
+  u32 iterations;
+  u32 parallelism;
+  u32 memory_usage_in_kib;
+
+  u32 segment_length;
+  u32 lane_length;
+  u32 memory_block_count;
+  u32 digest_len;
+
+} argon2_options_t;
+
+typedef struct argon2_pos
+{
+  u32 pass;
+  u32 slice;
+  u32 lane;
+
+} argon2_pos_t;
+
+DECLSPEC void argon2_init (GLOBAL_AS const pw_t *pw, GLOBAL_AS const salt_t *salt, const argon2_options_t *options, GLOBAL_AS argon2_block_t *out);
+DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, const argon2_options_t *options, const argon2_pos_t *pos);
+DECLSPEC void argon2_final (GLOBAL_AS argon2_block_t *blocks, const argon2_options_t *options, u32 *out);
+
+#endif // INC_HASH_ARGON2_H

--- a/OpenCL/inc_platform.cl
+++ b/OpenCL/inc_platform.cl
@@ -104,9 +104,17 @@ DECLSPEC u32 hc_atomic_or (GLOBAL_AS u32 *p, volatile const u32 val)
   return atomicOr (p, val);
 }
 
-DECLSPEC size_t get_group_id  (const u32 dimindx __attribute__((unused)))
+DECLSPEC size_t get_group_id (const u32 dimindx)
 {
-  return blockIdx.x;
+  switch (dimindx)
+  {
+    case 0:
+      return blockIdx.x;
+    case 1:
+      return blockIdx.y;
+    case 2:
+      return blockIdx.z;
+  }  
 }
 
 DECLSPEC size_t get_global_id  (const u32 dimindx __attribute__((unused)))
@@ -114,15 +122,30 @@ DECLSPEC size_t get_global_id  (const u32 dimindx __attribute__((unused)))
   return (blockIdx.x * blockDim.x) + threadIdx.x;
 }
 
-DECLSPEC size_t get_local_id (const u32 dimindx __attribute__((unused)))
+DECLSPEC size_t get_local_id (const u32 dimindx)
 {
-  return threadIdx.x;
+  switch (dimindx)
+  {
+    case 0:
+      return threadIdx.x;
+    case 1:
+      return threadIdx.y;
+    case 2:
+      return threadIdx.z;
+  }
 }
 
-DECLSPEC size_t get_local_size (const u32 dimindx __attribute__((unused)))
+DECLSPEC size_t get_local_size (const u32 dimindx)
 {
-  // verify
-  return blockDim.x;
+  switch (dimindx)
+  {
+    case 0:
+      return blockDim.x;
+    case 1:
+      return blockDim.y;
+    case 2:
+      return blockDim.z;
+  }  
 }
 
 DECLSPEC u32x rotl32 (const u32x a, const int n)

--- a/OpenCL/inc_platform.h
+++ b/OpenCL/inc_platform.h
@@ -27,8 +27,9 @@ DECLSPEC u32 hc_atomic_inc (volatile GLOBAL_AS u32 *p);
 DECLSPEC u32 hc_atomic_or  (volatile GLOBAL_AS u32 *p, volatile const u32 val);
 
 DECLSPEC size_t get_global_id   (const u32 dimindx __attribute__((unused)));
-DECLSPEC size_t get_local_id    (const u32 dimindx __attribute__((unused)));
-DECLSPEC size_t get_local_size  (const u32 dimindx __attribute__((unused)));
+DECLSPEC size_t get_group_id    (const u32 dimindx);
+DECLSPEC size_t get_local_id    (const u32 dimindx);
+DECLSPEC size_t get_local_size  (const u32 dimindx);
 
 DECLSPEC u32x rotl32   (const u32x a, const int n);
 DECLSPEC u32x rotr32   (const u32x a, const int n);

--- a/OpenCL/m34000-pure.cl
+++ b/OpenCL/m34000-pure.cl
@@ -1,0 +1,93 @@
+/**
+ * Author......: Netherlands Forensic Institute
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_hash_blake2b.cl)
+#include M2S(INCLUDE_PATH/inc_hash_argon2.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct argon2_tmp
+{
+#ifndef ARGON2_TMP_ELEM
+#define ARGON2_TMP_ELEM 1
+#endif
+
+  argon2_block_t blocks[ARGON2_TMP_ELEM];
+
+} argon2_tmp_t;
+
+KERNEL_FQ void m34000_init (_KERN_ATTR_TMPS_ESALT (argon2_tmp_t, argon2_options_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  const argon2_options_t options = esalt_bufs[DIGESTS_OFFSET_HOST];
+
+  argon2_init (&pws[gid], &salt_bufs[SALT_POS_HOST], &options, tmps[gid].blocks);
+}
+
+KERNEL_FQ void m34000_loop (_KERN_ATTR_TMPS_ESALT (argon2_tmp_t, argon2_options_t))
+{
+  const u64 gid = get_group_id (0);
+  const u64 lid = get_local_id (1);
+  const u64 lsz = get_local_size (1);
+
+  if (gid >= GID_CNT) return;
+
+  argon2_options_t options = esalt_bufs[DIGESTS_OFFSET_HOST];
+
+  options.parallelism = ARGON2_PARALLELISM;
+
+  argon2_pos_t pos;
+
+  pos.pass   = (LOOP_POS / ARGON2_SYNC_POINTS);
+  pos.slice  = (LOOP_POS % ARGON2_SYNC_POINTS);
+
+  for (u32 i = 0; i < LOOP_CNT; i++)
+  {
+    for (pos.lane = lid; pos.lane < options.parallelism; pos.lane += lsz)
+    {
+      argon2_fill_segment (tmps[gid].blocks, &options, &pos);
+    }
+
+    SYNC_THREADS ();
+
+    pos.slice++;
+
+    if (pos.slice == ARGON2_SYNC_POINTS)
+    {
+      pos.slice = 0;
+      pos.pass++;
+    }
+  }
+}
+
+KERNEL_FQ void m34000_comp ( _KERN_ATTR_TMPS_ESALT (argon2_tmp_t, argon2_options_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 out[8];
+
+  const argon2_options_t options = esalt_bufs[DIGESTS_OFFSET_HOST];
+
+  argon2_final (tmps[gid].blocks, &options, out);
+
+  const u32 r0 = out[0];
+  const u32 r1 = out[1];
+  const u32 r2 = out[2];
+  const u32 r3 = out[3];
+
+  #define il_pos 0
+
+  #include COMPARE_M
+}

--- a/src/autotune.c
+++ b/src/autotune.c
@@ -107,7 +107,7 @@ static int autotune (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
   const double target_msec = backend_ctx->target_msec;
 
-  const u32 kernel_accel_min = device_param->kernel_accel_min;
+  const u32 kernel_accel_min =  (hashconfig->opts_type & OPTS_TYPE_MAXIMUM_ACCEL) ? device_param->kernel_accel_max : device_param->kernel_accel_min;
   const u32 kernel_accel_max = device_param->kernel_accel_max;
 
   const u32 kernel_loops_min = device_param->kernel_loops_min;

--- a/src/backend.c
+++ b/src/backend.c
@@ -2662,7 +2662,16 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
 
     if (hc_cuEventRecord (hashcat_ctx, device_param->cuda_event1, device_param->cuda_stream) == -1) return -1;
 
-    if (hc_cuLaunchKernel (hashcat_ctx, cuda_function, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, dynamic_shared_mem, device_param->cuda_stream, device_param->kernel_params, NULL) == -1) return -1;
+    if ((kern_run == KERN_RUN_2) && (hashconfig->opti_type & OPTI_TYPE_SLOW_HASH_DIMY_LOOP))
+    {
+      const u32 warp_size = device_param->kernel_preferred_wgs_multiple;
+
+      if (hc_cuLaunchKernel (hashcat_ctx, cuda_function, num, 1, 1, warp_size, blockDimY, 1, dynamic_shared_mem, device_param->cuda_stream, device_param->kernel_params, NULL) == -1) return -1;
+    }
+    else
+    {
+      if (hc_cuLaunchKernel (hashcat_ctx, cuda_function, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, dynamic_shared_mem, device_param->cuda_stream, device_param->kernel_params, NULL) == -1) return -1;
+    }
 
     if (hc_cuEventRecord (hashcat_ctx, device_param->cuda_event2, device_param->cuda_stream) == -1) return -1;
 
@@ -16225,7 +16234,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     // Still not 100% sure about the 64MiB here
 
-    const u64 size_device_extra = MAX ((64ULL * 1024 * 1024), size_device_extra1234);
+    const u64 size_device_extra = MAX ((1024 * 1024 * 1024), size_device_extra1234);
 
     // we will first decrease accel and when reached that limit, we will decrease threads
     // when we decrease limit this will restore accel_max

--- a/src/modules/module_34000.c
+++ b/src/modules/module_34000.c
@@ -1,0 +1,363 @@
+/**
+ * Author......: Netherlands Forensic Institute
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+#define ARGON2_SYNC_POINTS  4
+#define ARGON2_BLOCK_SIZE   1024
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_8;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_GENERIC_KDF;
+static const char *HASH_NAME      = "Argon2ID";
+static const u64   KERN_TYPE      = 34000;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_SLOW_HASH_DIMY_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_NATIVE_THREADS
+                                  | OPTS_TYPE_MP_MULTI_DISABLE
+                                  | OPTS_TYPE_MAXIMUM_ACCEL;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$argon2id$v=19$m=65536,t=3,p=1$FBMjI4RJBhIykCgol1KEJA$2ky5GAdhT1kH4kIgPN/oERE3Taiy43vNN70a3HpiKQU";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct argon2_options
+{
+  u32 type;
+  u32 version;
+
+  u32 iterations;
+  u32 parallelism;
+  u32 memory_usage_in_kib;
+
+  u32 segment_length;
+  u32 lane_length;
+  u32 memory_block_count;
+
+  u32 digest_len;
+
+} argon2_options_t;
+
+static const char *SIGNATURE_ARGON2ID = "$argon2id$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (argon2_options_t);
+
+  return esalt_size;
+}
+
+u32 module_kernel_threads_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_threads_min = 1;
+
+  return kernel_threads_min;
+}
+
+u32 module_kernel_threads_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_threads_max = 1;
+
+  return kernel_threads_max;
+}
+
+u32 module_kernel_loops_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_min = 1;
+
+  return kernel_loops_min;
+}
+
+u32 module_kernel_loops_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_max = 1;
+
+  return kernel_loops_max;
+}
+
+bool module_warmup_disable (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool warmup_disable = true;
+
+  return warmup_disable;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = 0; // we'll add some later
+
+  return tmp_size;
+}
+
+u64 module_extra_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes)
+{
+  argon2_options_t *options = (argon2_options_t *) hashes->esalts_buf;
+
+  const u32 memory_block_count = options[0].memory_block_count;
+
+  // we need to check that all hashes have the same memory requirement
+  for (u32 i = 1; i < hashes->salts_cnt; i++)
+  {
+    if (options[i].memory_block_count != memory_block_count) return (1ULL << 63) + i;
+  }
+
+  // now that we know they all have the same settings, we also need to check the self-test hash is different to what the user hash is using
+
+  if (user_options->self_test == true)
+  {
+    argon2_options_t *st_options = (argon2_options_t *) hashes->st_esalts_buf;
+
+    if (st_options[0].memory_block_count != memory_block_count) return (1ULL << 62);
+  }
+
+  const u64 tmp_size = ARGON2_BLOCK_SIZE * memory_block_count;
+
+  return tmp_size;
+}
+
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  argon2_options_t *options = (argon2_options_t *) hashes->esalts_buf;
+
+  char *jit_build_options = NULL;
+
+  hc_asprintf (&jit_build_options, "-D ARGON2_PARALLELISM=%" PRIu32 " -D ARGON2_TMP_ELEM=%" PRIu32, options[0].parallelism, options[0].memory_block_count);
+
+  return jit_build_options;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  argon2_options_t *options  = (argon2_options_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 7;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_ARGON2ID;
+
+  token.len[0]     = 10;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // version
+  token.len[1]     = 4;
+  token.sep[1]     = '$';
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
+
+  // memoryUsageInKib
+  token.len_min[2] = 3;
+  token.len_max[2] = 12;
+  token.sep[2]     = ',';
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // iterations
+  token.len_min[3] = 3;
+  token.len_max[3] = 5;
+  token.sep[3]     = ',';
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // parallelism
+  token.len_min[4] = 3;
+  token.len_max[4] = 5;
+  token.sep[4]     = '$';
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // salt
+  token.len_min[5] = ((SALT_MIN * 8) / 6) + 0;
+  token.len_max[5] = ((SALT_MAX * 8) / 6) + 3;
+  token.sep[5]     = '$';
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64A;
+
+  // target hash
+  token.len_min[6] = ((SALT_MIN * 8) / 6) + 0;
+  token.len_max[6] = ((SALT_MAX * 8) / 6) + 3;
+  token.sep[6]     = '$';
+  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64A;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // argon2id config
+  const u8 *ver_pos = token.buf[1];
+  const u8 *mem_pos = token.buf[2];
+  const u8 *it_pos  = token.buf[3];
+  const u8 *par_pos = token.buf[4];
+
+  options->type                = 2; // Only support for Argon2id
+  options->version             = hc_strtoul ((const char *) ver_pos + 2, NULL, 10);
+  options->memory_usage_in_kib = hc_strtoul ((const char *) mem_pos + 2, NULL, 10);
+  options->iterations          = hc_strtoul ((const char *) it_pos  + 2, NULL, 10);
+  options->parallelism         = hc_strtoul ((const char *) par_pos + 2, NULL, 10);
+
+  if (options->version != 19 && options->version != 16) return (PARSER_HASH_VALUE);
+  if (options->memory_usage_in_kib < 1) return (PARSER_HASH_VALUE);
+  if (options->iterations < 1) return (PARSER_HASH_VALUE);
+  if (options->parallelism < 1 || options->parallelism > 32) return (PARSER_HASH_VALUE);
+
+  options->segment_length     = MAX (2, (options->memory_usage_in_kib / (ARGON2_SYNC_POINTS * options->parallelism)));
+  options->lane_length        = options->segment_length * ARGON2_SYNC_POINTS;
+  options->memory_block_count = options->lane_length * options->parallelism;
+
+  // salt
+  const int salt_len = token.len[5];
+  const u8 *salt_pos = token.buf[5];
+
+  salt->salt_iter = options->iterations * ARGON2_SYNC_POINTS;
+  salt->salt_dimy = options->parallelism;
+  salt->salt_len = base64_decode (base64_to_int, (const u8 *) salt_pos, salt_len, (u8 *) salt->salt_buf);
+
+  // digest/ target hash
+  const int digest_len = token.len[6];
+  const u8 *digest_pos = token.buf[6];
+
+  options->digest_len = base64_decode (base64_to_int, (const u8 *) digest_pos, digest_len, (u8 *) digest);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  argon2_options_t *options  = (argon2_options_t *) esalt_buf;
+
+  // salt
+  char base64_salt[512] = { 0 };
+  base64_encode (int_to_base64, (const u8 *) salt->salt_buf, salt->salt_len, (u8 *) base64_salt);
+
+  // digest
+  char base64_digest[512] = { 0 };
+  base64_encode (int_to_base64, (const u8 *) digest, options->digest_len, (u8 *) base64_digest);
+
+  // out
+  u8 *out_buf = (u8 *) line_buf;
+
+  const int out_len = snprintf ((char *) out_buf, line_size, "%sv=%d$m=%d,t=%d,p=%d$%s$%s",
+    SIGNATURE_ARGON2ID,
+    options->version,
+    options->memory_usage_in_kib,
+    options->iterations,
+    options->parallelism,
+    base64_salt,
+    base64_digest);
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = module_extra_tmp_size;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = module_kernel_loops_max;
+  module_ctx->module_kernel_loops_min         = module_kernel_loops_min;
+  module_ctx->module_kernel_threads_max       = module_kernel_threads_max;
+  module_ctx->module_kernel_threads_min       = module_kernel_threads_min;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = module_warmup_disable;
+}


### PR DESCRIPTION
**Adding Argon2id Support**
This plugin introduces support for Argon2id, a modern and secure slow hashing algorithm, to Hashcat. 

Performance on various GPU with the testhash (64 MB, iterations 3, parallellism 1):
```
NVIDIA GeForce GTX 1080 TI  :  536 H/s
NVIDIA GeForce GTX 1650     :  158 H/s
NVIDIA GeForce RTX 2080     :  522 H/s
NVIDIA GeForce RTX 4090     : 1667 H/s
```

**Changes:**
- Added support for the Argon2 hash primitive
- Added hash mode 34000 for Argon2id

This implementation is optimized for recent NVIDIA GPUs, using multiple warps per password. Support for other GPU architectures will be provided in a later commit.

Note that the recent improvement to 'size_device_extra' has been temporarily reversed in this patch, in consultation with jsteube. This results in about 10% lower performance than what we initially measured during development of this new hash mode. A fix will be provided within the next few days.

Credit to Ondrej Mosnáček for creating the original warp-based GPU implementation of Argon2id.

Happy cracking!

Kind regards,

Pelle & Ewald
Netherlands Forensic Institute