### PR TITLE
Fix terminal TODO: Implement Windows system info display

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1254,21 +1254,60 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
     }
 
     #if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
-    // TODO
+    // Get Windows system information
+    SYSTEM_INFO sysinfo;
+    OSVERSIONINFO osvi;
+    char platform_buf[256] = "N/A";
+    char release_buf[256] = "N/A";
+    
+    GetSystemInfo (&sysinfo);
+    
+    // Initialize version info structure
+    ZeroMemory (&osvi, sizeof (OSVERSIONINFO));
+    osvi.dwOSVersionInfoSize = sizeof (OSVERSIONINFO);
+    
+    bool rc_version = (GetVersionEx (&osvi) != 0);
+    
+    // Get processor architecture string
+    switch (sysinfo.wProcessorArchitecture)
+    {
+      case PROCESSOR_ARCHITECTURE_AMD64:
+        snprintf (platform_buf, sizeof (platform_buf), "x86_64");
+        break;
+      case PROCESSOR_ARCHITECTURE_INTEL:
+        snprintf (platform_buf, sizeof (platform_buf), "x86");
+        break;
+      case PROCESSOR_ARCHITECTURE_ARM64:
+        snprintf (platform_buf, sizeof (platform_buf), "ARM64");
+        break;
+      case PROCESSOR_ARCHITECTURE_ARM:
+        snprintf (platform_buf, sizeof (platform_buf), "ARM");
+        break;
+      default:
+        snprintf (platform_buf, sizeof (platform_buf), "Unknown");
+    }
+    
+    // Get Windows version string
+    if (rc_version)
+    {
+      snprintf (release_buf, sizeof (release_buf), "%lu.%lu.%lu",
+               osvi.dwMajorVersion, osvi.dwMinorVersion, osvi.dwBuildNumber);
+    }
+    
     if (user_options->machine_readable == false)
     {
       event_log_info (hashcat_ctx, "OS.Name......: Windows");
-      event_log_info (hashcat_ctx, "OS.Release...: N/A");
-      event_log_info (hashcat_ctx, "HW.Platform..: N/A");
+      event_log_info (hashcat_ctx, "OS.Release...: %s", rc_version ? release_buf : "N/A");
+      event_log_info (hashcat_ctx, "HW.Platform..: %s", platform_buf);
       event_log_info (hashcat_ctx, "HW.Model.....: N/A");
     }
     else
     {
       printf ("\"OS\": { ");
       printf ("\"Name\": \"%s\", ", "Windows");
-      printf ("\"Release\": \"%s\" }, ", "N/A");
+      printf ("\"Release\": \"%s\" }, ", rc_version ? release_buf : "N/A");
       printf ("\"Hardware\": { ");
-      printf ("\"Platform\": \"%s\", ", "N/A");
+      printf ("\"Platform\": \"%s\", ", platform_buf);
       printf ("\"Model\": \"%s\" } ", "N/A");
       printf ("}, ");
     }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1297,7 +1297,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
     if (user_options->machine_readable == false)
     {
       event_log_info (hashcat_ctx, "OS.Name......: Windows");
-      event_log_info (hashcat_ctx, "OS.Release...: %s", rc_version ? release_buf : "N/A");
+      event_log_info (hashcat_ctx, "OS.Release...: %s", release_buf);
       event_log_info (hashcat_ctx, "HW.Platform..: %s", platform_buf);
       event_log_info (hashcat_ctx, "HW.Model.....: N/A");
     }
@@ -1305,7 +1305,7 @@ void backend_info (hashcat_ctx_t *hashcat_ctx)
     {
       printf ("\"OS\": { ");
       printf ("\"Name\": \"%s\", ", "Windows");
-      printf ("\"Release\": \"%s\" }, ", rc_version ? release_buf : "N/A");
+      printf ("\"Release\": \"%s\" }, ", release_buf);
       printf ("\"Hardware\": { ");
       printf ("\"Platform\": \"%s\", ", platform_buf);
       printf ("\"Model\": \"%s\" } ", "N/A");


### PR DESCRIPTION
- Replace hardcoded 'N/A' values with actual Windows system information
- Add GetSystemInfo() for processor architecture detection
- Add GetVersionEx() for Windows version information
- Support both machine-readable and human-readable output formats
- Follow existing Linux uname() implementation pattern
- Maintain cross-platform compatibility

Resolves TODO comment in src/terminal.c line 1257