### PR TITLE
got stable cracking with argon2 on Apple Metal

### DIFF
--- a/OpenCL/inc_hash_argon2.cl
+++ b/OpenCL/inc_hash_argon2.cl
@@ -219,14 +219,9 @@ DECLSPEC void argon2_hash_block (u64 R[4], int argon2_thread, LOCAL_AS u64 *shuf
 
 DECLSPEC void argon2_next_addresses (PRIVATE_AS const argon2_options_t *options, PRIVATE_AS const argon2_pos_t *pos, PRIVATE_AS u32 *addresses, u32 start_index, u32 argon2_thread, LOCAL_AS u64 *shuffle_buf, u32 argon2_lsz)
 {
-  u64 Z[4];
+  u64 Z[4] = { 0 };
 
-  Z[0] = 0;
-  Z[1] = 0;
-  Z[2] = 0;
-  Z[3] = 0;
-
-  u64 tmp[4];
+  u64 tmp[4] = { 0 };
 
   tmp[0] = 0;
   tmp[1] = 0;
@@ -299,7 +294,7 @@ DECLSPEC void argon2_fill_subsegment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_
 {
   for (u32 index = start_index; index < end_index; index++, cur_block += options->parallelism)
   {
-    u32 ref_address;
+    u32 ref_address = 0;
 
     if (indep_addr)
     {
@@ -340,7 +335,7 @@ DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS 
   const u32 skip_blocks   = (pos->pass == 0) && (pos->slice == 0) ? 2 : 0;
   const u32 index_in_lane = (pos->slice * options->segment_length) + skip_blocks;
 
-  u64 R[4];
+  u64 R[4] = { 0 };
 
   GLOBAL_AS argon2_block_t *cur_block = argon2_get_current_block (blocks, options, pos->lane, index_in_lane, R, argon2_thread);
 
@@ -351,7 +346,7 @@ DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS 
       const u32 start_index = (block_index == 0) ? skip_blocks : block_index;
       const u32 end_index   = MIN(((start_index | 127) + 1), options->segment_length);
 
-      u32 addresses[4] = { 0, 0, 0, 0 };
+      u32 addresses[4] = { 0 };
 
       argon2_next_addresses (options, pos, addresses, block_index, argon2_thread, shuffle_buf, argon2_lsz);
       argon2_fill_subsegment (blocks, options, pos, true, addresses, start_index, end_index, cur_block, R, argon2_thread, shuffle_buf, argon2_lsz);
@@ -379,8 +374,8 @@ DECLSPEC void argon2_final (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const a
     for (u32 idx = 0; idx < 128; idx++) final_block.values[idx] ^= blocks[((lane_length - 1) * lanes) + l].values[idx];
   }
 
-  u32 output_len [32] = {0};
-  output_len [0] = options->digest_len;
+  u32 output_len[32] = { 0 };
+  output_len[0] = options->digest_len;
 
   blake2b_ctx_t ctx;
   blake2b_init (&ctx);
@@ -400,7 +395,7 @@ DECLSPEC void argon2_final (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const a
   }
 }
 
-DECLSPEC GLOBAL_AS argon2_block_t *get_argon2_block (const argon2_options_t *options, GLOBAL_AS void *buf, const int idx)
+DECLSPEC GLOBAL_AS argon2_block_t *get_argon2_block (PRIVATE_AS const argon2_options_t *options, GLOBAL_AS void *buf, const int idx)
 {
   GLOBAL_AS u32 *buf32 = (GLOBAL_AS u32 *) buf;
 

--- a/OpenCL/inc_hash_argon2.h
+++ b/OpenCL/inc_hash_argon2.h
@@ -76,6 +76,8 @@ DECLSPEC u64 hc__shfl (MAYBE_UNUSED LOCAL_AS u64 *shuffle_buf, const u64 var, co
 
   const u64 out = shuffle_buf[src_lane & (argon2_lsz - 1)];
 
+  barrier (CLK_LOCAL_MEM_FENCE);
+
   return out;
 }
 #endif
@@ -90,6 +92,8 @@ DECLSPEC u64 hc__shfl (LOCAL_AS u64 *shuffle_buf, const u64 var, const int src_l
   SYNC_THREADS();
 
   const u64 out = shuffle_buf[src_lane & (argon2_lsz - 1)];
+
+  SYNC_THREADS();
 
   return out;
 }
@@ -153,6 +157,6 @@ typedef struct argon2_pos
 DECLSPEC void argon2_init (GLOBAL_AS const pw_t *pw, GLOBAL_AS const salt_t *salt, PRIVATE_AS const argon2_options_t *options, GLOBAL_AS argon2_block_t *out);
 DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const argon2_options_t *options, PRIVATE_AS const argon2_pos_t *pos, LOCAL_AS u64 *shuffle_buf, const u32 argon2_thread, const u32 argon2_lsz);
 DECLSPEC void argon2_final (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const argon2_options_t *options, PRIVATE_AS u32 *out);
-DECLSPEC GLOBAL_AS argon2_block_t *get_argon2_block (const argon2_options_t *options, GLOBAL_AS void *buf, const int idx);
+DECLSPEC GLOBAL_AS argon2_block_t *get_argon2_block (PRIVATE_AS const argon2_options_t *options, GLOBAL_AS void *buf, const int idx);
 
 #endif // INC_HASH_ARGON2_H

--- a/OpenCL/m34000-pure.cl
+++ b/OpenCL/m34000-pure.cl
@@ -66,6 +66,8 @@ KERNEL_FQ KERNEL_FA void m34000_loop (KERN_ATTR_TMPS_ESALT (argon2_tmp_t, argon2
 
   LOCAL_AS u64 *shuffle_buf = shuffle_bufs[lid];
 
+  SYNC_THREADS();
+
   const u32 bd4 = bid / 4;
   const u32 bm4 = bid % 4;
 


### PR DESCRIPTION
Not perfect but best results for now with argon2 on Apple Metal 

```
bash-3.2$ for i in $(seq 0 10); do ./tools/test.sh -m 34000 -d 1 -t all -a all; done
[ test_1752006649 ] > Init test for hash type 34000.
[ test_1752006649 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006649 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006649 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006649 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006747 ] > Init test for hash type 34000.
[ test_1752006747 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006747 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006747 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006747 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006806 ] > Init test for hash type 34000.
[ test_1752006806 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006806 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006806 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006806 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006862 ] > Init test for hash type 34000.
[ test_1752006862 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006862 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006862 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006862 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006945 ] > Init test for hash type 34000.
[ test_1752006945 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006945 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752006945 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752006945 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007000 ] > Init test for hash type 34000.
[ test_1752007000 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007000 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007000 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007000 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007076 ] > Init test for hash type 34000.
[ test_1752007076 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007076 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Error : 1/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007076 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007076 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > Error : 1/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007131 ] > Init test for hash type 34000.
[ test_1752007131 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007131 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Error : 1/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007131 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007131 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > Error : 1/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007182 ] > Init test for hash type 34000.
[ test_1752007182 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007182 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007182 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007182 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007237 ] > Init test for hash type 34000.
[ test_1752007237 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007237 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007237 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007237 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007312 ] > Init test for hash type 34000.
[ test_1752007312 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007312 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Error : 1/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752007312 ] [ Type 34000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752007312 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > Error : 1/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped

```