### PR TITLE
Fix Windows build: Add missing windows.h header

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -17,6 +17,10 @@
 #include "timer.h"
 #include "terminal.h"
 
+#if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
+#include <windows.h>
+#endif
+
 static const size_t MAXIMUM_EXAMPLE_HASH_LENGTH = 200;
 
 static const size_t TERMINAL_LINE_LENGTH = 79;


### PR DESCRIPTION
- Add conditional #include <windows.h> for Windows platforms
- Fixes undefined SYSTEM_INFO, GetSystemInfo, GetVersionEx
- Resolves Windows CI/CD build failures
- Follows existing hashcat conditional header pattern

Critical hotfix for Windows build regression