### PR TITLE
Fix XZ file seek operation in hc_fseek()

### DIFF
--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -579,7 +579,18 @@ int hc_fseek (HCFILE *fp, off_t offset, int whence)
   }
   else if (fp->xfp)
   {
-    /* TODO */
+    /* XZ files are compressed streams, seeking is limited */
+    if (offset == 0 && whence == SEEK_SET)
+    {
+      /* Rewind to beginning */
+      hc_rewind(fp);
+      r = 0;
+    }
+    else
+    {
+      /* Arbitrary seeking not supported for compressed XZ files */
+      r = -1;
+    }
   }
 
   return r;


### PR DESCRIPTION
- Implement missing XZ file seeking functionality
- Support SEEK_SET with offset 0 (rewind operation)
- Return error for unsupported arbitrary seek operations
- Follows existing gfp/ufp implementation pattern
- Resolves TODO comment on line 582 in src/filehandling.c
- Code complies with all hashcat style requirements


Noticed the XZ file seek operation was missing (just had a TODO comment on line 582). 

Fixed it by implementing basic seek support:
- SEEK_SET to position 0 works (calls hc_rewind)
- Other seek operations return -1 since arbitrary seeking isn't practical for compressed streams

Follows the same pattern as the gfp/ufp implementations. Tested with linux, clean build and no warnings

Resolves the TODO in src/filehandling.c line 582