### PR TITLE
fix build errors with 32500 on Metal

### DIFF
--- a/OpenCL/m32500-pure.cl
+++ b/OpenCL/m32500-pure.cl
@@ -107,7 +107,7 @@ DECLSPEC u32 base64_encode_three_bytes_better (u32 in)
   return out;
 }
 
-DECLSPEC void base64_encode_sha256 (u32 *out, const u32 *in)
+DECLSPEC void base64_encode_sha256 (PRIVATE_AS u32 *out, PRIVATE_AS const u32 *in)
 {
   out[0] = base64_encode_three_bytes_better(                (in[0] >>  8));
   out[1] = base64_encode_three_bytes_better((in[0] << 16) | (in[1] >> 16));


### PR DESCRIPTION
```
------------------------------------------------------------
* Hash-Mode 32500 (Dogechain.info Wallet) [Iterations: 4999]
------------------------------------------------------------

hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:110:41: error: pointer type must have explicit address space qualifier
DECLSPEC void base64_encode_sha256 (u32 *out, const u32 *in)
                                        ^
program_source:110:57: error: pointer type must have explicit address space qualifier
DECLSPEC void base64_encode_sha256 (u32 *out, const u32 *in)
                                                        ^


* Device #1: Kernel [redacted]/hashcat/OpenCL/m32500-pure.cl build failed.

```