### PR TITLE
fix build errors with 32700 on Metal

### DIFF
--- a/OpenCL/m32700-pure.cl
+++ b/OpenCL/m32700-pure.cl
@@ -41,7 +41,7 @@ CONSTANT_VK u32 newdes_rotor[256] =
   0x3a, 0x37, 0x03, 0xf4, 0x61, 0xc5, 0xee, 0xe3, 0x76, 0x31, 0x4f, 0xe6, 0xdf, 0xa5, 0x99, 0x3b,
 };
 
-DECLSPEC void new_des (u32 *block, u32 *newdes_key)
+DECLSPEC void new_des (PRIVATE_AS u32 *block, PRIVATE_AS u32 *newdes_key)
 {
   #define B0 (*(block+0))
   #define B1 (*(block+1))
@@ -71,7 +71,7 @@ DECLSPEC void new_des (u32 *block, u32 *newdes_key)
   B7 = B7 ^ newdes_rotor[B3 ^ *(newdes_key++)];
 }
 
-DECLSPEC void key_expansion (const u8 *sha1sum, u32 *result)
+DECLSPEC void key_expansion (PRIVATE_AS const u8 *sha1sum, PRIVATE_AS u32 *result)
 {
   for (int count = 0; count < 15; count++)
   {
@@ -143,7 +143,7 @@ KERNEL_FQ KERNEL_FA void m32700_init (KERN_ATTR_TMPS (sha1_tmp_t))
   // Crate a NewDES key
   u32 newdes_key32[60];
 
-  key_expansion ((const u8 *) ctx.h, newdes_key32);
+  key_expansion ((PRIVATE_AS const u8 *) ctx.h, newdes_key32);
 
   for (int i = 0; i < 60; i++)
   {
@@ -182,7 +182,7 @@ KERNEL_FQ KERNEL_FA void m32700_loop (KERN_ATTR_TMPS (sha1_tmp_t))
   }
 
   // Run 1000 iterations of NewDES on the derived salt
-  for (int i = 0; i < LOOP_CNT; i++)
+  for (u32 i = 0; i < LOOP_CNT; i++)
   {
     new_des (salt32, newdes_key32);
   }


### PR DESCRIPTION
```
-------------------------------------------------------------------
* Hash-Mode 32700 (Kremlin Encrypt 3.0 w/NewDES) [Iterations: 1000]
-------------------------------------------------------------------

hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:44:28: error: pointer type must have explicit address space qualifier
DECLSPEC void new_des (u32 *block, u32 *newdes_key)
                           ^
program_source:44:40: error: pointer type must have explicit address space qualifier
DECLSPEC void new_des (u32 *block, u32 *newdes_key)
                                       ^
program_source:74:39: error: pointer type must have explicit address space qualifier
DECLSPEC void key_expansion (const u8 *sha1sum, u32 *result)
                                      ^
program_source:74:53: error: pointer type must have explicit address space qualifier
DECLSPEC void key_expansion (const u8 *sha1sum, u32 *result)
                                                    ^
program_source:146:28: error: pointer type must have explicit address space qualifier
  key_expansion ((const u8 *) ctx.h, newdes_key32);
                           ^
program_source:185:21: warning: comparison of integers of different signs: 'int' and 'const device u32' (aka 'const device unsigned int') [-Wsign-compare]
  for (int i = 0; i < LOOP_CNT; i++)
                  ~ ^ ~~~~~~~~


* Device #1: Kernel [redacted]/hashcat/OpenCL/m32700-pure.cl build failed.

```