### PR TITLE
Fix building on aarch64

### DIFF
--- a/deps/phc-winner-argon2-20190702/_hashcat/blake2/blamka-round-opt.h
+++ b/deps/phc-winner-argon2-20190702/_hashcat/blake2/blamka-round-opt.h
@@ -23,7 +23,7 @@
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #include <emmintrin.h>
 #elif defined(__aarch64__)
-#include <sse2neon.h>
+#include "../../../deps/sse2neon/sse2neon.h"
 #endif
 
 #if defined(__SSSE3__)

--- a/deps/sse2neon/Makefile
+++ b/deps/sse2neon/Makefile
@@ -57,7 +57,7 @@ ARCH_CFLAGS := $(ARCH_CFLAGS)+$(subst $(COMMA),+,$(FEATURE))
 endif
 endif
 
-CXXFLAGS += -Wall -Wcast-qual -Wconversion -I. $(ARCH_CFLAGS) -std=gnu++14
+CXXFLAGS += -Wall -Wcast-qual -Wold-style-cast -Wconversion -I. $(ARCH_CFLAGS) -std=gnu++14
 LDFLAGS	+= -lm
 OBJS = \
     tests/binding.o \


### PR DESCRIPTION
Hi sir!

I recon your activity lately, appreciate that!
This commit fixes the builds on aarch64 platforms. 
There may be ways to improve it, but this is working fine for now.

Cheers,
Christian, Kali Linux