### PR TITLE
JSON device_id formatting fix

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -70,7 +70,7 @@
 
 - Added new feature (-Y) that creates N virtual instances for each device in your system at the cost of N times the device memory consumption
 - Added options --benchmark-min and --benchmark-max to set a hash-mode range to be used during the benchmark
-- Added option --total-candidates to provide the total candidate count for an attack insteda of the internal "--keyspace" value
+- Added option --total-candidates to provide the total candidate count for an attack instead of the internal "--keyspace" value
 - Added option --backend-devices-keepfree to configure X percentage of device memory available to keep free
 
 ##

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2632,7 +2632,7 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
       printf (",");
     }
 
-    printf (" { \"device_id\": %02u,", device_id + 1);
+    printf (" { \"device_id\": %u,", device_id + 1);
 
     char *device_name_json_encoded = (char *) hcmalloc (strlen (device_info->device_name) * 2);
 


### PR DESCRIPTION
JSON device_id integer formatting was broken in a recent set of changes, fixed here. Typo in changes.txt also fixed.