### PR TITLE
Search for more Electrum prv key prefixes

### DIFF
--- a/OpenCL/m16600_a0-optimized.cl
+++ b/OpenCL/m16600_a0-optimized.cl
@@ -392,7 +392,15 @@ KERNEL_FQ KERNEL_FA void m16600_m04 (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;
@@ -804,7 +812,15 @@ KERNEL_FQ KERNEL_FA void m16600_s04 (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;

--- a/OpenCL/m16600_a0-pure.cl
+++ b/OpenCL/m16600_a0-pure.cl
@@ -206,7 +206,15 @@ KERNEL_FQ KERNEL_FA void m16600_mxx (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;
@@ -424,7 +432,15 @@ KERNEL_FQ KERNEL_FA void m16600_sxx (KERN_ATTR_RULES_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;

--- a/OpenCL/m16600_a1-optimized.cl
+++ b/OpenCL/m16600_a1-optimized.cl
@@ -448,7 +448,15 @@ KERNEL_FQ KERNEL_FA void m16600_m04 (KERN_ATTR_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;
@@ -918,7 +926,15 @@ KERNEL_FQ KERNEL_FA void m16600_s04 (KERN_ATTR_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;

--- a/OpenCL/m16600_a1-pure.cl
+++ b/OpenCL/m16600_a1-pure.cl
@@ -202,7 +202,15 @@ KERNEL_FQ KERNEL_FA void m16600_mxx (KERN_ATTR_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;
@@ -418,7 +426,15 @@ KERNEL_FQ KERNEL_FA void m16600_sxx (KERN_ATTR_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;

--- a/OpenCL/m16600_a3-optimized.cl
+++ b/OpenCL/m16600_a3-optimized.cl
@@ -167,7 +167,15 @@ DECLSPEC void m16600 (SHM_TYPE u32a *s_te0, SHM_TYPE u32a *s_te1, SHM_TYPE u32a 
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;

--- a/OpenCL/m16600_a3-pure.cl
+++ b/OpenCL/m16600_a3-pure.cl
@@ -215,7 +215,15 @@ KERNEL_FQ KERNEL_FA void m16600_mxx (KERN_ATTR_VECTOR_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;
@@ -444,7 +452,15 @@ KERNEL_FQ KERNEL_FA void m16600_sxx (KERN_ATTR_VECTOR_ESALT (electrum_wallet_t))
 
     if (salt_type == 2)
     {
-      if ((u8) (out[0] >> 0) != 'x') continue;
+      u8 version = (u8) (out[0] >> 0);
+
+      // https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst
+      // Does not include testnet addresses
+      if (version != 'x' &&
+          version != 'y' &&
+          version != 'Y' &&
+          version != 'z' &&
+          version != 'Z' ) continue;
       if ((u8) (out[0] >> 8) != 'p') continue;
       if ((u8) (out[0] >> 16) != 'r') continue;
       if ((u8) (out[0] >> 24) != 'v') continue;


### PR DESCRIPTION
Currently, -m 16600 with a type 2 salts only check for "xprv" as a valid decryption as part of Legacy / "x" prefix private keys, this change will open the kernel up to Segwit, Native Segwit and Multisig wallets too (not including testnet). It will increase the chance of false-positives a little but should be more than manageable, especially for the accuracy boost. I have not tested this individually on each type of wallet but used the information in the official docs here:
https://github.com/spesmilo/electrum-docs/blob/master/xpub_version_bytes.rst

I also tested using a bitmask lookup table for checking instead of using many if statements to avoid branching but turned out to be a 0.31% hashrate difference - easily margin-of-error. 

```
$ ./tools/test.sh -m 16600 -a all -t all -o win -V 1 -P
[ test_1752175617 ] > Init test for hash type 16600.
[ test_1752175617 ] [ Type 16600, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752175617 ] [ Type 16600, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752175617 ] [ Type 16600, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752175617 ] [ Type 16600, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752175617 ] [ Type 16600, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752175617 ] [ Type 16600, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752175617 ] [ Type 16600, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 1/7 timeout, 0/7 skipped
[ test_1752175617 ] [ Type 16600, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752175617 ] [ Type 16600, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752175617 ] [ Type 16600, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped

$ ./tools/test.sh -m 16600 -a all -t all -o win -V 1 -O
[ test_1752176459 ] > Init test for hash type 16600.
[ test_1752176459 ] [ Type 16600, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1752176459 ] [ Type 16600, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752176459 ] [ Type 16600, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752176459 ] [ Type 16600, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752176459 ] [ Type 16600, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752176459 ] [ Type 16600, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1752176459 ] [ Type 16600, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > Warning : 0/7 not found, 0/7 not matched, 1/7 timeout, 0/7 skipped
[ test_1752176459 ] [ Type 16600, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752176459 ] [ Type 16600, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1752176459 ] [ Type 16600, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```

Bitmask lookup table (Not used in the PR)
```
0x00000000,
0x00000000,
0x06000000,  // Y,Z
0x07000000,  // x, y, z
0x00000000,
0x00000000,
0x00000000,
0x00000000
```