### PR TITLE
fix module_constraints (Optimized-Mode-PW-Constraints) for -m 400

### DIFF
--- a/tools/test_modules/m00400.pm
+++ b/tools/test_modules/m00400.pm
@@ -12,7 +12,7 @@ use warnings;
 
 use Authen::Passphrase::PHPass;
 
-sub module_constraints { [[0, 256], [8, 8], [0, 55], [8, 8], [-1, -1]] }
+sub module_constraints { [[0, 256], [8, 8], [0, 39], [8, 8], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
finded by edge testing

```
[ test_edge_1752181658 ] !> error (255) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable -d 1 --runtime 270 -O --backend-vector-width 1 -m 400 '$P$9802777192h5G8Ekx8FWtIKSGe0ygu0' -a 3 98403646748164877816566835756603095854312562965916814?d?d
[ test_edge_1752181658 ] !> Hash-Type 400, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 55, Salt len 8, Word '9840364674816487781656683575660309585431256296591681493', Hash '$P$9802777192h5G8Ekx8FWtIKSGe0ygu0'

Skipping mask '98403646748164877816566835756603095854312562965916814?d?d' because it is larger than the maximum password length.

[ test_edge_1752181658 ] # Processing Hash-Type 400, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type multi
[ test_edge_1752181658 ] !> error (255) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable -d 1 --runtime 270 -O --backend-vector-width 1 -m 400 test_edge_1752181658/edge_400_optimized_3_1.hashes -a 3 test_edge_1752181658/test_400_optimized_3.1.words.masks
[ test_edge_1752181658 ] !> Hash-Type 400, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Words test_edge_1752181658/edge_400_optimized_3_1.words, Hashes test_edge_1752181658/edge_400_optimized_3_1.hashes

$P$919358894oCBrqC3.UsvFN8Uv9Iw7c.:25
STATUS	5	SPEED	2303	1000	EXEC_RUNTIME	0.746583	CURKU	10	PROGRESS	20	20	RECHASH	1	2	RECSALT	1	2	TEMP	-1	REJECTED	0	UTIL	0	

Skipping mask '98403646748164877816566835756603095854312562965916814?d?d' because it is larger than the maximum password length.

```

Output of hash-info:

```
$ ./hashcat -HH -a 3 -O -m 400
hashcat (v6.2.6-1184-g5ffbc5edc+) starting in hash-info mode

Hash Info:
==========

Hash mode #400
  Name................: phpass
  Category............: Generic KDF
  Slow.Hash...........: Yes
  Deprecated..........: No
  Deprecated.Notice...: N/A
  Password.Type.......: plain
  Password.Len.Min....: 0
  Password.Len.Max....: 39
  [...]
```