### PR TITLE
fix min salt (username) len with hash-mode 3100

### DIFF
--- a/src/modules/module_03100.c
+++ b/src/modules/module_03100.c
@@ -84,7 +84,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.len_min[1] = 0;
+  token.len_min[1] = 1;
   token.len_max[1] = 30;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 

--- a/tools/test_modules/m03100.pm
+++ b/tools/test_modules/m03100.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Crypt::CBC;
 
-sub module_constraints { [[-1, -1], [-1, -1], [0, 30], [0, 30], [-1, -1]] }
+sub module_constraints { [[-1, -1], [-1, -1], [0, 30], [1, 30], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
Password must be empty but not the username, so salt min must be 1.

Finded with edge testing

```
[ test_edge_1752130985 ] # Export tests for Hash-Type 3100, Attack-Type 0, Kernel-Type optimized
[ test_edge_1752130985 ] # Processing Hash-Type 3100, Attack-Type 0, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752130985 ] > Hash-Type 3100, Attack-Type 0, Kernel-Type optimized, Test ID 1, Word len 0, Salt len 0, Word '', Salt '', Hash 'C85716F631CE7901:'
STATUS	5	SPEED	2717	1000	0	1000	EXEC_RUNTIME	0.009216	0.000000	CURKU	0	PROGRESS	1	0	RECHASH	0	1	RECSALT	0	1	TEMP	4952	REJECTED	0	UTIL	0	0	
[ test_edge_1752130985 ] !> error (1) detected with CMD: echo  | ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable -D 2 --runtime 270 -O --backend-vector-width 1 -m 3100 'C85716F631CE7901:' -a 0
[ test_edge_1752130985 ] !> Hash-Type 3100, Attack-Type 0, Kernel-Type optimized, Vector-Width 1, Test ID 1, Word len 0, Salt len 0, Word '', Hash 'C85716F631CE7901:'

STATUS	5	SPEED	2717	1000	0	1000	EXEC_RUNTIME	0.009216	0.000000	CURKU	0	PROGRESS	1	0	RECHASH	0	1	RECSALT	0	1	TEMP	4952	REJECTED	0	UTIL	0	0	
```
