### PR TITLE
fix bug on Makefile with detection of Apple Silicon systems

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -85,7 +85,7 @@ AR                      := /usr/bin/ar
 SED                     := /usr/bin/sed
 SED_IN_PLACE            := -i ""
 DARWIN_VERSION          := $(shell uname -r | cut -d. -f1)
-IS_APPLE_SILICON        := $(shell lipo /bin/zsh -verify_arch arm64e && echo 1 || echo 0)
+IS_APPLE_SILICON        := $(shell [ "$$(sysctl -in hw.optional.arm64 2>/dev/null)" = "1" ] && echo 1 || echo 0)
 endif
 
 ifneq (,$(filter $(UNAME),FreeBSD NetBSD))
@@ -237,7 +237,9 @@ CFLAGS_UNRAR            += -Wno-class-memaccess
 CFLAGS_UNRAR            += -Wno-misleading-indentation
 CFLAGS_UNRAR            += -Wno-format-overflow
 else
+ifeq ($(IS_APPLE_SILICON),0)
 CFLAGS_UNRAR            += -Wno-nontrivial-memcall
+endif
 endif
 CFLAGS_UNRAR            += -Wno-missing-braces
 CFLAGS_UNRAR            += -Wno-unused-variable


### PR DESCRIPTION
the result of "lipo /bin/zsh -verify_arch arm64e" is the same on Apple Intel and Apple Silicon, so there're wrong checks on Makefile