### PR TITLE
Update error when using --skip/--limit in an invalid attack config

### DIFF
--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -795,7 +795,7 @@ static int outer_loop (hashcat_ctx_t *hashcat_ctx)
   {
     if ((mask_ctx->masks_cnt > 1) || (straight_ctx->dicts_cnt > 1))
     {
-      event_log_error (hashcat_ctx, "Use of --skip/--limit is not supported with --increment, mask files, or --stdout.");
+      event_log_error (hashcat_ctx, "Use of --skip/--limit is not supported with --increment, mask files, multiple dictionaries, or --stdout.");
 
       return -1;
     }


### PR DESCRIPTION
Current error misses an invalid configuration, updated to include multiple dictionaries as invalid with --skip/--limit.