### PR TITLE
Enhancement: Set --benchmark to true if --benchmark-all is passed

### DIFF
--- a/src/user_options.c
+++ b/src/user_options.c
@@ -1298,6 +1298,11 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
     }
   }
 
+  if (user_options->benchmark_all == true)
+  {
+    user_options->benchmark = true;
+  }
+
   if (user_options->benchmark == true)
   {
     // sanity checks based on automatically overwritten configuration variables by


### PR DESCRIPTION
Users should only ever pass --benchmark-all if they intend to run a benchmark, so we can assume that --benchmark-all should trigger -b/--benchmark. This allows starting hashcat with just `./hashcat --benchmark-all` to kick off a full benchmark.