### PR TITLE
Add CPU support for argon2 (34000)

### DIFF
--- a/OpenCL/inc_hash_argon2.cl
+++ b/OpenCL/inc_hash_argon2.cl
@@ -12,24 +12,26 @@
 #include "inc_hash_blake2b.h"
 #include "inc_hash_argon2.h"
 
+#define LBLOCKSIZE      (128 / THREADS_PER_LANE)
+
 DECLSPEC void argon2_initial_block (PRIVATE_AS const u32 *in, const u32 lane, const u32 blocknum, const u32 parallelism, GLOBAL_AS argon2_block_t *blocks)
 {
   blake2b_ctx_t ctx;
 
   blake2b_init (&ctx);
 
-  u64 blake_buf[16] = { 0 };
+  ctx.m[0] = hl32_to_64 (in[ 0],   sizeof(argon2_block_t));
+  ctx.m[1] = hl32_to_64 (in[ 2],   in[ 1]);
+  ctx.m[2] = hl32_to_64 (in[ 4],   in[ 3]);
+  ctx.m[3] = hl32_to_64 (in[ 6],   in[ 5]);
+  ctx.m[4] = hl32_to_64 (in[ 8],   in[ 7]);
+  ctx.m[5] = hl32_to_64 (in[10],   in[ 9]);
+  ctx.m[6] = hl32_to_64 (in[12],   in[11]);
+  ctx.m[7] = hl32_to_64 (in[14],   in[13]);
+  ctx.m[8] = hl32_to_64 (blocknum, in[15]);
+  ctx.m[9] = hl32_to_64 (0,        lane);
 
-  blake_buf[0] = sizeof(argon2_block_t);
-
-  blake2b_update (&ctx, (PRIVATE_AS u32 *) blake_buf, 4);
-  blake2b_update (&ctx, in, 64);
-
-  blake_buf[0] = hl32_to_64 (lane, blocknum);
-
-  blake2b_update (&ctx, (PRIVATE_AS u32 *) blake_buf, 8);
-
-  blake2b_final (&ctx);
+  blake2b_transform (ctx.h, ctx.m, 76, (u64) BLAKE2B_FINAL);
 
   GLOBAL_AS u64 *out = blocks[(blocknum * parallelism) + lane].values;
 
@@ -38,12 +40,23 @@ DECLSPEC void argon2_initial_block (PRIVATE_AS const u32 *in, const u32 lane, co
   out[2] = ctx.h[2];
   out[3] = ctx.h[3];
 
+  ctx.m[8] = 0;
+  ctx.m[9] = 0;
+
   for (u32 off = 4; off < 124; off += 4)
   {
-    for (u32 idx = 0; idx < 8; idx++) blake_buf[idx] = ctx.h[idx];
+    for (u32 idx = 0; idx < 8; idx++) ctx.m[idx] = ctx.h[idx];
 
-    blake2b_init (&ctx);
-    blake2b_transform (ctx.h, blake_buf, 64, (u64) BLAKE2B_FINAL);
+    ctx.h[0] = BLAKE2B_IV_00 ^ 0x01010040; // default output length: 0x40 = 64 bytes
+    ctx.h[1] = BLAKE2B_IV_01;
+    ctx.h[2] = BLAKE2B_IV_02;
+    ctx.h[3] = BLAKE2B_IV_03;
+    ctx.h[4] = BLAKE2B_IV_04;
+    ctx.h[5] = BLAKE2B_IV_05;
+    ctx.h[6] = BLAKE2B_IV_06;
+    ctx.h[7] = BLAKE2B_IV_07;
+
+    blake2b_transform (ctx.h, ctx.m, 64, (u64) BLAKE2B_FINAL);
 
     out[off + 0] = ctx.h[0];
     out[off + 1] = ctx.h[1];
@@ -57,39 +70,85 @@ DECLSPEC void argon2_initial_block (PRIVATE_AS const u32 *in, const u32 lane, co
   out[127] = ctx.h[7];
 }
 
+DECLSPEC void blake2b_update_8 (PRIVATE_AS blake2b_ctx_t *ctx, const u32 w0, const u32 w1, const int len)
+{
+  const int pos = ctx->len & 127;
+
+  if (pos == 0)
+  {
+    if (ctx->len > 0) // if new block (pos == 0) AND the (old) len is not zero => transform
+    {
+      blake2b_transform (ctx->h, ctx->m, ctx->len, BLAKE2B_UPDATE);
+    }
+  }
+
+  const u64 m  = hl32_to_64 (w1, w0);
+  const u32 s  = (pos & 7) * 8;
+  const u64 m0 = (m << s);
+  const u64 m1 = (m >> 8) >> (56 - s);
+
+  const int idx = pos / 8;
+
+  ctx->m[ 0] |= (idx ==  0) ? m0 :                    0;
+  ctx->m[ 1] |= (idx ==  1) ? m0 : (idx ==  0) ? m1 : 0;
+  ctx->m[ 2] |= (idx ==  2) ? m0 : (idx ==  1) ? m1 : 0;
+  ctx->m[ 3] |= (idx ==  3) ? m0 : (idx ==  2) ? m1 : 0;
+  ctx->m[ 4] |= (idx ==  4) ? m0 : (idx ==  3) ? m1 : 0;
+  ctx->m[ 5] |= (idx ==  5) ? m0 : (idx ==  4) ? m1 : 0;
+  ctx->m[ 6] |= (idx ==  6) ? m0 : (idx ==  5) ? m1 : 0;
+  ctx->m[ 7] |= (idx ==  7) ? m0 : (idx ==  6) ? m1 : 0;
+  ctx->m[ 8] |= (idx ==  8) ? m0 : (idx ==  7) ? m1 : 0;
+  ctx->m[ 9] |= (idx ==  9) ? m0 : (idx ==  8) ? m1 : 0;
+  ctx->m[10] |= (idx == 10) ? m0 : (idx ==  9) ? m1 : 0;
+  ctx->m[11] |= (idx == 11) ? m0 : (idx == 10) ? m1 : 0;
+  ctx->m[12] |= (idx == 12) ? m0 : (idx == 11) ? m1 : 0;
+  ctx->m[13] |= (idx == 13) ? m0 : (idx == 12) ? m1 : 0;
+  ctx->m[14] |= (idx == 14) ? m0 : (idx == 13) ? m1 : 0;
+  ctx->m[15] |= (idx == 15) ? m0 : (idx == 14) ? m1 : 0;
+
+  if ((pos + len) > 128)
+  {
+    const u32 cur_len = ((ctx->len + len) / 128) * 128;
+
+    blake2b_transform (ctx->h, ctx->m, cur_len, (u64) BLAKE2B_UPDATE);
+
+    for (u32 i = 1; i < 16; i++) ctx->m[i] = 0;
+
+    ctx->m[0] = m1;
+  }
+
+  ctx->len += len;
+}
+
 DECLSPEC void argon2_initial_hash (GLOBAL_AS const pw_t *pw, GLOBAL_AS const salt_t *salt, PRIVATE_AS const argon2_options_t *options, PRIVATE_AS u64 *blockhash)
 {
   blake2b_ctx_t ctx;
   blake2b_init (&ctx);
 
-  u32 option_input[32] = { 0 };
+  ctx.m[0] = hl32_to_64 (options->digest_len, options->parallelism);
+  ctx.m[1] = hl32_to_64 (options->iterations, options->memory_usage_in_kib);
+  ctx.m[2] = hl32_to_64 (options->type,       options->version);
+  ctx.len  = 24;
 
-  option_input[0] = options->parallelism;
-  option_input[1] = options->digest_len;
-  option_input[2] = options->memory_usage_in_kib;
-  option_input[3] = options->iterations;
-  option_input[4] = options->version;
-  option_input[5] = options->type;
+  const u32 pw_len = pw->pw_len;
 
-  blake2b_update (&ctx, option_input, 24);
+  blake2b_update_8 (&ctx, pw_len, 0, 4);
 
-  u32 len_input[32] = { 0 };
+  for (u32 i = 0, idx = 0; i < pw_len; i += 8, idx += 2)
+  {
+    blake2b_update_8 (&ctx, pw->i[idx + 0], pw->i[idx + 1], MIN((pw_len - i), 8));
+  }
 
-  len_input[0] = pw->pw_len;
+  const u32 salt_len = salt->salt_len;
 
-  blake2b_update (&ctx, len_input, 4);
-  blake2b_update_global (&ctx, pw->i, pw->pw_len);
+  blake2b_update_8 (&ctx, salt_len, 0, 4);
 
-  len_input[0] = salt->salt_len;
+  for (u32 i = 0, idx = 0; i < salt_len; i += 8, idx += 2)
+  {
+    blake2b_update_8 (&ctx, salt->salt_buf[idx + 0], salt->salt_buf[idx + 1], MIN((salt_len - i), 8));
+  }
 
-  blake2b_update (&ctx, len_input, 4);
-  blake2b_update_global (&ctx, salt->salt_buf, salt->salt_len);
-
-  len_input[0] = 0;
-
-  blake2b_update (&ctx, len_input, 4); // secret (K)
-  blake2b_update (&ctx, len_input, 4); // associated data (X)
-
+  blake2b_update_8 (&ctx, 0, 0, 8); // secret (K) and associated data (X)
   blake2b_final (&ctx);
 
   for (u32 idx = 0; idx < 8; idx++) blockhash[idx] = ctx.h[idx];
@@ -110,7 +169,6 @@ DECLSPEC void argon2_init (GLOBAL_AS const pw_t *pw, GLOBAL_AS const salt_t *sal
   }
 }
 
-// TODO: reconsider 'trunc_mul()'
 DECLSPEC u64 trunc_mul (u64 x, u64 y)
 {
   const u32 xlo = (u32) x;
@@ -141,8 +199,6 @@ DECLSPEC inline u32 argon2_ref_address (PRIVATE_AS const argon2_options_t *optio
   {
       ref_area += (index - 1);
   }
-
-  // if ref_area == 0xFFFFFFFF => bug
 
   const u32 j1 = l32_from_64_S (pseudo_random);
 
@@ -188,8 +244,36 @@ DECLSPEC int argon2_shift (int idx, int argon2_thread)
   return (argon2_thread & 0x0e) | (((argon2_thread & 0x11) + delta + 0x0e) & 0x11);
 }
 
-DECLSPEC void argon2_hash_block (u64 R[4], int argon2_thread, LOCAL_AS u64 *shuffle_buf, int argon2_lsz)
+DECLSPEC void argon2_hash_block (u64 R[LBLOCKSIZE], int argon2_thread, LOCAL_AS u64 *shuffle_buf, int argon2_lsz)
 {
+#if THREADS_PER_LANE == 1
+  u64 v[16];
+
+  for (u32 i = 0, offset = 0; i < 8; i++, offset += 16)
+  {
+    for (u32 j = 0; j < 16; j++) v[j] = R[offset + j];
+
+    ARGON2_P();
+
+    for (u32 j = 0; j < 16; j++) R[offset + j] = v[j];
+  }
+
+  for (u32 i = 0, offset = 0; i < 8; i++, offset += 2)
+  {
+    for (u32 j = 0, k = offset; j < 16; j += 2, k += 16) {
+      v[j + 0] = R[k + 0];
+      v[j + 1] = R[k + 1];
+    }
+
+    ARGON2_P();
+
+    for (u32 j = 0, k = offset; j < 16; j += 2, k += 16)
+    {
+      R[k + 0] = v[j + 0];
+      R[k + 1] = v[j + 1];
+    }
+  }
+#else
   for (u32 idx = 1; idx < 4; idx++) R[idx] = hc__shfl_sync (shuffle_buf, FULL_MASK, R[idx], argon2_thread ^ (idx << 2), argon2_thread, argon2_lsz);
 
   transpose_permute_block (R, argon2_thread);
@@ -215,49 +299,45 @@ DECLSPEC void argon2_hash_block (u64 R[4], int argon2_thread, LOCAL_AS u64 *shuf
   ARGON2_G(R[0], R[1], R[2], R[3]);
 
   for (u32 idx = 1; idx < 4; idx++) R[idx] = hc__shfl_sync (shuffle_buf, FULL_MASK, R[idx], argon2_shift ((4 - idx), argon2_thread), argon2_thread, argon2_lsz);
+#endif
 }
 
 DECLSPEC void argon2_next_addresses (PRIVATE_AS const argon2_options_t *options, PRIVATE_AS const argon2_pos_t *pos, PRIVATE_AS u32 *addresses, u32 start_index, u32 argon2_thread, LOCAL_AS u64 *shuffle_buf, u32 argon2_lsz)
 {
-  u64 Z[4] = { 0 };
+  u64 Z[LBLOCKSIZE] = { 0 };
+  u64 tmp[LBLOCKSIZE] = { 0 };
 
-  u64 tmp[4] = { 0 };
-
-  tmp[0] = 0;
-  tmp[1] = 0;
-  tmp[2] = 0;
-  tmp[3] = 0;
-
-  switch (argon2_thread)
+  for (u32 i = 0, index = argon2_thread; i < (LBLOCKSIZE / 4); i++, index += THREADS_PER_LANE)
   {
-    case 0:  Z[0] = pos->pass;                   break;
-    case 1:  Z[0] = pos->lane;                   break;
-    case 2:  Z[0] = pos->slice;                  break;
-    case 3:  Z[0] = options->memory_block_count; break;
-    case 4:  Z[0] = options->iterations;         break;
-    case 5:  Z[0] = options->type;               break;
-    case 6:  Z[0] = (start_index / 128) + 1;     break;
-    default: Z[0] = 0;                           break;
+    switch (index)
+    {
+      case 0:  Z[i] = pos->pass;                   break;
+      case 1:  Z[i] = pos->lane;                   break;
+      case 2:  Z[i] = pos->slice;                  break;
+      case 3:  Z[i] = options->memory_block_count; break;
+      case 4:  Z[i] = options->iterations;         break;
+      case 5:  Z[i] = options->type;               break;
+      case 6:  Z[i] = (start_index / 128) + 1;     break;
+      default: Z[i] = 0;                           break;
+    }
+
+    tmp[i] = Z[i];
   }
 
-  tmp[0] = Z[0];
+  argon2_hash_block (Z, argon2_thread, shuffle_buf, argon2_lsz);
+
+  for (u32 idx = 0; idx < (LBLOCKSIZE / 4); idx++) Z[idx]  ^= tmp[idx];
+
+  for (u32 idx = 0; idx < LBLOCKSIZE; idx++) tmp[idx] = Z[idx];
 
   argon2_hash_block (Z, argon2_thread, shuffle_buf, argon2_lsz);
 
-  Z[0]  ^= tmp[0];
+  for (u32 idx = 0; idx < LBLOCKSIZE; idx++) Z[idx]  ^= tmp[idx];
 
-  for (u32 idx = 0; idx < 4; idx++) tmp[idx] = Z[idx];
-
-  argon2_hash_block (Z, argon2_thread, shuffle_buf, argon2_lsz);
-
-  for (u32 idx = 0; idx < 4; idx++) Z[idx]  ^= tmp[idx];
-
-  for (u32 i = 0, index = (start_index + argon2_thread); i < 4; i++, index += THREADS_PER_LANE)
+  for (u32 i = 0, index = (start_index + argon2_thread); i < LBLOCKSIZE; i++, index += THREADS_PER_LANE)
   {
     addresses[i] = argon2_ref_address (options, pos, index, Z[i]);
   }
-
-  // if addresses[0] == 0xFFFFFFFE => bug
 }
 
 DECLSPEC u32 index_u32x4 (const u32 array[4], u32 index)
@@ -277,20 +357,20 @@ DECLSPEC u32 index_u32x4 (const u32 array[4], u32 index)
   return (u32) -1;
 }
 
-DECLSPEC GLOBAL_AS argon2_block_t *argon2_get_current_block (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const argon2_options_t *options, u32 lane, u32 index_in_lane, u64 R[4], u32 argon2_thread)
+DECLSPEC GLOBAL_AS argon2_block_t *argon2_get_current_block (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const argon2_options_t *options, u32 lane, u32 index_in_lane, u64 R[LBLOCKSIZE], u32 argon2_thread)
 {
   // Apply wrap-around to previous block index if the current block is the first block in the lane
   const u32 prev_in_lane = (index_in_lane == 0) ? (options->lane_length - 1) : (index_in_lane - 1);
 
   GLOBAL_AS argon2_block_t *prev_block = &blocks[(prev_in_lane * options->parallelism) + lane];
 
-  for (u32 idx = 0; idx < 4; idx++) R[idx] = prev_block->values[(idx * THREADS_PER_LANE) + argon2_thread];
+  for (u32 idx = 0; idx < LBLOCKSIZE; idx++) R[idx] = prev_block->values[(idx * THREADS_PER_LANE) + argon2_thread];
 
   return &blocks[(index_in_lane * options->parallelism) + lane];
 }
 
-DECLSPEC void argon2_fill_subsegment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const argon2_options_t *options, PRIVATE_AS const argon2_pos_t *pos, bool indep_addr, const u32 addresses[4],
-                                      u32 start_index, u32 end_index, GLOBAL_AS argon2_block_t *cur_block, u64 R[4], u32 argon2_thread, LOCAL_AS u64 *shuffle_buf, u32 argon2_lsz)
+DECLSPEC void argon2_fill_subsegment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const argon2_options_t *options, PRIVATE_AS const argon2_pos_t *pos, bool indep_addr, const u32 addresses[LBLOCKSIZE],
+                                      u32 start_index, u32 end_index, GLOBAL_AS argon2_block_t *cur_block, u64 R[LBLOCKSIZE], u32 argon2_thread, LOCAL_AS u64 *shuffle_buf, u32 argon2_lsz)
 {
   for (u32 index = start_index; index < end_index; index++, cur_block += options->parallelism)
   {
@@ -298,34 +378,40 @@ DECLSPEC void argon2_fill_subsegment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_
 
     if (indep_addr)
     {
-      ref_address = index_u32x4 (addresses, (index / THREADS_PER_LANE) % ARGON2_SYNC_POINTS);
+#if THREADS_PER_LANE == 1
+      ref_address = addresses[(index / THREADS_PER_LANE) % LBLOCKSIZE];
+#else
+      ref_address = index_u32x4 (addresses, (index / THREADS_PER_LANE) % LBLOCKSIZE);
       ref_address = hc__shfl_sync (shuffle_buf, FULL_MASK, ref_address, index, argon2_thread, argon2_lsz);
+#endif
     }
     else
     {
       ref_address = argon2_ref_address (options, pos, index, R[0]);
+#if THREADS_PER_LANE != 1
       ref_address = hc__shfl_sync (shuffle_buf, FULL_MASK, ref_address, 0, argon2_thread, argon2_lsz);
+#endif
     }
 
     GLOBAL_AS const argon2_block_t *ref_block = &blocks[ref_address];
 
-    u64 tmp[4] = { 0 };
+    u64 tmp[LBLOCKSIZE] = { 0 };
 
     // First pass is overwrite, next passes are XOR with previous
     if ((pos->pass > 0) && (options->version != ARGON2_VERSION_10))
     {
-      for (u32 idx = 0; idx < 4; idx++) tmp[idx]  = cur_block->values[(idx * THREADS_PER_LANE) + argon2_thread];
+      for (u32 idx = 0; idx < LBLOCKSIZE; idx++) tmp[idx]  = cur_block->values[(idx * THREADS_PER_LANE) + argon2_thread];
     }
 
-    for (u32 idx = 0; idx < 4; idx++) R[idx]   ^= ref_block->values[(idx * THREADS_PER_LANE) + argon2_thread];
+    for (u32 idx = 0; idx < LBLOCKSIZE; idx++) R[idx]   ^= ref_block->values[(idx * THREADS_PER_LANE) + argon2_thread];
 
-    for (u32 idx = 0; idx < 4; idx++) tmp[idx] ^= R[idx];
+    for (u32 idx = 0; idx < LBLOCKSIZE; idx++) tmp[idx] ^= R[idx];
 
     argon2_hash_block (R, argon2_thread, shuffle_buf, argon2_lsz);
 
-    for (u32 idx = 0; idx < 4; idx++) R[idx]   ^= tmp[idx];
+    for (u32 idx = 0; idx < LBLOCKSIZE; idx++) R[idx]   ^= tmp[idx];
 
-    for (u32 idx = 0; idx < 4; idx++) cur_block->values[(idx * THREADS_PER_LANE) + argon2_thread] = R[idx];
+    for (u32 idx = 0; idx < LBLOCKSIZE; idx++) cur_block->values[(idx * THREADS_PER_LANE) + argon2_thread] = R[idx];
   }
 }
 
@@ -335,7 +421,7 @@ DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS 
   const u32 skip_blocks   = (pos->pass == 0) && (pos->slice == 0) ? 2 : 0;
   const u32 index_in_lane = (pos->slice * options->segment_length) + skip_blocks;
 
-  u64 R[4] = { 0 };
+  u64 R[LBLOCKSIZE] = { 0 };
 
   GLOBAL_AS argon2_block_t *cur_block = argon2_get_current_block (blocks, options, pos->lane, index_in_lane, R, argon2_thread);
 
@@ -346,7 +432,7 @@ DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS 
       const u32 start_index = (block_index == 0) ? skip_blocks : block_index;
       const u32 end_index   = MIN(((start_index | 127) + 1), options->segment_length);
 
-      u32 addresses[4] = { 0 };
+      u32 addresses[LBLOCKSIZE] = { 0 };
 
       argon2_next_addresses (options, pos, addresses, block_index, argon2_thread, shuffle_buf, argon2_lsz);
       argon2_fill_subsegment (blocks, options, pos, true, addresses, start_index, end_index, cur_block, R, argon2_thread, shuffle_buf, argon2_lsz);
@@ -356,7 +442,7 @@ DECLSPEC void argon2_fill_segment (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS 
   }
   else
   {
-    u32 addresses[4] = { 0 };
+    u32 addresses[LBLOCKSIZE] = { 0 };
 
     argon2_fill_subsegment (blocks, options, pos, false, addresses, skip_blocks, options->segment_length, cur_block, R, argon2_thread, shuffle_buf, argon2_lsz);
   }
@@ -367,26 +453,43 @@ DECLSPEC void argon2_final (GLOBAL_AS argon2_block_t *blocks, PRIVATE_AS const a
   const u32 lane_length = options->lane_length;
   const u32 lanes = options->parallelism;
 
-  argon2_block_t final_block = { };
-
-  for (u32 l = 0; l < lanes; l++)
-  {
-    for (u32 idx = 0; idx < 128; idx++) final_block.values[idx] ^= blocks[((lane_length - 1) * lanes) + l].values[idx];
-  }
-
-  u32 output_len[32] = { 0 };
-  output_len[0] = options->digest_len;
-
   blake2b_ctx_t ctx;
   blake2b_init (&ctx);
 
   // Override default (0x40) value in BLAKE2b
   ctx.h[0] ^= 0x40 ^ options->digest_len;
 
-  blake2b_update (&ctx, output_len, 4);
-  blake2b_update (&ctx, (PRIVATE_AS u32 *) final_block.values, sizeof(final_block));
+  u32 rem = options->digest_len;
 
-  blake2b_final (&ctx);
+  for (u32 offset = 0; offset < 128; offset += 16)
+  {
+    for (u32 l = 0; l < lanes; l++)
+    {
+      for (u32 idx = 0; idx < 16; idx++)
+      {
+        ctx.m[idx] ^= blocks[((lane_length - 1) * lanes) + l].values[idx + offset];
+      }
+    }
+
+    for (u32 idx = 0; idx < 16; idx++)
+    {
+      const u64 value = ctx.m[idx];
+
+      ctx.m[idx] = hl32_to_64 (l32_from_64_S (value), rem);
+
+      rem = h32_from_64_S (value);
+    }
+
+    ctx.len += 128;
+
+    blake2b_transform (ctx.h, ctx.m, ctx.len, (u64) BLAKE2B_UPDATE);
+
+    for (u32 idx = 0; idx < 16; idx++) ctx.m[idx] = 0;
+  }
+
+  ctx.m[0] = hl32_to_64 (0, rem);
+
+  blake2b_transform (ctx.h, ctx.m, 1028, (u64) BLAKE2B_FINAL);
 
   for (uint i = 0, idx = 0; i < (options->digest_len / 4); i += 2, idx += 1)
   {

--- a/OpenCL/inc_hash_argon2.h
+++ b/OpenCL/inc_hash_argon2.h
@@ -1,4 +1,3 @@
-
 /**
  * Author......: Netherlands Forensic Institute
  * License.....: MIT
@@ -12,7 +11,10 @@
 #define ARGON2_VERSION_10 0x10
 #define ARGON2_VERSION_13 0x13
 
+#ifndef THREADS_PER_LANE
 #define THREADS_PER_LANE 32
+#endif
+
 #define FULL_MASK 0xffffffff
 
 #define BLAKE2B_OUTBYTES 64

--- a/src/modules/argon2_common.c
+++ b/src/modules/argon2_common.c
@@ -143,7 +143,12 @@ char *argon2_module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconf
 
   char *jit_build_options = NULL;
 
-  //hc_asprintf (&jit_build_options, "-D ARGON2_PARALLELISM=%u -D ARGON2_TMP_ELEM=%u", options[0].parallelism, options[0].memory_block_count);
+  //hc_asprintf (&jit_build_options, "-D ARGON2_PARALLELISM=%u", options[0].parallelism);
+
+  if (device_param->opencl_device_type & CL_DEVICE_TYPE_CPU)
+  {
+    hc_asprintf (&jit_build_options, "-D THREADS_PER_LANE=1");
+  }
 
   return jit_build_options;
 }


### PR DESCRIPTION
**Argon2 support for CPU**
This resolves issues running the current argon2 implementation on CPU backends.

Some performance numbers on various CPUs using the self-test hash of 64 MB and 3 iterations:
```
Intel Xeon W-2235 @ 3.8GHz    : 48 H/s
Intel Xeon Gold 5317 @ 3.0GHz : 65 H/s
AMD Ryzen 7950X               : 75 H/s
Intel i7-14700K               : 91 H/s
```

**Changes**
 - Used `blake2b_transform()` instead of `blake2b_update()` to avoid compiler problems on Intel OpenCL and segfaults on POCL (still unsure of exact cause but possibly related to the shuffle functions in combination with these OpenCL drivers).
 - Remove 'bug' comments (these are resolved now).
 - Added implementation of `argon2_hash_block()` for non-warped (CPU) case.
 - Introduced `LBLOCKSIZE` for the size of an argon2 block per thread in u64.
 
Except for `argon2_hash_block()`, the implementation should be able to support any warp/wavefront/simd size in the future.

Kind regards,

Pelle & Ewald
Netherlands Forensic Institute