### PR TITLE
Fixed build failed for aarch64 (es: rpi)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -106,6 +106,7 @@
 - Fixed build failed for 18400 with Apple Metal
 - Fixed build failed for 18600 with Apple Metal
 - Fixed build failed for 4410 with vector width > 1
+- Fixed build failed for aarch64 (es: rpi)
 - Fixed clang identification in src/Makefile
 - Fixed build failure for almost all hash modes that make use of hc_swap64 and/or hc_swap64_S with Apple Metal / Apple Silicon
 - Fixed debug mode 5 by adding the missing colon between original-word and finding-rule

--- a/src/Makefile
+++ b/src/Makefile
@@ -88,6 +88,9 @@ DARWIN_VERSION          := $(shell uname -r | cut -d. -f1)
 IS_APPLE_SILICON        := $(shell [ "$$(sysctl -in hw.optional.arm64 2>/dev/null)" = "1" ] && echo 1 || echo 0)
 endif
 
+IS_AARCH64              := $(shell [ "$$(arch 2>/dev/null)" = "aarch64" ] && echo 1 || echo 0)
+IS_ARM                  := $(or $(filter 1,$(IS_APPLE_SILICON)),$(filter 1,$(IS_AARCH64)))
+
 ifneq (,$(filter $(UNAME),FreeBSD NetBSD))
 CC                      := cc
 CXX                     := c++
@@ -380,8 +383,6 @@ LFLAGS_NATIVE           += -lpthread
 LFLAGS_NATIVE           += -liconv
 
 ifeq ($(IS_APPLE_SILICON),1)
-CFLAGS_NATIVE           += -DSSE2NEON_SUPPRESS_WARNINGS
-CFLAGS_NATIVE           += -I$(DEPS_SSE2NEON)
 CFLAGS_NATIVE           += -arch arm64
 CFLAGS_NATIVE           += -arch x86_64
 ifeq ($(SHARED),1)
@@ -391,6 +392,11 @@ endif
 endif
 
 endif # Darwin
+
+ifeq ($(IS_ARM),1)
+CFLAGS_NATIVE           += -DSSE2NEON_SUPPRESS_WARNINGS
+CFLAGS_NATIVE           += -I$(DEPS_SSE2NEON)
+endif
 
 ifeq ($(UNAME),CYGWIN)
 CFLAGS_NATIVE           := $(CFLAGS)
@@ -838,11 +844,11 @@ CFLAGS_LZMA_WIN         += -Wno-misleading-indentation
 
 CFLAGS_UNRAR_WIN        += -Wno-misleading-indentation
 CFLAGS_UNRAR_WIN        += -Wno-class-memaccess
+endif
 
-ifeq ($(IS_APPLE_SILICON),1)
+ifeq ($(IS_ARM),1)
 CFLAGS_CROSS_LINUX      += -DSSE2NEON_SUPPRESS_WARNINGS
 CFLAGS_CROSS_LINUX      += -I$(DEPS_SSE2NEON)
-endif
 endif
 
 ##


### PR DESCRIPTION
replace PR #4305

```
OpenCL API (OpenCL 3.0 PoCL 3.1+debian  Linux, None+Asserts, RELOC, SPIR, LLVM 15.0.6, SLEEF, POCL_DEBUG) - Platform #1 [The pocl project]
==========================================================================================================================================
* Device #01: pthread--cortex-a72, 1450/2901 MB (512 MB allocatable), 4MCU

Benchmark relevant options:
===========================
* --backend-devices-virtmulti=1
* --backend-devices-virthost=1
* --optimized-kernel-enable

-------------------------------------------
* Hash-Mode 34000 (Argon2) [Iterations: 12]
-------------------------------------------

Speed.#01........:        3 H/s (94.55ms) @ Accel:4 Loops:1 Thr:1 Vec:4
```

```
Assimilation Bridge
===================
* Unit #01 -> #02: Argon2 reference implementation + tunings

OpenCL API (OpenCL 3.0 PoCL 3.1+debian  Linux, None+Asserts, RELOC, SPIR, LLVM 15.0.6, SLEEF, POCL_DEBUG) - Platform #1 [The pocl project]
==========================================================================================================================================
* Device #01 -> #02: pthread--cortex-a72, 1450/2901 MB (512 MB allocatable), 4MCU

Benchmark relevant options:
===========================
* --backend-devices-virtmulti=1
* --backend-devices-virthost=1
* --optimized-kernel-enable

------------------------------------------------------------------------------------------
* Hash-Mode 70000 (argon2id [Bridged: reference implementation + tunings]) [Iterations: 1]
------------------------------------------------------------------------------------------

Speed.#01........:        2 H/s (0.00ms) @ Accel:8 Loops:1 Thr:1 Vec:4
Speed.#02........:        2 H/s (0.00ms) @ Accel:8 Loops:1 Thr:1 Vec:4
Speed.#*.........:        3 H/s
```
