### PR TITLE
Fixed bug in module_constraints and kernel for hash-mode 7800

### DIFF
--- a/OpenCL/m07800_a3-optimized.cl
+++ b/OpenCL/m07800_a3-optimized.cl
@@ -62,16 +62,12 @@ DECLSPEC void m07800m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
    * salt
    */
 
-  u32 salt_buf[8];
+  u32 salt_buf[4];
 
   salt_buf[0] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[0]);
   salt_buf[1] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[1]);
   salt_buf[2] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[2]);
   salt_buf[3] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[3]);
-  salt_buf[4] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[4]);
-  salt_buf[5] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[5]);
-  salt_buf[6] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[6]);
-  salt_buf[7] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[7]);
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
@@ -84,10 +80,10 @@ DECLSPEC void m07800m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
   s0[1] = salt_buf[1];
   s0[2] = salt_buf[2];
   s0[3] = salt_buf[3];
-  s1[0] = salt_buf[4];
-  s1[1] = salt_buf[5];
-  s1[2] = salt_buf[6];
-  s1[3] = salt_buf[7];
+  s1[0] = 0;
+  s1[1] = 0;
+  s1[2] = 0;
+  s1[3] = 0;
   s2[0] = 0;
   s2[1] = 0;
   s2[2] = 0;
@@ -206,8 +202,8 @@ DECLSPEC void m07800m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final[ 5] = w1[1];
     final[ 6] = w1[2];
     final[ 7] = w1[3];
-    final[ 8] = 0;
-    final[ 9] = 0;
+    final[ 8] = w2[0];
+    final[ 9] = w2[1];
     final[10] = 0;
     final[11] = 0;
     final[12] = 0;
@@ -279,16 +275,12 @@ DECLSPEC void m07800s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
    * salt
    */
 
-  u32 salt_buf[8];
+  u32 salt_buf[4];
 
   salt_buf[0] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[0]);
   salt_buf[1] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[1]);
   salt_buf[2] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[2]);
   salt_buf[3] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[3]);
-  salt_buf[4] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[4]);
-  salt_buf[5] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[5]);
-  salt_buf[6] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[6]);
-  salt_buf[7] = hc_swap32_S (salt_bufs[SALT_POS_HOST].salt_buf[7]);
 
   const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
 
@@ -301,10 +293,10 @@ DECLSPEC void m07800s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
   s0[1] = salt_buf[1];
   s0[2] = salt_buf[2];
   s0[3] = salt_buf[3];
-  s1[0] = salt_buf[4];
-  s1[1] = salt_buf[5];
-  s1[2] = salt_buf[6];
-  s1[3] = salt_buf[7];
+  s1[0] = 0;
+  s1[1] = 0;
+  s1[2] = 0;
+  s1[3] = 0;
   s2[0] = 0;
   s2[1] = 0;
   s2[2] = 0;
@@ -435,8 +427,8 @@ DECLSPEC void m07800s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final[ 5] = w1[1];
     final[ 6] = w1[2];
     final[ 7] = w1[3];
-    final[ 8] = 0;
-    final[ 9] = 0;
+    final[ 8] = w2[0];
+    final[ 9] = w2[1];
     final[10] = 0;
     final[11] = 0;
     final[12] = 0;
@@ -514,8 +506,6 @@ KERNEL_FQ KERNEL_FA void m07800_m04 (KERN_ATTR_BASIC ())
    * modifier
    */
 
-  //const u64 lid = get_local_id (0);
-
   u32 w0[4];
 
   w0[0] = pws[gid].i[ 0];
@@ -569,8 +559,6 @@ KERNEL_FQ KERNEL_FA void m07800_m08 (KERN_ATTR_BASIC ())
    * modifier
    */
 
-  //const u64 lid = get_local_id (0);
-
   u32 w0[4];
 
   w0[0] = pws[gid].i[ 0];
@@ -610,6 +598,55 @@ KERNEL_FQ KERNEL_FA void m07800_m08 (KERN_ATTR_BASIC ())
 
 KERNEL_FQ KERNEL_FA void m07800_m16 (KERN_ATTR_BASIC ())
 {
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m07800m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
 }
 
 KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_BASIC ())
@@ -627,8 +664,6 @@ KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_BASIC ())
   /**
    * modifier
    */
-
-  //const u64 lid = get_local_id (0);
 
   u32 w0[4];
 
@@ -683,8 +718,6 @@ KERNEL_FQ KERNEL_FA void m07800_s08 (KERN_ATTR_BASIC ())
    * modifier
    */
 
-  //const u64 lid = get_local_id (0);
-
   u32 w0[4];
 
   w0[0] = pws[gid].i[ 0];
@@ -724,4 +757,53 @@ KERNEL_FQ KERNEL_FA void m07800_s08 (KERN_ATTR_BASIC ())
 
 KERNEL_FQ KERNEL_FA void m07800_s16 (KERN_ATTR_BASIC ())
 {
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * modifier
+   */
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m07800s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
 }

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -91,6 +91,7 @@
 - Added verification of token buffer length when using TOKEN_ATTR_FIXED_LENGTH
 - Fixed a bug in all SCRYPT-based hash modes with Apple Metal
 - Fixed buffer overflow on module_26600.c / module_hash_encode()
+- Fixed bug in module_constraints and kernel for hash-mode 7800
 - Fixed bug in 18400 module_hash_encode
 - Fixed bug in 23800/unrar with Apple Silicon
 - Fixed bug in 26900 module_hash_encode

--- a/tools/test_modules/m07800.pm
+++ b/tools/test_modules/m07800.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::SHA qw (sha1 sha1_hex);
 
-sub module_constraints { [[-1, -1], [-1, -1], [0, 55], [1, 12], [0, 55]] }
+sub module_constraints { [[-1, -1], [-1, -1], [0, 40], [1, 12], [0, 55]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
```
$ ./tools/test_edge.sh -m 7800 -V 1 -a 3 -v -t single -v
Global hashcat options selected: --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270
7800,3,1,2,1,'20','2','2$83D670DC8DAACE05D619891879CD7CEC6569AA39'
7800,3,1,2,12,'74','592400460963','592400460963$045CA1B4F874512327C3B839DD2E8DD5395F0235'
7800,3,1,54,1,'296078623830385343863486568153366122417288857210483040','9','9$8B7C887B4614E65A6AE3910D1185E6E3373B7123'
7800,3,1,54,1,'779452464866548352416900728758953407322730885692893912','3','3$9527F2EF6C38869DF7F2BAE2BD322D1AC9B47B3C'
[ test_edge_1752276418 ] # Processing Hash-Type 7800, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752276418 ] > Hash-Type 7800, Attack-Type 3, Kernel-Type optimized, Test ID 1, Word len 2, Salt len 1, Word '20', Salt '2', Hash '2$83D670DC8DAACE05D619891879CD7CEC6569AA39'
[ test_edge_1752276418 ] > Hash-Type 7800, Attack-Type 3, Kernel-Type optimized, Test ID 2, Word len 2, Salt len 12, Word '74', Salt '592400460963', Hash '592400460963$045CA1B4F874512327C3B839DD2E8DD5395F0235'
[ test_edge_1752276418 ] > Hash-Type 7800, Attack-Type 3, Kernel-Type optimized, Test ID 3, Word len 54, Salt len 1, Word '296078623830385343863486568153366122417288857210483040', Salt '9', Hash '9$8B7C887B4614E65A6AE3910D1185E6E3373B7123'
[ test_edge_1752276418 ] !> error (1) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 7800 '9$8B7C887B4614E65A6AE3910D1185E6E3373B7123' -a 3 296078623830385343863486568153366122417288857210483?d?d?d
[ test_edge_1752276418 ] !> Hash-Type 7800, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 3, Word len 54, Salt len 1, Word '296078623830385343863486568153366122417288857210483040', Hash '9$8B7C887B4614E65A6AE3910D1185E6E3373B7123'

STATUS	5	SPEED	4065883	1000	0	1000	EXEC_RUNTIME	0.012224	0.000000	CURKU	0	PROGRESS	1000	1000	RECHASH	0	1	RECSALT	0	1	TEMP	3962	REJECTED	0	UTIL	0	24	

[ test_edge_1752276418 ] > Hash-Type 7800, Attack-Type 3, Kernel-Type optimized, Test ID 4, Word len 54, Salt len 1, Word '779452464866548352416900728758953407322730885692893912', Salt '3', Hash '3$9527F2EF6C38869DF7F2BAE2BD322D1AC9B47B3C'
[ test_edge_1752276418 ] !> error (1) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 7800 '3$9527F2EF6C38869DF7F2BAE2BD322D1AC9B47B3C' -a 3 779452464866548352416900728758953407322730885692893?d?d?d
[ test_edge_1752276418 ] !> Hash-Type 7800, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 4, Word len 54, Salt len 1, Word '779452464866548352416900728758953407322730885692893912', Hash '3$9527F2EF6C38869DF7F2BAE2BD322D1AC9B47B3C'

STATUS	5	SPEED	3960396	1000	0	1000	EXEC_RUNTIME	0.010240	0.000000	CURKU	0	PROGRESS	1000	1000	RECHASH	0	1	RECSALT	0	1	TEMP	3962	REJECTED	0	UTIL	2	26
```