### PR TITLE
Fixed bug in module_constraints for hash-mode 8700

### DIFF
--- a/tools/test_modules/m08700.pm
+++ b/tools/test_modules/m08700.pm
@@ -8,7 +8,7 @@
 use strict;
 use warnings;
 
-sub module_constraints { [[-1, -1], [-1, -1], [0, 55], [5, 5], [-1, -1]] }
+sub module_constraints { [[-1, -1], [-1, -1], [0, 32], [5, 5], [0, 55]] }
 
 my $LOTUS_MAGIC_TABLE =
 [


### PR DESCRIPTION
```
$ ./tools/test_edge.sh -m 8700 -V 1 -a 3 -v -t single -v
Global hashcat options selected: --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270
8700,3,1,2,5,'66','25438','(GCZKqDpX9gjxWWhSxaIh)'
8700,3,1,55,5,'5209241155990592999884873396291906671491154051271301742','65574','(GDZKrEpJthbKt4hHHxDZ)'
[ test_edge_1752278084 ] # Processing Hash-Type 8700, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752278084 ] > Hash-Type 8700, Attack-Type 3, Kernel-Type optimized, Test ID 1, Word len 2, Salt len 5, Word '66', Salt '25438', Hash '(GCZKqDpX9gjxWWhSxaIh)'
[ test_edge_1752278084 ] > Hash-Type 8700, Attack-Type 3, Kernel-Type optimized, Test ID 2, Word len 55, Salt len 5, Word '5209241155990592999884873396291906671491154051271301742', Salt '65574', Hash '(GDZKrEpJthbKt4hHHxDZ)'
[ test_edge_1752278084 ] !> error (255) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 8700 '(GDZKrEpJthbKt4hHHxDZ)' -a 3 5209241155990592999884873396291906671491154051271301?d?d?d
[ test_edge_1752278084 ] !> Hash-Type 8700, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 55, Salt len 5, Word '5209241155990592999884873396291906671491154051271301742', Hash '(GDZKrEpJthbKt4hHHxDZ)'

Skipping mask '5209241155990592999884873396291906671491154051271301?d?d?d' because it is larger than the maximum password length.
```