### PR TITLE
Fixed bug in module_constraints for hash-mode 10100

### DIFF
--- a/tools/test_modules/m10100.pm
+++ b/tools/test_modules/m10100.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::SipHash qw (siphash);
 
-sub module_constraints { [[-1, -1], [-1, -1], [0, 55], [32, 32], [-1, -1]] }
+sub module_constraints { [[-1, -1], [-1, -1], [0, 55], [32, 32], [0, 55]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
```
$ ./tools/test_edge.sh -m 10100 -V 1 -a 3 -v -t single -v
Global hashcat options selected: --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270
10100,3,1,2,32,'51','72479563433149440049510277872014','7811d4e51c6c2c26:2:4:72479563433149440049510277872014'
10100,3,1,55,32,'4004886461608808299657042980516606735796440983942515197','16103877965820012204574718130908','51cc428b49be4a4e:2:4:16103877965820012204574718130908'
[ test_edge_1752278722 ] # Processing Hash-Type 10100, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752278722 ] > Hash-Type 10100, Attack-Type 3, Kernel-Type optimized, Test ID 1, Word len 2, Salt len 32, Word '51', Salt '72479563433149440049510277872014', Hash '7811d4e51c6c2c26:2:4:72479563433149440049510277872014'
[ test_edge_1752278722 ] > Hash-Type 10100, Attack-Type 3, Kernel-Type optimized, Test ID 2, Word len 55, Salt len 32, Word '4004886461608808299657042980516606735796440983942515197', Salt '16103877965820012204574718130908', Hash '51cc428b49be4a4e:2:4:16103877965820012204574718130908'
[ test_edge_1752278722 ] !> error (1) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 10100 '51cc428b49be4a4e:2:4:16103877965820012204574718130908' -a 3 4004886461608808299657042980516606735796440983942515?d?d?d
[ test_edge_1752278722 ] !> Hash-Type 10100, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 55, Salt len 32, Word '4004886461608808299657042980516606735796440983942515197', Hash '51cc428b49be4a4e:2:4:16103877965820012204574718130908'

STATUS	5	SPEED	1619005	1000	0	1000	EXEC_RUNTIME	0.073632	0.000000	CURKU	0	PROGRESS	1000	1000	RECHASH	0	1	RECSALT	0	1	TEMP	4054	REJECTED	0	UTIL	0	19
```