### PR TITLE
Fixed bug in module_constraints for hash-mode 11100

### DIFF
--- a/tools/test_modules/m11100.pm
+++ b/tools/test_modules/m11100.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::MD5 qw (md5_hex);
 
-sub module_constraints { [[0, 256], [8, 8], [0, 55], [8, 8], [-1, -1]] }
+sub module_constraints { [[0, 256], [8, 8], [0, 55], [8, 8], [0, 55]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
```
$ ./tools/test_edge.sh -m 11100 -V 1 -a 3 -v -t single -v
Global hashcat options selected: --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270
11100,3,0,2,8,'42','25364042','$postgres$postgres*25364042*1dcb63d4b40ba6ada3ee04acd262888f'
11100,3,0,256,8,'5273626654838730590986856644913861096445688049359307779126874660750248758798798563919152616783424987487687422986950433109750808915542899940211216395070454168529960560903935163913077415550398349005921021088790687118451961339401843403071246345082183443758621','03120206','$postgres$postgres*03120206*5662e35077e8ad9757b50a8691a04a49'
[ test_edge_1752279560 ] # Processing Hash-Type 11100, Attack-Type 3, Kernel-Type pure, Vector-Width 1, Target-Type single
[ test_edge_1752279560 ] > Hash-Type 11100, Attack-Type 3, Kernel-Type pure, Test ID 1, Word len 2, Salt len 8, Word '42', Salt '25364042', Hash '$postgres$postgres*25364042*1dcb63d4b40ba6ada3ee04acd262888f'
[ test_edge_1752279560 ] > Hash-Type 11100, Attack-Type 3, Kernel-Type pure, Test ID 2, Word len 256, Salt len 8, Word '5273626654838730590986856644913861096445688049359307779126874660750248758798798563919152616783424987487687422986950433109750808915542899940211216395070454168529960560903935163913077415550398349005921021088790687118451961339401843403071246345082183443758621', Salt '03120206', Hash '$postgres$postgres*03120206*5662e35077e8ad9757b50a8691a04a49'
11100,3,1,2,8,'11','99936901','$postgres$postgres*99936901*ed23ad000faecbbfe81ca1bb280595d7'
11100,3,1,55,8,'7217932631441760867910423416103050348581181014167503066','14194230','$postgres$postgres*14194230*986419451fae9f3236fb3a170a4735c9'
[ test_edge_1752279560 ] # Processing Hash-Type 11100, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752279560 ] > Hash-Type 11100, Attack-Type 3, Kernel-Type optimized, Test ID 1, Word len 2, Salt len 8, Word '11', Salt '99936901', Hash '$postgres$postgres*99936901*ed23ad000faecbbfe81ca1bb280595d7'
[ test_edge_1752279560 ] > Hash-Type 11100, Attack-Type 3, Kernel-Type optimized, Test ID 2, Word len 55, Salt len 8, Word '7217932631441760867910423416103050348581181014167503066', Salt '14194230', Hash '$postgres$postgres*14194230*986419451fae9f3236fb3a170a4735c9'
[ test_edge_1752279560 ] !> error (1) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 11100 '$postgres$postgres*14194230*986419451fae9f3236fb3a170a4735c9' -a 3 7217932631441760867910423416103050348581181014167503?d?d?d
[ test_edge_1752279560 ] !> Hash-Type 11100, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 55, Salt len 8, Word '7217932631441760867910423416103050348581181014167503066', Hash '$postgres$postgres*14194230*986419451fae9f3236fb3a170a4735c9'

STATUS	5	SPEED	1662797	1000	0	1000	EXEC_RUNTIME	0.073696	0.000000	CURKU	0	PROGRESS	1000	1000	RECHASH	0	1	RECSALT	0	1	TEMP	4657	REJECTED	0	UTIL	0	36	
```