### PR TITLE
Fixed bug in module_constraints for hash-mode 15000

### DIFF
--- a/tools/test_modules/m15000.pm
+++ b/tools/test_modules/m15000.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::SHA qw (sha512_hex);
 
-sub module_constraints { [[0, 256], [64, 64], [0, 55], [64, 64], [-1, -1]] }
+sub module_constraints { [[0, 256], [64, 64], [0, 47], [64, 64], [0, 55]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
```
$ ./tools/test_edge.sh -m 15000 -V 1 -a 3 -v -t single -v -K 1
Global hashcat options selected: --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270
15000,3,1,2,64,'80','8306257254070883643893533589874627087884831787573679470637749071','18d6d7edf839f6dd309a015cb581a712b95ae06efc8a1b49d63dc01e75718b92086270dd515e41495c898a71ab9126bc897713d6ac8ee2d444e313152e1086a9:8306257254070883643893533589874627087884831787573679470637749071'
15000,3,1,55,64,'2067459285479098467878434929480739384662283356793370410','7805216064870691899909643734602834242562939194685545923643799809','dbaf0bf5f2fa9ebab990219e87d0d05e38d65be2ee5d79174db6deece422facb8030785879412eb9e3d2fe8c6884774ea13277f31faee89eccfa71d9e7a0a209:7805216064870691899909643734602834242562939194685545923643799809'
[ test_edge_1752280507 ] # Processing Hash-Type 15000, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752280507 ] > Hash-Type 15000, Attack-Type 3, Kernel-Type optimized, Test ID 1, Word len 2, Salt len 64, Word '80', Salt '8306257254070883643893533589874627087884831787573679470637749071', Hash '18d6d7edf839f6dd309a015cb581a712b95ae06efc8a1b49d63dc01e75718b92086270dd515e41495c898a71ab9126bc897713d6ac8ee2d444e313152e1086a9:8306257254070883643893533589874627087884831787573679470637749071'
[ test_edge_1752280507 ] > Hash-Type 15000, Attack-Type 3, Kernel-Type optimized, Test ID 2, Word len 55, Salt len 64, Word '2067459285479098467878434929480739384662283356793370410', Salt '7805216064870691899909643734602834242562939194685545923643799809', Hash 'dbaf0bf5f2fa9ebab990219e87d0d05e38d65be2ee5d79174db6deece422facb8030785879412eb9e3d2fe8c6884774ea13277f31faee89eccfa71d9e7a0a209:7805216064870691899909643734602834242562939194685545923643799809'
[ test_edge_1752280507 ] !> error (1) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 15000 'dbaf0bf5f2fa9ebab990219e87d0d05e38d65be2ee5d79174db6deece422facb8030785879412eb9e3d2fe8c6884774ea13277f31faee89eccfa71d9e7a0a209:7805216064870691899909643734602834242562939194685545923643799809' -a 3 2067459285479098467878434929480739384662283356793370?d?d?d
[ test_edge_1752280507 ] !> Hash-Type 15000, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 55, Salt len 64, Word '2067459285479098467878434929480739384662283356793370410', Hash 'dbaf0bf5f2fa9ebab990219e87d0d05e38d65be2ee5d79174db6deece422facb8030785879412eb9e3d2fe8c6884774ea13277f31faee89eccfa71d9e7a0a209:7805216064870691899909643734602834242562939194685545923643799809'

STATUS	5	SPEED	1641432	1000	0	1000	EXEC_RUNTIME	0.029024	0.000000	CURKU	0	PROGRESS	1000	1000	RECHASH	0	1	RECSALT	0	1	TEMP	3658	REJECTED	0	UTIL	0	34	

```