### PR TITLE
Fixed bug in optimized kernel for hash-mode 20800

### DIFF
--- a/OpenCL/m20800_a3-optimized.cl
+++ b/OpenCL/m20800_a3-optimized.cl
@@ -738,8 +738,8 @@ KERNEL_FQ KERNEL_FA void m20800_m16 (KERN_ATTR_BASIC ())
 
   w3[0] = pws[gid].i[12];
   w3[1] = pws[gid].i[13];
-  w3[2] = pws[gid].i[14];
-  w3[3] = pws[gid].i[15];
+  w3[2] = pws[gid].i[15];
+  w3[3] = 0;
 
   const u32 pw_len = pws[gid].pw_len & 63;
 
@@ -948,8 +948,8 @@ KERNEL_FQ KERNEL_FA void m20800_s16 (KERN_ATTR_BASIC ())
 
   w3[0] = pws[gid].i[12];
   w3[1] = pws[gid].i[13];
-  w3[2] = pws[gid].i[14];
-  w3[3] = pws[gid].i[15];
+  w3[2] = pws[gid].i[15];
+  w3[3] = 0;
 
   const u32 pw_len = pws[gid].pw_len & 63;
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -97,6 +97,7 @@
 - Fixed bug in 29600 module OPTS_TYPE setting
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
+- Fixed bug in optimized kernel for hash-mode 20800
 - Fixed bug in --stdout that caused certain rules to malfunction
 - Fixed bug in --stdout when multiple computing devices are active
 - Fixed bug in Hardware Monitor: prevent disable if ADL fail


### PR DESCRIPTION
```
[ test_edge_1752282276 ] # Processing Hash-Type 20800, Attack-Type 3, Kernel-Type pure, Vector-Width 1, Target-Type single
[ test_edge_1752282276 ] > Hash-Type 20800, Attack-Type 3, Kernel-Type pure, Test ID 1, Word len 2, Salt len None, Word '65', Salt '', Hash 'ec496d18f927cfe7ef04863dd096652f9791da7daa3d8d47fa38ceb76913ee34'
[ test_edge_1752282276 ] > Hash-Type 20800, Attack-Type 3, Kernel-Type pure, Test ID 2, Word len 256, Salt len None, Word '6996503285776725357138224915551457045753268207019305606385215373859164694127137336366076236972403682005955075592716918199469202193978909303689866971709732800922823959819018629845500354402469505372261955656812254056637361125254795750723395432145801009387457', Salt '', Hash '64115af3116f0708b78e73af87552f99bab243ba5601a098b40298b05c7729dd'
20800,3,1,2,0,'72','','9534800dc9d4b7c298eaa9e4d21b476e9a6676f734b4fb324fdccc451f33f060'
20800,3,1,55,0,'6117575534756270143321384694499306960103464979560918067','','3c9b5a0e4edc014989ad2a95d60c3644a150300af0e5eb5140f6159827109b73'
[ test_edge_1752282276 ] # Processing Hash-Type 20800, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752282276 ] > Hash-Type 20800, Attack-Type 3, Kernel-Type optimized, Test ID 1, Word len 2, Salt len None, Word '72', Salt '', Hash '9534800dc9d4b7c298eaa9e4d21b476e9a6676f734b4fb324fdccc451f33f060'
[ test_edge_1752282276 ] > Hash-Type 20800, Attack-Type 3, Kernel-Type optimized, Test ID 2, Word len 55, Salt len None, Word '6117575534756270143321384694499306960103464979560918067', Salt '', Hash '3c9b5a0e4edc014989ad2a95d60c3644a150300af0e5eb5140f6159827109b73'
[ test_edge_1752282276 ] !> error (1) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 20800 '3c9b5a0e4edc014989ad2a95d60c3644a150300af0e5eb5140f6159827109b73' -a 3 6117575534756270143321384694499306960103464979560918?d?d?d
[ test_edge_1752282276 ] !> Hash-Type 20800, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 55, Salt len None, Word '6117575534756270143321384694499306960103464979560918067', Hash '3c9b5a0e4edc014989ad2a95d60c3644a150300af0e5eb5140f6159827109b73'

STATUS	5	SPEED	2329172	1000	0	1000	EXEC_RUNTIME	0.020512	0.000000	CURKU	0	PROGRESS	1000	1000	RECHASH	0	1	RECSALT	0	1	TEMP	4356	REJECTED	0	UTIL	0	36	

```