### PR TITLE
Fixed bug in module_constraints for hash-mode 31000

### DIFF
--- a/tools/test_modules/m31000.pm
+++ b/tools/test_modules/m31000.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Crypt::Digest::BLAKE2s_256 qw (blake2s_256_hex);
 
-sub module_constraints { [[0, 128], [-1, -1], [0, 64], [-1, -1], [-1, -1]] }
+sub module_constraints { [[0, 128], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
```
$ ./tools/test_edge.sh -m 31000 -V 1 -vv -a3
Global hashcat options selected: --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270
31000,3,0,2,0,'29','','$BLAKE2$96ef2f77413e884d742c05579e8b45b34394bec86bc573bf884c83655c3fbe64'
31000,3,0,128,0,'67309459875078406485850092372350361213665594508620999705213754780936555889225713408356208174874122413761245480370815352241627840','','$BLAKE2$8306feba383742461ea473e91f2c8fb100325be0ae42e315f1d0c4899265587a'
[ test_edge_1752303070 ] # Processing Hash-Type 31000, Attack-Type 3, Kernel-Type pure, Vector-Width 1, Target-Type single
[ test_edge_1752303070 ] > Hash-Type 31000, Attack-Type 3, Kernel-Type pure, Test ID 1, Word len 2, Salt len None, Word '29', Salt '', Hash '$BLAKE2$96ef2f77413e884d742c05579e8b45b34394bec86bc573bf884c83655c3fbe64'
[ test_edge_1752303070 ] > Hash-Type 31000, Attack-Type 3, Kernel-Type pure, Test ID 2, Word len 128, Salt len None, Word '67309459875078406485850092372350361213665594508620999705213754780936555889225713408356208174874122413761245480370815352241627840', Salt '', Hash '$BLAKE2$8306feba383742461ea473e91f2c8fb100325be0ae42e315f1d0c4899265587a'
[ test_edge_1752303070 ] # Processing Hash-Type 31000, Attack-Type 3, Kernel-Type pure, Vector-Width 1, Target-Type multi
31000,3,1,2,0,'30','','$BLAKE2$803d729a8ca8142c2d1a952c969a846c07d0c35b1b9893d2ee54e9235b9800c5'
31000,3,1,64,0,'9858768028136140466181184939329617449397153006915699567561140835','','$BLAKE2$36930a9cd00c7ae642863f0f7f22e4c93c0202632349f443ca2ff244ac79fcc0'
[ test_edge_1752303070 ] # Processing Hash-Type 31000, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752303070 ] > Hash-Type 31000, Attack-Type 3, Kernel-Type optimized, Test ID 1, Word len 2, Salt len None, Word '30', Salt '', Hash '$BLAKE2$803d729a8ca8142c2d1a952c969a846c07d0c35b1b9893d2ee54e9235b9800c5'
[ test_edge_1752303070 ] > Hash-Type 31000, Attack-Type 3, Kernel-Type optimized, Test ID 2, Word len 64, Salt len None, Word '9858768028136140466181184939329617449397153006915699567561140835', Salt '', Hash '$BLAKE2$36930a9cd00c7ae642863f0f7f22e4c93c0202632349f443ca2ff244ac79fcc0'
[ test_edge_1752303070 ] !> error (255) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 31000 '$BLAKE2$36930a9cd00c7ae642863f0f7f22e4c93c0202632349f443ca2ff244ac79fcc0' -a 3 9858768028136140466181184939329617449397153006915699567561140?d?d?d
[ test_edge_1752303070 ] !> Hash-Type 31000, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 64, Salt len None, Word '9858768028136140466181184939329617449397153006915699567561140835', Hash '$BLAKE2$36930a9cd00c7ae642863f0f7f22e4c93c0202632349f443ca2ff244ac79fcc0'

Skipping mask '9858768028136140466181184939329617449397153006915699567561140?d?d?d' because it is larger than the maximum password length.

[ test_edge_1752303070 ] # Processing Hash-Type 31000, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type multi
[ test_edge_1752303070 ] !> error (255) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable --runtime 270 -O --backend-vector-width 1 -m 31000 test_edge_1752303070/edge_31000_optimized_3_1.hashes -a 3 test_edge_1752303070/test_31000_optimized_3.1.words.masks
[ test_edge_1752303070 ] !> Hash-Type 31000, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Words test_edge_1752303070/edge_31000_optimized_3_1.words, Hashes test_edge_1752303070/edge_31000_optimized_3_1.hashes

$BLAKE2$803d729a8ca8142c2d1a952c969a846c07d0c35b1b9893d2ee54e9235b9800c5:30
STATUS	5	SPEED	26427	1000	0	1000	EXEC_RUNTIME	0.132096	0.000000	CURKU	0	PROGRESS	10	10	RECHASH	1	2	RECSALT	0	1	TEMP	4256	REJECTED	0	UTIL	0	36	
Skipping mask '9858768028136140466181184939329617449397153006915699567561140?d?d?d' because it is larger than the maximum password length.

```