### PR TITLE
Unit tests: Updated install_modules.sh to use an external module for Digest::BLAKE2, due to maintenance being discontinued

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -163,6 +163,7 @@
 - Scrypt: Increase buffer sizes in module for hash mode 8900 to allow longer scrypt digests
 - Unicode: Update UTF-8 to UTF-16 conversion to match RFC 3629
 - Unit tests: Updated install_modules.sh with Crypt::Argon2
+- Unit tests: Updated install_modules.sh to use an external module for Digest::BLAKE2, due to maintenance being discontinued
 - User Options: Added error message when mixing --username and --show to warn users of exponential delay
 - MetaMask: update extraction tool to support MetaMask Mobile wallets
 - SecureCRT MasterPassphrase v2: update module, pure kernels and test unit. Add optimized kernels.

--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -45,7 +45,6 @@ cpan install Authen::Passphrase::LANManager \
              Crypt::Twofish                 \
              Crypt::UnixCrypt_XS            \
              Data::Types                    \
-             Digest::BLAKE2                 \
              Digest::CMAC                   \
              Digest::CRC                    \
              Digest::GOST                   \
@@ -69,6 +68,10 @@ cpan install Authen::Passphrase::LANManager \
              POSIX                          \
              Text::Iconv                    \
              ;
+
+ERRORS=$((ERRORS+$?))
+
+cpanm https://github.com/matrix/p5-Digest-BLAKE2.git
 
 ERRORS=$((ERRORS+$?))
 


### PR DESCRIPTION
tested on Linux and Apple Silicon

```
$ cpanm https://github.com/matrix/p5-Digest-BLAKE2.git
Cloning https://github.com/matrix/p5-Digest-BLAKE2.git ... OK
--> Working on https://github.com/matrix/p5-Digest-BLAKE2.git
Configuring /var/folders/y5/q8xqt2bx4nn4pwjbzb54xnqr0000gn/T/4vBmjLJ0br ... OK
Building and testing Digest-BLAKE2-0.03 ... OK
Successfully installed Digest-BLAKE2-0.03
1 distribution installed
bash-3.2$ tools/test.pl single 600
echo                                 | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce'
echo 7                               | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$d5c47f63555ae063383c2a0df82bf309d90932bc8dd66a056d80e4d913e821faacf7e0e962c7bbac6c193e1e638b58b8baa1e71f57a945958b84c11536b7a82d'
echo 7528284                         | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$6a2ed7bad0b149d7f24842642da94d4d844089c85211a6a378d49d6cb54f1bd3372f0d2740008b6f29983e321bb097442240fbfebf1c15eb61da3a3221d22e64'
echo 26389073348                     | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$3086bb2a9c41c2f5b6fcda1ea8f75438b7ccf18abb481af31a801ec65f4c41973c18db385d32a5cc0d10e0c12f7bda130346cfd41fee927a341c5f578d4ed3ac'
echo 858629164346                    | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$958441ed758dcfcebad7fc54b36fc0ca34762249275ccb0c36afab678a5d778888f8391bff10e8590b56f0ad9f971dc3c60bd6cadf0c2e4b8084fe1c02bb6af3'
echo 407176124398174323193           | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$6320a32a59bb0ca4364324a753c665b3f5f4a698cd101784b7da7c589317bd5bebc39031f8ac1e76215e8e58dbfa991115c1caaafbf28764d0fbf5c5c290d2cf'
echo 7105609207300218407179285582722 | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$2d4e45c7313f551c7774c4a9b44e28ed2be933ec04a29a6e8e9969fbab307ad205e332e44e34655decb54a441e175fc18a919fe3487855281277f1e97d451f9b'
echo 9776839910040172207312233019165 | ./hashcat ${OPTS} -a 0 -m 600 '$BLAKE2$920fa782ccd7533e7815aceeb091841ac524a7d0ae1ea5bd45f65089d9e90bcf555fd236ed068d3d02a1273ca0ce8e2c94c9278eb11bdc68afcb75e24387d3f5'
bash-3.2$ tools/test.pl edge 600 0 0
600,0,0,0,0,'','','$BLAKE2$786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce'
600,0,0,256,0,'1946656951268867223320081456468677875702440235311156129302366603248178355742542999139657333384104937196534432101723297323446994002131294116200546027313780709064638409792959159970433825555641798306950943273153061334247292251589996932620467973763772000114262','','$BLAKE2$2d38db75e778019ec0f88609e3601335923c9dee0f6efa1095dc63d54aa5094626e10292dafce79f81b3688bba69897cde4d2d4efc0bf9e5c7f2e5e9c7dacb44'
bash-3.2$ tools/test.pl edge 600 0 1
600,0,1,0,0,'','','$BLAKE2$786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce'
600,0,1,31,0,'7426611192410959848362445198652','','$BLAKE2$6512a4f8701450a13591dfb66c6ddc517b52308fd45ec2c683d65f229e6a4fd2442a83ac4ed801d47627d7545bb03f91a84fb31dfaecd61dd2e2d86005252992'

```