### PR TITLE
Unit tests: Updated install_modules.sh with Crypt::Passwd::XS, to test suite works also on Apple (ex: 1800)

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -163,6 +163,7 @@
 - Scrypt: Increase buffer sizes in module for hash mode 8900 to allow longer scrypt digests
 - Unicode: Update UTF-8 to UTF-16 conversion to match RFC 3629
 - Unit tests: Updated install_modules.sh with Crypt::Argon2
+- Unit tests: Updated install_modules.sh with Crypt::Passwd::XS, to test suite works also on Apple (ex: 1800)
 - User Options: Added error message when mixing --username and --show to warn users of exponential delay
 - MetaMask: update extraction tool to support MetaMask Mobile wallets
 - SecureCRT MasterPassphrase v2: update module, pure kernels and test unit. Add optimized kernels.

--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -37,6 +37,7 @@ cpan install Authen::Passphrase::LANManager \
              Crypt::OpenSSH::ChachaPoly     \
              Crypt::OpenSSL::EC             \
              Crypt::OpenSSL::Bignum::CTX    \
+             Crypt::Passwd::XS              \
              Crypt::PBKDF2                  \
              Crypt::RC4                     \
              Crypt::Rijndael                \

--- a/tools/test_modules/m01800.pm
+++ b/tools/test_modules/m01800.pm
@@ -7,6 +7,7 @@
 
 use strict;
 use warnings;
+use Crypt::Passwd::XS;
 
 sub module_constraints { [[0, 256], [0, 16], [0, 15], [0, 16], [-1, -1]] }
 
@@ -20,11 +21,11 @@ sub module_generate_hash
 
   if (defined $iter)
   {
-    $hash_buf = crypt ($word, "\$6\$rounds=$iter\$$salt\$");
+    $hash_buf = Crypt::Passwd::XS::unix_sha512_crypt ($word, "\$6\$rounds=$iter\$$salt\$");
   }
   else
   {
-    $hash_buf = crypt ($word, "\$6\$$salt\$");
+    $hash_buf = Crypt::Passwd::XS::unix_sha512_crypt ($word, "\$6\$$salt\$");
   }
 
   my $hash = sprintf ("%s", $hash_buf);


### PR DESCRIPTION
Hi,

on Apple the crypt() function on perl return different type of hash. In this way I fix 1800 module and we will fix all others if crypt() is used to make test vectors

POC before this patch, on Apple

```
$ ./tools/test.pl single 1800
echo                                 | ./hashcat ${OPTS} -a 0 -m 1800 '$6UCLzI8sPv16'
echo 7                               | ./hashcat ${OPTS} -a 0 -m 1800 '$6nPfIvwK3FEI'
echo 82                              | ./hashcat ${OPTS} -a 0 -m 1800 '$6v4bWx6GACR.'
echo 7357241184                      | ./hashcat ${OPTS} -a 0 -m 1800 '$6auszhALp7lI'
echo 772074906074                    | ./hashcat ${OPTS} -a 0 -m 1800 '$6jMg3c8IFnOQ'
echo 3219292268666                   | ./hashcat ${OPTS} -a 0 -m 1800 '$6blanJi3g2ws'
echo 57329589905945                  | ./hashcat ${OPTS} -a 0 -m 1800 '$6qdfBjfsefTs'
echo 166794863206421                 | ./hashcat ${OPTS} -a 0 -m 1800 '$6YZGIXvZC6Vs'
```

With the patch

```
$ ./tools/test.pl single 1800
echo                                 | ./hashcat ${OPTS} -a 0 -m 1800 '$6$3552969266862$epUfs/jRI1p3StpIHj0U7U8KetAsADF20MnoteZFGicCQPyJUMrdQE9lYPKAf8IzYjaIZK2pklqLkws0vx2FF.'
echo 7                               | ./hashcat ${OPTS} -a 0 -m 1800 '$6$5589647638$ouC5VST3tV7swgktg9IbGsgvoruCnppKJg9QUysr4JONOsrWEWRW7CMQFzKyYwkGT4x1HxJnTPE24jxW0vjrv/'
echo 177344                          | ./hashcat ${OPTS} -a 0 -m 1800 '$6$$hjM8bby5NE1VumJT4aCWQUJF9bmgDZ2AVOZcfGFF3P4ajZ9xBBUUwOaK7Z7EVjkHsaNqwrGI2gjmWuot0WaPx0'
echo 6796775                         | ./hashcat ${OPTS} -a 0 -m 1800 '$6$4436293051743250$6HVoYfECHD0clJfvfUtAkm5elLgfKp.7zYUHhqtb4p/uC30v0ImqciRmHHQQfpInuxCLFIfMGD/0cUzUEz8rr0'
echo 878413188                       | ./hashcat ${OPTS} -a 0 -m 1800 '$6$99191792618498$nzUZGIYVXjBMV.emwGxdcfGRUuv/wbbREPY.gu/0peqJN1FFpS2faa7rsZE7UDwNxdBS7ef3mAWz9l..K977P1'
echo 7037057683                      | ./hashcat ${OPTS} -a 0 -m 1800 '$6$49827974$pfIIA3qIjbjON0Sk727IWvLpMOzYMop1/xFdxk42ENWYNSlFIAvQLHC8rHsLH0Ftx7hhT4pR.prvdDojPRPka/'
echo 670760198481924                 | ./hashcat ${OPTS} -a 0 -m 1800 '$6$6198$hg9zlZIU9jpsNY1Zt5xSeqRUwxu3MuS9OB2LvtDKSVMZJL1kL7T4bgCvNFkD/FpWD2wBbLN79cbLJD9IH3xsG/'
echo 515004113967722                 | ./hashcat ${OPTS} -a 0 -m 1800 '$6$5813822301744902$MxMVlk9QBWp5ZtJtwnxvm6szeCo6sUBOFi6/j/Md80Suo23mShNzS/ItvZxZ55qZN/64chJf.HX7VZ0Fkhhcx/'
```

Tested also on Linux

Thanks