### PR TITLE
fix module_constraints for -m 600

### DIFF
--- a/tools/test_modules/m00600.pm
+++ b/tools/test_modules/m00600.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::BLAKE2 qw (blake2b_hex);
 
-sub module_constraints { [[0, 256], [-1, -1], [0, 64], [-1, -1], [-1, -1]] }
+sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
```
[ test_edge_1752330753 ] # Processing Hash-Type 600, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Target-Type single
[ test_edge_1752330753 ] !> error (255) detected with CMD: ./hashcat --quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable -d 1 --runtime 270 -O --backend-vector-width 1 -m 600 '$BLAKE2$39281914397b6e1e46f409f3d3fc42f99df157807896b7f11c907eb313b89a78d5e7e7bb954b5ecec693a3d471fd229970171cc7fe20972f3a3aaf584a962d63' -a 3 4346176722254814787702244186318942890095545403692228004635416?d?d?d
[ test_edge_1752330753 ] !> Hash-Type 600, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2, Word len 64, Salt len None, Word '4346176722254814787702244186318942890095545403692228004635416572', Hash '$BLAKE2$39281914397b6e1e46f409f3d3fc42f99df157807896b7f11c907eb313b89a78d5e7e7bb954b5ecec693a3d471fd229970171cc7fe20972f3a3aaf584a962d63'

Skipping mask '4346176722254814787702244186318942890095545403692228004635416?d?d?d' because it is larger than the maximum password length.
```
