### PR TITLE
Metal Backend: define USE_BITSELECT and USE_SWIZZLE for Apple Intel

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -1115,7 +1115,12 @@ DECLSPEC u32 hc_swap32_S (const u32 v)
   asm volatile ("prmt.b32 %0, %1, 0, 0x0123;" : "=r"(r) : "r"(v));
   #else
   #ifdef USE_SWIZZLE
+  #ifdef IS_METAL
+  uchar4 u = uchar4 ((v >> 0) & 0xFF, (v >> 8) & 0xFF, (v >> 16) & 0xFF, (v >> 24) & 0xFF);
+  r = as_type<u32>(u.wzyx);
+  #else
   r = as_uint (as_uchar4 (v).s3210);
+  #endif
   #else
   r = ((v & 0xff000000) >> 24)
     | ((v & 0x00ff0000) >>  8)

--- a/OpenCL/inc_vendor.h
+++ b/OpenCL/inc_vendor.h
@@ -201,6 +201,10 @@ using namespace metal;
 
 #ifdef IS_METAL
 #define USE_ROTATE
+#ifndef IS_APPLE_SILICON
+#define USE_BITSELECT
+#define USE_SWIZZLE
+#endif
 
 // Metal support max VECT_SIZE = 4
 #define s0 x

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -177,6 +177,7 @@
 - Metal Backend: allow use of devices with Metal if runtime version is >= 200
 - Metal Backend: disable Metal devices only if at least one OpenCL device is active
 - Metal Backend: improved compute workloads calculation
+- Metal Backend: define USE_BITSELECT and USE_SWIZZLE for Apple Intel
 - Modules: Check UnpackSize to raise false positive with hc_decompress_rar
 - User Options: added --metal-compiler-runtime option
 - User Options: limit --bitmap-max value to 31


### PR DESCRIPTION
bitselect and swizzle are supported on Apple Metal, but perform better only on Apple Intel (and not on my M1)
As soon as I have access to an M4 I'll try to see if things change or not
