### PR TITLE
Fixed bug in inc_rp_optimized.cl on Apple Intel with Metal

### DIFF
--- a/OpenCL/inc_common.h
+++ b/OpenCL/inc_common.h
@@ -304,6 +304,8 @@ DECLSPEC void hc_enc_init (PRIVATE_AS hc_enc_t *hc_enc);
 DECLSPEC int hc_enc_has_next (PRIVATE_AS hc_enc_t *hc_enc, const int sz);
 DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src_buf, const int src_len, const int src_sz, PRIVATE_AS u32 *dst_buf, const int dst_sz);
 DECLSPEC int hc_enc_next_global (PRIVATE_AS hc_enc_t *hc_enc, GLOBAL_AS const u32 *src_buf, const int src_len, const int src_sz, PRIVATE_AS u32 *dst_buf, const int dst_sz);
+DECLSPEC int hc_enc_validate_utf8 (PRIVATE_AS const u32 *src_buf, const int src_pos, const int extraBytesToRead);
+DECLSPEC int hc_enc_validate_utf8_global (GLOBAL_AS const u32 *src_buf, const int src_pos, const int extraBytesToRead);
 
 DECLSPEC int pkcs_padding_bs8 (PRIVATE_AS const u32 *data_buf, const int data_len);
 DECLSPEC int pkcs_padding_bs16 (PRIVATE_AS const u32 *data_buf, const int data_len);
@@ -359,6 +361,7 @@ DECLSPEC void append_0x01_2x4_S (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, const u
 DECLSPEC void append_0x06_2x4_S (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, const u32 offset);
 DECLSPEC void append_0x01_4x4_S (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 offset);
 DECLSPEC void append_0x2d_4x4_S (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 offset);
+DECLSPEC void append_0x3a_4x4_S (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 offset);
 DECLSPEC void append_0x80_1x4_S (PRIVATE_AS u32 *w0, const u32 offset);
 DECLSPEC void append_0x80_2x4_S (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, const u32 offset);
 DECLSPEC void append_0x80_3x4_S (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, const u32 offset);
@@ -386,5 +389,6 @@ DECLSPEC void append_0x06_2x4_VV (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, cons
 DECLSPEC void append_0x80_2x4_VV (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, const u32x offset);
 DECLSPEC void append_0x80_4x4_VV (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, const u32x offset);
 DECLSPEC void append_0x2d_4x4_VV (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, const u32x offset);
+DECLSPEC void append_0x3a_4x4_VV (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, const u32x offset);
 
 #endif // INC_COMMON_H

--- a/OpenCL/inc_rp_optimized.cl
+++ b/OpenCL/inc_rp_optimized.cl
@@ -1045,58 +1045,6 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at (MAYBE_UNUSED const u32 p0, M
   return (in_len);
 }
 
-DECLSPEC HC_INLINE_RP u32 find_bit_occurrence (u32 rn, u32 p0)
-{
-  u32 occurence = 0;
-  u32 ro = 0;
-  u32 done = 0;
-
-  #ifdef _unroll
-  #pragma unroll
-  #endif
-  for (int i = 0; i < 32; i++)
-  {
-    const u32 bit = (rn >> i) & 1;
-
-    // solo se non abbiamo ancora trovato
-    const u32 match = (bit & (occurence == p0) & (done == 0));
-
-    ro |= (1 << i) * match;
-
-    occurence += (bit & (done == 0));
-    done |= match;
-  }
-
-  return ro;
-}
-
-/*
-DECLSPEC HC_INLINE_RP u32 find_bit_occurrence (u32 rn, u32 p0)
-{
-  u32 occurence = 0;
-  u32 ro = 0;
-
-  #ifdef _unroll
-  #pragma unroll
-  #endif
-  for (int i = 0; i < 32; i++)
-  {
-    if ((rn >> i) & 1)
-    {
-      if (occurence == p0)
-      {
-        ro = 1 << i;
-
-        break; // bug with Metal - Apple Intel
-      }
-      occurence++;
-    }
-  }
-
-  return ro;
-}
-*/
-
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at_sep (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len)
 {
   if (in_len == 0) return in_len;
@@ -1121,7 +1069,36 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at_sep (MAYBE_UNUSED const u32 p
 
   if (rn == 0) return in_len;
 
-  u32 ro = find_bit_occurrence (rn, p0);
+  u32 occurence = 0;
+
+  u32 ro = 0;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int i = 0; i < 32; i++)
+  {
+    if ((rn >> i) & 1)
+    {
+      if (occurence == p0)
+      {
+        ro = 1 << i;
+
+        #if defined(IS_METAL) && !defined(IS_APPLE_SILICON)
+
+        i = 32;
+
+        continue;
+
+        #else
+
+        break; // bug on Apple Intel with Metal
+
+        #endif
+      }
+      occurence++;
+    }
+  }
 
   r0 = (ro >>  0) & 15;
   r1 = (ro >>  4) & 15;
@@ -2351,14 +2328,6 @@ DECLSPEC u32x apply_rules_vect_optimized (PRIVATE_AS const u32 *pw_buf0, PRIVATE
   buf1[2] = pw_buf1[2];
   buf1[3] = pw_buf1[3];
 
-  /*
-  u32 tmp_cmds[32];
-
-  for (int j = 0; j < 32; j++) tmp_cmds[j] = kernel_rules[il_pos].cmds[j];
-
-  return apply_rules_optimized (tmp_cmds, buf0, buf1, pw_len);
-  */
-
   return apply_rules_optimized (kernel_rules[il_pos].cmds, buf0, buf1, pw_len);
 
   #else
@@ -2381,14 +2350,6 @@ DECLSPEC u32x apply_rules_vect_optimized (PRIVATE_AS const u32 *pw_buf0, PRIVATE
     tmp1[1] = pw_buf1[1];
     tmp1[2] = pw_buf1[2];
     tmp1[3] = pw_buf1[3];
-
-    /*
-    u32 tmp_cmds[32];
-
-    for (int j = 0; j < 32; j++) tmp_cmds[j] = kernel_rules[il_pos + i].cmds[j];
-
-    const u32 tmp_len = apply_rules_optimized (tmp_cmds, tmp0, tmp1, pw_len);
-    */
 
     const u32 tmp_len = apply_rules_optimized (kernel_rules[il_pos + i].cmds, tmp0, tmp1, pw_len);
 

--- a/OpenCL/inc_rp_optimized.h
+++ b/OpenCL/inc_rp_optimized.h
@@ -92,7 +92,6 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_lrest_ufirst (MAYBE_UNUSED const u32 p0
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_urest_lfirst (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_trest (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
-DECLSPEC HC_INLINE_RP u32 find_bit_occurrence (u32 rn, u32 p0);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at_sep (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_reverse (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_dupeword (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
@@ -131,7 +130,6 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_dupeblock_last (MAYBE_UNUSED const u32 
 DECLSPEC u32 toggle_on_register (const u32 in, const u32 r);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_title_sep (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC u32 apply_rule_optimized (const u32 name, const u32 p0, const u32 p1, PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 in_len);
-//DECLSPEC u32 apply_rules_optimized (PRIVATE_AS const u32 *cmds, PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 len);
 DECLSPEC u32 apply_rules_optimized (CONSTANT_AS const u32 *cmds, PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 len);
 DECLSPEC u32x apply_rules_vect_optimized (PRIVATE_AS const u32 *pw_buf0, PRIVATE_AS const u32 *pw_buf1, const u32 pw_len, CONSTANT_AS const kernel_rule_t *kernel_rules, const u32 il_pos, PRIVATE_AS u32x *buf0, PRIVATE_AS u32x *buf1);
 

--- a/OpenCL/inc_rp_optimized.h
+++ b/OpenCL/inc_rp_optimized.h
@@ -14,7 +14,7 @@
 #define MAYBE_UNUSED
 #endif
 
-#ifdef IS_METAL
+#if defined(IS_METAL) && !defined(IS_APPLE_SILICON)
 #define HC_INLINE_RP __attribute__ ((noinline))
 #else
 #define HC_INLINE_RP

--- a/OpenCL/inc_rp_optimized.h
+++ b/OpenCL/inc_rp_optimized.h
@@ -14,7 +14,7 @@
 #define MAYBE_UNUSED
 #endif
 
-#ifdef IS_APPLE_SILICON
+#ifdef IS_METAL
 #define HC_INLINE_RP __attribute__ ((noinline))
 #else
 #define HC_INLINE_RP
@@ -92,6 +92,7 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_lrest_ufirst (MAYBE_UNUSED const u32 p0
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_urest_lfirst (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_trest (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
+DECLSPEC HC_INLINE_RP u32 find_bit_occurrence (u32 rn, u32 p0);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at_sep (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_reverse (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_dupeword (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
@@ -130,6 +131,7 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_dupeblock_last (MAYBE_UNUSED const u32 
 DECLSPEC u32 toggle_on_register (const u32 in, const u32 r);
 DECLSPEC HC_INLINE_RP u32 rule_op_mangle_title_sep (MAYBE_UNUSED const u32 p0, MAYBE_UNUSED const u32 p1, MAYBE_UNUSED PRIVATE_AS u32 *buf0, MAYBE_UNUSED PRIVATE_AS u32 *buf1, const u32 in_len);
 DECLSPEC u32 apply_rule_optimized (const u32 name, const u32 p0, const u32 p1, PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 in_len);
+//DECLSPEC u32 apply_rules_optimized (PRIVATE_AS const u32 *cmds, PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 len);
 DECLSPEC u32 apply_rules_optimized (CONSTANT_AS const u32 *cmds, PRIVATE_AS u32 *buf0, PRIVATE_AS u32 *buf1, const u32 len);
 DECLSPEC u32x apply_rules_vect_optimized (PRIVATE_AS const u32 *pw_buf0, PRIVATE_AS const u32 *pw_buf1, const u32 pw_len, CONSTANT_AS const kernel_rule_t *kernel_rules, const u32 il_pos, PRIVATE_AS u32x *buf0, PRIVATE_AS u32x *buf1);
 

--- a/OpenCL/inc_shared.h
+++ b/OpenCL/inc_shared.h
@@ -63,4 +63,6 @@
 
 #endif // IS_METAL
 
+DECLSPEC void gpu_decompress_entry (GLOBAL_AS pw_idx_t *pws_idx, GLOBAL_AS u32 *pws_comp, PRIVATE_AS pw_t *buf, const u64 gid);
+
 #endif // INC_SHARED_H

--- a/OpenCL/m00000_a0-optimized.cl
+++ b/OpenCL/m00000_a0-optimized.cl
@@ -19,12 +19,6 @@
 KERNEL_FQ KERNEL_FA void m00000_m04 (KERN_ATTR_RULES ())
 {
   /**
-   * modifier
-   */
-
-  const u64 lid = get_local_id (0);
-
-  /**
    * base
    */
 
@@ -153,12 +147,6 @@ KERNEL_FQ KERNEL_FA void m00000_m16 (KERN_ATTR_RULES ())
 
 KERNEL_FQ KERNEL_FA void m00000_s04 (KERN_ATTR_RULES ())
 {
-  /**
-   * modifier
-   */
-
-  const u64 lid = get_local_id (0);
-
   /**
    * base
    */

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -91,6 +91,7 @@
 - Added verification of token buffer length when using TOKEN_ATTR_FIXED_LENGTH
 - Fixed a bug in all SCRYPT-based hash modes with Apple Metal
 - Fixed buffer overflow on module_26600.c / module_hash_encode()
+- Fixed bug in inc_rp_optimized.cl on Apple Intel with Metal
 - Fixed bug in module_constraints and kernel for hash-mode 7801
 - Fixed bug in module_constraints and kernel for hash-mode 7800
 - Fixed bug in 18400 module_hash_encode
@@ -175,9 +176,10 @@
 - Metal Backend: added workaround to set the true Processor value in Metal devices on Apple Intel
 - Metal Backend: added support to 2D/3D Compute
 - Metal Backend: allow use of devices with Metal if runtime version is >= 200
+- Metal Backend: define USE_BITSELECT and USE_SWIZZLE for Apple Intel
 - Metal Backend: disable Metal devices only if at least one OpenCL device is active
 - Metal Backend: improved compute workloads calculation
-- Metal Backend: define USE_BITSELECT and USE_SWIZZLE for Apple Intel
+- Metal Backend: parallelize pipeline state object (PSO) compilation internally
 - Modules: Check UnpackSize to raise false positive with hc_decompress_rar
 - User Options: added --metal-compiler-runtime option
 - User Options: limit --bitmap-max value to 31

--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -11,6 +11,7 @@
 #include "ext_metal.h"
 
 #include <sys/sysctl.h>
+#include <objc/message.h>
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <Foundation/Foundation.h>
@@ -307,6 +308,13 @@ int hc_mtlDeviceGet (void *hashcat_ctx, mtl_device_id *metal_device, int ordinal
     event_log_error (hashcat_ctx, "metalDeviceGet(): invalid index");
 
     return -1;
+  }
+
+  // parallelize pipeline state object (PSO) compilation internally
+
+  if ([device respondsToSelector:@selector(setShouldMaximizeConcurrentCompilation:)])
+  {
+    ((void (*)(id, SEL, BOOL))objc_msgSend)(device, @selector(setShouldMaximizeConcurrentCompilation:), YES);
   }
 
   *metal_device = device;
@@ -1440,6 +1448,7 @@ int hc_mtlCreateLibraryWithSource (void *hashcat_ctx, mtl_device_id metal_device
       }
 
       compileOptions.preprocessorMacros = build_options_dict;
+
       /*
       compileOptions.optimizationLevel = MTLLibraryOptimizationLevelSize;
       compileOptions.mathMode = MTLMathModeSafe;


### PR DESCRIPTION
### Fixed old/critical bug on Apple Intel with Metal by patching inc_rp_optimized.cl.
Tested on Apple Intel and Silicon with Metal/OpenCL and on Linux with CUDA, HIP, OpenCL GPU/CPU

### Metal Backend: parallelize pipeline state object (PSO) compilation internally
Set unexported setting, setShouldMaximizeConcurrentCompilation, to boost kernel build process on Apple Metal (only >= 3)

### Other
Fixed warning messages during build md5 kernel