### PR TITLE
Update edge, backend, inc_rp_optimized

### DIFF
--- a/OpenCL/inc_rp_optimized.cl
+++ b/OpenCL/inc_rp_optimized.cl
@@ -1084,7 +1084,7 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at_sep (MAYBE_UNUSED const u32 p
       {
         ro = 1 << i;
 
-        #if defined(IS_METAL) && !defined(IS_APPLE_SILICON)
+        #ifdef IS_METAL
 
         i = 32;
 
@@ -1092,7 +1092,7 @@ DECLSPEC HC_INLINE_RP u32 rule_op_mangle_toggle_at_sep (MAYBE_UNUSED const u32 p
 
         #else
 
-        break; // bug on Apple Intel with Metal
+        break; // bug on Apple Intel/Silicon with Metal
 
         #endif
       }

--- a/OpenCL/inc_rp_optimized.h
+++ b/OpenCL/inc_rp_optimized.h
@@ -14,7 +14,7 @@
 #define MAYBE_UNUSED
 #endif
 
-#if defined(IS_METAL) && !defined(IS_APPLE_SILICON)
+#ifdef IS_METAL
 #define HC_INLINE_RP __attribute__ ((noinline))
 #else
 #define HC_INLINE_RP

--- a/src/backend.c
+++ b/src/backend.c
@@ -9337,8 +9337,10 @@ static int get_opencl_kernel_wgs (hashcat_ctx_t *hashcat_ctx, hc_device_param_t 
     if (kernel_threads < cwgs_total)
     {
       // Very likely some bug, because the runtime was unable to follow our requirement to run N threads guaranteed on this kernel
-
-      event_log_warning (hashcat_ctx, "* Device #%u: Runtime returned CL_KERNEL_WORK_GROUP_SIZE=%d, but CL_KERNEL_COMPILE_WORK_GROUP_SIZE=%d. Use -T%d if you run into problems.", device_param->device_id + 1, (int) kernel_threads, (int) cwgs_total, (int) kernel_threads);
+      if (user_options->machine_readable == false)
+      {
+        event_log_warning (hashcat_ctx, "* Device #%u: Runtime returned CL_KERNEL_WORK_GROUP_SIZE=%d, but CL_KERNEL_COMPILE_WORK_GROUP_SIZE=%d. Use -T%d if you run into problems.", device_param->device_id + 1, (int) kernel_threads, (int) cwgs_total, (int) kernel_threads);
+      }
     }
 
     kernel_threads = cwgs_total;

--- a/src/backend.c
+++ b/src/backend.c
@@ -9320,6 +9320,8 @@ static int get_hip_kernel_local_mem_size (hashcat_ctx_t *hashcat_ctx, hipFunctio
 
 static int get_opencl_kernel_wgs (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, cl_kernel kernel, u32 *result)
 {
+  user_options_t *user_options = hashcat_ctx->user_options;
+
   size_t work_group_size = 0;
 
   if (hc_clGetKernelWorkGroupInfo (hashcat_ctx, kernel, device_param->opencl_device, CL_KERNEL_WORK_GROUP_SIZE, sizeof (work_group_size), &work_group_size, NULL) == -1) return -1;


### PR DESCRIPTION
On backend.c
- Hide 'Runtime returned CL_KERNEL_WORK_GROUP_SIZE ...' with --machine-readable

On test_edge.sh
- Skip attack types other than Straight with hash types with attack exec outside kernel by default
- Override the previous skip with --allow-all-attacks options
- Fix inconsistent error messages
- Add attack exec filter with -A
- Skip output check for hash-types 14000, 14100 and 22000
- Add execution time at the end of tests
- Add errors counter and show a message at the end of tests

On inc_rp_optimized.h/.cl
- Fix the same Apple Intel bug with Metal on inc_rp_optimized, this time on Apple Silicon