### PR TITLE
Update edge, modules

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -98,6 +98,7 @@
 - Fixed bug in 23800/unrar with Apple Silicon
 - Fixed bug in 26900 module_hash_encode
 - Fixed bug in 29600 module OPTS_TYPE setting
+- Fixed bug in 32600 by adding missing module_jit_build_options
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
 - Fixed bug in --stdout that caused certain rules to malfunction
@@ -113,6 +114,7 @@
 - Fixed clang identification in src/Makefile
 - Fixed build failure for almost all hash modes that make use of hc_swap64 and/or hc_swap64_S with Apple Metal / Apple Silicon
 - Fixed debug mode 5 by adding the missing colon between original-word and finding-rule
+- Fixed perl deprecation warnings on test module for 30906
 - Fixed display problem of the "Optimizers applied" list for algorithms using OPTI_TYPE_SLOW_HASH_SIMD_INIT2 and/or OPTI_TYPE_SLOW_HASH_SIMD_LOOP2
 - Fixed incompatible pointer types (salt1 and salt2 buf) in 3730 a3 kernel
 - Fixed incorrect plaintext check for 25400 and 26610. Increased plaintext check to 32 bytes to prevent false positives.

--- a/src/modules/module_32600.c
+++ b/src/modules/module_32600.c
@@ -60,6 +60,22 @@ bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE
   return false;
 }
 
+char *module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hashes_t *hashes, MAYBE_UNUSED const hc_device_param_t *device_param)
+{
+  char *jit_build_options = NULL;
+
+  // Extra treatment for Apple systems
+  if (device_param->opencl_platform_vendor_id == VENDOR_ID_APPLE)
+  {
+    // hc_mtlCreateKernel_block_invoke(): failed to create 'm32600_sxx' pipeline, Threadgroup memory size (33024) exceeds the maximum threadgroup memory allowed (32768)
+    hc_asprintf (&jit_build_options, "-D FORCE_DISABLE_SHM");
+
+    return jit_build_options;
+  }
+
+  return jit_build_options;
+}
+
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
   u32 *digest = (u32 *) digest_buf;
@@ -261,7 +277,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_hook23                   = MODULE_DEFAULT;
   module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
   module_ctx->module_hook_size                = MODULE_DEFAULT;
-  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = module_jit_build_options;
   module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
   module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
   module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -94,6 +94,11 @@ sub edge_format
     $word = random_numeric_string ($word_len) // "";
     $salt = random_numeric_string ($salt_len) // "";
 
+    if (exists &{module_get_random_password}) # if hash mode requires special format of passwords
+    {
+      $word = module_get_random_password ($word);
+    }
+
     $hash = module_generate_hash ($word, $salt);
 
     $cond = 1;

--- a/tools/test_edge.sh
+++ b/tools/test_edge.sh
@@ -95,8 +95,9 @@ ALL_ATTACKS=0
 OPTS="--quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable"
 
 SKIP_HASH_TYPES="" #2000 2500 2501 16800 16801 99999 32000"
-SKIP_HASH_TYPES_METAL="" #1800 10700 11700 11750 11760 11800 11850 11860 19200 21600"
-SKIP_METAL_SCRYPT="" #8900 15700 9300 22700 27700 28200 29800"
+SKIP_HASH_TYPES_METAL="21800"
+
+METAL_FORCE_KEEPFREE="8900 22700 27700 28200 29800"
 
 SKIP_OUT_MATCH_HASH_TYPES="14000 14100 22000"
 SKIP_SAME_SALT_HASH_TYPES="6600 7100 7200 8200 13200 13400 15300 15310 15900 15910 16900 18300 18900 20200 20300 20400 27000 27100 29700 29930 29940"
@@ -547,11 +548,6 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
       echo "[ ${OUTD} ] > Skip processing Hash-Type ${hash_type} (due to metal kernel build failed)" | tee -a ${OUTD}/test_edge.details.log
       continue
     fi
-
-    if is_in_array "${hash_type}" ${SKIP_METAL_SCRYPT}; then
-      echo "[ ${OUTD} ] > Skip processing Hash-Type ${hash_type} (due to metal scrypt is broken)" | tee -a ${OUTD}/test_edge.details.log
-      continue
-    fi
   fi
 
   deprecated=$(./hashcat -m ${hash_type} -HH | grep "Deprecated\\.\\." | awk '{print $2}')
@@ -655,6 +651,12 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
 
           if [ $pt_hex -eq 1 ]; then
             CUR_OPTS_V="${CUR_OPTS_V} --hex-charset"
+          fi
+
+          if [ $METAL_BACKEND -eq 1 ]; then
+            if is_in_array "${hash_type}" ${METAL_FORCE_KEEPFREE}; then
+              CUR_OPTS_V="${CUR_OPTS_V} --backend-devices-keepfree 1"
+            fi
           fi
 
           # single hash

--- a/tools/test_modules/m30906.pm
+++ b/tools/test_modules/m30906.pm
@@ -8,8 +8,11 @@
 use strict;
 use warnings;
 
-use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto         qw (btc_extprv);
+use Bitcoin::Crypto::Util   qw (to_format);
 use Bitcoin::Crypto::Base58 qw (decode_base58check);
+
+use Bitcoin::Crypto::Key::Private;
 
 sub module_constraints { [[51, 51], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 
@@ -23,14 +26,7 @@ sub module_generate_hash
 
   return unless ($word =~ m/^[0-9a-fA-F]{64}$/);
 
-  my $priv = "";
-
-  my @is_valid_hex = eval
-  {
-    $priv = btc_prv->from_hex ($word);
-  };
-
-  return if (! @is_valid_hex);
+  my $priv = Bitcoin::Crypto::Key::Private->from_serialized([hex => $word]);
 
   my $IS_COMPRESSED = 0;
 
@@ -79,7 +75,7 @@ sub module_get_random_password
 
   my $priv = $derived_key->get_basic_key ();
 
-  return $priv->to_hex (); # the result is padded (32 raw bytes)
+  return to_format([hex => $priv->to_serialized()]); # the result is padded (32 raw bytes)
 }
 
 1;


### PR DESCRIPTION
Fix deprecation warning on m30906.pm
Fix pipeline error with -m 32600 on Apple
Update edge_test.sh
Fix edge test vectors generation for hash-type 28501, 28502, 28503, 28504, 28505, 28506