### PR TITLE
Update types, modules, edge

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -184,7 +184,9 @@
 - Metal Backend: disable Metal devices only if at least one OpenCL device is active
 - Metal Backend: improved compute workloads calculation
 - Metal Backend: parallelize pipeline state object (PSO) compilation internally
+- Modules: Added OPTS_TYPE_PT_BASE58 in 28501 28502 28503 28504 28505 28506 30901 30902 30903 30904 30905 30906
 - Modules: Check UnpackSize to raise false positive with hc_decompress_rar
+- Types: Added OPTS_TYPE_PT_BASE58 and removed OPTS_TYPE_MAXIMUM_ACCEL in opts_type
 - User Options: added --metal-compiler-runtime option
 - User Options: limit --bitmap-max value to 31
 - User Options: assigned -H to --hash-info

--- a/include/types.h
+++ b/include/types.h
@@ -421,108 +421,105 @@ typedef enum opti_type
 
 typedef enum opts_type
 {
-  OPTS_TYPE_PT_UTF16LE        = (1ULL <<  0),
-  OPTS_TYPE_PT_UTF16BE        = (1ULL <<  1),
-  OPTS_TYPE_PT_UPPER          = (1ULL <<  2),
-  OPTS_TYPE_PT_LOWER          = (1ULL <<  3),
-  OPTS_TYPE_PT_ADD01          = (1ULL <<  4),
-  OPTS_TYPE_PT_ADD02          = (1ULL <<  5),
-  OPTS_TYPE_PT_ADD80          = (1ULL <<  6),
-  OPTS_TYPE_PT_ADDBITS14      = (1ULL <<  7),
-  OPTS_TYPE_PT_ADDBITS15      = (1ULL <<  8),
-  OPTS_TYPE_PT_GENERATE_LE    = (1ULL <<  9),
-  OPTS_TYPE_PT_GENERATE_BE    = (1ULL << 10),
-  OPTS_TYPE_PT_NEVERCRACK     = (1ULL << 11), // if we want all possible results
-  OPTS_TYPE_PT_ALWAYS_ASCII   = (1ULL << 12),
-  OPTS_TYPE_PT_ALWAYS_HEXIFY  = (1ULL << 13),
-  OPTS_TYPE_PT_LM             = (1ULL << 14), // special handling: all lower, 7 max, ...
-  OPTS_TYPE_PT_HEX            = (1ULL << 15), // input wordlist is always in hex
-  OPTS_TYPE_ST_UTF16LE        = (1ULL << 16),
-  OPTS_TYPE_ST_UTF16BE        = (1ULL << 17),
-  OPTS_TYPE_ST_UPPER          = (1ULL << 18),
-  OPTS_TYPE_ST_LOWER          = (1ULL << 19),
-  OPTS_TYPE_ST_ADD01          = (1ULL << 20),
-  OPTS_TYPE_ST_ADD02          = (1ULL << 21),
-  OPTS_TYPE_ST_ADD80          = (1ULL << 22),
-  OPTS_TYPE_ST_ADDBITS14      = (1ULL << 23),
-  OPTS_TYPE_ST_ADDBITS15      = (1ULL << 24),
-  OPTS_TYPE_ST_HEX            = (1ULL << 25),
-  OPTS_TYPE_ST_BASE64         = (1ULL << 26),
-  OPTS_TYPE_MT_HEX            = (1ULL << 27), // mask is always in hex
-  OPTS_TYPE_HASH_COPY         = (1ULL << 28),
-  OPTS_TYPE_HASH_SPLIT        = (1ULL << 29),
-  OPTS_TYPE_INIT              = (1ULL << 30), // Added v7, since bridge can fully replace these, but are set by default automatically
-  OPTS_TYPE_LOOP              = (1ULL << 31), // Added v7, since bridge can fully replace these, but are set by default automatically
-  OPTS_TYPE_COMP              = (1ULL << 32), // Added v7, since bridge can fully replace these, but are set by default automatically
-  OPTS_TYPE_LOOP_PREPARE      = (1ULL << 33), // a kernel which is called each time before _loop kernel started.
-                                              // like a hook12 kernel but without extra buffers.
-  OPTS_TYPE_LOOP_EXTENDED     = (1ULL << 34), // a kernel which is called each time normal _loop kernel finished.
-                                              // but unlike a hook kernel this kernel is called for every _loop iteration offset
-  OPTS_TYPE_HOOK12            = (1ULL << 35),
-  OPTS_TYPE_HOOK23            = (1ULL << 36),
-  OPTS_TYPE_INIT2             = (1ULL << 37),
-  OPTS_TYPE_LOOP2_PREPARE     = (1ULL << 38), // same as OPTS_TYPE_LOOP_PREPARE but for loop2 kernel
-  OPTS_TYPE_LOOP2             = (1ULL << 39),
-  OPTS_TYPE_AUX1              = (1ULL << 40),
-  OPTS_TYPE_AUX2              = (1ULL << 41),
-  OPTS_TYPE_AUX3              = (1ULL << 42),
-  OPTS_TYPE_AUX4              = (1ULL << 43),
-  OPTS_TYPE_BINARY_HASHFILE   = (1ULL << 44),
-  OPTS_TYPE_BINARY_HASHFILE_OPTIONAL
-                              = (1ULL << 45), // this allows us to not enforce the use of a binary file. requires OPTS_TYPE_BINARY_HASHFILE set to be effective.
-  OPTS_TYPE_PT_ADD06          = (1ULL << 46),
-  OPTS_TYPE_KEYBOARD_MAPPING  = (1ULL << 47),
-  OPTS_TYPE_DEEP_COMP_KERNEL  = (1ULL << 48), // if we have to iterate through each hash inside the comp kernel, for example if each hash has to be decrypted separately
-  OPTS_TYPE_TM_KERNEL         = (1ULL << 49),
-  OPTS_TYPE_SUGGEST_KG        = (1ULL << 50), // suggest keep guessing for modules the user maybe wants to use --keep-guessing
-  OPTS_TYPE_COPY_TMPS         = (1ULL << 51), // if we want to use data from tmps buffer (for example get the PMK in WPA)
-  OPTS_TYPE_POTFILE_NOPASS    = (1ULL << 52), // sometimes the password should not be printed to potfile
-  OPTS_TYPE_DYNAMIC_SHARED    = (1ULL << 53), // use dynamic shared memory (note: needs special kernel changes)
-  OPTS_TYPE_SELF_TEST_DISABLE = (1ULL << 54), // some algos use JiT in combinations with a salt or create too much startup time
-  OPTS_TYPE_MP_MULTI_DISABLE  = (1ULL << 55), // do not multiply the kernel-accel with the multiprocessor count per device to allow more fine-tuned workload settings
-  OPTS_TYPE_THREAD_MULTI_DISABLE              // do not multiply the kernel-power with the thread count per device for super slow algos
-                              = (1ULL << 56),
-  OPTS_TYPE_NATIVE_THREADS    = (1ULL << 57), // forces "native" thread count: CPU=1, GPU-Intel=8, GPU-AMD=64 (wavefront), GPU-NV=32 (warps)
-  OPTS_TYPE_MAXIMUM_THREADS   = (1ULL << 58), // disable else branch in pre-compilation thread count optimization setting
-  OPTS_TYPE_POST_AMP_UTF16LE  = (1ULL << 59), // run the utf8 to utf16le conversion kernel after they have been processed from amplifiers
-  OPTS_TYPE_AUTODETECT_DISABLE
-                              = (1ULL << 60), // skip autodetect engine
-  OPTS_TYPE_STOCK_MODULE      = (1ULL << 61), // module included with hashcat default distribution
-  OPTS_TYPE_MULTIHASH_DESPITE_ESALT
-                              = (1ULL << 62), // overrule multihash cracking check same salt but not same esalt
-  OPTS_TYPE_MAXIMUM_ACCEL     = (1ULL << 63)  // try to maximize kernel-accel during autotune
+  OPTS_TYPE_PT_UTF16LE               = (1ULL <<  0),
+  OPTS_TYPE_PT_UTF16BE               = (1ULL <<  1),
+  OPTS_TYPE_PT_UPPER                 = (1ULL <<  2),
+  OPTS_TYPE_PT_LOWER                 = (1ULL <<  3),
+  OPTS_TYPE_PT_ADD01                 = (1ULL <<  4),
+  OPTS_TYPE_PT_ADD02                 = (1ULL <<  5),
+  OPTS_TYPE_PT_ADD80                 = (1ULL <<  6),
+  OPTS_TYPE_PT_ADDBITS14             = (1ULL <<  7),
+  OPTS_TYPE_PT_ADDBITS15             = (1ULL <<  8),
+  OPTS_TYPE_PT_GENERATE_LE           = (1ULL <<  9),
+  OPTS_TYPE_PT_GENERATE_BE           = (1ULL << 10),
+  OPTS_TYPE_PT_NEVERCRACK            = (1ULL << 11), // if we want all possible results
+  OPTS_TYPE_PT_ALWAYS_ASCII          = (1ULL << 12),
+  OPTS_TYPE_PT_ALWAYS_HEXIFY         = (1ULL << 13),
+  OPTS_TYPE_PT_LM                    = (1ULL << 14), // special handling: all lower, 7 max, ...
+  OPTS_TYPE_PT_HEX                   = (1ULL << 15), // input wordlist is always in hex
+  OPTS_TYPE_PT_BASE58                = (1ULL << 16), // only informative
+  OPTS_TYPE_ST_UTF16LE               = (1ULL << 17),
+  OPTS_TYPE_ST_UTF16BE               = (1ULL << 18),
+  OPTS_TYPE_ST_UPPER                 = (1ULL << 19),
+  OPTS_TYPE_ST_LOWER                 = (1ULL << 20),
+  OPTS_TYPE_ST_ADD01                 = (1ULL << 21),
+  OPTS_TYPE_ST_ADD02                 = (1ULL << 22),
+  OPTS_TYPE_ST_ADD80                 = (1ULL << 23),
+  OPTS_TYPE_ST_ADDBITS14             = (1ULL << 24),
+  OPTS_TYPE_ST_ADDBITS15             = (1ULL << 25),
+  OPTS_TYPE_ST_HEX                   = (1ULL << 26),
+  OPTS_TYPE_ST_BASE64                = (1ULL << 27),
+  OPTS_TYPE_MT_HEX                   = (1ULL << 28), // mask is always in hex
+  OPTS_TYPE_HASH_COPY                = (1ULL << 29),
+  OPTS_TYPE_HASH_SPLIT               = (1ULL << 30),
+  OPTS_TYPE_INIT                     = (1ULL << 31), // Added v7, since bridge can fully replace these, but are set by default automatically
+  OPTS_TYPE_LOOP                     = (1ULL << 32), // Added v7, since bridge can fully replace these, but are set by default automatically
+  OPTS_TYPE_COMP                     = (1ULL << 33), // Added v7, since bridge can fully replace these, but are set by default automatically
+  OPTS_TYPE_LOOP_PREPARE             = (1ULL << 34), // a kernel which is called each time before _loop kernel started.
+                                                     // like a hook12 kernel but without extra buffers.
+  OPTS_TYPE_LOOP_EXTENDED            = (1ULL << 35), // a kernel which is called each time normal _loop kernel finished.
+                                                     // but unlike a hook kernel this kernel is called for every _loop iteration offset
+  OPTS_TYPE_HOOK12                   = (1ULL << 36),
+  OPTS_TYPE_HOOK23                   = (1ULL << 37),
+  OPTS_TYPE_INIT2                    = (1ULL << 38),
+  OPTS_TYPE_LOOP2_PREPARE            = (1ULL << 39), // same as OPTS_TYPE_LOOP_PREPARE but for loop2 kernel
+  OPTS_TYPE_LOOP2                    = (1ULL << 40),
+  OPTS_TYPE_AUX1                     = (1ULL << 41),
+  OPTS_TYPE_AUX2                     = (1ULL << 42),
+  OPTS_TYPE_AUX3                     = (1ULL << 43),
+  OPTS_TYPE_AUX4                     = (1ULL << 44),
+  OPTS_TYPE_BINARY_HASHFILE          = (1ULL << 45),
+  OPTS_TYPE_BINARY_HASHFILE_OPTIONAL = (1ULL << 46), // this allows us to not enforce the use of a binary file. requires OPTS_TYPE_BINARY_HASHFILE set to be effective.
+  OPTS_TYPE_PT_ADD06                 = (1ULL << 47),
+  OPTS_TYPE_KEYBOARD_MAPPING         = (1ULL << 48),
+  OPTS_TYPE_DEEP_COMP_KERNEL         = (1ULL << 49), // if we have to iterate through each hash inside the comp kernel, for example if each hash has to be decrypted separately
+  OPTS_TYPE_TM_KERNEL                = (1ULL << 50),
+  OPTS_TYPE_SUGGEST_KG               = (1ULL << 51), // suggest keep guessing for modules the user maybe wants to use --keep-guessing
+  OPTS_TYPE_COPY_TMPS                = (1ULL << 52), // if we want to use data from tmps buffer (for example get the PMK in WPA)
+  OPTS_TYPE_POTFILE_NOPASS           = (1ULL << 53), // sometimes the password should not be printed to potfile
+  OPTS_TYPE_DYNAMIC_SHARED           = (1ULL << 54), // use dynamic shared memory (note: needs special kernel changes)
+  OPTS_TYPE_SELF_TEST_DISABLE        = (1ULL << 55), // some algos use JiT in combinations with a salt or create too much startup time
+  OPTS_TYPE_MP_MULTI_DISABLE         = (1ULL << 56), // do not multiply the kernel-accel with the multiprocessor count per device to allow more fine-tuned workload settings
+  OPTS_TYPE_THREAD_MULTI_DISABLE     = (1ULL << 57), // do not multiply the kernel-power with the thread count per device for super slow algos
+  OPTS_TYPE_NATIVE_THREADS           = (1ULL << 58), // forces "native" thread count: CPU=1, GPU-Intel=8, GPU-AMD=64 (wavefront), GPU-NV=32 (warps)
+  OPTS_TYPE_MAXIMUM_THREADS          = (1ULL << 59), // disable else branch in pre-compilation thread count optimization setting
+  OPTS_TYPE_POST_AMP_UTF16LE         = (1ULL << 60), // run the utf8 to utf16le conversion kernel after they have been processed from amplifiers
+  OPTS_TYPE_AUTODETECT_DISABLE       = (1ULL << 61), // skip autodetect engine
+  OPTS_TYPE_STOCK_MODULE             = (1ULL << 62), // module included with hashcat default distribution
+  OPTS_TYPE_MULTIHASH_DESPITE_ESALT  = (1ULL << 63)  // overrule multihash cracking check same salt but not same esalt
+//OPTS_TYPE_MAXIMUM_ACCEL            = (1ULL << 64)  // try to maximize kernel-accel during autotune
 
 } opts_type_t;
 
 typedef enum bridge_type
 {
-  BRIDGE_TYPE_NONE                = 0,            // no bridge support
-  BRIDGE_TYPE_MATCH_TUNINGS       = (1ULL <<  1), // Disables autotune and adjusts -n, -u and -T for the backend device according to match bridge dimensions
-  BRIDGE_TYPE_UPDATE_SELFTEST     = (1ULL <<  2), // updates the selftest configured in the module. Can be useful for generic hash modes such as the python one
+  BRIDGE_TYPE_NONE                   = 0,            // no bridge support
+  BRIDGE_TYPE_MATCH_TUNINGS          = (1ULL <<  1), // Disables autotune and adjusts -n, -u and -T for the backend device according to match bridge dimensions
+  BRIDGE_TYPE_UPDATE_SELFTEST        = (1ULL <<  2), // updates the selftest configured in the module. Can be useful for generic hash modes such as the python one
 
-  BRIDGE_TYPE_LAUNCH_INIT         = (1ULL << 10), // attention! not yet implemented
-  BRIDGE_TYPE_LAUNCH_LOOP         = (1ULL << 11),
-  BRIDGE_TYPE_LAUNCH_LOOP2        = (1ULL << 12),
-  BRIDGE_TYPE_LAUNCH_COMP         = (1ULL << 13), // attention! not yet implemented
+  BRIDGE_TYPE_LAUNCH_INIT            = (1ULL << 10), // attention! not yet implemented
+  BRIDGE_TYPE_LAUNCH_LOOP            = (1ULL << 11),
+  BRIDGE_TYPE_LAUNCH_LOOP2           = (1ULL << 12),
+  BRIDGE_TYPE_LAUNCH_COMP            = (1ULL << 13), // attention! not yet implemented
 
   // BRIDGE_TYPE_REPLACE_* is like
   // BRIDGE_TYPE_LAUNCH_*, but
   // deactivates KERN_RUN INIT/LOOP/COMP
 
-  BRIDGE_TYPE_REPLACE_INIT        = (1ULL << 20), // attention! not yet implemented
-  BRIDGE_TYPE_REPLACE_LOOP        = (1ULL << 21),
-  BRIDGE_TYPE_REPLACE_LOOP2       = (1ULL << 22),
-  BRIDGE_TYPE_REPLACE_COMP        = (1ULL << 23), // attention! not yet implemented
+  BRIDGE_TYPE_REPLACE_INIT           = (1ULL << 20), // attention! not yet implemented
+  BRIDGE_TYPE_REPLACE_LOOP           = (1ULL << 21),
+  BRIDGE_TYPE_REPLACE_LOOP2          = (1ULL << 22),
+  BRIDGE_TYPE_REPLACE_COMP           = (1ULL << 23), // attention! not yet implemented
 
-  BRIDGE_TYPE_FORCE_WORKITEMS_001 = (1ULL << 30), // This override the workitem counts reported from the bridge device
-  BRIDGE_TYPE_FORCE_WORKITEMS_002 = (1ULL << 31), // Can be useful if this is not a physical hardware
-  BRIDGE_TYPE_FORCE_WORKITEMS_004 = (1ULL << 32),
-  BRIDGE_TYPE_FORCE_WORKITEMS_008 = (1ULL << 33),
-  BRIDGE_TYPE_FORCE_WORKITEMS_016 = (1ULL << 34),
-  BRIDGE_TYPE_FORCE_WORKITEMS_032 = (1ULL << 35),
-  BRIDGE_TYPE_FORCE_WORKITEMS_064 = (1ULL << 36),
-  BRIDGE_TYPE_FORCE_WORKITEMS_128 = (1ULL << 37),
-  BRIDGE_TYPE_FORCE_WORKITEMS_256 = (1ULL << 36),
+  BRIDGE_TYPE_FORCE_WORKITEMS_001    = (1ULL << 30), // This override the workitem counts reported from the bridge device
+  BRIDGE_TYPE_FORCE_WORKITEMS_002    = (1ULL << 31), // Can be useful if this is not a physical hardware
+  BRIDGE_TYPE_FORCE_WORKITEMS_004    = (1ULL << 32),
+  BRIDGE_TYPE_FORCE_WORKITEMS_008    = (1ULL << 33),
+  BRIDGE_TYPE_FORCE_WORKITEMS_016    = (1ULL << 34),
+  BRIDGE_TYPE_FORCE_WORKITEMS_032    = (1ULL << 35),
+  BRIDGE_TYPE_FORCE_WORKITEMS_064    = (1ULL << 36),
+  BRIDGE_TYPE_FORCE_WORKITEMS_128    = (1ULL << 37),
+  BRIDGE_TYPE_FORCE_WORKITEMS_256    = (1ULL << 36),
 
 } bridge_type_t;
 

--- a/src/modules/module_28501.c
+++ b/src/modules/module_28501.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin WIF private key (P2PKH), compres
 static const u64   KERN_TYPE         = 28501;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "KxhashcatxhXkULNJYF8Fu46G28SJrC7x2qwFtRuf38kVjkWxHg3";

--- a/src/modules/module_28502.c
+++ b/src/modules/module_28502.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin WIF private key (P2PKH), uncompr
 static const u64   KERN_TYPE         = 28502;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "5KcL859EUnBDtVG76134U6DZWnVmpE996emJnWmTLRW2hashcat";

--- a/src/modules/module_28503.c
+++ b/src/modules/module_28503.c
@@ -22,6 +22,7 @@ static const char *HASH_NAME         = "Bitcoin WIF private key (P2WPKH, Bech32)
 static const u64   KERN_TYPE         = 28501;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "KyhashcatpL2CQmMUDVMVuEXqdLSvfQ6TBjkUuyttSvBa7GMiuLi";

--- a/src/modules/module_28504.c
+++ b/src/modules/module_28504.c
@@ -22,6 +22,7 @@ static const char *HASH_NAME         = "Bitcoin WIF private key (P2WPKH, Bech32)
 static const u64   KERN_TYPE         = 28502;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "5HzV19ffW9QTnmZHbwETRpPHm1d4hAP8PG1etUb3T3jjhashcat";

--- a/src/modules/module_28505.c
+++ b/src/modules/module_28505.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin WIF private key (P2SH(P2WPKH)), 
 static const u64   KERN_TYPE         = 28505;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "L4hashcat7q6HMnMFcukyvxxVJvpabXYjxXLey8846NtWUyX4YLi";

--- a/src/modules/module_28506.c
+++ b/src/modules/module_28506.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin WIF private key (P2SH(P2WPKH)), 
 static const u64   KERN_TYPE         = 28506;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "5JjDR424kMePbt5Uxnm2t1NizhdiVPcf8gCj68PQpP2ihashcat";

--- a/src/modules/module_30901.c
+++ b/src/modules/module_30901.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin raw private key (P2PKH), compres
 static const u64   KERN_TYPE         = 30901;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "59887ec9920239bd45b6a9f82b7c4e024f80beaf887e5ee6aac5de0a899d3068";

--- a/src/modules/module_30902.c
+++ b/src/modules/module_30902.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin raw private key (P2PKH), uncompr
 static const u64   KERN_TYPE         = 30902;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "2006a306cf8f61c18c4e78e5fc0f5a7aa473b5ffb41f34344a32f8e042786fa1";

--- a/src/modules/module_30903.c
+++ b/src/modules/module_30903.c
@@ -22,6 +22,7 @@ static const char *HASH_NAME         = "Bitcoin raw private key (P2WPKH, Bech32)
 static const u64   KERN_TYPE         = 30901;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "4d1987d7a341d51557af59996845740135ab2506515426ada57cc8ec05adf794";

--- a/src/modules/module_30904.c
+++ b/src/modules/module_30904.c
@@ -22,6 +22,7 @@ static const char *HASH_NAME         = "Bitcoin raw private key (P2WPKH, Bech32)
 static const u64   KERN_TYPE         = 30902;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "25c9f8f734d87aacd9308705ca50b9819a57425ffbfae41cef869b19764d72c2";

--- a/src/modules/module_30905.c
+++ b/src/modules/module_30905.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin raw private key (P2SH(P2WPKH)), 
 static const u64   KERN_TYPE         = 30905;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "83b45ff8d85f37aafc05a8accd1f1cd5e50868b57e2ef0ef6f287bb4d8d17786";

--- a/src/modules/module_30906.c
+++ b/src/modules/module_30906.c
@@ -24,6 +24,7 @@ static const char *HASH_NAME         = "Bitcoin raw private key (P2SH(P2WPKH)), 
 static const u64   KERN_TYPE         = 30906;
 static const u32   OPTI_TYPE         = OPTI_TYPE_NOT_SALTED;
 static const u64   OPTS_TYPE         = OPTS_TYPE_STOCK_MODULE
+                                     | OPTS_TYPE_PT_BASE58
                                      | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "4c969ccc86d9e1f557b4ff1f19badc9a99718dd2aec8fcf66460612e05f5f7dd";

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -716,7 +716,9 @@ void hash_info_single_json (hashcat_ctx_t *hashcat_ctx, user_options_extra_t *us
       printf ("\"deprecated_notice\": \"%s\", ", "N/A");
     }
 
-    const char *t_pw_desc = (hashconfig->opts_type & OPTS_TYPE_PT_HEX) ? "HEX" : "plain";
+    char *t_pw_desc = "plain";
+    if (hashconfig->opts_type & OPTS_TYPE_PT_HEX) t_pw_desc = "HEX";
+    else if (hashconfig->opts_type & OPTS_TYPE_PT_BASE58) t_pw_desc = "BASE58";
 
     u32 t_pw_min = hashconfig->pw_min;
     u32 t_pw_max = hashconfig->pw_max;
@@ -943,7 +945,7 @@ void hash_info_single (hashcat_ctx_t *hashcat_ctx, user_options_extra_t *user_op
 
     event_log_info (hashcat_ctx, "  Deprecated..........: %s", (module_ctx->module_deprecated_notice != MODULE_DEFAULT) ? "Yes" : "No");
 
-    char *t_deprecated_notice = "N/A\0";
+    char *t_deprecated_notice = "N/A";
 
     if (module_ctx->module_deprecated_notice != MODULE_DEFAULT)
     {
@@ -952,7 +954,9 @@ void hash_info_single (hashcat_ctx_t *hashcat_ctx, user_options_extra_t *user_op
 
     event_log_info (hashcat_ctx, "  Deprecated.Notice...: %s", t_deprecated_notice);
 
-    const char *t_pw_desc = (hashconfig->opts_type & OPTS_TYPE_PT_HEX) ? "HEX\0" : "plain\0";
+    char *t_pw_desc = "plain";
+    if (hashconfig->opts_type & OPTS_TYPE_PT_HEX) t_pw_desc = "HEX";
+    else if (hashconfig->opts_type & OPTS_TYPE_PT_BASE58) t_pw_desc = "BASE58";
 
     u32 t_pw_min = hashconfig->pw_min;
     u32 t_pw_max = hashconfig->pw_max;
@@ -974,7 +978,7 @@ void hash_info_single (hashcat_ctx_t *hashcat_ctx, user_options_extra_t *user_op
     {
       u32 t = hashconfig->salt_type;
 
-      const char *t_salt_desc = (t == SALT_TYPE_EMBEDDED) ? "Embedded\0" : (t == SALT_TYPE_GENERIC) ? "Generic\0" : "Virtual\0";
+      const char *t_salt_desc = (t == SALT_TYPE_EMBEDDED) ? "Embedded" : (t == SALT_TYPE_GENERIC) ? "Generic" : "Virtual";
 
       event_log_info (hashcat_ctx, "  Salt.Type...........: %s", t_salt_desc);
 


### PR DESCRIPTION
Add OPTS_TYPE_PT_BASE58 in modules 28501 28502 28503 28504 28505 28506 30901 30902 30903 30904 30905 30906
Add OPTS_TYPE_PT_BASE58 and remove OPTS_TYPE_MAXIMUM_ACCEL in opts_type Re-format opts_type section
Handle new BASE58 password type in terminal.c
Handle free_threaded python library checks in test_edge.sh Handle new BASE58 checks in test_edge.sh
Improve errors handling in test_edge.sh