### PR TITLE
Debug: Added -g to build_options if DEBUG >= 1 and not on Apple

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -149,6 +149,7 @@
 - Backend Checks: Describe workaround in error message when detecting more than 64 backend devices
 - Backend Info: Added --machine-readable format
 - Brain: Added sanity check and corresponding error message for invalid --brain-port values
+- Debug: Added -g to build_options if DEBUG >= 1 and not on Apple
 - Dependencies: Added sse2neon v1.8.0 (commit 658eeac)
 - Dependencies: Updated LZMA SDK to 24.09
 - Dependencies: Updated unrar source to 6.2.7

--- a/src/backend.c
+++ b/src/backend.c
@@ -11036,7 +11036,11 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     char *build_options_buf = (char *) hcmalloc (build_options_sz);
 
-    int build_options_len = snprintf (build_options_buf, build_options_sz, "-D KERNEL_STATIC ");
+    #if !defined (__APPLE__) && defined (DEBUG) && (DEBUG >= 1)
+    int build_options_len = snprintf(build_options_buf, build_options_sz, "-g -D KERNEL_STATIC ");
+    #else
+    int build_options_len = snprintf(build_options_buf, build_options_sz, "-D KERNEL_STATIC ");
+    #endif
 
     if ((device_param->is_cuda == true) || (device_param->is_hip == true))
     {


### PR DESCRIPTION
Using the -g flag is useful for debugging cl kernel code. Is not supported on Apple