### PR TITLE
Updated OpenCL/Metal backends, memory functions, backend and brigde

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -185,7 +185,9 @@
 - Backend: Splitting backend_ctx_devices_init into smaller runtime-specific functions
 - Backend: Updated OpenCL/CUDA/HIP/Metal API's
 - Backend: Updated filename chksum format to prevent invalid cache on Apple Silicon when switching arch
+- Backend: Updated references of hcmalloc_aligned and hcfree_aligned to the new memory defined functions
 - Brain: Added sanity check and corresponding error message for invalid --brain-port values
+- Bridge: Updated references of hcmalloc_aligned and hcfree_aligned to the new memory defined functions
 - Building: Support building windows binaries on macOS using MinGW
 - Debug: Added -g to build_options if DEBUG >= 1 (only with HIP and OpenCL)
 - Dependencies: Added sse2neon v1.8.0 (commit 658eeac)
@@ -205,6 +207,9 @@
 - Makefile: prevent make failure with Apple Silicon in case of partial rebuild
 - Makefile: updated MACOSX_DEPLOYMENT_TARGET to 15.0
 - MetaMask: update extraction tool to support MetaMask Mobile wallets
+- Memory: added hc_alloc_aligned and hc_free_aligned
+- Memory: renamed hcmalloc_aligned and hcfree_aligned to hcmalloc_bridge_aligned and hcfree_bridge_aligned
+- Metal Backend: Added hc_mtlFinish
 - Metal Backend: added support to 2D/3D Compute
 - Metal Backend: added workaround to prevent 'Infinite Loop' bug when build kernels
 - Metal Backend: added workaround to set the true Processor value in Metal devices on Apple Intel
@@ -215,6 +220,7 @@
 - Metal Backend: improved memory management
 - Metal Backend: fixed memory leaks
 - Metal Backend: parallelize pipeline state object (PSO) compilation internally
+- Metal Backend: Updated hc_mtlCreateBuffer
 - Modules: Added OPTS_TYPE_PT_BASE58 in 28501 28502 28503 28504 28505 28506 30901 30902 30903 30904 30905 30906
 - Modules: Added module_unstable_warning for 22500, update module_unstable_warning for 10700
 - Modules: Added support for non-zero IVs for -m 6800 (Lastpass). Also added `tools/lastpass2hashcat.py`
@@ -222,6 +228,7 @@
 - Modules: Updated module_unstable_warning
 - Open Document Format: Added support for small documents with content length < 1024
 - OpenCL Backend: added workaround to set device_available_memory from CUDA/HIP alias device
+- OpenCL Backend: Added hc_clCreateBuffer wrapper: hc_clCreateBuffer_pre
 - OpenCL Backend: using CL_TRUE with all hc_clEnqueueWriteBuffer() call
 - OpenCL Backend: using HC_OCL_CREATEBUFFER macro for buffer allocation and openclMemoryFlags array to configure the memory flags
 - Rules: Add support to character class rules

--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -123,11 +123,11 @@ static const cl_mem_flags openclMemoryFlags[OCL_BUFFER_CNT] =
   [opencl_d_kernel_param_memoryFlags] = CL_MEM_READ_ONLY
 };
 
-#define HC_OCL_CREATEBUFFER(ctx, size, ptr, buf_name)                                 \
-  do {                                                                                \
-    if (hc_clCreateBuffer(ctx, device_param->opencl_context,                          \
-                          openclMemoryFlags[opencl_d_##buf_name##_memoryFlags], size, \
-                          ptr, &device_param->opencl_d_##buf_name) == -1) return -1;  \
+#define HC_OCL_CREATEBUFFER(ctx, size, ptr, buf_name)                                     \
+  do {                                                                                    \
+    if (hc_clCreateBuffer_pre(ctx, device_param->opencl_context,                          \
+                              openclMemoryFlags[opencl_d_##buf_name##_memoryFlags], size, \
+                              ptr, &device_param->opencl_d_##buf_name) == -1) return -1;  \
   } while (0)
 
 #define CL_PLATFORMS_MAX 16
@@ -239,6 +239,7 @@ int hc_clGetDeviceInfo           (void *hashcat_ctx, cl_device_id device, cl_dev
 int hc_clCreateContext           (void *hashcat_ctx, const cl_context_properties *properties, cl_uint num_devices, const cl_device_id *devices, void (CL_CALLBACK *pfn_notify) (const char *errinfo, const void *private_info, size_t cb, void *user_data), void *user_data, cl_context *context);
 int hc_clCreateCommandQueue      (void *hashcat_ctx, cl_context context, cl_device_id device, cl_command_queue_properties properties, cl_command_queue *command_queue);
 int hc_clCreateBuffer            (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem);
+int hc_clCreateBuffer_pre        (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem);
 int hc_clCreateProgramWithSource (void *hashcat_ctx, cl_context context, cl_uint count, const char **strings, const size_t *lengths, cl_program *program);
 int hc_clCreateProgramWithBinary (void *hashcat_ctx, cl_context context, cl_uint num_devices, const cl_device_id *device_list, const size_t *lengths, const unsigned char **binaries, cl_int *binary_status, cl_program *program);
 int hc_clBuildProgram            (void *hashcat_ctx, cl_program program, cl_uint num_devices, const cl_device_id *device_list, const char *options, void (CL_CALLBACK *pfn_notify) (cl_program program, void *user_data), void *user_data);

--- a/include/ext_metal.h
+++ b/include/ext_metal.h
@@ -226,6 +226,8 @@ int  hc_mtlSetCommandEncoderArg             (void *hashcat_ctx, mtl_command_enco
 
 int  hc_mtlEncodeComputeCommand             (void *hashcat_ctx, mtl_command_encoder metal_command_encoder, mtl_command_buffer metal_command_buffer, const unsigned int work_dim, const size_t global_work_size[3], const size_t local_work_size[3], double *ms);
 
+int  hc_mtlFinish                           (void *hashcat_ctx, mtl_command_queue command_queue);
+
 #endif // __APPLE__
 
 #endif // HC_EXT_METAL_H

--- a/include/memory.h
+++ b/include/memory.h
@@ -12,13 +12,16 @@
 
 #define MSG_ENOMEM "Insufficient memory available"
 
-void *hccalloc  (const size_t nmemb, const size_t sz);
-void *hcmalloc  (const size_t sz);
-void *hcrealloc (void *ptr, const size_t oldsz, const size_t addsz);
-char *hcstrdup  (const char *s);
-void  hcfree    (void *ptr);
+void *hccalloc                (const size_t nmemb, const size_t sz);
+void *hcmalloc                (const size_t sz);
+void *hcrealloc               (void *ptr, const size_t oldsz, const size_t addsz);
+char *hcstrdup                (const char *s);
+void  hcfree                  (void *ptr);
 
-void *hcmalloc_aligned (const size_t sz, const int align);
-void  hcfree_aligned   (void *ptr);
+void *hc_alloc_aligned        (size_t alignment, size_t size);
+void  hc_free_aligned         (void **ptr);
+
+void *hcmalloc_bridge_aligned (const size_t sz, const int align);
+void  hcfree_bridge_aligned   (void *ptr);
 
 #endif // HC_MEMORY_H

--- a/src/backend.c
+++ b/src/backend.c
@@ -16638,7 +16638,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     if (hashconfig->bridge_type)
     {
-      void *h_tmps = hcmalloc_aligned (device_param->size_tmps, 64);
+      void *h_tmps = hcmalloc_bridge_aligned (device_param->size_tmps, 64);
 
       device_param->h_tmps = h_tmps;
     }
@@ -16967,7 +16967,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
 
     if (device_param->skipped == true) continue;
 
-    hcfree_aligned (device_param->h_tmps);
+    hcfree_bridge_aligned (device_param->h_tmps);
     hcfree (device_param->pws_comp);
     hcfree (device_param->pws_idx);
     hcfree (device_param->pws_pre_buf);
@@ -17457,8 +17457,8 @@ int backend_session_update_mp (hashcat_ctx_t *hashcat_ctx)
 
     if (device_param->is_opencl == true)
     {
-      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_root_css_buf,   CL_FALSE, 0, device_param->size_root_css,   mask_ctx->root_css_buf,   0, NULL, NULL) == -1) return -1;
-      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_markov_css_buf, CL_TRUE,  0, device_param->size_markov_css, mask_ctx->markov_css_buf, 0, NULL, NULL) == -1) return -1;
+      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_root_css_buf,   CL_TRUE, 0, device_param->size_root_css,   mask_ctx->root_css_buf,   0, NULL, NULL) == -1) return -1;
+      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_markov_css_buf, CL_TRUE, 0, device_param->size_markov_css, mask_ctx->markov_css_buf, 0, NULL, NULL) == -1) return -1;
 
       if (hc_clFlush (hashcat_ctx, device_param->opencl_command_queue) == -1) return -1;
     }
@@ -17513,8 +17513,8 @@ int backend_session_update_mp_rl (hashcat_ctx_t *hashcat_ctx, const u32 css_cnt_
 
     if (device_param->is_opencl == true)
     {
-      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_root_css_buf,   CL_FALSE, 0, device_param->size_root_css,   mask_ctx->root_css_buf,   0, NULL, NULL) == -1) return -1;
-      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_markov_css_buf, CL_TRUE,  0, device_param->size_markov_css, mask_ctx->markov_css_buf, 0, NULL, NULL) == -1) return -1;
+      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_root_css_buf,   CL_TRUE, 0, device_param->size_root_css,   mask_ctx->root_css_buf,   0, NULL, NULL) == -1) return -1;
+      if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_markov_css_buf, CL_TRUE, 0, device_param->size_markov_css, mask_ctx->markov_css_buf, 0, NULL, NULL) == -1) return -1;
 
       if (hc_clFlush (hashcat_ctx, device_param->opencl_command_queue) == -1) return -1;
     }

--- a/src/bridges/bridge_argon2id_reference.c
+++ b/src/bridges/bridge_argon2id_reference.c
@@ -215,7 +215,7 @@ bool salt_prepare (void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig
   {
     unit_t *unit_buf = &bridge_argon2id->units_buf[unit_idx];
 
-    unit_buf->memory = hcmalloc_aligned ((largest_m * 1024), 32); // because AVX2
+    unit_buf->memory = hcmalloc_bridge_aligned ((largest_m * 1024), 32); // because AVX2
   }
 
   return true;
@@ -229,7 +229,7 @@ void salt_destroy (void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig
   {
     unit_t *unit_buf = &bridge_argon2id->units_buf[unit_idx];
 
-    hcfree_aligned (unit_buf->memory);
+    hcfree_bridge_aligned (unit_buf->memory);
   }
 }
 

--- a/src/bridges/bridge_scrypt_jane.c
+++ b/src/bridges/bridge_scrypt_jane.c
@@ -200,9 +200,9 @@ bool salt_prepare (void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig
   {
     unit_t *unit_buf = &bridge_scrypt_jane->units_buf[unit_idx];
 
-    unit_buf->V = hcmalloc_aligned (largest_V, 64);
-    //unit_buf->X = hcmalloc_aligned (largest_X, 64);
-    unit_buf->Y = hcmalloc_aligned (largest_Y, 64);
+    unit_buf->V = hcmalloc_bridge_aligned (largest_V, 64);
+    //unit_buf->X = hcmalloc_bridge_aligned (largest_X, 64);
+    unit_buf->Y = hcmalloc_bridge_aligned (largest_Y, 64);
   }
 
   return true;
@@ -216,9 +216,9 @@ void salt_destroy (void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig
   {
     unit_t *unit_buf = &bridge_scrypt_jane->units_buf[unit_idx];
 
-    hcfree_aligned (unit_buf->V);
-    //hcfree_aligned (unit_buf->X);
-    hcfree_aligned (unit_buf->Y);
+    hcfree_bridge_aligned (unit_buf->V);
+    //hcfree_bridge_aligned (unit_buf->X);
+    hcfree_bridge_aligned (unit_buf->Y);
   }
 }
 

--- a/src/bridges/bridge_scrypt_yescrypt.c
+++ b/src/bridges/bridge_scrypt_yescrypt.c
@@ -195,8 +195,8 @@ bool salt_prepare (void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig
   {
     unit_t *unit_buf = &bridge_scrypt_yescrypt->units_buf[unit_idx];
 
-    unit_buf->V  = hcmalloc_aligned (largest_V,  64);
-    unit_buf->XY = hcmalloc_aligned (largest_XY, 64);
+    unit_buf->V  = hcmalloc_bridge_aligned (largest_V,  64);
+    unit_buf->XY = hcmalloc_bridge_aligned (largest_XY, 64);
   }
 
   return true;
@@ -210,8 +210,8 @@ void salt_destroy (void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig
   {
     unit_t *unit_buf = &bridge_scrypt_yescrypt->units_buf[unit_idx];
 
-    hcfree_aligned (unit_buf->V);
-    hcfree_aligned (unit_buf->XY);
+    hcfree_bridge_aligned (unit_buf->V);
+    hcfree_bridge_aligned (unit_buf->XY);
   }
 }
 

--- a/src/ext_OpenCL.c
+++ b/src/ext_OpenCL.c
@@ -566,6 +566,18 @@ int hc_clCreateCommandQueue (void *hashcat_ctx, cl_context context, cl_device_id
   return 0;
 }
 
+int hc_clCreateBuffer_pre (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem)
+{
+  if (host_ptr != NULL)
+  {
+    // using unified memory
+
+    flags |= CL_MEM_USE_HOST_PTR;
+  }
+
+  return hc_clCreateBuffer (hashcat_ctx, context, flags, size, host_ptr, mem);
+}
+
 int hc_clCreateBuffer (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem)
 {
   backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;

--- a/src/memory.c
+++ b/src/memory.c
@@ -71,7 +71,7 @@ void *hc_alloc_aligned (size_t alignment, size_t size)
 {
   void *ptr = NULL;
 
-  #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+  #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined (__CYGWIN__) || defined (__MSYS__)
 
   if (posix_memalign (&ptr, alignment, size) != 0)
   {

--- a/src/memory.c
+++ b/src/memory.c
@@ -80,7 +80,7 @@ void *hc_alloc_aligned (size_t alignment, size_t size)
     return NULL;
   }
 
-  #elif defined(_WIN32)
+  #elif defined(_WIN)
 
   ptr = _aligned_malloc (size, alignment);
 
@@ -106,7 +106,7 @@ void hc_free_aligned (void **ptr)
 {
   if (ptr == NULL || *ptr == NULL) return;
 
-  #if defined(_WIN32)
+  #if defined(_WIN)
 
   _aligned_free (*ptr);
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -67,7 +67,59 @@ void hcfree (void *ptr)
   free (ptr);
 }
 
-void *hcmalloc_aligned (const size_t sz, const int align)
+void *hc_alloc_aligned (size_t alignment, size_t size)
+{
+  void *ptr = NULL;
+
+  #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+
+  if (posix_memalign (&ptr, alignment, size) != 0)
+  {
+    fprintf (stderr, "! hc_aligned_alloc: %s\n", MSG_ENOMEM);
+
+    return NULL;
+  }
+
+  #elif defined(_WIN32)
+
+  ptr = _aligned_malloc (size, alignment);
+
+  if (ptr == NULL)
+  {
+    fprintf (stderr, "! hc_aligned_alloc: %s\n", MSG_ENOMEM);
+
+    return NULL;
+  }
+
+  #else
+
+  #error "Platform not supported for aligned allocation"
+
+  #endif
+
+  memset (ptr, 0, size);
+
+  return ptr;
+}
+
+void hc_free_aligned (void **ptr)
+{
+  if (ptr == NULL || *ptr == NULL) return;
+
+  #if defined(_WIN32)
+
+  _aligned_free (*ptr);
+
+  #else
+
+  free (*ptr);
+
+  #endif
+
+  *ptr = NULL;
+}
+
+void *hcmalloc_bridge_aligned (const size_t sz, const int align)
 {
   uintptr_t align_mask = (uintptr_t) (align - 1);
 
@@ -86,7 +138,7 @@ void *hcmalloc_aligned (const size_t sz, const int align)
   return aligned_ptr;
 }
 
-void hcfree_aligned(void *ptr)
+void hcfree_bridge_aligned (void *ptr)
 {
   if (ptr != NULL)
   {


### PR DESCRIPTION
## OpenCL Backend

- added hc_clCreateBuffer wrapper, hc_clCreateBuffer_pre
- updated HC_OCL_CREATEBUFFER macro
- updated other two hc_clEnqueueWriteBuffer from CL_FALSE to CL_TRUE

## Metal Backend

- added hc_mtlFinish
- updated hc_mtlCreateBuffer

## Memory

- added hc_alloc_aligned and hc_free_aligned
- renamed hcmalloc_aligned and hcfree_aligned to hcmalloc_bridge_aligned and hcfree_bridge_aligned

## Backend & Bridge

- updated references of hcmalloc_aligned and hcfree_aligned to the new memory defined functions