### PR TITLE
Adjustments pre v7 (part 2)

### DIFF
--- a/OpenCL/m34200_a1-pure.cl
+++ b/OpenCL/m34200_a1-pure.cl
@@ -81,10 +81,10 @@ KERNEL_FQ KERNEL_FA void m34200_mxx (KERN_ATTR_BASIC ())
    */
 
   PRIVATE_AS u8 combined_buf[256] = {0};
-  const u32 *comb_ptr = (u32*) combined_buf;
+  PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
   // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8*) pws[gid].i;
+  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
   // probably bad for performance
   for (u32 i = 0; i < pws[gid].pw_len; i++)
   {
@@ -107,7 +107,7 @@ KERNEL_FQ KERNEL_FA void m34200_mxx (KERN_ATTR_BASIC ())
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
     // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8*) combs_buf[il_pos].i;
+    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
     for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
     {
       combined_buf[i + pws[gid].pw_len] = right[i];
@@ -139,10 +139,10 @@ KERNEL_FQ KERNEL_FA void m34200_sxx (KERN_ATTR_BASIC ())
    */
 
   PRIVATE_AS u8 combined_buf[256] = {0};
-  const u32 *comb_ptr = (u32*) combined_buf;
+  PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
   // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8*) pws[gid].i;
+  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
   // probably bad for performance
   for (u32 i = 0; i < pws[gid].pw_len; i++)
   {
@@ -177,7 +177,7 @@ KERNEL_FQ KERNEL_FA void m34200_sxx (KERN_ATTR_BASIC ())
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
     // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8*) combs_buf[il_pos].i;
+    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
     for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
     {
       combined_buf[i + pws[gid].pw_len] = right[i];

--- a/OpenCL/m34201_a1-pure.cl
+++ b/OpenCL/m34201_a1-pure.cl
@@ -81,10 +81,10 @@ KERNEL_FQ KERNEL_FA void m34201_mxx (KERN_ATTR_BASIC ())
    */
 
   PRIVATE_AS u8 combined_buf[256] = {0};
-  const u32 *comb_ptr = (u32*) combined_buf;
+  PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
   // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8*) pws[gid].i;
+  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
   // probably bad for performance
   for (u32 i = 0; i < pws[gid].pw_len; i++)
   {
@@ -98,7 +98,7 @@ KERNEL_FQ KERNEL_FA void m34201_mxx (KERN_ATTR_BASIC ())
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
     // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8*) combs_buf[il_pos].i;
+    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
     for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
     {
       combined_buf[i + pws[gid].pw_len] = right[i];
@@ -130,10 +130,10 @@ KERNEL_FQ KERNEL_FA void m34201_sxx (KERN_ATTR_BASIC ())
    */
 
   PRIVATE_AS u8 combined_buf[256] = {0};
-  const u32 *comb_ptr = (u32*) combined_buf;
+  PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
   // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8*) pws[gid].i;
+  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
   // probably bad for performance
   for (u32 i = 0; i < pws[gid].pw_len; i++)
   {
@@ -159,7 +159,7 @@ KERNEL_FQ KERNEL_FA void m34201_sxx (KERN_ATTR_BASIC ())
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
     // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8*) combs_buf[il_pos].i;
+    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
     for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
     {
       combined_buf[i + pws[gid].pw_len] = right[i];

--- a/OpenCL/m34211_a1-pure.cl
+++ b/OpenCL/m34211_a1-pure.cl
@@ -82,10 +82,10 @@ KERNEL_FQ KERNEL_FA void m34211_mxx (KERN_ATTR_BASIC ())
    */
 
   PRIVATE_AS u8 combined_buf[256] = {0};
-  const u32 *comb_ptr = (u32*) combined_buf;
+  PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
   // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8*) pws[gid].i;
+  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
   // probably bad for performance
   for (u32 i = 0; i < pws[gid].pw_len; i++)
   {
@@ -99,7 +99,7 @@ KERNEL_FQ KERNEL_FA void m34211_mxx (KERN_ATTR_BASIC ())
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
     // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8*) combs_buf[il_pos].i;
+    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
     for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
     {
       combined_buf[i + pws[gid].pw_len] = right[i];
@@ -129,10 +129,10 @@ KERNEL_FQ KERNEL_FA void m34211_sxx (KERN_ATTR_BASIC ())
    */
 
   PRIVATE_AS u8 combined_buf[256] = {0};
-  const u32 *comb_ptr = (u32*) combined_buf;
+  PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
   // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8*) pws[gid].i;
+  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
   // probably bad for performance
   for (u32 i = 0; i < pws[gid].pw_len; i++)
   {
@@ -158,7 +158,7 @@ KERNEL_FQ KERNEL_FA void m34211_sxx (KERN_ATTR_BASIC ())
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
     // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8*) combs_buf[il_pos].i;
+    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
     for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
     {
       combined_buf[i + pws[gid].pw_len] = right[i];

--- a/include/ext_OpenCL.h
+++ b/include/ext_OpenCL.h
@@ -125,7 +125,7 @@ static const cl_mem_flags openclMemoryFlags[OCL_BUFFER_CNT] =
 
 #define HC_OCL_CREATEBUFFER(ctx, size, ptr, buf_name)                                     \
   do {                                                                                    \
-    if (hc_clCreateBuffer_pre(ctx, device_param->opencl_context,                          \
+    if (hc_clCreateBuffer_ext(ctx, device_param->opencl_context,                          \
                               openclMemoryFlags[opencl_d_##buf_name##_memoryFlags], size, \
                               ptr, &device_param->opencl_d_##buf_name) == -1) return -1;  \
   } while (0)
@@ -239,7 +239,7 @@ int hc_clGetDeviceInfo           (void *hashcat_ctx, cl_device_id device, cl_dev
 int hc_clCreateContext           (void *hashcat_ctx, const cl_context_properties *properties, cl_uint num_devices, const cl_device_id *devices, void (CL_CALLBACK *pfn_notify) (const char *errinfo, const void *private_info, size_t cb, void *user_data), void *user_data, cl_context *context);
 int hc_clCreateCommandQueue      (void *hashcat_ctx, cl_context context, cl_device_id device, cl_command_queue_properties properties, cl_command_queue *command_queue);
 int hc_clCreateBuffer            (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem);
-int hc_clCreateBuffer_pre        (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem);
+int hc_clCreateBuffer_ext        (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem);
 int hc_clCreateProgramWithSource (void *hashcat_ctx, cl_context context, cl_uint count, const char **strings, const size_t *lengths, cl_program *program);
 int hc_clCreateProgramWithBinary (void *hashcat_ctx, cl_context context, cl_uint num_devices, const cl_device_id *device_list, const size_t *lengths, const unsigned char **binaries, cl_int *binary_status, cl_program *program);
 int hc_clBuildProgram            (void *hashcat_ctx, cl_program program, cl_uint num_devices, const cl_device_id *device_list, const char *options, void (CL_CALLBACK *pfn_notify) (cl_program program, void *user_data), void *user_data);

--- a/src/backend.c
+++ b/src/backend.c
@@ -6966,7 +6966,10 @@ static void backend_ctx_devices_init_metal (hashcat_ctx_t *hashcat_ctx, MAYBE_UN
 
 static void backend_ctx_devices_init_opencl (hashcat_ctx_t *hashcat_ctx, int *virthost, int *virthost_finder, int *backend_devices_idx, int *bridge_link_device)
 {
+  #if defined (__linux__)
   const folder_config_t *folder_config = hashcat_ctx->folder_config;
+  #endif
+
   const bridge_ctx_t    *bridge_ctx    = hashcat_ctx->bridge_ctx;
         backend_ctx_t   *backend_ctx   = hashcat_ctx->backend_ctx;
         user_options_t  *user_options  = hashcat_ctx->user_options;

--- a/src/ext_OpenCL.c
+++ b/src/ext_OpenCL.c
@@ -566,7 +566,9 @@ int hc_clCreateCommandQueue (void *hashcat_ctx, cl_context context, cl_device_id
   return 0;
 }
 
-int hc_clCreateBuffer_pre (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem)
+// extended version of hc_clCreateBuffer
+
+int hc_clCreateBuffer_ext (void *hashcat_ctx, cl_context context, cl_mem_flags flags, size_t size, void *host_ptr, cl_mem *mem)
 {
   if (host_ptr != NULL)
   {

--- a/tools/test_edge.sh
+++ b/tools/test_edge.sh
@@ -46,6 +46,8 @@ function usage()
   echo ""
   echo "     --allow-all-attacks            : Do not skip attack types other than Straight with hash types with attack exec outside kernel"
   echo ""
+  echo "     --allow-self-tests             : Do not skip self tests"
+  echo ""
   echo "-f / --force                        : run hashcat using --force"
   echo ""
   echo "-v / --verbose                      : show debug messages (supported: -v or -vv)"
@@ -94,8 +96,9 @@ METAL_BACKEND=0
 METAL_COMPILER_RUNTIME=120
 BACKEND_DEVICES_KEEPFREE=0
 ALL_ATTACKS=0
+SELF_TEST_DISABLE=1
 
-OPTS="--quiet --potfile-disable --hwmon-disable --self-test-disable --machine-readable --logfile-disable"
+OPTS="--quiet --potfile-disable --hwmon-disable --machine-readable --logfile-disable"
 
 SKIP_HASH_TYPES="" #2000 2500 2501 16800 16801 99999 32000"
 SKIP_HASH_TYPES_METAL="21800"
@@ -144,6 +147,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --allow-all-attacks)
       ALL_ATTACKS=1
+      shift
+      ;;
+    --allow-self-tests)
+      SELF_TEST_DISABLE=0
       shift
       ;;
     --vector-width-min)
@@ -517,6 +524,10 @@ fi
 if [[ "$VECTOR_WIDTH" != "all" && ( "$VECTOR_WIDTH_MIN" -ne 1 || "$VECTOR_WIDTH_MAX" -ne 16 ) ]]; then
   echo "Error: cannot set --vector-width and --vector-width-min/--vector-width-max"
   usage
+fi
+
+if [ ${SELF_TEST_DISABLE} -eq 1 ]; then
+  OPTS="${OPTS} --self-test-disable"
 fi
 
 if [ ${FORCE} -eq 1 ]; then


### PR DESCRIPTION
- fix **folder_config** build warning

```
src/backend.c:6969:26: warning: unused variable 'folder_config' [-Wunused-variable]
 6969 |   const folder_config_t *folder_config = hashcat_ctx->folder_config;
      |                          ^~~~~~~~~~~~~
1 warning generated.
src/backend.c:6969:26: warning: unused variable 'folder_config' [-Wunused-variable]
 6969 |   const folder_config_t *folder_config = hashcat_ctx->folder_config;
      |                          ^~~~~~~~~~~~~
1 warning generated.
```
- rename **hc_clCreateBuffer_pre** to **hc_clCreateBuffer_ext**

- add missing explicit address space qualifier into MurmurHash2 kernels to support Metal

```
hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:84:13: error: pointer type must have explicit address space qualifier
  const u32 *comb_ptr = (u32*) combined_buf;
```