### PR TITLE
Fixed bug in 34000 with Metal and OpenCL on Apple

### DIFF
--- a/OpenCL/m34000-pure.cl
+++ b/OpenCL/m34000-pure.cl
@@ -83,8 +83,12 @@ KERNEL_FQ KERNEL_FA void m34000_loop (KERN_ATTR_TMPS_ESALT (argon2_tmp_t, argon2
 
   argon2_options_t options = esalt_bufs[DIGESTS_OFFSET_HOST_BID];
 
+  #ifdef IS_APPLE
+  // it doesn't work on Apple, so we won't set it up
+  #else
   #ifdef ARGON2_PARALLELISM
   options.parallelism = ARGON2_PARALLELISM;
+  #endif
   #endif
 
   GLOBAL_AS argon2_block_t *argon2_block = get_argon2_block (&options, V, bd4);

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -137,6 +137,7 @@
 - Fixed bug in 26900 module_hash_encode
 - Fixed bug in 29600 module OPTS_TYPE setting
 - Fixed bug in 32600 by adding missing module_jit_build_options
+- Fixed bug in 34000 with Metal and OpenCL on Apple
 - Fixed bug in Hardware Monitor: prevent disable if ADL fail
 - Fixed bug in grep out-of-memory workaround on Unit Test
 - Fixed bug in inc_rp_optimized.cl on Apple Intel with Metal


### PR DESCRIPTION
Unfortunately, the latest changes to Argon2 have not resolved the issue described in #4367. The only solution on Apple is this one at the moment.