### PR TITLE
Get rid of false positive on 3090x modules, updated test_edge.sh

### DIFF
--- a/OpenCL/m30901_a0-pure.cl
+++ b/OpenCL/m30901_a0-pure.cl
@@ -52,7 +52,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -62,7 +61,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -76,11 +74,18 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -91,7 +96,7 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -102,14 +107,12 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -127,7 +130,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_RULES ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -142,7 +144,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_RULES ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 
@@ -171,7 +172,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -184,7 +184,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -194,7 +193,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -208,11 +206,18 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -223,7 +228,7 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -234,14 +239,12 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -259,7 +262,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -274,7 +276,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_RULES ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 

--- a/OpenCL/m30901_a1-pure.cl
+++ b/OpenCL/m30901_a1-pure.cl
@@ -50,7 +50,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -61,7 +60,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -70,7 +68,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -102,11 +99,18 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -117,7 +121,7 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -128,14 +132,12 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -153,7 +155,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -168,7 +169,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 
@@ -197,7 +197,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -210,7 +209,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -221,7 +219,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -230,7 +227,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -262,11 +258,18 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -277,7 +280,7 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -288,14 +291,12 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -313,7 +314,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -328,7 +328,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 

--- a/OpenCL/m30901_a3-pure.cl
+++ b/OpenCL/m30901_a3-pure.cl
@@ -92,7 +92,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -101,12 +100,11 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
-  u32 w[16];
+  u32 w[16] = { 0 };
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -119,7 +117,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -137,7 +134,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -147,7 +143,7 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -158,14 +154,12 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -183,7 +177,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -198,7 +191,6 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_VECTOR ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 
@@ -227,7 +219,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -248,12 +239,11 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
-  u32 w[16];
+  u32 w[16] = { 0 };
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -266,7 +256,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -284,7 +273,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -294,7 +282,7 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -305,14 +293,12 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -330,7 +316,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -345,7 +330,6 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_VECTOR ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 

--- a/OpenCL/m30902_a0-pure.cl
+++ b/OpenCL/m30902_a0-pure.cl
@@ -52,7 +52,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -62,7 +61,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -76,11 +74,18 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -91,7 +96,7 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -102,14 +107,12 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -133,7 +136,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_RULES ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -148,7 +150,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_RULES ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 
@@ -177,7 +178,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -190,7 +190,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -200,7 +199,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -214,11 +212,18 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -229,7 +234,7 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -240,14 +245,12 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -271,7 +274,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -286,7 +288,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_RULES ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 

--- a/OpenCL/m30902_a1-pure.cl
+++ b/OpenCL/m30902_a1-pure.cl
@@ -50,7 +50,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -61,7 +60,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -70,7 +68,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -102,11 +99,18 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -117,7 +121,7 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -128,14 +132,12 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -159,7 +161,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -174,7 +175,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 
@@ -203,7 +203,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -216,7 +215,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -227,7 +225,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -236,7 +233,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -268,11 +264,18 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -283,7 +286,7 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -294,14 +297,12 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -325,7 +326,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -340,7 +340,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 

--- a/OpenCL/m30902_a3-pure.cl
+++ b/OpenCL/m30902_a3-pure.cl
@@ -50,7 +50,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -59,12 +58,11 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
-  u32 w[16];
+  u32 w[16] = { 0 };
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -77,7 +75,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -95,7 +92,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -105,7 +101,7 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -116,14 +112,12 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -147,7 +141,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -162,7 +155,6 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_VECTOR ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 
@@ -191,7 +183,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -212,12 +203,11 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
-  u32 w[16];
+  u32 w[16] = { 0 };
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -230,7 +220,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -248,7 +237,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -258,7 +246,7 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -269,14 +257,12 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -300,7 +286,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -315,7 +300,6 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_VECTOR ())
     // tmp[12] = 0; tmp[13] = 0; tmp[14] = 0; tmp[15] = 0;
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
-
 
     // now let's do RIPEMD-160 on the sha256sum
 

--- a/OpenCL/m30905_a0-pure.cl
+++ b/OpenCL/m30905_a0-pure.cl
@@ -52,7 +52,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -62,7 +61,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -76,11 +74,18 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -91,7 +96,7 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -102,14 +107,12 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -127,7 +130,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -143,7 +145,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -151,7 +152,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_RULES ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):
@@ -195,7 +195,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -208,7 +207,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -218,7 +216,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -232,11 +229,18 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -247,7 +251,7 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -258,14 +262,12 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -283,7 +285,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -299,7 +300,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -307,7 +307,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_RULES ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):

--- a/OpenCL/m30905_a1-pure.cl
+++ b/OpenCL/m30905_a1-pure.cl
@@ -50,7 +50,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -61,7 +60,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -70,7 +68,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -102,11 +99,18 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -117,7 +121,7 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -128,14 +132,12 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
     u32 x[8];
     u32 y[8];
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -153,7 +155,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -169,7 +170,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -177,7 +177,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):
@@ -221,7 +220,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -234,7 +232,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -245,7 +242,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -254,7 +250,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -286,11 +281,18 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -301,7 +303,7 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -312,14 +314,12 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -337,7 +337,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -353,7 +352,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -361,7 +359,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):

--- a/OpenCL/m30905_a3-pure.cl
+++ b/OpenCL/m30905_a3-pure.cl
@@ -51,7 +51,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -60,12 +59,11 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
   u32 w[16];
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -78,7 +76,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -96,7 +93,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -106,7 +102,7 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -117,14 +113,12 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -142,7 +136,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -158,7 +151,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -166,7 +158,6 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_VECTOR ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):
@@ -210,7 +201,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -231,12 +221,11 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
   u32 w[16];
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -249,7 +238,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -267,7 +255,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -277,7 +264,7 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -288,14 +275,12 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -313,7 +298,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
     pub_key[1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[0] = (x[7] >> 8) | (type << 24);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -329,7 +313,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -337,7 +320,6 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_VECTOR ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):

--- a/OpenCL/m30906_a0-pure.cl
+++ b/OpenCL/m30906_a0-pure.cl
@@ -52,7 +52,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -62,7 +61,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -76,11 +74,18 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -91,7 +96,7 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -102,14 +107,12 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -133,7 +136,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -149,7 +151,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -157,7 +158,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_RULES ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):
@@ -201,7 +201,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -214,7 +213,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -224,7 +222,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
   set_precomputed_basepoint_g (&preG);
 
   COPY_PW (pws[gid]);
-
 
   /**
    * loop
@@ -238,11 +235,18 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
 
     if (p.pw_len != 64) continue;
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (p.i[i]) == 0) continue;
+      if (is_valid_hex_32 (p.i[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -253,7 +257,7 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
       tmp[i] = hex_u32_to_u32 (p.i[j + 0], p.i[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -264,14 +268,12 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -295,7 +297,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -311,7 +312,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -319,7 +319,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_RULES ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):

--- a/OpenCL/m30906_a1-pure.cl
+++ b/OpenCL/m30906_a1-pure.cl
@@ -61,7 +61,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -70,7 +69,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -102,11 +100,18 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -117,7 +122,7 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -128,14 +133,12 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -159,7 +162,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -175,7 +177,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -183,7 +184,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):
@@ -227,7 +227,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -240,7 +239,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
     digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
   };
 
-
   /**
    * base
    */
@@ -251,7 +249,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
 
   u32 w[16] = { 0 };
 
-  // for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
   for (u32 idx = 0; idx < 16; idx++)
   {
     w[idx] = pws[gid].i[idx];
@@ -260,7 +257,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -292,11 +288,18 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
       c[i] |= w[i];
     }
 
+    u32 e = 0;
+
     for (u32 i = 0; i < 16; i++)
     {
-      if (is_valid_hex_32 (c[i]) == 0) continue;
+      if (is_valid_hex_32 (c[i]) != 0) continue;
+
+      e = 1;
+
+      break;
     }
 
+    if (e == 1) continue; // not a valid hex
 
     // convert password from hex to binary
 
@@ -307,7 +310,7 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
       tmp[i] = hex_u32_to_u32 (c[j + 0], c[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -318,14 +321,12 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -349,7 +350,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -365,7 +365,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -373,7 +372,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):

--- a/OpenCL/m30906_a3-pure.cl
+++ b/OpenCL/m30906_a3-pure.cl
@@ -50,7 +50,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * base
    */
@@ -59,12 +58,11 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
   u32 w[16];
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -77,7 +75,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -95,7 +92,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -105,7 +101,7 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -116,14 +112,12 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -147,7 +141,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -163,7 +156,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -171,7 +163,6 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_VECTOR ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):
@@ -215,7 +206,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
 
   if (gid >= GID_CNT) return;
 
-
   /**
    * digest
    */
@@ -236,12 +226,11 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
 
   if (pw_len != 64) return;
 
-
   // copy password to w
 
   u32 w[16];
 
-  for (u32 i = 0; i < 16; i++) // pw_len / 4
+  for (u32 i = 0; i < 16; i++)
   {
     w[i] = pws[gid].i[i];
   }
@@ -254,7 +243,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
   secp256k1_t preG; // need to change SECP256K1_TMPS_TYPE above to: PRIVATE_AS
 
   set_precomputed_basepoint_g (&preG);
-
 
   /**
    * loop
@@ -272,7 +260,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
 
     if (is_valid_hex_32 (w[0]) == 0) continue;
 
-
     // convert password from hex to binary
 
     u32 tmp[16] = { 0 };
@@ -282,7 +269,7 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
       tmp[i] = hex_u32_to_u32 (w[j + 0], w[j + 1]);
     }
 
-    u32 prv_key[9];
+    u32 prv_key[9] = { 0 };
 
     prv_key[0] = tmp[7];
     prv_key[1] = tmp[6];
@@ -293,14 +280,12 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
     prv_key[6] = tmp[1];
     prv_key[7] = tmp[0];
 
-
     // convert: pub_key = G * prv_key
 
-    u32 x[8];
-    u32 y[8];
+    u32 x[8] = { 0 };
+    u32 y[8] = { 0 };
 
     point_mul_xy (x, y, prv_key, &preG);
-
 
     // to public key:
 
@@ -324,7 +309,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
     pub_key[ 1] = (x[6] >> 8) | (x[7] << 24);
     pub_key[ 0] = (x[7] >> 8) | (0x04000000);
 
-
     // calculate HASH160 for pub key
 
     sha256_ctx_t ctx;
@@ -340,7 +324,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
 
     for (u32 i = 8; i < 16; i++) tmp[i] = 0;
 
-
     // now let's do RIPEMD-160 on the sha256sum
 
     ripemd160_ctx_t rctx;
@@ -348,7 +331,6 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_VECTOR ())
     ripemd160_init        (&rctx);
     ripemd160_update_swap (&rctx, tmp, 32);
     ripemd160_final       (&rctx);
-
 
     /*
      * 2nd RIPEMD160 (SHA256 ()):

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -143,6 +143,7 @@
 - Fixed bug in input_tokenizer when TOKEN_ATTR_FIXED_LENGTH is used and refactor modules
 - Fixed bug in module_constraints and kernel for hash-mode 7800
 - Fixed bug in module_constraints and kernel for hash-mode 7801
+- Fixed bugs in 3090x kernels which produced false positives
 - Fixed build failed for 10700 optimized with Apple Metal
 - Fixed build failed for 13772 and 13773 with Apple Metal
 - Fixed build failed for 18400 with Apple Metal
@@ -251,6 +252,7 @@
 - Unit tests: Updated install_modules.sh with Crypt::Argon2
 - Unit tests: Updated install_modules.sh with Crypt::Passwd::XS, to test suite works also on Apple (ex: 1800)
 - Unit tests: Updated install_modules.sh, test.pl and some test modules (1000, 16000, 31300, 31500, 31600) by removing Text:Iconv and using Encode instead
+- Unit tests: Updated test_edge.sh, introducing clean_cache function and fix for 20510 module
 - User Options: Added error message when mixing --username and --show to warn users of exponential delay
 - User Options: added --metal-compiler-runtime option
 - User Options: assigned -H to --hash-info


### PR DESCRIPTION
- Fixed bugs in 3090x kernels which produced false positives
- Updated test_edge.sh, introducing clean_cache function and fix for 20510 module