### PR TITLE
Added current power consumption indicator on Apple

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -202,11 +202,15 @@
 - Documents: Updated BUILD.md and added BUILD_macOS.md (containing instructions for building windows binaries on macOS)
 - Filehandling: Solved TODOs in hc_fstat()
 - HIP Backend: Avoid deprecated functions
+- Hardware Monitor: Added current power consumption indicator (only supported on Apple)
+- Hardware Monitor: Added hm_get_power_* primitives (only supported on Apple)
+- Hardware Monitor: Renamed src/ext_iokit.c to src/ext_iokit.m
 - Hardware Monitor: Splitting hwmon_ctx_init function into smaller library-specific functions
 - Hardware Monitor: avoid sprintf in src/ext_iokit.c
 - Hash-Info: show more details using -HH
 - Help: show supported hash-modes only with -hh
 - Kernel: Renamed multiple defines in CAST cipher to fit expected naming convention of the C++ language standard
+- Makefile: Added -lIOReport into LFLAGS_NATIVE for Apple and moved ext_iokit into OBJS_METAL
 - Makefile: prevent make failure with Apple Silicon in case of partial rebuild
 - Makefile: updated MACOSX_DEPLOYMENT_TARGET to 15.0
 - MetaMask: update extraction tool to support MetaMask Mobile wallets

--- a/include/ext_iokit.h
+++ b/include/ext_iokit.h
@@ -97,16 +97,41 @@ typedef struct
 
 } SMCVal_t;
 
+// IOReport
+
+typedef struct IOReportSubscriptionRef* IOReportSubscriptionRef;
+
 #endif // __APPLE__
 
 typedef int HM_ADAPTER_IOKIT;
 
 typedef void *IOKIT_LIB;
 
+#define MAX_WINDOW 10
+
+typedef struct
+{
+  int64_t buffer[MAX_WINDOW];
+
+  int index;
+  int count;
+
+} moving_avg_t;
+
 typedef struct hm_iokit_lib
 {
   #if defined(__APPLE__)
-  io_connect_t conn;
+
+  io_connect_t            conn;
+
+  IOReportSubscriptionRef sub;
+  CFMutableDictionaryRef  subscribed;
+
+  int64_t pwr_e1;
+  int64_t pwr_t1;
+
+  moving_avg_t avg_power;
+
   #endif // __APPLE__
 
 } hm_iokit_lib_t;
@@ -114,19 +139,24 @@ typedef struct hm_iokit_lib
 typedef hm_iokit_lib_t IOKIT_PTR;
 
 #if defined(__APPLE__)
-UInt32 hm_IOKIT_strtoul (const char *str, int size, int base);
-void hm_IOKIT_ultostr (char *str, UInt32 val);
-kern_return_t hm_IOKIT_SMCOpen (void *hashcat_ctx, io_connect_t *conn);
-kern_return_t hm_IOKIT_SMCClose (io_connect_t conn);
-kern_return_t hm_IOKIT_SMCCall (int index, SMCKeyData_t *inData, SMCKeyData_t *outData, io_connect_t conn);
-kern_return_t hm_IOKIT_SMCReadKey (UInt32Char_t key, SMCVal_t *val, io_connect_t conn);
-int hm_IOKIT_SMCGetSensorGraphicHot (void *hashcat_ctx);
-int hm_IOKIT_SMCGetTemperature (void *hashcat_ctx, char *key, double *temp);
-bool hm_IOKIT_SMCGetFanRPM (char *key, io_connect_t conn, float *ret);
-int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf);
-int hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization);
-bool iokit_init (void *hashcat_ctx);
-bool iokit_close (void *hashcat_ctx);
+UInt32 hm_IOKIT_strtoul               (const char *str, int size, int base);
+void   hm_IOKIT_ultostr               (char *str, UInt32 val);
+
+kern_return_t hm_IOKIT_SMCOpen        (void *hashcat_ctx, io_connect_t *conn);
+kern_return_t hm_IOKIT_SMCClose       (io_connect_t conn);
+kern_return_t hm_IOKIT_SMCCall        (int index, SMCKeyData_t *inData, SMCKeyData_t *outData, io_connect_t conn);
+kern_return_t hm_IOKIT_SMCReadKey     (UInt32Char_t key, SMCVal_t *val, io_connect_t conn);
+
+bool hm_IOKIT_SMCGetFanRPM            (char *key, io_connect_t conn, float *ret);
+
+int  hm_IOKIT_SMCGetSensorGraphicHot  (void *hashcat_ctx);
+int  hm_IOKIT_SMCGetTemperature       (void *hashcat_ctx, char *key, double *temp);
+int  hm_IOKIT_get_fan_speed_current   (void *hashcat_ctx, char *fan_speed_buf);
+int  hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization);
+int  hm_IOKIT_get_power_current       (void *hashcat_ctx, int64_t *power);
+
+bool iokit_init                       (void *hashcat_ctx);
+bool iokit_close                      (void *hashcat_ctx);
 #endif // __APPLE__
 
 #endif // HC_EXT_IOKIT_H

--- a/include/hwmon.h
+++ b/include/hwmon.h
@@ -25,6 +25,7 @@ int hm_get_memoryspeed_with_devices_idx        (hashcat_ctx_t *hashcat_ctx, cons
 int hm_get_corespeed_with_devices_idx          (hashcat_ctx_t *hashcat_ctx, const int backend_device_idx);
 int hm_get_throttle_with_devices_idx           (hashcat_ctx_t *hashcat_ctx, const int backend_device_idx);
 u64 hm_get_memoryused_with_devices_idx         (hashcat_ctx_t *hashcat_ctx, const int backend_device_idx);
+int64_t hm_get_power_with_devices_idx          (hashcat_ctx_t *hashcat_ctx, const int backend_device_idx);
 
 int  hwmon_ctx_init    (hashcat_ctx_t *hashcat_ctx);
 void hwmon_ctx_destroy (hashcat_ctx_t *hashcat_ctx);

--- a/include/types.h
+++ b/include/types.h
@@ -2119,6 +2119,7 @@ typedef struct hm_attrs
   bool throttle_get_supported;
   bool utilization_get_supported;
   bool memoryused_get_supported;
+  bool power_get_supported;
 
 } hm_attrs_t;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -379,6 +379,7 @@ LFLAGS_NATIVE           += -framework CoreGraphics
 LFLAGS_NATIVE           += -framework Foundation
 LFLAGS_NATIVE           += -framework IOKit
 LFLAGS_NATIVE           += -framework Metal
+LFLAGS_NATIVE           += -lIOReport
 LFLAGS_NATIVE           += -lpthread
 LFLAGS_NATIVE           += -liconv
 
@@ -436,7 +437,7 @@ EMU_OBJS_ALL            += emu_inc_hash_md4 emu_inc_hash_md5 emu_inc_hash_ripemd
 EMU_OBJS_ALL            += emu_inc_cipher_aes emu_inc_cipher_camellia emu_inc_cipher_des emu_inc_cipher_kuznyechik emu_inc_cipher_serpent emu_inc_cipher_twofish
 EMU_OBJS_ALL            += emu_inc_hash_base58
 
-OBJS_ALL                := affinity autotune backend benchmark bitmap bitops bridges combinator common convert cpt cpu_crc32 debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_intelgpu ext_sysfs_cpu ext_iokit ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
+OBJS_ALL                := affinity autotune backend benchmark bitmap bitops bridges combinator common convert cpt cpu_crc32 debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_intelgpu ext_sysfs_cpu ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
 
 ifeq ($(ENABLE_BRAIN),1)
 OBJS_ALL                += brain
@@ -447,7 +448,7 @@ LINUX_OBJS              := $(foreach OBJ,$(OBJS_ALL),obj/$(OBJ).LINUX.o)
 WIN_OBJS                := $(foreach OBJ,$(OBJS_ALL),obj/$(OBJ).WIN.o)
 
 ifeq ($(UNAME),Darwin)
-OBJS_METAL              := ext_metal
+OBJS_METAL              := ext_metal ext_iokit
 
 NATIVE_OBJS             += $(foreach OBJ,$(OBJS_METAL),obj/$(OBJ).METAL.NATIVE.o)
 endif

--- a/src/ext_iokit.m
+++ b/src/ext_iokit.m
@@ -11,7 +11,65 @@
 #include "ext_iokit.h"
 
 #if defined (__APPLE__)
+#include <mach/mach_time.h>
 #include <IOKit/IOKitLib.h>
+#include <Foundation/Foundation.h>
+
+typedef CFDictionaryRef IOReportSampleRef;
+
+typedef int (^ioreportiterateblock) (IOReportSampleRef ch);
+
+extern CFDictionaryRef IOReportCreateSamples (IOReportSubscriptionRef iorsub, CFMutableDictionaryRef subbedChannels, CFTypeRef a);
+extern void IOReportIterate (CFDictionaryRef samples, ioreportiterateblock);
+extern NSString* IOReportChannelGetChannelName (CFDictionaryRef);
+extern int IOReportChannelGetFormat (CFDictionaryRef samples);
+extern long IOReportSimpleGetIntegerValue (CFDictionaryRef, int);
+extern CFMutableDictionaryRef IOReportCopyAllChannels (uint64_t, uint64_t);
+extern IOReportSubscriptionRef IOReportCreateSubscription (void *a, CFMutableDictionaryRef desiredChannels, CFMutableDictionaryRef* subbedChannels, uint64_t channel_id, CFTypeRef b);
+
+enum
+{
+  kIOReportFormatSimple = 1,
+};
+
+static void moving_avg_init (moving_avg_t *avg)
+{
+  memset (avg, 0, sizeof (moving_avg_t));
+}
+
+static void moving_avg_add (moving_avg_t *avg, int64_t value)
+{
+  avg->buffer[avg->index] = value;
+
+  avg->index = (avg->index + 1) % MAX_WINDOW;
+
+  if (avg->count < MAX_WINDOW) avg->count++;
+}
+
+static int64_t moving_avg_get (const moving_avg_t *avg)
+{
+  int64_t sum = 0;
+
+  for (int i = 0; i < avg->count; i++)
+  {
+    sum += avg->buffer[i];
+  }
+
+  return (avg->count > 0) ? sum / avg->count : 0;
+}
+
+static void moving_avg_reset (moving_avg_t *avg)
+{
+  if (avg == NULL) return;
+
+  avg->index = 0;
+  avg->count = 0;
+
+  for (int i = 0; i < MAX_WINDOW; i++)
+  {
+    avg->buffer[i] = 0;
+  }
+}
 
 UInt32 hm_IOKIT_strtoul (const char *str, int size, int base)
 {
@@ -30,6 +88,7 @@ UInt32 hm_IOKIT_strtoul (const char *str, int size, int base)
       total += (unsigned char) (str[i] << (size - 1 - i) * 8);
     }
   }
+
   return total;
 }
 
@@ -44,7 +103,7 @@ kern_return_t hm_IOKIT_SMCOpen (void *hashcat_ctx, io_connect_t *conn)
 {
   kern_return_t result;
   io_iterator_t iterator;
-  io_object_t device;
+  io_object_t   device;
 
   CFMutableDictionaryRef matchingDictionary = IOServiceMatching ("AppleSMC");
 
@@ -210,6 +269,7 @@ bool hm_IOKIT_SMCGetFanRPM (char *key, io_connect_t conn, float *ret)
       if (strcmp (val.dataType, DATATYPE_FPE2) == 0)
       {
         // convert fpe2 value to RPM
+
         *ret = ntohs (*(UInt16*) val.bytes) / 4.0;
 
         return true;
@@ -221,6 +281,98 @@ bool hm_IOKIT_SMCGetFanRPM (char *key, io_connect_t conn, float *ret)
   *ret = -1.f;
 
   return false;
+}
+
+u64 hm_IOKIT_IOReport_get_gpu_energy (IOReportSubscriptionRef sub, CFMutableDictionaryRef subscribed)
+{
+  __block uint64_t energy = 0;
+
+  CFDictionaryRef samples = IOReportCreateSamples(sub, subscribed, NULL);
+
+  if (!samples) return -1;
+
+  IOReportIterate(samples, ^int(IOReportSampleRef ch)
+  {
+    NSString* channelName = IOReportChannelGetChannelName(ch);
+
+    if ([channelName isEqualToString:@"GPU Energy"])
+    {
+      if (IOReportChannelGetFormat(ch) == kIOReportFormatSimple)
+      {
+        energy = IOReportSimpleGetIntegerValue(ch, 0);
+
+        return 0;
+      }
+    }
+
+    return 0;
+  });
+
+  CFRelease (samples);
+
+  return energy;
+}
+
+int hm_IOKIT_get_power_current (void *hashcat_ctx, int64_t *power)
+{
+  hwmon_ctx_t *hwmon_ctx = ((hashcat_ctx_t *) hashcat_ctx)->hwmon_ctx;
+
+  IOKIT_PTR *iokit = hwmon_ctx->hm_iokit;
+
+  // get last saved timestamp and power
+
+  uint64_t t1 = iokit->pwr_t1;
+  uint64_t e1 = iokit->pwr_e1;
+
+  uint64_t t2 = mach_absolute_time();
+  uint64_t e2 = hm_IOKIT_IOReport_get_gpu_energy (iokit->sub, iokit->subscribed);
+
+  // update values for the next call
+
+  iokit->pwr_t1 = t2;
+  iokit->pwr_e1 = e2;
+
+  mach_timebase_info_data_t timebase;
+  mach_timebase_info (&timebase);
+
+  // elapsed time in nanoseconds
+
+  int64_t delta_mach = (int64_t) (t2 - t1);
+
+  double delta_ns = (double) (delta_mach * timebase.numer / timebase.denom);
+
+  // nanoseconds to seconds as a double for precision
+
+  double delta_sc = delta_ns / 1e9;
+
+  // calculate energy difference in nanojoules
+
+  uint64_t delta_e_nJ = e2 - e1;
+
+  double delta_e_J = (double) (delta_e_nJ / 1e9);
+
+  // check for negative energy delta which can happen on counter reset or overflow
+
+  double power_W = 0.0;
+
+  if (delta_sc > 0.0)
+  {
+    power_W = delta_e_J / delta_sc;
+  }
+
+  // Convert power to milliwatts for your output
+
+  int64_t raw_power_mW = (int64_t)(power_W * 1000.0);
+
+  // add new power sample to moving average filter
+
+  moving_avg_add (&iokit->avg_power, raw_power_mW);
+
+  // return filtered power value
+
+  *power = moving_avg_get (&iokit->avg_power);
+
+  return 0;
 }
 
 int hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization)
@@ -243,11 +395,13 @@ int hm_IOKIT_get_utilization_current (void *hashcat_ctx, int *utilization)
   while ((regEntry = IOIteratorNext (iterator)))
   {
     // Put this services object into a dictionary object.
+
     CFMutableDictionaryRef serviceDictionary;
 
     if (IORegistryEntryCreateCFProperties (regEntry, &serviceDictionary, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess)
     {
       // Service dictionary creation failed.
+
       IOObjectRelease (regEntry);
 
       continue;
@@ -302,6 +456,7 @@ int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf)
     if (totalFans <= 0) return -1;
 
     // limit totalFans to 10
+
     if (totalFans > 10) totalFans = 10;
 
     char tmp_buf[16];
@@ -312,14 +467,18 @@ int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf)
       float actual_speed  = 0.0f;
       float maximum_speed = 0.0f;
 
-      memset (&key, 0, sizeof (UInt32Char_t));
-      snprintf (key, 5, "F%dAc", i);
+      memset   (&key, 0, sizeof (UInt32Char_t));
+      snprintf (key,  5, "F%dAc", i);
+
       hm_IOKIT_SMCGetFanRPM (key, iokit->conn, &actual_speed);
+
       if (actual_speed < 0.f) continue;
 
-      memset (&key, 0, sizeof (UInt32Char_t));
-      snprintf (key, 5, "F%dMx", i);
+      memset   (&key, 0, sizeof (UInt32Char_t));
+      snprintf (key,  5, "F%dMx", i);
+
       hm_IOKIT_SMCGetFanRPM (key, iokit->conn, &maximum_speed);
+
       if (maximum_speed < 0.f) continue;
 
       fan_speed = (actual_speed / maximum_speed) * 100.f;
@@ -330,7 +489,9 @@ int hm_IOKIT_get_fan_speed_current (void *hashcat_ctx, char *fan_speed_buf)
     }
 
     // remove last two bytes
+
     size_t out_len = strlen (fan_speed_buf);
+
     if (out_len > 2) fan_speed_buf[out_len-2] = '\0';
   }
 
@@ -345,13 +506,61 @@ bool iokit_init (void *hashcat_ctx)
 
   memset (iokit, 0, sizeof (IOKIT_PTR));
 
-  if (hm_IOKIT_SMCOpen (hashcat_ctx, &iokit->conn) == kIOReturnSuccess) return true;
+  moving_avg_reset (&iokit->avg_power);
 
-  hcfree (hwmon_ctx->hm_iokit);
+  if (hm_IOKIT_SMCOpen (hashcat_ctx, &iokit->conn) != kIOReturnSuccess)
+  {
+    hcfree (hwmon_ctx->hm_iokit);
 
-  hwmon_ctx->hm_iokit = NULL;
+    hwmon_ctx->hm_iokit = NULL;
 
-  return false;
+    return false;
+  }
+
+  CFMutableDictionaryRef allChannels = IOReportCopyAllChannels (0,0);
+
+  if (!allChannels)
+  {
+    hcfree (hwmon_ctx->hm_iokit);
+
+    hwmon_ctx->hm_iokit = NULL;
+
+    return false;
+  }
+
+  iokit->subscribed = NULL;
+
+  iokit->sub = IOReportCreateSubscription (NULL, allChannels, &iokit->subscribed, 0, NULL);
+
+  CFRelease (allChannels);
+
+  if (!iokit->sub)
+  {
+    hcfree (hwmon_ctx->hm_iokit);
+
+    hwmon_ctx->hm_iokit = NULL;
+
+    return false;
+  }
+
+  if (!iokit->subscribed)
+  {
+    CFRelease (iokit->sub);
+
+    hcfree (hwmon_ctx->hm_iokit);
+
+    hwmon_ctx->hm_iokit = NULL;
+
+    return false;
+  }
+
+  moving_avg_init (&iokit->avg_power);
+
+  iokit->pwr_t1 = mach_absolute_time();
+
+  iokit->pwr_e1 = hm_IOKIT_IOReport_get_gpu_energy (iokit->sub, iokit->subscribed);
+
+  return true;
 }
 
 bool iokit_close (void *hashcat_ctx)
@@ -361,6 +570,16 @@ bool iokit_close (void *hashcat_ctx)
   IOKIT_PTR *iokit = hwmon_ctx->hm_iokit;
 
   hm_IOKIT_SMCClose (iokit->conn);
+
+  moving_avg_reset (&iokit->avg_power);
+
+  CFRelease (iokit->subscribed);
+
+  iokit->subscribed = NULL;
+
+  CFRelease (iokit->sub);
+
+  iokit->sub = NULL;
 
   return true;
 }

--- a/src/status.c
+++ b/src/status.c
@@ -2132,6 +2132,7 @@ char *status_get_hwmon_dev (const hashcat_ctx_t *hashcat_ctx, const int backend_
   const int num_corespeed   = hm_get_corespeed_with_devices_idx   ((hashcat_ctx_t *) hashcat_ctx, backend_devices_idx);
   const int num_memoryspeed = hm_get_memoryspeed_with_devices_idx ((hashcat_ctx_t *) hashcat_ctx, backend_devices_idx);
   const int num_buslanes    = hm_get_buslanes_with_devices_idx    ((hashcat_ctx_t *) hashcat_ctx, backend_devices_idx);
+  const int64_t num_power   = hm_get_power_with_devices_idx       ((hashcat_ctx_t *) hashcat_ctx, backend_devices_idx);
 
   int output_len = 0;
 
@@ -2163,6 +2164,11 @@ char *status_get_hwmon_dev (const hashcat_ctx_t *hashcat_ctx, const int backend_
   if (num_buslanes >= 0)
   {
     output_len += snprintf (output_buf + output_len, HCBUFSIZ_TINY - output_len, "Bus:%u ", num_buslanes);
+  }
+
+  if (num_power >= 0)
+  {
+    output_len += snprintf (output_buf + output_len, HCBUFSIZ_TINY - output_len, "Pwr:%" PRId64 "mW ", num_power);
   }
 
   if (output_len > 0)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2720,6 +2720,22 @@ void status_display_machine_readable (hashcat_ctx_t *hashcat_ctx)
     printf ("%d\t", util);
   }
 
+  printf ("POWER\t");
+
+  for (int device_id = 0; device_id < hashcat_status->device_info_cnt; device_id++)
+  {
+    const device_info_t *device_info = hashcat_status->device_info_buf + device_id;
+
+    if (device_info->skipped_dev == true) continue;
+    if (device_info->skipped_warning_dev == true) continue;
+
+    // ok, little cheat here again...
+
+    const int64_t power = hm_get_power_with_devices_idx (hashcat_ctx, device_id);
+
+    printf("%" PRId64 "\t", power);
+  }
+
   fwrite (EOL, strlen (EOL), 1, stdout);
 
   fflush (stdout);
@@ -2863,12 +2879,13 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
 
     printf (" \"speed\": %" PRIu64 ",", (u64) (device_info->hashes_msec_dev * 1000));
 
-    const int temp = hm_get_temperature_with_devices_idx (hashcat_ctx, device_id);
-    const int util = hm_get_utilization_with_devices_idx (hashcat_ctx, device_id);
-    const int fanspeed = hm_get_fanspeed_with_devices_idx (hashcat_ctx, device_id);
-    const int corespeed = hm_get_corespeed_with_devices_idx (hashcat_ctx, device_id);
+    const int temp        = hm_get_temperature_with_devices_idx (hashcat_ctx, device_id);
+    const int util        = hm_get_utilization_with_devices_idx (hashcat_ctx, device_id);
+    const int fanspeed    = hm_get_fanspeed_with_devices_idx (hashcat_ctx, device_id);
+    const int corespeed   = hm_get_corespeed_with_devices_idx (hashcat_ctx, device_id);
     const int memoryspeed = hm_get_memoryspeed_with_devices_idx (hashcat_ctx, device_id);
-    const int buslanes = hm_get_buslanes_with_devices_idx (hashcat_ctx, device_id);
+    const int buslanes    = hm_get_buslanes_with_devices_idx (hashcat_ctx, device_id);
+    const int64_t power   = hm_get_power_with_devices_idx (hashcat_ctx, device_id);
 
     printf (" \"temp\": %d,", temp);
     printf (" \"util\": %d,", util);
@@ -2876,6 +2893,7 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
     printf (" \"corespeed\": %d,", corespeed);
     printf (" \"memoryspeed\": %d,", memoryspeed);
     printf (" \"buslanes\": %d }", buslanes);
+    printf (" \"power\": %" PRId64 " }", power);
   }
 
   printf (" ],");


### PR DESCRIPTION
- Hardware Monitor: Added current power consumption indicator (only supported on Apple)
- Hardware Monitor: Added hm_get_power_* primitives (only supported on Apple)
- Hardware Monitor: Renamed src/ext_iokit.c to src/ext_iokit.m
- Makefile: Added -lIOReport into LFLAGS_NATIVE for Apple and moved ext_iokit into OBJS_METAL

PoC on #4369 comment