### PR TITLE
Fixed bugs in 34100 kernel on Apple Silicon

### DIFF
--- a/OpenCL/inc_luks_aes.cl
+++ b/OpenCL/inc_luks_aes.cl
@@ -2592,7 +2592,7 @@ DECLSPEC void luks_af_sha1_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs, 
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -2625,7 +2625,7 @@ DECLSPEC void luks_af_sha1_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs, 
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -2651,7 +2651,7 @@ DECLSPEC void luks_af_sha1_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs, 
 
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -2678,7 +2678,7 @@ DECLSPEC void luks_af_sha1_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs, 
 
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -2713,7 +2713,7 @@ DECLSPEC void luks_af_sha1_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs, 
       aes128_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes128_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -2753,7 +2753,7 @@ DECLSPEC void luks_af_sha1_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs, 
       aes256_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -2983,7 +2983,7 @@ DECLSPEC void luks_af_sha256_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3016,7 +3016,7 @@ DECLSPEC void luks_af_sha256_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3042,7 +3042,7 @@ DECLSPEC void luks_af_sha256_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
 
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3069,7 +3069,7 @@ DECLSPEC void luks_af_sha256_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
 
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3104,7 +3104,7 @@ DECLSPEC void luks_af_sha256_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes128_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes128_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3144,7 +3144,7 @@ DECLSPEC void luks_af_sha256_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes256_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3361,7 +3361,7 @@ DECLSPEC void luks_af_sha512_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3394,7 +3394,7 @@ DECLSPEC void luks_af_sha512_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3420,7 +3420,7 @@ DECLSPEC void luks_af_sha512_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
 
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3447,7 +3447,7 @@ DECLSPEC void luks_af_sha512_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
 
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3482,7 +3482,7 @@ DECLSPEC void luks_af_sha512_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes128_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes128_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3522,7 +3522,7 @@ DECLSPEC void luks_af_sha512_then_aes_decrypt (GLOBAL_AS const luks_t *luks_bufs
       aes256_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3720,7 +3720,7 @@ DECLSPEC void luks_af_ripemd160_then_aes_decrypt (GLOBAL_AS const luks_t *luks_b
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3753,7 +3753,7 @@ DECLSPEC void luks_af_ripemd160_then_aes_decrypt (GLOBAL_AS const luks_t *luks_b
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, essivhash, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3779,7 +3779,7 @@ DECLSPEC void luks_af_ripemd160_then_aes_decrypt (GLOBAL_AS const luks_t *luks_b
 
       aes128_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3806,7 +3806,7 @@ DECLSPEC void luks_af_ripemd160_then_aes_decrypt (GLOBAL_AS const luks_t *luks_b
 
       aes256_set_decrypt_key (ks1, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3841,7 +3841,7 @@ DECLSPEC void luks_af_ripemd160_then_aes_decrypt (GLOBAL_AS const luks_t *luks_b
       aes128_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes128_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
@@ -3881,7 +3881,7 @@ DECLSPEC void luks_af_ripemd160_then_aes_decrypt (GLOBAL_AS const luks_t *luks_b
       aes256_set_decrypt_key (ks1, ukey1, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
       aes256_set_encrypt_key (ks2, ukey2, s_te0, s_te1, s_te2, s_te3);
 
-      int sector = 0;
+      u32 sector = 0;
       int offset = 0;
 
       for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)

--- a/OpenCL/m34100-pure.cl
+++ b/OpenCL/m34100-pure.cl
@@ -10,7 +10,10 @@
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_hash_blake2b.cl)
 #include M2S(INCLUDE_PATH/inc_hash_argon2.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
 #include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#include M2S(INCLUDE_PATH/inc_hash_ripemd160.cl)
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
@@ -99,7 +102,7 @@ typedef struct luks_tmp
 
 #define MAX_ENTROPY 7.0
 
-KERNEL_FQ void m34100_init (_KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
+KERNEL_FQ void m34100_init (KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
 {
   const u64 gid = get_global_id (0);
 
@@ -125,7 +128,7 @@ KERNEL_FQ void m34100_init (_KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
   argon2_init (&pws[gid], &salt_bufs[SALT_POS_HOST], &options, argon2_block);
 }
 
-KERNEL_FQ void m34100_loop (_KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
+KERNEL_FQ void m34100_loop (KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
 {
   const u64 gid = get_global_id (0);
   const u64 bid = get_group_id (0);
@@ -162,8 +165,12 @@ KERNEL_FQ void m34100_loop (_KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
 
   argon2_options_t options = esalt_bufs[DIGESTS_OFFSET_HOST_BID].options;
 
+  #ifdef IS_APPLE
+  // it doesn't work on Apple, so we won't set it up
+  #else
   #ifdef ARGON2_PARALLELISM
   options.parallelism = ARGON2_PARALLELISM;
+  #endif
   #endif
 
   GLOBAL_AS argon2_block_t *argon2_block = get_argon2_block (&options, V, bd4);
@@ -192,7 +199,7 @@ KERNEL_FQ void m34100_loop (_KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
   }
 }
 
-KERNEL_FQ void m34100_comp (_KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
+KERNEL_FQ void m34100_comp (KERN_ATTR_TMPS_ESALT (luks_tmp_t, luks_t))
 {
   const u64 gid = get_global_id (0);
   const u64 lid = get_local_id (0);

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -145,7 +145,7 @@
 - Fixed bug in module_constraints and kernel for hash-mode 7800
 - Fixed bug in module_constraints and kernel for hash-mode 7801
 - Fixed bugs in 3090x kernels which produced false positives
-- Fixed bugs in 34100 kernel on Apple Silicon
+- Fixed bugs in 34100 kernel and inc_luks_aes.cl on Apple Silicon
 - Fixed build failed for 10700 optimized with Apple Metal
 - Fixed build failed for 13772 and 13773 with Apple Metal
 - Fixed build failed for 18400 with Apple Metal

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -145,7 +145,7 @@
 - Fixed bug in module_constraints and kernel for hash-mode 7800
 - Fixed bug in module_constraints and kernel for hash-mode 7801
 - Fixed bugs in 3090x kernels which produced false positives
-- Fixed bugs in 34100 kernels on Apple Silicon
+- Fixed bugs in 34100 kernel on Apple Silicon
 - Fixed build failed for 10700 optimized with Apple Metal
 - Fixed build failed for 13772 and 13773 with Apple Metal
 - Fixed build failed for 18400 with Apple Metal

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -145,6 +145,7 @@
 - Fixed bug in module_constraints and kernel for hash-mode 7800
 - Fixed bug in module_constraints and kernel for hash-mode 7801
 - Fixed bugs in 3090x kernels which produced false positives
+- Fixed bugs in 34100 kernels on Apple Silicon
 - Fixed build failed for 10700 optimized with Apple Metal
 - Fixed build failed for 13772 and 13773 with Apple Metal
 - Fixed build failed for 18400 with Apple Metal

--- a/src/modules/module_34100.c
+++ b/src/modules/module_34100.c
@@ -341,7 +341,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   options->type                = ARGON2_TYPE_ID;
   options->version             = ARGON2_VERSION_13;
   options->iterations          = iter;
-  options->parallelism         = par; 
+  options->parallelism         = par;
   options->memory_usage_in_kib = mem;
   options->segment_length      = MAX (2, (mem / (ARGON2_SYNC_POINTS * par)));
   options->lane_length         = options->segment_length * ARGON2_SYNC_POINTS;


### PR DESCRIPTION
PoC

```
hc_mtlCreateLibraryWithSource(): failed to create metal library, In file included from program_source:94:
[redacted]/OpenCL/inc_luks_aes.cl:2598:31: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
      for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
                       ~~~~~~ ^ ~~~~~~~~~~~~~~~~~
[redacted]/OpenCL/inc_luks_aes.cl:2631:31: warning: comparison of integers of different signs: 'int' and 'unsigned int' [-Wsign-compare]
      for (sector = 0; sector < SECTOR_PER_AF - 1; sector++, offset += OFFSET_PER_SECTOR)
                       ~~~~~~ ^ ~~~~~~~~~~~~~~~~~
```

```
program_source:104:19: error: use of undeclared identifier 'hc_gid'
  const u64 gid = get_global_id (0);
                  ^
[redacted]/OpenCL/inc_platform.h:82:21: note: expanded from macro 'get_global_id'
  ((dimindx) == 0 ? hc_gid.x :   \
                    ^
```

```
Undefined symbol(s) for architecture 'air64':
  '_Z14sha1_transformPKjS0_S0_S0_Pj', referenced from:
      _Z50luks_decrypt_sector_aes_cbc_plain128_mk_sha1_finalPU9MTLdeviceKjPjPKjjPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z44luks_decrypt_sector_aes_cbc_plain128_mk_sha1PU9MTLdeviceKjPjPKjjPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z50luks_decrypt_sector_aes_cbc_essiv128_mk_sha1_finalPU9MTLdeviceKjPjPKjS3_jPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z44luks_decrypt_sector_aes_cbc_essiv128_mk_sha1PU9MTLdeviceKjPjPKjS3_jPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z17AF_sha1_diffuse64Pj in program_object_0
      _Z17AF_sha1_diffuse32Pj in program_object_0
      _Z17AF_sha1_diffuse16Pj in program_object_0
  '_Z19ripemd160_transformPKjS0_S0_S0_Pj', referenced from:
      _Z55luks_decrypt_sector_aes_cbc_plain128_mk_ripemd160_finalPU9MTLdeviceKjPjPKjjPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z49luks_decrypt_sector_aes_cbc_plain128_mk_ripemd160PU9MTLdeviceKjPjPKjjPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z55luks_decrypt_sector_aes_cbc_essiv128_mk_ripemd160_finalPU9MTLdeviceKjPjPKjS3_jPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z49luks_decrypt_sector_aes_cbc_essiv128_mk_ripemd160PU9MTLdeviceKjPjPKjS3_jPU14MTLthreadgroupjS5_S5_S5_S5_S5_S5_S5_S5_S5_ in program_object_0
      _Z22AF_ripemd160_diffuse64Pj in program_object_0
      _Z22AF_ripemd160_diffuse32Pj in program_object_0
      _Z22AF_ripemd160_diffuse16Pj in program_object_0
  '_Z16sha512_transformPKjS0_S0_S0_S0_S0_S0_S0_Pm', referenced from:
      _Z19AF_sha512_diffuse64Pj in program_object_0
      _Z19AF_sha512_diffuse32Pj in program_object_0
      _Z19AF_sha512_diffuse16Pj in program_object_0
error: symbol(s) not found for target 'air64-apple-macosx15.5.0'

```