### PR TITLE
support docker runtime with cuda

### DIFF
--- a/BUILD_Docker.md
+++ b/BUILD_Docker.md
@@ -50,5 +50,7 @@ For AMD go here https://rocm.docs.amd.com/projects/install-on-linux/en/latest/ho
 
 
 ```bash
-docker run --rm --gpus=all -it hashcat-binaries hashcat --help
+docker build -f docker/BinaryPackage.ubuntu20 -t hashcat-binaries .
+docker run --rm --gpus=all -it hashcat-binaries bash
+root@docker:~/# ./hashcat.bin --help
 ```

--- a/BUILD_Docker.md
+++ b/BUILD_Docker.md
@@ -43,7 +43,7 @@ docker run --rm -it hashcat-binaries /bin/bash
 If you want to run hashcat with your gpus inside docker you first need to install the appropriate container runtime.
 For nvidia go here https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 
-(The runtime stage in the dockerfile will use an offical nvidia image, make sure your host has at least the same cuda version or a newer version installed.)
+(The runtime stage in the dockerfile will use an offical nvidia image, make sure your host has at least the same cuda version or a newer version installed. If you wanna change the runtime version of cuda just have a search here https://hub.docker.com/r/nvidia/cuda/tags?name=12.9.1 and exchange it in the dockfile)
 
 For AMD go here https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
 
@@ -54,3 +54,4 @@ docker build -f docker/BinaryPackage.ubuntu20 -t hashcat-binaries .
 docker run --rm --gpus=all -it hashcat-binaries bash
 root@docker:~/# ./hashcat.bin --help
 ```
+

--- a/BUILD_Docker.md
+++ b/BUILD_Docker.md
@@ -42,7 +42,9 @@ docker run --rm -it hashcat-binaries /bin/bash
 
 If you want to run hashcat with your gpus inside docker you first need to install the appropriate container runtime.
 For nvidia go here https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
 (The runtime stage in the dockerfile will use an offical nvidia image, make sure your host has at least the same cuda version or a newer version installed.)
+
 For AMD go here https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
 
 

--- a/BUILD_Docker.md
+++ b/BUILD_Docker.md
@@ -42,7 +42,9 @@ docker run --rm -it hashcat-binaries /bin/bash
 
 If you want to run hashcat with your gpus inside docker you first need to install the appropriate container runtime.
 For nvidia go here https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+(The runtime stage in the dockerfile will use an offical nvidia image, make sure your host has at least the same cuda version or a newer version installed.)
 For AMD go here https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
+
 
 
 ```bash

--- a/BUILD_Docker.md
+++ b/BUILD_Docker.md
@@ -38,3 +38,13 @@ In case you want to play around in the docker, run:
 docker run --rm -it hashcat-binaries /bin/bash
 ```
 
+### Runtime ###
+
+If you want to run hashcat with your gpus inside docker you first need to install the appropriate container runtime.
+For nvidia go here https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+For AMD go here https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
+
+
+```bash
+docker run --rm --gpus=all -it hashcat-binaries hashcat --help
+```

--- a/docker/BinaryPackage.ubuntu20
+++ b/docker/BinaryPackage.ubuntu20
@@ -101,4 +101,11 @@ RUN make -s binaries
 
 RUN tools/package_bin.sh
 
-RUN ["/bin/bash"]
+FROM nvidia/cuda:12.6.3-devel-ubuntu24.04 as runtime
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+COPY --from=builder /root/hashcat /root/hashcat
+
+WORKDIR /root/hashcat

--- a/docker/BinaryPackage.ubuntu20
+++ b/docker/BinaryPackage.ubuntu20
@@ -101,7 +101,7 @@ RUN make -s binaries
 
 RUN tools/package_bin.sh
 
-FROM nvidia/cuda:12.9.1-runtime-ubuntu22.04 as runtime
+FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04 as runtime
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility

--- a/docker/BinaryPackage.ubuntu20
+++ b/docker/BinaryPackage.ubuntu20
@@ -101,7 +101,7 @@ RUN make -s binaries
 
 RUN tools/package_bin.sh
 
-FROM nvidia/cuda:12.6.3-devel-ubuntu24.04 as runtime
+FROM nvidia/cuda:12.9.1-runtime-ubuntu22.04 as runtime
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility

--- a/docker/BinaryPackage.ubuntu20
+++ b/docker/BinaryPackage.ubuntu20
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Added a runtime stage into the dockerfile to allow running the binaries build in pervious stage on cuda systems with cuda newer then 12.6.3