### PR TITLE
Fix Commit 571dae3 on Apple

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3705,9 +3705,9 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
       if (device_info0->hwmon_dev)
       {
         #if defined(__APPLE__)
-        if (first_dev && strlen (device_info->hwmon_fan_dev) > 0)
+        if (first_dev && strlen (device_info0->hwmon_fan_dev) > 0)
         {
-          event_log_info (hashcat_ctx, "Hardware.Mon.SMC.: %s", device_info->hwmon_fan_dev);
+          event_log_info (hashcat_ctx, "Hardware.Mon.SMC.: %s", device_info0->hwmon_fan_dev);
           first_dev = false;
         }
         #endif


### PR DESCRIPTION
```
src/terminal.c:3708:34: error: use of undeclared identifier 'device_info'; did you mean 'device_info0'?
 3708 |         if (first_dev && strlen (device_info->hwmon_fan_dev) > 0)
      |                                  ^~~~~~~~~~~
      |                                  device_info0
src/terminal.c:3703:28: note: 'device_info0' declared here
 3703 |       const device_info_t *device_info0 = hashcat_status->device_info_buf + 0;
      |                            ^
src/terminal.c:3710:65: error: use of undeclared identifier 'device_info'; did you mean 'device_info0'?
 3710 |           event_log_info (hashcat_ctx, "Hardware.Mon.SMC.: %s", device_info->hwmon_fan_dev);
      |                                                                 ^~~~~~~~~~~
      |                                                                 device_info0
src/terminal.c:3703:28: note: 'device_info0' declared here
 3703 |       const device_info_t *device_info0 = hashcat_status->device_info_buf + 0;
      |                            ^
2 errors generated.
make: *** [obj/terminal.NATIVE.o] Error 1
make: *** Waiting for unfinished jobs....

```