### PR TITLE
Remove default -march=native and -march=avx2 flags

### DIFF
--- a/deps/yescrypt-master/Makefile
+++ b/deps/yescrypt-master/Makefile
@@ -21,8 +21,8 @@ LD = $(CC)
 RM = rm -f
 OMPFLAGS = -fopenmp
 OMPFLAGS_MAYBE = $(OMPFLAGS)
-#CFLAGS = -Wall -O2 -fomit-frame-pointer $(OMPFLAGS_MAYBE) -DSKIP_MEMZERO
-CFLAGS = -Wall -O2 -march=native -fomit-frame-pointer $(OMPFLAGS_MAYBE) -DSKIP_MEMZERO
+CFLAGS = -Wall -O2 -fomit-frame-pointer $(OMPFLAGS_MAYBE) -DSKIP_MEMZERO
+#CFLAGS = -Wall -O2 -march=native -fomit-frame-pointer $(OMPFLAGS_MAYBE) -DSKIP_MEMZERO
 #CFLAGS = -Wall -O2 -funroll-loops -fomit-frame-pointer $(OMPFLAGS_MAYBE) -DSKIP_MEMZERO
 #CFLAGS = -Wall -O2 -march=native -funroll-loops -fomit-frame-pointer $(OMPFLAGS_MAYBE) -DSKIP_MEMZERO
 # -lrt is for userom's use of clock_gettime()

--- a/src/bridges/bridge_argon2id_reference.mk
+++ b/src/bridges/bridge_argon2id_reference.mk
@@ -3,18 +3,6 @@ ARGON2_REFERENCE := deps/phc-winner-argon2-20190702
 ARGON2_REFERENCE_CFLAGS := -I$(ARGON2_REFERENCE)/_hashcat/
 
 ifeq ($(BUILD_MODE),cross)
-ARGON2_REFERENCE_CFLAGS += -mavx2
-else
-ifeq ($(UNAME),Darwin)
-ifeq ($(IS_APPLE_SILICON),0)
-ARGON2_REFERENCE_CFLAGS += -mavx2
-endif
-else
-ARGON2_REFERENCE_CFLAGS += -march=native
-endif
-endif
-
-ifeq ($(BUILD_MODE),cross)
 bridges/bridge_argon2id_reference.so:  src/bridges/bridge_argon2id_reference.c src/cpu_features.c obj/combined.LINUX.a
 	$(CC_LINUX) $(CCFLAGS) $(CFLAGS_CROSS_LINUX)  $^ -o $@ $(LFLAGS_CROSS_LINUX) -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(ARGON2_REFERENCE_CFLAGS)
 bridges/bridge_argon2id_reference.dll: src/bridges/bridge_argon2id_reference.c src/cpu_features.c obj/combined.WIN.a

--- a/src/bridges/bridge_scrypt_jane.mk
+++ b/src/bridges/bridge_scrypt_jane.mk
@@ -3,18 +3,6 @@ SCRYPT_JANE := deps/scrypt-jane-master
 SCRYPT_JANE_CFLAGS := -I$(SCRYPT_JANE)/ -DSCRYPT_SHA256 -DSCRYPT_SALSA -DSCRYPT_CHOOSE_COMPILETIME -Wno-unused-function -Wno-unused-but-set-variable
 
 ifeq ($(BUILD_MODE),cross)
-SCRYPT_JANE_CFLAGS += -mavx2
-else
-ifeq ($(UNAME),Darwin)
-ifeq ($(IS_APPLE_SILICON),0)
-SCRYPT_JANE_CFLAGS += -mavx2
-endif
-else
-SCRYPT_JANE_CFLAGS += -march=native
-endif
-endif
-
-ifeq ($(BUILD_MODE),cross)
 bridges/bridge_scrypt_jane.so:  src/bridges/bridge_scrypt_jane.c src/cpu_features.c obj/combined.LINUX.a
 	$(CC_LINUX) $(CCFLAGS) $(CFLAGS_CROSS_LINUX)  $^ -o $@ $(LFLAGS_CROSS_LINUX) -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(SCRYPT_JANE_CFLAGS)
 bridges/bridge_scrypt_jane.dll: src/bridges/bridge_scrypt_jane.c src/cpu_features.c obj/combined.WIN.a

--- a/src/bridges/bridge_scrypt_yescrypt.mk
+++ b/src/bridges/bridge_scrypt_yescrypt.mk
@@ -3,18 +3,6 @@ SCRYPT_YESCRYPT := deps/yescrypt-master
 SCRYPT_YESCRYPT_CFLAGS := -I$(SCRYPT_YESCRYPT)/ -DSKIP_MEMZERO -Wno-cpp -Wno-type-limits
 
 ifeq ($(BUILD_MODE),cross)
-SCRYPT_YESCRYPT_CFLAGS += -mavx2
-else
-ifeq ($(UNAME),Darwin)
-ifeq ($(IS_APPLE_SILICON),0)
-SCRYPT_YESCRYPT_CFLAGS += -mavx2
-endif
-else
-SCRYPT_YESCRYPT_CFLAGS += -march=native
-endif
-endif
-
-ifeq ($(BUILD_MODE),cross)
 bridges/bridge_scrypt_yescrypt.so:  src/bridges/bridge_scrypt_yescrypt.c src/cpu_features.c $(SCRYPT_YESCRYPT)/yescrypt-opt.c $(SCRYPT_YESCRYPT)/sha256.c obj/combined.LINUX.a
 	$(CC_LINUX) $(CCFLAGS) $(CFLAGS_CROSS_LINUX)  $^ -o $@ $(LFLAGS_CROSS_LINUX) -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(SCRYPT_YESCRYPT_CFLAGS)
 bridges/bridge_scrypt_yescrypt.dll: src/bridges/bridge_scrypt_yescrypt.c src/cpu_features.c $(SCRYPT_YESCRYPT)/yescrypt-opt.c $(SCRYPT_YESCRYPT)/sha256.c obj/combined.WIN.a


### PR DESCRIPTION
Compiling with flags like `-mavx*`, `-march=native`, or `/arch:AVX*` will make the resulting binary incompatible with cpus not supporting the requested instruction set.

This created problems for maintainers on various distributions.

And architecures like RISC-V don't support -march=native.

Anyone who needs the flags can feed them manually.