### PR TITLE
Shared: with get_free_memory() on Linux, get MemAvailable from /proc/meminfo instead of using sysinfo.freeram

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -28,6 +28,7 @@
 - Backend: Splitting backend_session_begin into smaller runtime-specific functions
 - Backend: Work around JiT compiler issue in AMD OpenCL on Windows in UTF8->UTF16 conversion
 - Backend: Switch AMD OpenCL path to generic fallback and add HIP device check for Windows
+- Shared: with get_free_memory() on Linux, get MemAvailable from /proc/meminfo instead of using sysinfo.freeram
 
 * changes v6.2.6 -> v7.0.0
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -1712,13 +1712,31 @@ bool get_free_memory (u64 *free_mem)
 
   #else
 
-  struct sysinfo info;
+  // get MemAvailable from /proc/meminfo instead of sysinfo.freeram
 
-  if (sysinfo (&info) != 0) return false;
+  FILE *fp = fopen("/proc/meminfo", "r");
 
-  *free_mem = (u64) info.freeram * info.mem_unit;
+  if (!fp) false;
 
-  return true;
+  char line[256] = { 0 };
+
+  u64 memAvailable_kb = 0;
+
+  while (fgets (line, sizeof (line), fp))
+  {
+    if (sscanf(line, "MemAvailable: %" SCNu64 " kB", &memAvailable_kb) == 1)
+    {
+      fclose(fp);
+
+      *free_mem = (memAvailable_kb * 1024);
+
+      return true;
+    }
+  }
+
+  fclose (fp);
+
+  return false;
 
   #endif
 }


### PR DESCRIPTION
Hi,

sysinfo.freeram returns a less meaningful value for the subsequent calculation, so we can try using MemAvailable from /proc/meminfo.

This change needs to be tested.

Thanks