### PR TITLE
--status-json formatting fix

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2943,7 +2943,7 @@ void status_display_status_json (hashcat_ctx_t *hashcat_ctx)
       printf (" \"fanspeed\": %d,", fanspeed);
       printf (" \"corespeed\": %d,", corespeed);
       printf (" \"memoryspeed\": %d,", memoryspeed);
-      printf (" \"buslanes\": %d }", buslanes);
+      printf (" \"buslanes\": %d,", buslanes);
       printf (" \"power\": %" PRId64 " }", power);
     }
   }


### PR DESCRIPTION
Closes #4393. 

Fixes JSON formatting breaking closing bracket when using `--status-json` flag