### PR TITLE
Python plugin: Fix struct unpack error when extract_salts() is called.

### DIFF
--- a/Python/generic_hash_mp.py
+++ b/Python/generic_hash_mp.py
@@ -48,9 +48,9 @@ def term(ctx):
 
 if __name__ == '__main__':
   ctx = {
-    "salts_buf": bytes(568),
+    "salts_buf": bytes(572),
     "esalts_buf": bytes(131080),
-    "st_salts_buf": bytes(568),
+    "st_salts_buf": bytes(572),
     "st_esalts_buf": bytes(131080),
     "parallelism": 4
   }

--- a/Python/generic_hash_sp.py
+++ b/Python/generic_hash_sp.py
@@ -48,9 +48,9 @@ def term(ctx):
 
 if __name__ == '__main__':
   ctx = {
-    "salts_buf": bytes(568),
+    "salts_buf": bytes(572),
     "esalts_buf": bytes(131080),
-    "st_salts_buf": bytes(568),
+    "st_salts_buf": bytes(572),
     "st_esalts_buf": bytes(131080),
     "parallelism": 1
   }


### PR DESCRIPTION
Running current `generic_hash_mp.py` and `generic_hash_sp.py` directly from Python as documented (with  `$python generic_hash_sp.py`) returns an error:
```struct.error: iterative unpacking requires a buffer of a multiple of 572 bytes```

Because the salt struct in `hcshared.py` expects 4 more bytes instead of the currently allocated 568 bytes due to the struct changes pushed in commit: https://github.com/hashcat/hashcat/commit/f8df94f4571d557e50ca3a25e5e62111df18dcf4 .

This PR fixes the struct unpack error when running the python example plugin as a standalone script. 

(Both `generic_hash` python example scripts still fail, but I am trying to open small separate PR's at a time)
