### PR TITLE
tools: add/update shebangs

### DIFF
--- a/tools/bisq2hashcat.py
+++ b/tools/bisq2hashcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This software is Copyright (c) 2017, Dhiru Kholia <dhiru.kholia at gmail.com>
 # and it is hereby released under GPL v2 license.

--- a/tools/bitlocker2hashcat.py
+++ b/tools/bitlocker2hashcat.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Construct a hash for use with hashcat mode 22100
 # Usage: python3 bitlocker2hashcat.py <bitlocker_image> -o <bitlocker_partition_offset>
 # Hashcat supports modes $bitlocker$0$ and $bitlocker$1$ and therefore this script will output hashes that relate to a VMK protected by a user password only.

--- a/tools/bitwarden2hashcat.py
+++ b/tools/bitwarden2hashcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Utility to extract Bitwarden hash for hashcat from Google Chrome / Firefox / Desktop local data"""
 
 #

--- a/tools/cryptoloop2hashcat.py
+++ b/tools/cryptoloop2hashcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Author: Gabriele 'matrix' Gristina

--- a/tools/gitea2hashcat.py
+++ b/tools/gitea2hashcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Converts gitea PBKDF2-HMAC-SHA256 hashes into a format hashcat can use
 # written by unix-ninja
 

--- a/tools/keybag2hashcat.py
+++ b/tools/keybag2hashcat.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import logging
 import sys

--- a/tools/metamask2hashcat.py
+++ b/tools/metamask2hashcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Author: Gabriele 'matrix' Gristina

--- a/tools/mozilla2hashcat.py
+++ b/tools/mozilla2hashcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Script to extract the "hash" from a password protected key3.db or key4.db file.
 #

--- a/tools/package_bin.sh
+++ b/tools/package_bin.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 ##
 ## Author......: See docs/credits.txt

--- a/tools/shiro1-to-hashcat.py
+++ b/tools/shiro1-to-hashcat.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import re
 import glob

--- a/tools/veeamvbk2hashcat.py
+++ b/tools/veeamvbk2hashcat.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import binascii
 

--- a/tools/vmwarevmx2hashcat.py
+++ b/tools/vmwarevmx2hashcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Based on "pyvmx-cracker" (https://github.com/axcheron/pyvmx-cracker) (MIT license)


### PR DESCRIPTION
Added and updates Python and Bash shebangs to use `#!/usr/bin/env python3` and `#!/usr/bin/env sh` respectively. These scripts are installed in `bin` directory if `make install` is used, even though they cannot be executed. Adding shebangs should fix this problem

Related to Homebrew/homebrew-core#232632