### PR TITLE
$HEX plains that end in whitespace

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -189,42 +189,41 @@ size_t exec_unhexify (const u8 *in_buf, const size_t in_len, u8 *out_buf, const 
 
 bool need_hexify (const u8 *buf, const size_t len, const char separator, bool always_ascii)
 {
-  bool rc = false;
-
   if (always_ascii == true)
   {
     if (printable_ascii (buf, len) == false)
     {
-      rc = true;
+      return true;
     }
   }
   else
   {
     if (printable_utf8 (buf, len) == false)
     {
-      rc = true;
+      return true;
     }
   }
 
-  if (rc == false)
+  if (matches_separator (buf, len, separator) == true)
   {
-    if (matches_separator (buf, len, separator) == true)
-    {
-      rc = true;
-    }
+    return true;
   }
 
   // also test if the password is of the format $HEX[]:
 
-  if (rc == false)
+  if (is_hexify (buf, len))
   {
-    if (is_hexify (buf, len))
-    {
-      rc = true;
-    }
+    return true;
   }
 
-  return rc;
+  // check if the password ends in whitespace
+
+  if (len > 0 && isspace(buf[len - 1]))
+  {
+    return true;
+  }
+
+  return false;
 }
 
 void exec_hexify (const u8 *buf, const size_t len, u8 *out)

--- a/src/convert.c
+++ b/src/convert.c
@@ -218,7 +218,7 @@ bool need_hexify (const u8 *buf, const size_t len, const char separator, bool al
 
   // check if the password ends in whitespace
 
-  if (len > 0 && isspace(buf[len - 1]))
+  if (len > 0 && isspace (buf[len - 1]))
   {
     return true;
   }


### PR DESCRIPTION
For a good while, there have been multiple conversations about this topic - "If a plain ends in a whitespace, should it be $HEXed for improved readability?" and there are people who agree and disagree, so feel free to reject this PR. At very least, it can be an archive of the decision made.

The pro is that it'd be possible to see in a terminal that a plain has a whitespace character at the end of it and would make seeing these whitespaces in text editors more obvious.

The con is that it increases the number of semi-annoying $HEX conversions Hashcat does, forcing the user to manually unhex the plain.

Old behaviour:
```
a631788bc60c8bfdcc4edef7a318d18c:penguin 
```

New behaviour:
```
a631788bc60c8bfdcc4edef7a318d18c:$HEX[70656e6775696e20]
```

Example command:
```
> echo "penguin " | ./hashcat -m 0 a631788bc60c8bfdcc4edef7a318d18c --potfile-disable --quiet
```

(Also cleans up some slightly unsightly code in the hex checking function)