### PR TITLE
add Crypt::Digest::RIPEMD320 and Crypt::Mode::CFB to our perl deps

### DIFF
--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -53,10 +53,12 @@ cpanm Authen::Passphrase::LANManager   \
       Crypt::DES_EDE3                  \
       Crypt::Digest::BLAKE2s_256       \
       Crypt::Digest::RIPEMD160         \
+      Crypt::Digest::RIPEMD320         \
       Crypt::Digest::Whirlpool         \
       Crypt::ECB                       \
       Crypt::Eksblowfish::Bcrypt       \
       Crypt::Mode::CBC                 \
+      Crypt::Mode::CFB                 \
       Crypt::Mode::ECB                 \
       Crypt::MySQL                     \
       Crypt::OpenSSH::ChachaPoly       \


### PR DESCRIPTION
I think it's best to list all the perl dependencies in `tools/install_modules.sh` even through it's true that some of them are dependencies of other perl modules that we already install, most importantly of `CryptX` which seems to just install almost every possible hashing/cipher etc related perl module: see https://metacpan.org/pod/CryptX

I'm also not sure if we really need to install `CryptX` directly, because we do not use it within any of our `tools/test_modules/*.pm` files directly (i.e. no "use CryptX" or use CryptX::..." within any test files).

I've found out it was first introduced here: 1cc8ed779eee1c7775d56ec35b28b85f33b23a90 but I'm not sure why we don't directly added "Crypt::Blowfish" and "Crypt::Mode::CFB" ... (yeah, I understand that by installing "Crypt::Mode::CFB" perl also indirectly installs some dependencies, like `CryptX`, but this way it's more explicit what WE NEED). Maybe @matrix knows why installing `Crypt::Mode::CFB` was not the prefered way of doing it (of course at the end it could end up being the same modules installed, but this way it is much more consistent, otherwise if we think of that installing `CryptX` is "everything we need" we could also remove literally most of the other modules within the list).

Should we leave `CryptX` or not ?

Thanks