### PR TITLE
-m 16501 test does not verify correctly

### DIFF
--- a/tools/test_modules/m16501.pm
+++ b/tools/test_modules/m16501.pm
@@ -34,17 +34,11 @@ sub module_verify_hash
   return unless defined $hash;
   return unless defined $word;
 
-  my @data = split (/--/, $hash);
+  my $index= rindex ($hash, "--");
 
-  return unless scalar @data == 2;
+  return unless $index > 0;
 
-  my ($padded_cookie, $signature) = @data;
-
-  my $unpadded_cookie = $padded_cookie =~ s/Z*$//;
-
-  my ($cookie_name, $cookie_value) = split('=', $unpadded_cookie);
-
-  my $salt = $cookie_name . "=" . $cookie_value;
+  my $salt = substr ($hash, 0, $index);
 
   my $word_packed = pack_if_HEX_notation ($word);
 


### PR DESCRIPTION
The problem with the "verify" for this test module is that it didn't accept (and correctly verify) the (example) hashes.

Remember that you can test the "verify" mode of the (or a new) perl test module by running:
`tools/test.pl verify 16501 hash.txt in.txt out.txt; cat out.txt`

where:
- hash.txt is the list of hashes
- in.txt is the list of cracks (hash:[salt:]pass)
- out.txt is the resulting output file where all the successfully tested cracks are written

With this commit I introduce this little change that makes the verify mode work with -m 16501.

CC: @stigtsp @jkramarz 


Thank you all so much!
