### PR TITLE
-m 30601 test does not verify correctly

### DIFF
--- a/tools/test_modules/m30601.pm
+++ b/tools/test_modules/m30601.pm
@@ -55,10 +55,15 @@ sub module_verify_hash
   my $hash = substr ($line, 0, $index1);
   my $word = substr ($line, $index1 + 1);
 
-  my $index2 = index ($hash, "=", 24);
-  my $index3 = index ($hash, "\$", 24);
+  my $index2 = index ($hash, "r=");
 
-  my $iter = substr ($hash, $index2, $index3 - $index2);
+  return unless $index2 >= 0;
+
+  my $index3 = index ($hash, "\$", $index2);
+
+  return unless $index3 >= 0;
+
+  my $iter = substr ($hash, $index2 + 2, $index3 - $index2 - 2);
 
   my $plain_base64 = substr ($hash, $index3 + 1, 22);
 


### PR DESCRIPTION
The problem with the "verify" for this test module is that it didn't accept (and correctly verify) the (example) hashes (especially the round, i.e. `r=`, field). 

Remember that you can test the "verify" mode of the (or a new) perl test module by running:
`tools/test.pl verify 30601 hash.txt in.txt out.txt; cat out.txt`

where:

- hash.txt is the list of hashes
- in.txt is the list of cracks (hash:[salt:]pass)
- out.txt is the resulting output file where all the successfully tested cracks are written

With this commit I introduce this little change that makes the verify mode work with -m 30601.

CC: @twier

Thank you all so much!