### PR TITLE
-m 34400 test does not verify correctly

### DIFF
--- a/tools/test_modules/m34400.pm
+++ b/tools/test_modules/m34400.pm
@@ -15,7 +15,6 @@ sub module_constraints { [[0, 256], [0, 0], [0, 55], [0, 0], [-1, -1]] }
 sub module_generate_hash
 {
   my $word = shift;
-  my $salt = shift;
 
   my $digest = sha224_hex (sha224_hex ($word));
 
@@ -28,15 +27,14 @@ sub module_verify_hash
 {
   my $line = shift;
 
-  my ($digest, $salt, $word) = split (':', $line);
+  my ($digest, $word) = split (':', $line);
 
   return unless defined $digest;
-  return unless defined $salt;
   return unless defined $word;
 
   my $word_packed = pack_if_HEX_notation ($word);
 
-  my $new_hash = module_generate_hash ($word_packed, $salt);
+  my $new_hash = module_generate_hash ($word_packed);
 
   return ($new_hash, $word);
 }


### PR DESCRIPTION
The problem with the "verify" for this test module is that it didn't accept (and correctly verify) the (example) hashes. The problem here is that we do **NOT** have any salts for -m 34400 = `sha224(sha224($pass))"`

Remember that you can test the "verify" mode of the (or a new) perl test module by running:
`tools/test.pl verify 34400 hash.txt in.txt out.txt; cat out.txt`

Thank you all so much!