### PR TITLE
 Improve: Automatically generate docs using Github actions 3; more robust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,8 +128,12 @@ jobs:
           git add docs/hashcat-example-hashes.md
           if ! git diff --staged --quiet; then
             if [ "$GITHUB_EVENT_NAME" = "push" ]; then
-              git commit -m "Automatically updated docs/hashcat-help.md or docs/hashcat-example-hashes.md (by Github Action)"
-              git push
+              if [ "$GITHUB_REF_NAME" = "master" ]; then
+                git commit -m "Automatically updated docs/hashcat-help.md or docs/hashcat-example-hashes.md (by Github Action)"
+                git push
+              else
+                echo "Not on master branch (currently: $GITHUB_REF_NAME): skipping commit because otherwise we may be in detached head"
+              fi
             else
               echo "docs/hashcat-help.md or docs/hashcat-example-hashes.md are not up-to-date:"
               echo "..."


### PR DESCRIPTION
Make sure to check we're on master such that we don't run into DETACHED head errors: 
`fatal: You are not currently on a branch.`
when for some reason a tag is fetched 
`+refs/tags/v7.1.0:refs/tags/v7.1.0`
https://github.com/hashcat/hashcat/actions/runs/17007344091/job/48218880950#step:8:45