### PR TITLE
Unit tests: Updated install_modules.sh to use an external module for Digest::MD6, due to maintenance being discontinued

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -2,6 +2,7 @@
 
 - Docker: Add initial support for AMD GPUs running hashcat inside Docker using HIP and/or OpenCL
 - Hardware-Monitor: Suppress fan speed warnings for unified memory (internal GPUs)
+- Unit tests: Updated install_modules.sh to use an external module for Digest::MD6, due to maintenance being discontinued
 
 * changes v7.0.0 -> v7.1.0
 

--- a/tools/install_modules.sh
+++ b/tools/install_modules.sh
@@ -80,7 +80,6 @@ cpanm Authen::Passphrase::LANManager   \
       Digest::Keccak                   \
       Digest::MD4                      \
       Digest::MD5                      \
-      Digest::MD6                      \
       Digest::MurmurHash3              \
       Digest::Perl::MD5                \
       Digest::SHA                      \
@@ -89,6 +88,7 @@ cpanm Authen::Passphrase::LANManager   \
       Digest::SipHash                  \
       Encode                           \
       JSON                             \
+      LWP::Simple                      \
       Math::BigInt                     \
       MIME::Base64                     \
       Module::Build                    \
@@ -107,6 +107,9 @@ cpanm https://github.com/matrix/digest-gost.git
 ERRORS=$((ERRORS+$?))
 
 cpanm https://github.com/matrix/perl-Crypt-OpenSSL-EC.git
+ERRORS=$((ERRORS+$?))
+
+cpanm https://github.com/matrix/Digest--MD6.git
 ERRORS=$((ERRORS+$?))
 
 # checks for pyenv
@@ -171,7 +174,7 @@ else
   pip3 install setuptools
   ERRORS=$((ERRORS+$?))
 
-  pip install argon2-cffi
+  pip3 install argon2-cffi
   ERRORS=$((ERRORS+$?))
 
 fi


### PR DESCRIPTION
fix #4430 