### PR TITLE
Argon2 bugfix: hashes with different p and m values

### DIFF
--- a/src/modules/argon2_common.c
+++ b/src/modules/argon2_common.c
@@ -34,7 +34,9 @@ u64 get_largest_memory_block_count (MAYBE_UNUSED const hashconfig_t *hashconfig,
 
   for (u32 i = 0; i < hashes->salts_cnt; i++)
   {
-    largest_memory_block_count = MAX (largest_memory_block_count, argon2_options[i].memory_block_count);
+    argon2_options = &merged_options[i].argon2_options;
+
+    largest_memory_block_count = MAX (largest_memory_block_count, argon2_options->memory_block_count);
   }
 
   return largest_memory_block_count;
@@ -156,9 +158,11 @@ char *argon2_module_jit_build_options (MAYBE_UNUSED const hashconfig_t *hashconf
 
   for (u32 i = 0; i < hashes->salts_cnt; i++)
   {
-    if (memory_block_count != argon2_options[i].memory_block_count) all_same_memory_block_count = false;
+    argon2_options = &merged_options[i].argon2_options;
 
-    if (parallelism != argon2_options[i].parallelism) all_same_parallelism = false;
+    if (memory_block_count != argon2_options->memory_block_count) all_same_memory_block_count = false;
+
+    if (parallelism != argon2_options->parallelism) all_same_parallelism = false;
   }
 
   if (all_same_memory_block_count == true)


### PR DESCRIPTION
Attacking 100 different hashes without the patch I get
```
Tuning-db: Invalid kernel_accel '0' in Line '1'
* Device #1: Not enough allocatable device memory for this hashlist/ruleset.
```

Without patch:
```
$ ./tools/test.sh -m 34300 -D1 -t all                                           
[ test_1755434887 ] > Init test for hash type 34300.
[ test_1755434887 ] [ Type 34300, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1755434887 ] [ Type 34300, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > Skip : 0/1 not found, 0/1 not matched, 0/1 timeout, 1/1 skipped
[ test_1755434887 ] [ Type 34300, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1755434887 ] [ Type 34300, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > Skip : 0/1 not found, 0/1 not matched, 0/1 timeout, 1/1 skipped
```
With patch:
```
$ ./tools/test.sh -m 34300 -D1 -t all
[ test_1755434268 ] > Init test for hash type 34300.  
[ test_1755434268 ] [ Type 34300, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1755434268 ] [ Type 34300, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1755434268 ] [ Type 34300, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1755434268 ] [ Type 34300, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
```