### PR TITLE
Add variation of dahua Auth working with Besder cameras

### DIFF
--- a/OpenCL/m24901_a0-optimized.cl
+++ b/OpenCL/m24901_a0-optimized.cl
@@ -310,14 +310,14 @@ KERNEL_FQ KERNEL_FA void m24901_s04 (KERN_ATTR_RULES ())
     c += make_u32x (MD5M_C);
     d += make_u32x (MD5M_D);
 
-    const u32x a0 = (((a >>  0) & 0xff) + ((a >>  8) & 0xff)) % 62;
-    const u32x a1 = (((a >> 16) & 0xff) + ((a >> 24) & 0xff)) % 62;
-    const u32x b0 = (((b >>  0) & 0xff) + ((b >>  8) & 0xff)) % 62;
-    const u32x b1 = (((b >> 16) & 0xff) + ((b >> 24) & 0xff)) % 62;
-    const u32x c0 = (((c >>  0) & 0xff) + ((c >>  8) & 0xff)) % 62;
-    const u32x c1 = (((c >> 16) & 0xff) + ((c >> 24) & 0xff)) % 62;
-    const u32x d0 = (((d >>  0) & 0xff) + ((d >>  8) & 0xff)) % 62;
-    const u32x d1 = (((d >> 16) & 0xff) + ((d >> 24) & 0xff)) % 62;
+    const u32x a0 = ((((a >>  0) & 0xff) + ((a >>  8) & 0xff)) & 0xff) % 62;
+    const u32x a1 = ((((a >> 16) & 0xff) + ((a >> 24) & 0xff)) & 0xff) % 62;
+    const u32x b0 = ((((b >>  0) & 0xff) + ((b >>  8) & 0xff)) & 0xff) % 62;
+    const u32x b1 = ((((b >> 16) & 0xff) + ((b >> 24) & 0xff)) & 0xff) % 62;
+    const u32x c0 = ((((c >>  0) & 0xff) + ((c >>  8) & 0xff)) & 0xff) % 62;
+    const u32x c1 = ((((c >> 16) & 0xff) + ((c >> 24) & 0xff)) & 0xff) % 62;
+    const u32x d0 = ((((d >>  0) & 0xff) + ((d >>  8) & 0xff)) & 0xff) % 62;
+    const u32x d1 = ((((d >> 16) & 0xff) + ((d >> 24) & 0xff)) & 0xff) % 62;
 
     const u32x ax = (a0 <<  0) | (a1 <<  8);
     const u32x bx = (b0 <<  0) | (b1 <<  8);

--- a/OpenCL/m24901_a0-optimized.cl
+++ b/OpenCL/m24901_a0-optimized.cl
@@ -1,0 +1,337 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.h)
+#include M2S(INCLUDE_PATH/inc_rp_optimized.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+KERNEL_FQ KERNEL_FA void m24901_m04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    w3[2] = out_len * 8;
+    w3[3] = 0;
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    const u32x a0 = ((((a >>  0) & 0xff) + ((a >>  8) & 0xff)) & 0xff) % 62;
+    const u32x a1 = ((((a >> 16) & 0xff) + ((a >> 24) & 0xff)) & 0xff) % 62;
+    const u32x b0 = ((((b >>  0) & 0xff) + ((b >>  8) & 0xff)) & 0xff) % 62;
+    const u32x b1 = ((((b >> 16) & 0xff) + ((b >> 24) & 0xff)) & 0xff) % 62;
+    const u32x c0 = ((((c >>  0) & 0xff) + ((c >>  8) & 0xff)) & 0xff) % 62;
+    const u32x c1 = ((((c >> 16) & 0xff) + ((c >> 24) & 0xff)) & 0xff) % 62;
+    const u32x d0 = ((((d >>  0) & 0xff) + ((d >>  8) & 0xff)) & 0xff) % 62;
+    const u32x d1 = ((((d >> 16) & 0xff) + ((d >> 24) & 0xff)) & 0xff) % 62;
+
+    const u32x ax = (a0 <<  0) | (a1 <<  8);
+    const u32x bx = (b0 <<  0) | (b1 <<  8);
+    const u32x cx = (c0 <<  0) | (c1 <<  8);
+    const u32x dx = (d0 <<  0) | (d1 <<  8);
+
+    COMPARE_M_SIMD (ax, bx, cx, dx);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m24901_m08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ KERNEL_FA void m24901_m16 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s04 (KERN_ATTR_RULES ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    u32x w0[4] = { 0 };
+    u32x w1[4] = { 0 };
+    u32x w2[4] = { 0 };
+    u32x w3[4] = { 0 };
+
+    const u32x out_len = apply_rules_vect_optimized (pw_buf0, pw_buf1, pw_len, rules_buf, il_pos, w0, w1);
+
+    append_0x80_2x4_VV (w0, w1, out_len);
+
+    w3[2] = out_len * 8;
+    w3[3] = 0;
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    const u32x a0 = (((a >>  0) & 0xff) + ((a >>  8) & 0xff)) % 62;
+    const u32x a1 = (((a >> 16) & 0xff) + ((a >> 24) & 0xff)) % 62;
+    const u32x b0 = (((b >>  0) & 0xff) + ((b >>  8) & 0xff)) % 62;
+    const u32x b1 = (((b >> 16) & 0xff) + ((b >> 24) & 0xff)) % 62;
+    const u32x c0 = (((c >>  0) & 0xff) + ((c >>  8) & 0xff)) % 62;
+    const u32x c1 = (((c >> 16) & 0xff) + ((c >> 24) & 0xff)) % 62;
+    const u32x d0 = (((d >>  0) & 0xff) + ((d >>  8) & 0xff)) % 62;
+    const u32x d1 = (((d >> 16) & 0xff) + ((d >> 24) & 0xff)) % 62;
+
+    const u32x ax = (a0 <<  0) | (a1 <<  8);
+    const u32x bx = (b0 <<  0) | (b1 <<  8);
+    const u32x cx = (c0 <<  0) | (c1 <<  8);
+    const u32x dx = (d0 <<  0) | (d1 <<  8);
+
+    COMPARE_S_SIMD (ax, bx, cx, dx);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s08 (KERN_ATTR_RULES ())
+{
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s16 (KERN_ATTR_RULES ())
+{
+}

--- a/OpenCL/m24901_a1-optimized.cl
+++ b/OpenCL/m24901_a1-optimized.cl
@@ -1,0 +1,454 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+KERNEL_FQ KERNEL_FA void m24901_m04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = pw_len * 8;
+    w3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    const u32x a0 = ((((a >>  0) & 0xff) + ((a >>  8) & 0xff)) & 0xff) % 62;
+    const u32x a1 = ((((a >> 16) & 0xff) + ((a >> 24) & 0xff)) & 0xff) % 62;
+    const u32x b0 = ((((b >>  0) & 0xff) + ((b >>  8) & 0xff)) & 0xff) % 62;
+    const u32x b1 = ((((b >> 16) & 0xff) + ((b >> 24) & 0xff)) & 0xff) % 62;
+    const u32x c0 = ((((c >>  0) & 0xff) + ((c >>  8) & 0xff)) & 0xff) % 62;
+    const u32x c1 = ((((c >> 16) & 0xff) + ((c >> 24) & 0xff)) & 0xff) % 62;
+    const u32x d0 = ((((d >>  0) & 0xff) + ((d >>  8) & 0xff)) & 0xff) % 62;
+    const u32x d1 = ((((d >> 16) & 0xff) + ((d >> 24) & 0xff)) & 0xff) % 62;
+
+    const u32x ax = (a0 <<  0) | (a1 <<  8);
+    const u32x bx = (b0 <<  0) | (b1 <<  8);
+    const u32x cx = (c0 <<  0) | (c1 <<  8);
+    const u32x dx = (d0 <<  0) | (d1 <<  8);
+
+    COMPARE_M_SIMD (ax, bx, cx, dx);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m24901_m08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ KERNEL_FA void m24901_m16 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 pw_buf0[4];
+  u32 pw_buf1[4];
+
+  pw_buf0[0] = pws[gid].i[0];
+  pw_buf0[1] = pws[gid].i[1];
+  pw_buf0[2] = pws[gid].i[2];
+  pw_buf0[3] = pws[gid].i[3];
+  pw_buf1[0] = pws[gid].i[4];
+  pw_buf1[1] = pws[gid].i[5];
+  pw_buf1[2] = pws[gid].i[6];
+  pw_buf1[3] = pws[gid].i[7];
+
+  const u32 pw_l_len = pws[gid].pw_len & 63;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x pw_r_len = pwlenx_create_combt (combs_buf, il_pos) & 63;
+
+    const u32x pw_len = (pw_l_len + pw_r_len) & 63;
+
+    /**
+     * concat password candidate
+     */
+
+    u32x wordl0[4] = { 0 };
+    u32x wordl1[4] = { 0 };
+    u32x wordl2[4] = { 0 };
+    u32x wordl3[4] = { 0 };
+
+    wordl0[0] = pw_buf0[0];
+    wordl0[1] = pw_buf0[1];
+    wordl0[2] = pw_buf0[2];
+    wordl0[3] = pw_buf0[3];
+    wordl1[0] = pw_buf1[0];
+    wordl1[1] = pw_buf1[1];
+    wordl1[2] = pw_buf1[2];
+    wordl1[3] = pw_buf1[3];
+
+    u32x wordr0[4] = { 0 };
+    u32x wordr1[4] = { 0 };
+    u32x wordr2[4] = { 0 };
+    u32x wordr3[4] = { 0 };
+
+    wordr0[0] = ix_create_combt (combs_buf, il_pos, 0);
+    wordr0[1] = ix_create_combt (combs_buf, il_pos, 1);
+    wordr0[2] = ix_create_combt (combs_buf, il_pos, 2);
+    wordr0[3] = ix_create_combt (combs_buf, il_pos, 3);
+    wordr1[0] = ix_create_combt (combs_buf, il_pos, 4);
+    wordr1[1] = ix_create_combt (combs_buf, il_pos, 5);
+    wordr1[2] = ix_create_combt (combs_buf, il_pos, 6);
+    wordr1[3] = ix_create_combt (combs_buf, il_pos, 7);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      switch_buffer_by_offset_le_VV (wordr0, wordr1, wordr2, wordr3, pw_l_len);
+    }
+    else
+    {
+      switch_buffer_by_offset_le_VV (wordl0, wordl1, wordl2, wordl3, pw_r_len);
+    }
+
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = wordl0[0] | wordr0[0];
+    w0[1] = wordl0[1] | wordr0[1];
+    w0[2] = wordl0[2] | wordr0[2];
+    w0[3] = wordl0[3] | wordr0[3];
+    w1[0] = wordl1[0] | wordr1[0];
+    w1[1] = wordl1[1] | wordr1[1];
+    w1[2] = wordl1[2] | wordr1[2];
+    w1[3] = wordl1[3] | wordr1[3];
+    w2[0] = wordl2[0] | wordr2[0];
+    w2[1] = wordl2[1] | wordr2[1];
+    w2[2] = wordl2[2] | wordr2[2];
+    w2[3] = wordl2[3] | wordr2[3];
+    w3[0] = wordl3[0] | wordr3[0];
+    w3[1] = wordl3[1] | wordr3[1];
+    w3[2] = pw_len * 8;
+    w3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, w0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, w3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, w3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, w3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, w3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, w0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, w3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, w0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, w1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, w3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, w1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, w2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, w3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, w3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, w0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, w0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, w1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, w2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, w0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, w2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    const u32x a0 = (((a >>  0) & 0xff) + ((a >>  8) & 0xff)) % 62;
+    const u32x a1 = (((a >> 16) & 0xff) + ((a >> 24) & 0xff)) % 62;
+    const u32x b0 = (((b >>  0) & 0xff) + ((b >>  8) & 0xff)) % 62;
+    const u32x b1 = (((b >> 16) & 0xff) + ((b >> 24) & 0xff)) % 62;
+    const u32x c0 = (((c >>  0) & 0xff) + ((c >>  8) & 0xff)) % 62;
+    const u32x c1 = (((c >> 16) & 0xff) + ((c >> 24) & 0xff)) % 62;
+    const u32x d0 = (((d >>  0) & 0xff) + ((d >>  8) & 0xff)) % 62;
+    const u32x d1 = (((d >> 16) & 0xff) + ((d >> 24) & 0xff)) % 62;
+
+    const u32x ax = (a0 <<  0) | (a1 <<  8);
+    const u32x bx = (b0 <<  0) | (b1 <<  8);
+    const u32x cx = (c0 <<  0) | (c1 <<  8);
+    const u32x dx = (d0 <<  0) | (d1 <<  8);
+
+    COMPARE_S_SIMD (ax, bx, cx, dx);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s08 (KERN_ATTR_BASIC ())
+{
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s16 (KERN_ATTR_BASIC ())
+{
+}

--- a/OpenCL/m24901_a1-optimized.cl
+++ b/OpenCL/m24901_a1-optimized.cl
@@ -427,14 +427,14 @@ KERNEL_FQ KERNEL_FA void m24901_s04 (KERN_ATTR_BASIC ())
     c += make_u32x (MD5M_C);
     d += make_u32x (MD5M_D);
 
-    const u32x a0 = (((a >>  0) & 0xff) + ((a >>  8) & 0xff)) % 62;
-    const u32x a1 = (((a >> 16) & 0xff) + ((a >> 24) & 0xff)) % 62;
-    const u32x b0 = (((b >>  0) & 0xff) + ((b >>  8) & 0xff)) % 62;
-    const u32x b1 = (((b >> 16) & 0xff) + ((b >> 24) & 0xff)) % 62;
-    const u32x c0 = (((c >>  0) & 0xff) + ((c >>  8) & 0xff)) % 62;
-    const u32x c1 = (((c >> 16) & 0xff) + ((c >> 24) & 0xff)) % 62;
-    const u32x d0 = (((d >>  0) & 0xff) + ((d >>  8) & 0xff)) % 62;
-    const u32x d1 = (((d >> 16) & 0xff) + ((d >> 24) & 0xff)) % 62;
+    const u32x a0 = ((((a >>  0) & 0xff) + ((a >>  8) & 0xff)) & 0xff) % 62;
+    const u32x a1 = ((((a >> 16) & 0xff) + ((a >> 24) & 0xff)) & 0xff) % 62;
+    const u32x b0 = ((((b >>  0) & 0xff) + ((b >>  8) & 0xff)) & 0xff) % 62;
+    const u32x b1 = ((((b >> 16) & 0xff) + ((b >> 24) & 0xff)) & 0xff) % 62;
+    const u32x c0 = ((((c >>  0) & 0xff) + ((c >>  8) & 0xff)) & 0xff) % 62;
+    const u32x c1 = ((((c >> 16) & 0xff) + ((c >> 24) & 0xff)) & 0xff) % 62;
+    const u32x d0 = ((((d >>  0) & 0xff) + ((d >>  8) & 0xff)) & 0xff) % 62;
+    const u32x d1 = ((((d >> 16) & 0xff) + ((d >> 24) & 0xff)) & 0xff) % 62;
 
     const u32x ax = (a0 <<  0) | (a1 <<  8);
     const u32x bx = (b0 <<  0) | (b1 <<  8);

--- a/OpenCL/m24901_a3-optimized.cl
+++ b/OpenCL/m24901_a3-optimized.cl
@@ -1,0 +1,605 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+DECLSPEC void m24901m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_BASIC ())
+{
+  /**
+   * modifiers are taken from args
+   */
+
+  /**
+   * loop
+   */
+
+  const u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x t0[4];
+    u32x t1[4];
+    u32x t2[4];
+    u32x t3[4];
+
+    t0[0] = w0lr;
+    t0[1] = w0[1];
+    t0[2] = w0[2];
+    t0[3] = w0[3];
+    t1[0] = w1[0];
+    t1[1] = w1[1];
+    t1[2] = w1[2];
+    t1[3] = w1[3];
+    t2[0] = w2[0];
+    t2[1] = w2[1];
+    t2[2] = w2[2];
+    t2[3] = w2[3];
+    t3[0] = w3[0];
+    t3[1] = w3[1];
+    t3[2] = pw_len * 8;
+    t3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, t0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, t0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, t1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, t0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    const u32x a0 = ((((a >>  0) & 0xff) + ((a >>  8) & 0xff)) & 0xff) % 62;
+    const u32x a1 = ((((a >> 16) & 0xff) + ((a >> 24) & 0xff)) & 0xff) % 62;
+    const u32x b0 = ((((b >>  0) & 0xff) + ((b >>  8) & 0xff)) & 0xff) % 62;
+    const u32x b1 = ((((b >> 16) & 0xff) + ((b >> 24) & 0xff)) & 0xff) % 62;
+    const u32x c0 = ((((c >>  0) & 0xff) + ((c >>  8) & 0xff)) & 0xff) % 62;
+    const u32x c1 = ((((c >> 16) & 0xff) + ((c >> 24) & 0xff)) & 0xff) % 62;
+    const u32x d0 = ((((d >>  0) & 0xff) + ((d >>  8) & 0xff)) & 0xff) % 62;
+    const u32x d1 = ((((d >> 16) & 0xff) + ((d >> 24) & 0xff)) & 0xff) % 62;
+
+    const u32x ax = (a0 <<  0) | (a1 <<  8);
+    const u32x bx = (b0 <<  0) | (b1 <<  8);
+    const u32x cx = (c0 <<  0) | (c1 <<  8);
+    const u32x dx = (d0 <<  0) | (d1 <<  8);
+
+    COMPARE_M_SIMD (ax, bx, cx, dx);
+  }
+}
+
+DECLSPEC void m24901s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_BASIC ())
+{
+  /**
+   * modifiers are taken from args
+   */
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3],
+  };
+
+  /**
+   * loop
+   */
+
+  const u32 w0l = w0[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = ix_create_bft (bfs_buf, il_pos);
+
+    const u32x w0lr = w0l | w0r;
+
+    u32x t0[4];
+    u32x t1[4];
+    u32x t2[4];
+    u32x t3[4];
+
+    t0[0] = w0lr;
+    t0[1] = w0[1];
+    t0[2] = w0[2];
+    t0[3] = w0[3];
+    t1[0] = w1[0];
+    t1[1] = w1[1];
+    t1[2] = w1[2];
+    t1[3] = w1[3];
+    t2[0] = w2[0];
+    t2[1] = w2[1];
+    t2[2] = w2[2];
+    t2[3] = w2[3];
+    t3[0] = w3[0];
+    t3[1] = w3[1];
+    t3[2] = pw_len * 8;
+    t3[3] = 0;
+
+    /**
+     * md5
+     */
+
+    u32x a = MD5M_A;
+    u32x b = MD5M_B;
+    u32x c = MD5M_C;
+    u32x d = MD5M_D;
+
+    MD5_STEP (MD5_Fo, a, b, c, d, t0[0], MD5C00, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t0[1], MD5C01, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t0[2], MD5C02, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t0[3], MD5C03, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t1[0], MD5C04, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t1[1], MD5C05, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t1[2], MD5C06, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t1[3], MD5C07, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t2[0], MD5C08, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t2[1], MD5C09, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t2[2], MD5C0a, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t2[3], MD5C0b, MD5S03);
+    MD5_STEP (MD5_Fo, a, b, c, d, t3[0], MD5C0c, MD5S00);
+    MD5_STEP (MD5_Fo, d, a, b, c, t3[1], MD5C0d, MD5S01);
+    MD5_STEP (MD5_Fo, c, d, a, b, t3[2], MD5C0e, MD5S02);
+    MD5_STEP (MD5_Fo, b, c, d, a, t3[3], MD5C0f, MD5S03);
+
+    MD5_STEP (MD5_Go, a, b, c, d, t0[1], MD5C10, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t1[2], MD5C11, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t2[3], MD5C12, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t0[0], MD5C13, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t1[1], MD5C14, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t2[2], MD5C15, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t3[3], MD5C16, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t1[0], MD5C17, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t2[1], MD5C18, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t3[2], MD5C19, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t0[3], MD5C1a, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t2[0], MD5C1b, MD5S13);
+    MD5_STEP (MD5_Go, a, b, c, d, t3[1], MD5C1c, MD5S10);
+    MD5_STEP (MD5_Go, d, a, b, c, t0[2], MD5C1d, MD5S11);
+    MD5_STEP (MD5_Go, c, d, a, b, t1[3], MD5C1e, MD5S12);
+    MD5_STEP (MD5_Go, b, c, d, a, t3[0], MD5C1f, MD5S13);
+
+    u32x t;
+
+    MD5_STEP (MD5_H1, a, b, c, d, t1[1], MD5C20, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t2[0], MD5C21, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t2[3], MD5C22, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t3[2], MD5C23, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t0[1], MD5C24, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t1[0], MD5C25, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t1[3], MD5C26, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t2[2], MD5C27, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t3[1], MD5C28, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t0[0], MD5C29, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t0[3], MD5C2a, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t1[2], MD5C2b, MD5S23);
+    MD5_STEP (MD5_H1, a, b, c, d, t2[1], MD5C2c, MD5S20);
+    MD5_STEP (MD5_H2, d, a, b, c, t3[0], MD5C2d, MD5S21);
+    MD5_STEP (MD5_H1, c, d, a, b, t3[3], MD5C2e, MD5S22);
+    MD5_STEP (MD5_H2, b, c, d, a, t0[2], MD5C2f, MD5S23);
+
+    MD5_STEP (MD5_I , a, b, c, d, t0[0], MD5C30, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t1[3], MD5C31, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t3[2], MD5C32, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t1[1], MD5C33, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t3[0], MD5C34, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t0[3], MD5C35, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t2[2], MD5C36, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t0[1], MD5C37, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t2[0], MD5C38, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t3[3], MD5C39, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t1[2], MD5C3a, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t3[1], MD5C3b, MD5S33);
+    MD5_STEP (MD5_I , a, b, c, d, t1[0], MD5C3c, MD5S30);
+    MD5_STEP (MD5_I , d, a, b, c, t2[3], MD5C3d, MD5S31);
+    MD5_STEP (MD5_I , c, d, a, b, t0[2], MD5C3e, MD5S32);
+    MD5_STEP (MD5_I , b, c, d, a, t2[1], MD5C3f, MD5S33);
+
+    a += make_u32x (MD5M_A);
+    b += make_u32x (MD5M_B);
+    c += make_u32x (MD5M_C);
+    d += make_u32x (MD5M_D);
+
+    const u32x a0 = ((((a >>  0) & 0xff) + ((a >>  8) & 0xff)) & 0xff) % 62;
+    const u32x a1 = ((((a >> 16) & 0xff) + ((a >> 24) & 0xff)) & 0xff) % 62;
+    const u32x b0 = ((((b >>  0) & 0xff) + ((b >>  8) & 0xff)) & 0xff) % 62;
+    const u32x b1 = ((((b >> 16) & 0xff) + ((b >> 24) & 0xff)) & 0xff) % 62;
+    const u32x c0 = ((((c >>  0) & 0xff) + ((c >>  8) & 0xff)) & 0xff) % 62;
+    const u32x c1 = ((((c >> 16) & 0xff) + ((c >> 24) & 0xff)) & 0xff) % 62;
+    const u32x d0 = ((((d >>  0) & 0xff) + ((d >>  8) & 0xff)) & 0xff) % 62;
+    const u32x d1 = ((((d >> 16) & 0xff) + ((d >> 24) & 0xff)) & 0xff) % 62;
+
+    const u32x ax = (a0 <<  0) | (a1 <<  8);
+    const u32x bx = (b0 <<  0) | (b1 <<  8);
+    const u32x cx = (c0 <<  0) | (c1 <<  8);
+    const u32x dx = (d0 <<  0) | (d1 <<  8);
+
+    COMPARE_S_SIMD (ax, bx, cx, dx);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m24901_m04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24901m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ KERNEL_FA void m24901_m08 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24901m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ KERNEL_FA void m24901_m16 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24901m (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s04 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24901s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s08 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+
+  u32 w3[4];
+
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24901s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}
+
+KERNEL_FQ KERNEL_FA void m24901_s16 (KERN_ATTR_BASIC ())
+{
+  /**
+   * base
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+  const u64 lsz = get_local_size (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 w0[4];
+
+  w0[0] = pws[gid].i[ 0];
+  w0[1] = pws[gid].i[ 1];
+  w0[2] = pws[gid].i[ 2];
+  w0[3] = pws[gid].i[ 3];
+
+  u32 w1[4];
+
+  w1[0] = pws[gid].i[ 4];
+  w1[1] = pws[gid].i[ 5];
+  w1[2] = pws[gid].i[ 6];
+  w1[3] = pws[gid].i[ 7];
+
+  u32 w2[4];
+
+  w2[0] = pws[gid].i[ 8];
+  w2[1] = pws[gid].i[ 9];
+  w2[2] = pws[gid].i[10];
+  w2[3] = pws[gid].i[11];
+
+  u32 w3[4];
+
+  w3[0] = pws[gid].i[12];
+  w3[1] = pws[gid].i[13];
+  w3[2] = 0;
+  w3[3] = 0;
+
+  const u32 pw_len = pws[gid].pw_len & 63;
+
+  /**
+   * main
+   */
+
+  m24901s (w0, w1, w2, w3, pw_len, pws, rules_buf, combs_buf, bfs_buf, tmps, hooks, bitmaps_buf_s1_a, bitmaps_buf_s1_b, bitmaps_buf_s1_c, bitmaps_buf_s1_d, bitmaps_buf_s2_a, bitmaps_buf_s2_b, bitmaps_buf_s2_c, bitmaps_buf_s2_d, plains_buf, digests_buf, hashes_shown, salt_bufs, esalt_bufs, d_return_buf, d_extra0_buf, d_extra1_buf, d_extra2_buf, d_extra3_buf, kernel_param, gid, lid, lsz);
+}

--- a/src/modules/module_24901.c
+++ b/src/modules/module_24901.c
@@ -1,0 +1,237 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_SERVER;
+static const char *HASH_NAME      = "Besder Authentication MD5";
+static const u64   KERN_TYPE      = 24901;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_NOT_SALTED
+                                  | OPTI_TYPE_RAW_HASH;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS14;
+static const u32   SALT_TYPE      = SALT_TYPE_NONE;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "GRmHbqVh";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+u32 dahua_decode (const u32 in)
+{
+  // chars used (alphabet):
+  // 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
+
+  if (            in < '0') return -1;
+  if (in > '9' && in < 'A') return -1;
+  if (in > 'Z' && in < 'a') return -1;
+  if (in > 'z'            ) return -1;
+
+  if (in >= 'a')
+  {
+    return (in - 61);
+  }
+  else if (in >= 'A')
+  {
+    return (in - 55);
+  }
+
+  return (in - 48);
+}
+
+u32 dahua_encode (const u32 in)
+{
+  if (in < 10)
+  {
+    return (in + 48);
+  }
+  else if (in < 36)
+  {
+    return (in + 55);
+  }
+  else
+  {
+    return (in + 61);
+  }
+
+  return -1;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 1;
+
+  token.len[0]     = 8;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *hash_pos = token.buf[0];
+
+  const u32 a0 = dahua_decode (hash_pos[0]);
+  const u32 a1 = dahua_decode (hash_pos[1]);
+  const u32 b0 = dahua_decode (hash_pos[2]);
+  const u32 b1 = dahua_decode (hash_pos[3]);
+  const u32 c0 = dahua_decode (hash_pos[4]);
+  const u32 c1 = dahua_decode (hash_pos[5]);
+  const u32 d0 = dahua_decode (hash_pos[6]);
+  const u32 d1 = dahua_decode (hash_pos[7]);
+
+  if (a0 == (u32) -1) return (PARSER_HASH_ENCODING);
+  if (a1 == (u32) -1) return (PARSER_HASH_ENCODING);
+  if (b0 == (u32) -1) return (PARSER_HASH_ENCODING);
+  if (b1 == (u32) -1) return (PARSER_HASH_ENCODING);
+  if (c0 == (u32) -1) return (PARSER_HASH_ENCODING);
+  if (c1 == (u32) -1) return (PARSER_HASH_ENCODING);
+  if (d0 == (u32) -1) return (PARSER_HASH_ENCODING);
+  if (d1 == (u32) -1) return (PARSER_HASH_ENCODING);
+
+  digest[0] = (a0 << 0) | (a1 << 8);
+  digest[1] = (b0 << 0) | (b1 << 8);
+  digest[2] = (c0 << 0) | (c1 << 8);
+  digest[3] = (d0 << 0) | (d1 << 8);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  out_buf[0] = (u8) dahua_encode ((digest[0] >> 0) & 0xff);
+  out_buf[1] = (u8) dahua_encode ((digest[0] >> 8) & 0xff);
+  out_buf[2] = (u8) dahua_encode ((digest[1] >> 0) & 0xff);
+  out_buf[3] = (u8) dahua_encode ((digest[1] >> 8) & 0xff);
+  out_buf[4] = (u8) dahua_encode ((digest[2] >> 0) & 0xff);
+  out_buf[5] = (u8) dahua_encode ((digest[2] >> 8) & 0xff);
+  out_buf[6] = (u8) dahua_encode ((digest[3] >> 0) & 0xff);
+  out_buf[7] = (u8) dahua_encode ((digest[3] >> 8) & 0xff);
+
+  const int out_len = 8;
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}
+
+


### PR DESCRIPTION
Module 24900, (dahua web Auth) has one minor difference to password hashing used by Besder cameras, module24901 works correctly with besder cameras that use xmeye sdk

Tested by discovering that firmware dump hash tzC42FmD:n51R6o[p
m24000 gives "({ZlIgk" for the same hash (first hit)
