### PR TITLE
Update module markings

### DIFF
--- a/src/modules/module_14200.c
+++ b/src/modules/module_14200.c
@@ -21,7 +21,8 @@ static const u32   HASH_CATEGORY  = HASH_CATEGORY_OS;
 static const char *HASH_NAME      = "RACF KDFAES";
 static const u64   KERN_TYPE      = 14200;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
-static const u64   OPTS_TYPE      = OPTS_TYPE_ST_UPPER
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_ST_UPPER
                                   | OPTS_TYPE_HASH_COPY
                                   | OPTS_TYPE_NATIVE_THREADS
                                   | OPTS_TYPE_INIT2

--- a/src/modules/module_31200.c
+++ b/src/modules/module_31200.c
@@ -21,7 +21,8 @@ static const char *HASH_NAME      = "Veeam VBK";
 static const u64   KERN_TYPE      = 31200;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
-static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "$vbk$*54731702769149752741495960625996207399688284541933702394775960978730695504382155223405444342855920150089170058956647576461877712*10000*78cf7df8f1ed8bb50bda1129ec8e6810";

--- a/src/modules/module_31500.c
+++ b/src/modules/module_31500.c
@@ -21,7 +21,8 @@ static const char *HASH_NAME      = "Domain Cached Credentials (DCC), MS Cache (
 static const u64   KERN_TYPE      = 31500;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_NOT_ITERATED;
-static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
                                   | OPTS_TYPE_PT_ADD80
                                   | OPTS_TYPE_PT_ADDBITS14
                                   | OPTS_TYPE_PT_UTF16LE


### PR DESCRIPTION
Some official modules self-identify as custom modules due to a lack of `OPTS_TYPE_STOCK_MODULE`:
```
$ grep -L "OPTS_TYPE_STOCK_MODULE" src/modules/module_*
src/modules/module_14200.c
src/modules/module_31200.c
src/modules/module_31500.c
```

Previous:
```
> ./hashcat -m 14200 --hash-info
Custom.Plugin.......: Yes
```
Fixed:
```
$ ./hashcat.exe -m 14200 --hash-info
...
Custom.Plugin.......: No
```
