### PR TITLE
Fix argon2 blake bug

### DIFF
--- a/OpenCL/inc_hash_argon2.cl
+++ b/OpenCL/inc_hash_argon2.cl
@@ -80,7 +80,7 @@ DECLSPEC void blake2b_update_8 (PRIVATE_AS blake2b_ctx_t *ctx, const u32 w0, con
     {
       blake2b_transform (ctx->h, ctx->m, ctx->len, BLAKE2B_UPDATE);
 
-	  for (u32 i = 0; i < 16; i++) ctx->m[i] = 0;
+      for (u32 i = 0; i < 16; i++) ctx->m[i] = 0;
     }
   }
 

--- a/OpenCL/inc_hash_argon2.cl
+++ b/OpenCL/inc_hash_argon2.cl
@@ -79,6 +79,8 @@ DECLSPEC void blake2b_update_8 (PRIVATE_AS blake2b_ctx_t *ctx, const u32 w0, con
     if (ctx->len > 0) // if new block (pos == 0) AND the (old) len is not zero => transform
     {
       blake2b_transform (ctx->h, ctx->m, ctx->len, BLAKE2B_UPDATE);
+
+	  for (u32 i = 0; i < 16; i++) ctx->m[i] = 0;
     }
   }
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -20,6 +20,7 @@
 ##
 
 - Argon2 Libraries: Fix call to vector datatype helper function using scalar datatype buffers
+- Fixed bug in Argon2 for passwords of a certain (longer) length
 
 * changes v7.1.0 -> v7.1.1
 


### PR DESCRIPTION
Thanks to unit tests created by thatux for LUKS2, a bug was discovered for passwords of a certain minimum length AND modulo 8.

This is caused by a failure to zero the internal blake2b buffer when it is exactly full (128 bytes). This would happen when the combined length of salt and password is exactly 96, or longer and also modulo 8.

Kind regards,
 
Pelle & Ewald