### PR TITLE
LUKS2 tests: generating test-containers on-the-fly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ obj/*.o
 obj/*.a
 include/CL
 tools/luks_tests
+tools/luks2_tests
 .vscode
 test_edge*
 Rust/generic_hash/target

--- a/src/Makefile
+++ b/src/Makefile
@@ -569,6 +569,7 @@ distclean: clean
 	$(RM) -f brain.*
 	$(RM) -rf test_[0-9]*
 	$(RM) -rf tools/luks_tests
+	$(RM) -rf tools/luks2_tests
 
 ##
 ## Targets: Linux install

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,4 +1,4 @@
-## test.sh usage
+# test.sh usage
 
 Hashcat's unit tests: full background in [docs/hashcat-plugin-development-guide.md](docs/hashcat-plugin-development-guide.md).
 Small summary on how to use:
@@ -24,7 +24,7 @@ sudo apt install cryptsetup #LUKS2 testing
 ```
 
 
-# Example usage
+### Example usage
 ```
 ./test.sh -m 0 -D1 -t all
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -30,6 +30,6 @@ sudo apt install cryptsetup
 
 ### Example usage
 ```
-./test.sh -m 0 -D1 -t all
+./test.sh -m 0 -t all
 ```
 All options: `./test.sh --help`

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,20 +5,24 @@ Small summary on how to use:
 
 ### Install pre-requisites
 ```
-sudo apt update
-sudo apt install cspanm
-
-# allow local installation of perl modules (such that we don't need root)
+# Allow local installation of perl modules (such that we don't need root)
+#  https://gwcbi.github.io/HPC/perl.html
 cd $HOME
 mkdir .perl
+wget -O- http://cpanmin.us | perl - -l $HOME/.perl5 App::cpanminus local::lib
+eval $(perl -I $HOME/.perl5/lib/perl5 -Mlocal::lib=$HOME/.perl5)
+echo 'eval $(perl -I $HOME/.perl5/lib/perl5 -Mlocal::lib=$HOME/.perl5)' >> .bashrc
+echo 'export MANPATH=$HOME/.perl5/man:$MANPATH' >> .bashrc
 
+# Install pyenv
+#  https://github.com/pyenv/pyenv
 curl https://pyenv.run | bash
 pyenv install $(pyenv install --list | grep -E "^\s*3\.[0-9]+\.[0-9]$" | tail -n 1)
 pyenv local $(pyenv install --list | grep -E "^\s*3\.[0-9]+\.[0-9]$" | tail -n 1)
 pip install --upgrade pip'
-# Check out https://github.com/pyenv/pyenv in order how to install pyenv.
 
-sudo apt install cryptsetup #LUKS2 testing
+# Enable LUKS2 on-the-fly crypto-container generation
+sudo apt install cryptsetup 
 
 ./install_modules.sh
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -22,7 +22,7 @@ pyenv local $(pyenv install --list | grep -E "^\s*3\.[0-9]+\.[0-9]$" | tail -n 1
 pip install --upgrade pip'
 
 # Enable LUKS2 on-the-fly crypto-container generation
-sudo apt install cryptsetup 
+sudo apt install cryptsetup
 
 ./install_modules.sh
 ```

--- a/tools/index.md
+++ b/tools/index.md
@@ -1,0 +1,31 @@
+## test.sh usage
+
+Hashcat's unit tests: full background in [docs/hashcat-plugin-development-guide.md](docs/hashcat-plugin-development-guide.md).
+Small summary on how to use:
+
+### Install pre-requisites
+```
+sudo apt update
+sudo apt install cspanm
+
+# allow local installation of perl modules (such that we don't need root)
+cd $HOME
+mkdir .perl
+
+curl https://pyenv.run | bash
+pyenv install $(pyenv install --list | grep -E "^\s*3\.[0-9]+\.[0-9]$" | tail -n 1)
+pyenv local $(pyenv install --list | grep -E "^\s*3\.[0-9]+\.[0-9]$" | tail -n 1)
+pip install --upgrade pip'
+# Check out https://github.com/pyenv/pyenv in order how to install pyenv.
+
+sudo apt install cryptsetup #LUKS2 testing
+
+./install_modules.sh
+```
+
+
+# Example usage
+```
+./test.sh -m 0 -D1 -t all
+```
+All options: `./test.sh --help`

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -4160,11 +4160,6 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
     if [ "${HT}" -eq 65535 ]; then
       for TMP_HT in ${HASH_TYPES}; do
 
-        if is_in_array "${TMP_HT}" ${GENERATE_CONTAINERS_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
-          echo "Skipping ${TMP_HT}: missing -g flag"
-          continue
-        fi
-
         if ! is_in_array "${TMP_HT}" ${LUKS_MODES}; then
           if ! ( is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] ); then
             if ! is_in_array "${TMP_HT}" ${TC_MODES}; then
@@ -4176,17 +4171,13 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
             fi
           fi
         fi
+
       done
     else
       for TMP_HT in $(seq "${HT_MIN}" "${HT_MAX}"); do
         if ! is_in_array "${TMP_HT}" ${HASH_TYPES}; then
           continue
         fi
-
-        # if is_in_array "${TMP_HT}" ${GENERATE_CONTAINERS_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
-        #   echo "Skipping ${TMP_HT}: missing -g flag"
-        #   continue
-        # fi
 
         if ! is_in_array "${TMP_HT}" ${LUKS_MODES}; then
           if ! ( is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] ); then

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -18,9 +18,6 @@ TC_MODES="6211 6212 6213 6221 6222 6223 6231 6232 6233 6241 6242 6243 29311 2931
 # List of VeraCrypt modes which have test containers
 VC_MODES="13711 13712 13713 13721 13722 13723 13731 13732 13733 13741 13742 13743 13751 13752 13753 13761 13762 13763 13771 13772 13773 13781 13782 13783 29411 29412 29413 29421 29422 29423 29431 29432 29433 29441 29442 29443 29451 29452 29453 29461 29462 29463 29471 29472 29473 29481 29482 29483"
 
-# List of modes that generate crypto-containers on the fly (only enabled with -g)
-GENERATE_CONTAINERS_MODES="34100"
-
 # List of modes which return a different output hash format than the input hash format
 NOCHECK_ENCODING="16800 22000"
 
@@ -198,7 +195,7 @@ function init()
   fi
 
   #LUKS1
-  if is_in_array "$hash_type" "${LUKS_MODES[@]}"; then
+  if is_in_array "$hash_type" ${LUKS_MODES}; then
     luks_tests_folder="${TDIR}/luks_tests/"
 
     if [ ! -d "${luks_tests_folder}" ]; then
@@ -259,7 +256,7 @@ function init()
 
 
   #LUKS2
-  if is_in_array "$hash_type" "${LUKS2_MODES[@]}" && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
+  if is_in_array "$hash_type" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
     luks2_tests_folder="${TDIR}/luks2_tests/"
 
     if [ ! -d "${luks2_tests_folder}" ]; then
@@ -4144,7 +4141,6 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
     else
       echo "We'll need sudo to generate crypto-containers on-the-fly"
     fi
-    # fi
   fi
 
   if [ -z "${PACKAGE_FOLDER}" ]; then
@@ -4177,7 +4173,6 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
 
         if ! is_in_array "${TMP_HT}" ${LUKS_MODES}; then
           if ! ( is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] ); then
-            # Exclude TrueCrypt and VeraCrypt testing modes
             if ! is_in_array "${TMP_HT}" ${TC_MODES}; then
               if ! is_in_array "${TMP_HT}" ${VC_MODES}; then
                 if ! is_in_array "${TMP_HT}" ${CL_MODES}; then

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -269,10 +269,8 @@ function init()
     luks2_first_test_file="${luks2_tests_folder}/luks2-aes-argon2id-t4-m16-p1-size20MiB.img"
 
     if [ ! -f "${luks2_first_test_file}" ]; then
-      # luks2_tests="hashcat_luks2_testfiles.7z"
-      # luks2_tests_url="https://hashcat.net/misc/example_hashes/${luks2_tests}"
       luks2_tests="luks2_tests.7z"
-      luks2_tests_url="https://github.com/thatux/hashcat/raw/refs/heads/luks2_test_clean/tools/${luks2_tests}"
+      luks2_tests_url="https://hashcat.net/misc/example_hashes/${luks2_tests}"
 
       cd "${TDIR}" || exit
 

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -27,11 +27,14 @@ NOCHECK_ENCODING="16800 22000"
 # List of LUKS modes which have test containers
 LUKS_MODES="14600 29511 29512 29513 29521 29522 29523 29531 29532 29533 29541 29542 29543"
 
+# List of LUKS2 modes which have test containers
+LUKS2_MODES="34100"
+
 # Cryptoloop mode which have test containers
 CL_MODES="14511 14512 14513 14521 14522 14523 14531 14532 14533 14541 14542 14543 14551 14552 14553"
 
 HASH_TYPES=$(ls "${TDIR}"/test_modules/*.pm | sed -E 's/.*m0*([0-9]+).pm/\1/')
-HASH_TYPES="${HASH_TYPES} ${TC_MODES} ${VC_MODES} ${LUKS_MODES} ${CL_MODES}"
+HASH_TYPES="${HASH_TYPES} ${TC_MODES} ${VC_MODES} ${LUKS_MODES} ${LUKS2_MODES} ${CL_MODES}"
 HASH_TYPES=$(echo -n "${HASH_TYPES}" | tr ' ' '\n' | sort -u -n | tr '\n' ' ')
 
 VECTOR_WIDTHS="1 2 4 8 16"
@@ -186,13 +189,16 @@ function init()
     return 0
   fi
 
-  if is_in_array "${hash_type}" ${LUKS_MODES}; then
+  if is_in_array "$hash_type" "${LUKS_MODES[@]}" || { is_in_array "$hash_type" "${LUKS2_MODES[@]}" && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] }; then
     which 7z &>/dev/null
     if [ $? -eq 1 ]; then
       echo "ATTENTION: 7z is missing. Skipping download and extract luks test files."
       return 0
     fi
+  fi
 
+  #LUKS1
+  if is_in_array "$hash_type" "${LUKS_MODES[@]}"; then
     luks_tests_folder="${TDIR}/luks_tests/"
 
     if [ ! -d "${luks_tests_folder}" ]; then
@@ -251,6 +257,69 @@ function init()
     return 0
   fi
 
+
+  #LUKS2
+  if is_in_array "$hash_type" "${LUKS2_MODES[@]}" && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
+    luks2_tests_folder="${TDIR}/luks2_tests/"
+
+    if [ ! -d "${luks2_tests_folder}" ]; then
+      mkdir -p "${luks2_tests_folder}"
+    fi
+
+    luks2_first_test_file="${luks2_tests_folder}/luks2-aes-argon2id-t4-m16-p1-size20MiB.img"
+
+    if [ ! -f "${luks2_first_test_file}" ]; then
+      # luks2_tests="hashcat_luks2_testfiles.7z"
+      # luks2_tests_url="https://hashcat.net/misc/example_hashes/${luks2_tests}"
+      luks2_tests="luks2_tests.7z"
+      luks2_tests_url="https://github.com/thatux/hashcat/raw/refs/heads/luks2_test_clean/tools/${luks2_tests}"
+
+      cd "${TDIR}" || exit
+
+      # if the file already exists, but was not successfully extracted, we assume it's a broken
+      # downloaded file and therefore it should be deleted
+
+      if [ -f "${luks2_tests}" ]; then
+        rm -f "${luks2_tests}"
+      fi
+
+      echo ""
+      echo "ATTENTION: the luks2 test files (for -m ${hash_type}) are currently missing on your system."
+      echo "They will be fetched from ${luks2_tests_url}"
+      echo "Note: this needs to be done only once and could take a little bit to download/extract."
+      echo "These luks2 test files are not shipped directly with hashcat because the file sizes are"
+      echo "particularly large and therefore a bandwidth burner for users who do not run these tests."
+      echo ""
+
+      # download:
+      wget -q "${luks2_tests_url}"
+
+      if [ $? -ne 0 ] || [ ! -f "${luks2_tests}" ]; then
+        cd - >/dev/null
+        echo "ERROR: Could not fetch the luks2 test files from this url: ${luks2_tests_url}"
+        return 0
+      fi
+
+      # extract:
+
+      ${EXTRACT_CMD} "${luks2_tests}" &>/dev/null
+
+      # cleanup:
+
+      rm -f "${luks2_tests}"
+      cd - >/dev/null || exit
+
+      # just to be very sure, check again that (one of) the files now exist:
+
+      if [ ! -f "${luks2_first_test_file}" ]; then
+        echo "ERROR: downloading and extracting ${luks2_tests} into ${luks2_tests_folder} did not complete successfully"
+        return 0
+      fi
+    fi
+
+    return 0 #which means this has been a success, we don't want to execute the remainder of this function
+  fi
+
   # create list of password and hashes of same type
   cmd_file=${OUTD}/${hash_type}.sh
 
@@ -261,6 +330,7 @@ function init()
   sed 's/^echo *|/echo "" |/' "${cmd_file}" | awk '{t="";for(i=10;i<=NF;i++){if(t){t=t" "$i}else{t=$i}};print t}' | cut -d"'" -f2 > "${OUTD}/${hash_type}_hashes.txt"
 
   if [ "${hash_type}" -eq 34100 ]; then
+    # 34100 LUKS2 dynamically generates filenames, we need to cat those to get the hashes
     mv "${OUTD}/${hash_type}_hashes.txt" "${OUTD}/${hash_type}_hashes.tmp"
     cat "${OUTD}/${hash_type}_hashes.tmp" | while read f; do cat $f; done > "${OUTD}/${hash_type}_hashes.txt"
     rm "${OUTD}/${hash_type}_hashes.tmp"
@@ -3617,6 +3687,121 @@ function luks_legacy_test()
   done
 }
 
+
+
+function luks2_test()
+{
+  local LUKS2_PASSWORD=$(cat "${TDIR}/luks2_tests/pw" 2>/dev/null)
+
+  hashType=$1
+  attackType=$2
+
+  # if -m all was set let us default to -a 3 only. You could specify the attack type directly, e.g. -m 0
+  # the problem with defaulting to all=0,1,3,6,7 is that it could take way too long
+
+  if [ "${attackType}" -eq 65535 ]; then
+    attackType=3
+  fi
+
+  chmod u+x "${TDIR}/luks2hashcat.py"
+
+  mkdir -p "${OUTD}/luks2_tests"
+  cp -r "${TDIR}/luks2_tests/." "${OUTD}/luks2_tests"
+
+  for luks2File in $(ls ${OUTD}/luks2_tests | grep "img$"); do #| grep ${hashType}
+    luksMainMask="?l"
+    luksMask="${luksMainMask}"
+
+    # for combination or hybrid attacks
+    luksPassPartFile1="${OUTD}/${hashType}_dict1"
+    luksPassPartFile2="${OUTD}/${hashType}_dict2"
+
+    luksContainer="${TDIR}/luks2_tests/${luks2File}"
+    luksHashFile="${OUTD}/luks2_tests/${luks2File}.hash"
+
+    case $attackType in
+      0)
+        CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luksHashFile}' '${TDIR}/luks2_tests/pw'"
+        ;;
+      1)
+        luksPassPart1Len=$((${#LUKS2_PASSWORD} / 2))
+        luksPassPart2Start=$((luksPassPart1Len + 1))
+
+        echo "${LUKS2_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
+        echo "${LUKS2_PASSWORD}" | cut -c${luksPassPart2Start}- > "${luksPassPartFile2}" 2>/dev/null
+
+        CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksPassPartFile2}"
+        ;;
+      3)
+        luksMaskFixedLen=$((${#LUKS2_PASSWORD} - 1))
+
+        luksMask="$(echo "${LUKS2_PASSWORD}" | cut -c-${luksMaskFixedLen} 2>/dev/null)"
+        luksMask="${luksMask}${luksMainMask}"
+
+        CMD="./${BIN} ${OPTS} -a 3 -m ${hashType} '${luksHashFile}' ${luksMask}"
+        ;;
+      6)
+        luksPassPart1Len=$((${#LUKS2_PASSWORD} - 1))
+
+        echo "${LUKS2_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
+
+        CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksMask}"
+        ;;
+      7)
+        echo "${LUKS2_PASSWORD}" | cut -c2- > "${luksPassPartFile1}" 2>/dev/null
+
+        CMD="./${BIN} ${OPTS} -a 7 -m ${hashType} '${luksHashFile}' ${luksMask} ${luksPassPartFile1}"
+        ;;
+    esac
+
+    eval \"${TDIR}/luks2hashcat.py\" \"${luksContainer}\" > "${luksHashFile}"
+
+    # luksMode="${luksHash}-${luksCipher}-${luksMode}-${luksKeySize}"
+    luksMode="$(basename "$luksContainer" .img)"
+
+    if [ -n "${CMD}" ] && [ ${#CMD} -gt 5 ]; then
+      echo "> Testing hash type ${hashType} with attack mode ${attackType}, markov ${MARKOV}, single hash, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, LUKS2-mode ${luksMode}" >> "${OUTD}/logfull.txt" 2>> "${OUTD}/logfull.txt"
+
+      if [ -f "${luks2_first_test_file}" ]; then
+        output=$(eval ${CMD} 2>&1)
+        ret=${?}
+
+        echo "${output}" >> "${OUTD}/logfull.txt"
+      else
+        ret=30
+      fi
+
+      e_ce=0
+      e_rs=0
+      e_to=0
+      e_nf=0
+      e_nm=0
+      cnt=0
+
+      status ${ret}
+
+      cnt=1
+
+      msg="OK"
+
+      if [ "${e_ce}" -ne 0 ]; then
+        msg="Compare Error"
+      elif [ "${e_rs}" -ne 0 ]; then
+        msg="Skip"
+      elif [ "${e_nf}" -ne 0 ] || [ "${e_nm}" -ne 0 ]; then
+        msg="Error"
+      elif [ "${e_to}" -ne 0 ]; then
+        msg="Warning"
+      fi
+
+      echo "[ ${OUTD} ] [ Type ${hash_type}, Attack ${attackType}, Mode single, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, LUKS2-mode ${luksMode} ] > $msg : ${e_nf}/${cnt} not found, ${e_nm}/${cnt} not matched, ${e_to}/${cnt} timeout, ${e_rs}/${cnt} skipped"
+
+      status ${ret}
+    fi
+  done
+}
+
+
 function usage()
 {
 cat << EOF
@@ -3958,25 +4143,12 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
 
 
   if [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
-    NEED_SUDO=0
-    if [[ ${HT} -eq 65535 ]]; then
-      NEED_SUDO=1
+    if sudo -n true 2>/dev/null; then
+      true
     else
-      for TMP_HT in $(seq "${HT_MIN}" "${HT_MAX}"); do
-        if is_in_array "${TMP_HT}" ${GENERATE_CONTAINERS_MODES}; then
-          NEED_SUDO=1
-          break
-        fi
-      done
+      echo "We'll need sudo to generate crypto-containers on-the-fly"
     fi
-
-    if [[ "${NEED_SUDO}" -eq 1 ]]; then
-      if sudo -n true 2>/dev/null; then
-        true
-      else
-        echo "We'll need sudo to generate crypto-containers on-the-fly"
-      fi
-    fi
+    # fi
   fi
 
   if [ -z "${PACKAGE_FOLDER}" ]; then
@@ -3994,10 +4166,12 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
         fi
 
         if ! is_in_array "${TMP_HT}" ${LUKS_MODES}; then
-          if ! is_in_array "${TMP_HT}" ${TC_MODES}; then
-            if ! is_in_array "${TMP_HT}" ${VC_MODES}; then
-              if ! is_in_array "${TMP_HT}" ${CL_MODES}; then
-                perl tools/test.pl single "${TMP_HT}" >> "${OUTD}/all.sh"
+          if ! ( is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] ); then
+            if ! is_in_array "${TMP_HT}" ${TC_MODES}; then
+              if ! is_in_array "${TMP_HT}" ${VC_MODES}; then
+                if ! is_in_array "${TMP_HT}" ${CL_MODES}; then
+                  perl tools/test.pl single "${TMP_HT}" >> "${OUTD}/all.sh"
+                fi
               fi
             fi
           fi
@@ -4009,17 +4183,19 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
           continue
         fi
 
-        if is_in_array "${TMP_HT}" ${GENERATE_CONTAINERS_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
-          echo "Skipping ${TMP_HT}: missing -g flag"
-          continue
-        fi
+        # if is_in_array "${TMP_HT}" ${GENERATE_CONTAINERS_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
+        #   echo "Skipping ${TMP_HT}: missing -g flag"
+        #   continue
+        # fi
 
         if ! is_in_array "${TMP_HT}" ${LUKS_MODES}; then
-          # Exclude TrueCrypt and VeraCrypt testing modes
-          if ! is_in_array "${TMP_HT}" ${TC_MODES}; then
-            if ! is_in_array "${TMP_HT}" ${VC_MODES}; then
-              if ! is_in_array "${TMP_HT}" ${CL_MODES}; then
-                perl tools/test.pl single "${TMP_HT}" >> "${OUTD}/all.sh"
+          if ! ( is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] ); then
+            # Exclude TrueCrypt and VeraCrypt testing modes
+            if ! is_in_array "${TMP_HT}" ${TC_MODES}; then
+              if ! is_in_array "${TMP_HT}" ${VC_MODES}; then
+                if ! is_in_array "${TMP_HT}" ${CL_MODES}; then
+                  perl tools/test.pl single "${TMP_HT}" >> "${OUTD}/all.sh"
+                fi
               fi
             fi
           fi
@@ -4174,6 +4350,9 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
                 # for new modes
                 luks_test "${hash_type}" ${ATTACK}
               fi
+            elif is_in_array "${hash_type}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
+              # run luks2 tests
+              luks2_test "${hash_type}" ${ATTACK}
             else
               # run attack mode 0 (stdin)
               if [ ${ATTACK} -eq 65535 ] || [ ${ATTACK} -eq 0 ]; then attack_0; fi
@@ -4238,6 +4417,7 @@ if [ "${PACKAGE}" -eq 1 ]; then
 
   if [ "${HT}" -eq 65535 ]; then
     copy_luks_dir=1
+    copy_luks2_dir=1
     copy_tc_dir=1
     copy_vc_dir=1
     copy_cl_dir=1
@@ -4245,6 +4425,8 @@ if [ "${PACKAGE}" -eq 1 ]; then
     for TMP_HT in $(seq "${HT_MIN}" "${HT_MAX}"); do
       if is_in_array "${TMP_HT}" ${LUKS_MODES}; then
         copy_luks_dir=1
+      elif is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
+        copy_luks2_dir=1
       elif is_in_array "${TMP_HT}" ${TC_MODES}; then
         copy_tc_dir=1
       elif is_in_array "${TMP_HT}" ${VC_MODES}; then
@@ -4258,6 +4440,11 @@ if [ "${PACKAGE}" -eq 1 ]; then
   if [ "${copy_luks_dir}" -eq 1 ]; then
     mkdir "${OUTD}/luks_tests/"
     cp ${TDIR}/luks_tests/* "${OUTD}/luks_tests/"
+  fi
+
+  if [ "${copy_luks2_dir}" -eq 1 ]; then
+    mkdir "${OUTD}/luks2_tests/"
+    cp ${TDIR}/luks2_tests/* "${OUTD}/luks2_tests/"
   fi
 
   if [ "${copy_tc_dir}" -eq 1 ]; then

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -4148,6 +4148,7 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
           VECTOR=${CUR_WIDTH}
           OPTS="${OPTS_OLD} --backend-vector-width ${VECTOR}"
 
+          # Slow hashes only have a single kernel to test, so we only test with a0
           if [ ${IS_SLOW} -eq 1 ]; then
 
             # Look up if this is one of supported VeraCrypt modes

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -3703,10 +3703,7 @@ function luks2_test()
 
   chmod u+x "${TDIR}/luks2hashcat.py"
 
-  mkdir -p "${OUTD}/luks2_tests"
-  cp -r "${TDIR}/luks2_tests/." "${OUTD}/luks2_tests"
-
-  for luks2File in $(ls ${OUTD}/luks2_tests | grep "img$"); do #| grep ${hashType}
+  for luks2File in $(ls ${TDIR}/luks2_tests | grep "img$"); do
     luksMainMask="?l"
     luksMask="${luksMainMask}"
 
@@ -3715,6 +3712,8 @@ function luks2_test()
     luksPassPartFile2="${OUTD}/${hashType}_dict2"
 
     luksContainer="${TDIR}/luks2_tests/${luks2File}"
+
+    mkdir -p "${OUTD}/luks2_tests"
     luksHashFile="${OUTD}/luks2_tests/${luks2File}.hash"
 
     case $attackType in
@@ -3754,7 +3753,6 @@ function luks2_test()
 
     eval \"${TDIR}/luks2hashcat.py\" \"${luksContainer}\" > "${luksHashFile}"
 
-    # luksMode="${luksHash}-${luksCipher}-${luksMode}-${luksKeySize}"
     luksMode="$(basename "$luksContainer" .img)"
 
     if [ -n "${CMD}" ] && [ ${#CMD} -gt 5 ]; then
@@ -4400,6 +4398,7 @@ if [ "${PACKAGE}" -eq 1 ]; then
   cp "${BASH_SOURCE[0]}" "${OUTD}/test.sh"
 
   copy_luks_dir=0
+  copy_luks2_dir=0
   copy_tc_dir=0
   copy_vc_dir=0
   copy_cl_dir=0
@@ -4414,7 +4413,7 @@ if [ "${PACKAGE}" -eq 1 ]; then
     for TMP_HT in $(seq "${HT_MIN}" "${HT_MAX}"); do
       if is_in_array "${TMP_HT}" ${LUKS_MODES}; then
         copy_luks_dir=1
-      elif is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
+      elif is_in_array "${TMP_HT}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
         copy_luks2_dir=1
       elif is_in_array "${TMP_HT}" ${TC_MODES}; then
         copy_tc_dir=1

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -186,7 +186,7 @@ function init()
     return 0
   fi
 
-  if is_in_array "$hash_type" "${LUKS_MODES[@]}" || { is_in_array "$hash_type" "${LUKS2_MODES[@]}" && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] }; then
+  if is_in_array "$hash_type" ${LUKS_MODES} || { is_in_array "$hash_type" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]] }; then
     which 7z &>/dev/null
     if [ $? -eq 1 ]; then
       echo "ATTENTION: 7z is missing. Skipping download and extract luks test files."

--- a/tools/test_modules/m34100.pm
+++ b/tools/test_modules/m34100.pm
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+use FindBin qw($Bin);
+
+sub module_constraints { [[0, 256], [0, 256], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $script = "$Bin/test_modules/m34100.sh";
+  # Capture stdout of the script safely (no shell):
+  open my $fh, "-|", $script, $word or die "exec $script: $!";
+  local $/;
+  my $digest = <$fh>;
+  close $fh;
+
+  $digest =~ s/[\r\n]//g;
+
+  return $digest;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $salt, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $salt;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m34100.sh
+++ b/tools/test_modules/m34100.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+#   echo "❌ Missing argument: password"
+  password=""
+else
+  password=$1
+fi
+
+TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+# Example arrays (adjust to your real ones)
+ARGON_KDFS=("argon2id" "argon2i")
+
+ARGON_TIMES=(4 5 6)
+ARGON_MEMORY=(16 32 64 128 256 512 1024)
+ARGON_THREADS=(1 2 3 4) # max is 4 https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/configure.ac?ref_type=heads#L787
+
+declare -A CIPHERS=(
+  ["aes"]="aes-xts-plain64"
+#   ["serpent"]="serpent-xts-plain64" # not supported by 34100 yet
+#   ["twofish"]="twofish-xts-plain64" # not supported by 34100 yet
+)
+
+size=20   # MiB
+
+OUTPUT_DIR="/tmp/out"
+mkdir -p "$OUTPUT_DIR"
+MOUNT_DIR="/tmp/mnt"
+mkdir -p "$MOUNT_DIR"
+
+create_luks_container() {
+  local PASSWORD="$1"
+  local filename="$2"
+  local luks_type="$3"
+  local cipher="$4"
+  local hash="$5"
+  local size_mb="$6"
+  shift 6
+  local extra_opts=("$@")
+
+
+  # echo  "🔧 Creating $filename (size ${size_mb}MiB) with password length ${#PASSWORD}: $PASSWORD..."
+  dd if=/dev/zero of="$filename" bs=1M count="$size_mb" status=none
+
+  loopdev=$(sudo losetup --show -f "$filename")
+
+cat >> /tmp/m34100.sh.log <<EOF
+sudo cryptsetup luksFormat \
+--batch-mode \
+--type "$luks_type" \
+--cipher "$cipher" \
+--key-size 512 \
+--hash "$hash" \
+${extra_opts:+${extra_opts[@]}} \
+"$loopdev" <<< "$PASSWORD" # $filename
+EOF
+chmod +x /tmp/m34100.sh.log
+
+  if sudo cryptsetup luksFormat \
+      --batch-mode \
+      --type "$luks_type" \
+      --cipher "$cipher" \
+      --key-size 512 \
+      --hash "$hash" \
+      "${extra_opts[@]}" \
+      "$loopdev" <<< "$PASSWORD"; then
+      true
+      echo "✅ Formatted: $filename" >> /tmp/m34100.sh
+  else
+    echo "❌ Failed to format: $filename" >> /tmp/m34100.sh
+    sudo losetup -d "$loopdev"
+    rm -f "$filename"
+    return
+  fi
+
+  name="luks$(basename "$filename" | sha1sum | cut -c1-8)"
+
+  if [ -e "/dev/mapper/$name" ]; then
+    echo "⚠️  Device $name already exists. Closing it first." >> /tmp/m34100.sh
+    sudo cryptsetup close "$name" || true
+  fi
+
+  if sudo cryptsetup open "$loopdev" "$name" <<< "$PASSWORD"; then
+    true
+    echo "✅ Decrypted: $filename" >> /tmp/m34100.sh
+  else
+    echo  "❌ Failed to decrypt: $filename" >> /tmp/m34100.sh
+    sudo losetup -d "$loopdev"
+    rm -f "$filename"
+    return
+  fi
+
+  mkfs.ext4 -q /dev/mapper/"$name" 2>/dev/null
+
+  mount_point="$MOUNT_DIR/$name"
+  mkdir -p "$mount_point"
+  sudo mount /dev/mapper/"$name" "$mount_point"
+
+  echo "Hello from $filename" > "$mount_point/info.txt"
+  while ! sudo umount "$mount_point"; do
+    # echo  "Waiting for $mount_point to become free..."
+    sleep 1
+  done
+
+  sudo cryptsetup close "$name"
+
+  # echo  "✅ ext4: $filename"
+
+  sudo losetup -D
+}
+
+
+# --- random picks ---
+kdf=${ARGON_KDFS[$RANDOM % ${#ARGON_KDFS[@]}]}
+time=${ARGON_TIMES[$RANDOM % ${#ARGON_TIMES[@]}]}
+memory=${ARGON_MEMORY[$RANDOM % ${#ARGON_MEMORY[@]}]}
+threads=${ARGON_THREADS[$RANDOM % ${#ARGON_THREADS[@]}]}
+cipher_name=$(printf "%s\n" "${!CIPHERS[@]}" | shuf -n1)
+cipher=${CIPHERS[$cipher_name]}
+
+file="${OUTPUT_DIR}/luks2-${cipher_name}-${kdf}-t${time}-m${memory}-p${threads}-size${size}MiB_$(date +%Y%m%d%H%M%S%6N).img"
+
+# echo  "➡️  Creating $file with:"
+# echo  "   kdf=$kdf time=$time memory=$memory threads=$threads cipher=$cipher"
+
+create_luks_container "$password" "$file" luks2 "$cipher" sha256 "$size" \
+  --pbkdf "$kdf" \
+  --pbkdf-force-iterations "$time" \
+  --pbkdf-memory "$((memory * 1024))" \
+  --pbkdf-parallel "$threads"
+
+
+${TDIR}/luks2hashcat.py $file | grep -vE '^[0-9]+$' > $file.hash
+
+echo $file.hash

--- a/tools/test_modules/m34100.sh
+++ b/tools/test_modules/m34100.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ -z "${1:-}" ]]; then
-#   echo "❌ Missing argument: password"
+#   echo "X Missing argument: password"
   password=""
 else
   password=$1
@@ -40,7 +40,7 @@ create_luks_container() {
   shift 6
   local extra_opts=("$@")
 
-  echo  "🔧 Creating $filename (size ${size_mb}MiB) with password length ${#PASSWORD}: $PASSWORD..." >> /tmp/m34100.sh
+  echo  "Creating $filename (size ${size_mb}MiB) with password length ${#PASSWORD}: $PASSWORD..." >> /tmp/m34100.sh
   dd if=/dev/zero of="$filename" bs=1M count="$size_mb" status=none
 
   loopdev=$(sudo losetup --show -f "$filename")
@@ -65,9 +65,9 @@ EOF
       "${extra_opts[@]}" \
       "$loopdev" <<< "$PASSWORD"; then
       true
-      echo "✅ Formatted: $filename" >> /tmp/m34100.sh
+      echo "Formatted: $filename" >> /tmp/m34100.sh
   else
-    echo "❌ Failed to format: $filename" >> /tmp/m34100.sh
+    echo "X Failed to format: $filename" >> /tmp/m34100.sh
     sudo losetup -d "$loopdev"
     rm -f "$filename"
     return
@@ -76,15 +76,15 @@ EOF
   name="luks$(basename "$filename" | sha1sum | cut -c1-8)"
 
   if [ -e "/dev/mapper/$name" ]; then
-    echo "⚠️  Device $name already exists. Closing it first." >> /tmp/m34100.sh
+    echo "! Device $name already exists. Closing it first." >> /tmp/m34100.sh
     sudo cryptsetup close "$name" || true
   fi
 
   if sudo cryptsetup open "$loopdev" "$name" <<< "$PASSWORD"; then
     true
-    echo "✅ Decrypted: $filename" >> /tmp/m34100.sh
+    echo "Decrypted: $filename" >> /tmp/m34100.sh
   else
-    echo  "❌ Failed to decrypt: $filename" >> /tmp/m34100.sh
+    echo  "X Failed to decrypt: $filename" >> /tmp/m34100.sh
     sudo losetup -d "$loopdev"
     rm -f "$filename"
     return
@@ -103,7 +103,7 @@ EOF
   done
   sudo cryptsetup close "$name"
 
-  echo  "✅ ext4: $filename" >> /tmp/m34100.sh
+  echo  "ext4: $filename" >> /tmp/m34100.sh
 
   sudo losetup -D
 }
@@ -118,8 +118,8 @@ cipher=${CIPHERS[$cipher_name]}
 
 file="${OUTPUT_DIR}/luks2-${cipher_name}-${kdf}-t${time}-m${memory}-p${threads}-size${size}MiB_$(date +%Y%m%d%H%M%S%6N).img"
 
-# echo  "➡️  Creating $file with:"
-# echo  "   kdf=$kdf time=$time memory=$memory threads=$threads cipher=$cipher"
+# echo -n "Creating $file with:"
+# echo  " kdf=$kdf time=$time memory=$memory threads=$threads cipher=$cipher"
 
 create_luks_container "$password" "$file" luks2 "$cipher" sha256 "$size" \
   --pbkdf "$kdf" \

--- a/tools/test_modules/m34100.sh
+++ b/tools/test_modules/m34100.sh
@@ -10,9 +10,8 @@ fi
 
 TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-# Example arrays (adjust to your real ones)
+# Different Argon2 options
 ARGON_KDFS=("argon2id" "argon2i")
-
 ARGON_TIMES=(4 5 6)
 ARGON_MEMORY=(16 32 64 128 256 512 1024)
 ARGON_THREADS=(1 2 3 4) # max is 4 https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/configure.ac?ref_type=heads#L787


### PR DESCRIPTION
Background: For LUKS1 we have [pre-generated/static test-containers](https://hashcat.net/misc/example_hashes/hashcat_luks_testfiles.7z): one for each option (e.g. hashing- & crypto-algorithm), all using the password `hashcat`.

LUKS2 introduces more options (e.g. Argon2 parameters), this would require pre-generating many different containers, resulting in a large archive as the [default metadata size is 16MiB](https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/docs/v2.1.0-ReleaseNotes#L27).
Still that would only test a single pre-generated password per container.

I've chosen to generate the LUKS2 tests-containers dynamically: m34100.pm calls m34100.sh with takes a password as argument and uses cryptsetup with random parameters to generate a containers.
It loop-mounts the container, creates a ext4 filesystem on it, and puts a text document in the container.

TODO:
- [x] Fix bug found by these tests: 64 (and some longer passwords lengths) for LUKS2 (and Argon2) don't crack --> https://github.com/hashcat/hashcat/pull/4447
- [x] finishes TODO in https://github.com/hashcat/hashcat/pull/4415
- [x] add all dependencies to install_modules.sh --> only cryptsetup !?
- [x] how to take sudo into account? --> only sudo where required & generated tests optional (using --generate flag)
- [x] do we need the md5 compare? --> I think so because of the large LUKS2 hashes (which cannot be passed on the commandline), if not now, then probably later..
- [x] add GENERATE_CONTAINERS_MODES array containing attacks that have dynamically generated tests (containers?) such that we can compare to GENERATE_CONTAINERS_MODES list of container-generating hashes (instead of only LUKS2)
- [x] currently only works for LUKS2 with -a0 --> expected behavior as it is part of SLOW_ALGOS and those have only a single kernel, therefore we don't need to test the other modes.
- [x]  test_modules/m34100.sh: do not use /tmp in m34100.sh, change OUTPUT_DIR and MOUNT_DIR to test-folder ($OUTD ) --> I'm fine with this
- [x] test.sh: try not to specifically match on '$luks$' --> don't care, we're making exceptions for LUKS anyways
- [x]  add static LUKS2 container tests: this approach is not crossplatform (windows/macos) which is why these tests are optional with -g flag. The generated-container tests are an addition to the static tests as it finds a different class of bugs (e.g. password lengths).

Future work:
- [x] support LUKS1 dynamic containers --> we can probably reuse (most of) m34100.sh but with luks1 as parameter to create_luks_container() --> https://github.com/hashcat/hashcat/pull/4487
- [ ] support GPG
- [ ] support PKZIP
- [ ]  test_modules/m34100.sh: generate multiple keyslots with random passwords, and one keyslot with the test.pl password, and pick that keyslot

Who wants to test `./tools/test.sh -m 34000-34300 -D1 -g` to check if this also works for you?