### PR TITLE
test.pl enable --help before installing modules

### DIFF
--- a/tools/test.pl
+++ b/tools/test.pl
@@ -8,11 +8,22 @@
 use strict;
 use warnings;
 
-use Data::Types qw (is_count is_whole);
 use File::Basename;
 use FindBin;
 use List::Util 'shuffle';
-use Digest::MD4 qw (md4_hex);
+
+my $TYPES = [ 'edge', 'single', 'passthrough', 'potthrough', 'verify' ];
+
+my $TYPE = shift @ARGV;
+my $MODE = shift @ARGV;
+
+is_in_array ($TYPE, $TYPES) or usage_exit ();
+
+eval {
+    require Data::Types;  Data::Types->import(qw(is_count is_whole));
+    require Digest::MD4;  Digest::MD4->import('md4_hex');
+    1;
+} or die "Missing Perl modules, read: docs/hashcat-plugin-development-guide.md (search test.pl), and run: ./tools/install_modules.sh\n";
 
 # allows require by filename
 use lib "$FindBin::Bin/test_modules";
@@ -23,13 +34,6 @@ if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"})
 {
   $IS_OPTIMIZED = $ENV{"IS_OPTIMIZED"};
 }
-
-my $TYPES = [ 'edge', 'single', 'passthrough', 'potthrough', 'verify' ];
-
-my $TYPE = shift @ARGV;
-my $MODE = shift @ARGV;
-
-is_in_array ($TYPE, $TYPES) or usage_exit ();
 
 is_whole ($MODE) or die "Mode must be a number\n";
 


### PR DESCRIPTION
Fixes https://github.com/hashcat/hashcat/issues/4413

### test.pl used to be
```
echo aa | tools/test.pl passthrough 0                                             
Can't locate Data/Types.pm in @INC (you may need to install the Data::Types module) (@INC entries checked: /home/k/.perl5/lib/perl5/5.38.2/x86_64-linux-gnu-thread-multi /home/k/.perl5/lib/perl5/5.38.2 /home/k/.perl5/lib/perl5/x86_64-linux-gnu-thread-multi /home/k/.perl5/lib/perl5 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at tools/test.pl line 11.
BEGIN failed--compilation aborted at tools/test.pl line 11.
```

### test.pl improved

```
echo aa | tools/test.pl passthrough 0      
Missing Perl modules, read: docs/hashcat-plugin-development-guide.md (search test.pl), and run: ./tools/install_modules.sh
```




Nice thing is that also test.sh warns about installing modules now:

### test.sh used to be
```
./tools/test.sh -m 34000-34300 -D1 
Can't locate Data/Types.pm in @INC (you may need to install the Data::Types module) (@INC entries checked: /home/k/.perl5/lib/perl5/5.38.2/x86_64-linux-gnu-thread-multi /home/k/.perl5/lib/perl5/5.38.2 /home/k/.perl5/lib/perl5/x86_64-linux-gnu-thread-multi /home/k/.perl5/lib/perl5 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.38.2 /usr/local/share/perl/5.38.2 /usr/lib/x86_64-linux-gnu/perl5/5.38 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.38 /usr/share/perl/5.38 /usr/local/lib/site_perl) at tools/test.pl line 11.
```

### test.sh improved
```
./tools/test.sh -m 34000-34300 -D1   
Missing Perl modules, read: docs/hashcat-plugin-development-guide.md (search test.pl), and run: ./tools/install_modules.sh
```