### PR TITLE
Add vectorized line scanning (AVX2/AVX512/NEON) with runtime dispatch

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -131,12 +131,12 @@ bool get_free_memory (u64 *free_mem);
 u32 previous_power_of_two (const u32 x);
 u32 next_power_of_two (const u32 x);
 
-typedef size_t (*vector_nl_scan_t) (const u8 *ptr, size_t max_len);
+typedef size_t (*hc_memchr_t) (const u8 *ptr, int ch, size_t max_len);
 
-size_t vector_find_next_nl_generic (const u8 *ptr, size_t max_len);
-size_t vector_find_next_nl_avx2    (const u8 *ptr, size_t max_len);
-size_t vector_find_next_nl_avx512  (const u8 *ptr, size_t max_len);
+size_t hc_memchr_generic      (const u8 *ptr, int ch, size_t max_len);
+size_t hc_memchr_avx2         (const u8 *ptr, int ch, size_t max_len);
+size_t hc_memchr_avx512       (const u8 *ptr, int ch, size_t max_len);
 
-vector_nl_scan_t vector_scan_get   (void);
+hc_memchr_t hc_memchr_get     (void);
 
 #endif // HC_SHARED_H

--- a/include/shared.h
+++ b/include/shared.h
@@ -131,4 +131,12 @@ bool get_free_memory (u64 *free_mem);
 u32 previous_power_of_two (const u32 x);
 u32 next_power_of_two (const u32 x);
 
+typedef size_t (*vector_nl_scan_t) (const u8 *ptr, size_t max_len);
+
+size_t vector_find_next_nl_generic (const u8 *ptr, size_t max_len);
+size_t vector_find_next_nl_avx2    (const u8 *ptr, size_t max_len);
+size_t vector_find_next_nl_avx512  (const u8 *ptr, size_t max_len);
+
+vector_nl_scan_t vector_scan_get   (void);
+
 #endif // HC_SHARED_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -469,7 +469,7 @@ EMU_OBJS_ALL            += emu_inc_hash_md4 emu_inc_hash_md5 emu_inc_hash_ripemd
 EMU_OBJS_ALL            += emu_inc_cipher_aes emu_inc_cipher_camellia emu_inc_cipher_des emu_inc_cipher_kuznyechik emu_inc_cipher_serpent emu_inc_cipher_twofish
 EMU_OBJS_ALL            += emu_inc_hash_base58
 
-OBJS_ALL                := affinity autotune backend benchmark bitmap bitops bridges combinator common convert cpt cpu_crc32 debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_intelgpu ext_sysfs_cpu ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight generic terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
+OBJS_ALL                := affinity autotune backend benchmark bitmap bitops bridges combinator common convert cpt cpu_crc32 cpu_features debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_intelgpu ext_sysfs_cpu ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight generic terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
 
 ifeq ($(ENABLE_BRAIN),1)
 OBJS_ALL                += brain

--- a/src/feeds/feed_wordlist.c
+++ b/src/feeds/feed_wordlist.c
@@ -229,10 +229,10 @@ int thread_next (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED gen
     return -1;
   }
 
-  vector_nl_scan_t vector_scan = vector_scan_get ();
+  hc_memchr_t hc_memchr = hc_memchr_get ();
 
   size_t remaining = fd_len - fd_off;
-  size_t step      = vector_scan (fd_mem + fd_off, remaining);
+  size_t step      = hc_memchr (fd_mem + fd_off, '\n', remaining);
 
   // if no newline, process till EOF
   if (step == remaining)
@@ -277,7 +277,7 @@ bool thread_seek (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED ge
     feed_thread->fd_line = idx * SEEKDB_STEP;
   }
 
-  vector_nl_scan_t vector_scan = vector_scan_get ();
+  hc_memchr_t hc_memchr = hc_memchr_get ();
 
   while (feed_thread->fd_line < offset)
   {
@@ -290,7 +290,7 @@ bool thread_seek (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED ge
       return false;
     }
 
-    size_t step = vector_scan (fd_mem + feed_thread->fd_off, remaining);
+    size_t step = hc_memchr (fd_mem + feed_thread->fd_off, '\n', remaining);
 
     feed_thread->fd_off += step + 1; // +1 for '\n'
     feed_thread->fd_line++;

--- a/src/shared.c
+++ b/src/shared.c
@@ -1953,17 +1953,17 @@ static void vector_scan_init (void)
   if (cpu_supports_avx512f ())
   {
     cached_scan = vector_find_next_nl_avx512;
-    printf("\n%s, using avx512\n", __func__);
+    //printf("\n%s, using avx512\n", __func__);
   }
   else if (cpu_supports_avx2 ())
   {
     cached_scan = vector_find_next_nl_avx2;
-    printf("\n%s, using avx2\n", __func__);
+    //printf("\n%s, using avx2\n", __func__);
   }
   else
   {
     cached_scan = vector_find_next_nl_generic;
-    printf("\n%s, using generic\n", __func__);
+    //printf("\n%s, using generic\n", __func__);
   }
 
   #elif defined (__aarch64__)
@@ -1974,12 +1974,12 @@ static void vector_scan_init (void)
 
   // Use 32-byte NEON-mapped function for Apple Silicon
   cached_scan = vector_find_next_nl_avx2;
-  printf("\n%s, using 32-byte NEON-mapped functions\n", __func__);
+  //printf("\n%s, using 32-byte NEON-mapped functions\n", __func__);
 
   #else
 
   cached_scan = vector_find_next_nl_generic;
-  printf("\n%s, using generic\n", __func__);
+  //printf("\n%s, using generic\n", __func__);
 
   #endif
 }

--- a/src/shared.c
+++ b/src/shared.c
@@ -9,6 +9,7 @@
 #include "shared.h"
 #include "memory.h"
 #include "ext_lzma.h"
+#include "cpu_features.h"
 #include <errno.h>
 
 #if defined (__CYGWIN__)
@@ -33,6 +34,12 @@
     !defined (__FreeBSD__) && !defined (__DragonFly__)
 #include <sys/sysinfo.h>
 #endif
+#endif
+
+#if defined (__x86_64__) || defined (_M_X64) || defined (__i386__) || defined (_M_IX86)
+#include <immintrin.h>
+#elif defined (__aarch64__)
+#include <sse2neon.h>
 #endif
 
 static const char *const PA_000 = "OK";
@@ -1844,3 +1851,140 @@ u32 next_power_of_two (const u32 x)
   return r;
 }
 
+size_t vector_find_next_nl_generic (const u8 *ptr, size_t max_len)
+{
+  const u8 *found = memchr (ptr, '\n', max_len);
+
+  return found ? (size_t)(found - ptr) : max_len;
+}
+
+#if defined (__x86_64__) || defined (_M_X64) || defined (__i386__) || defined (_M_IX86) || defined (__aarch64__)
+#if !defined (__aarch64__)
+__attribute__((target("avx2")))
+#endif
+size_t vector_find_next_nl_avx2 (const u8 *ptr, size_t max_len)
+{
+  while (max_len >= 32)
+  {
+    #if defined (__aarch64__)
+
+    __m128i block1 = _mm_loadu_si128 ((const __m128i *)ptr);
+    __m128i block2 = _mm_loadu_si128 ((const __m128i *)(ptr + 16));
+    __m128i nl     = _mm_set1_epi8 ('\n');
+    __m128i cmp1 = _mm_cmpeq_epi8 (block1, nl);
+    __m128i cmp2 = _mm_cmpeq_epi8 (block2, nl);
+
+    int mask1 = _mm_movemask_epi8 (cmp1);
+    int mask2 = _mm_movemask_epi8 (cmp2);
+
+    if (mask1) return __builtin_ctz (mask1);
+    if (mask2) return 16 + __builtin_ctz (mask2);
+
+    #else
+
+    __m256i block = _mm256_loadu_si256 ((const __m256i *)ptr);
+    __m256i nl    = _mm256_set1_epi8 ('\n');
+    __m256i cmp   = _mm256_cmpeq_epi8 (block, nl);
+
+    int mask      = _mm256_movemask_epi8 (cmp);
+
+    if (mask != 0) return __builtin_ctz (mask);
+
+    #endif
+
+    ptr     += 32;
+    max_len -= 32;
+  }
+
+  return vector_find_next_nl_generic (ptr, max_len);
+}
+
+#if !defined (__aarch64__)
+__attribute__((target("avx512f,avx512bw")))
+#endif
+size_t vector_find_next_nl_avx512 (const u8 *ptr, size_t max_len)
+{
+  while (max_len >= 64)
+  {
+    #if defined (__aarch64__)
+
+    // Map 64-byte scan using two 32-byte NEON blocks
+    __m128i block1 = _mm_loadu_si128 ((const __m128i *)ptr);
+    __m128i block2 = _mm_loadu_si128 ((const __m128i *)(ptr + 16));
+    __m128i block3 = _mm_loadu_si128 ((const __m128i *)(ptr + 32));
+    __m128i block4 = _mm_loadu_si128 ((const __m128i *)(ptr + 48));
+    __m128i nl = _mm_set1_epi8 ('\n');
+
+    int mask1 = _mm_movemask_epi8 (_mm_cmpeq_epi8 (block1, nl));
+    int mask2 = _mm_movemask_epi8 (_mm_cmpeq_epi8 (block2, nl));
+    int mask3 = _mm_movemask_epi8 (_mm_cmpeq_epi8 (block3, nl));
+    int mask4 = _mm_movemask_epi8 (_mm_cmpeq_epi8 (block4, nl));
+
+    if (mask1) return __builtin_ctz (mask1);
+    if (mask2) return 16 + __builtin_ctz (mask2);
+    if (mask3) return 32 + __builtin_ctz (mask3);
+    if (mask4) return 48 + __builtin_ctz (mask4);
+
+    #else
+
+    __m512i block = _mm512_loadu_si512 ((const __m512i *)ptr);
+    __m512i nl    = _mm512_set1_epi8 ('\n');
+    __mmask64 mask = _mm512_cmpeq_epi8_mask (block, nl);
+
+    if (mask != 0) return __builtin_ctzll (mask);
+
+    #endif
+
+    ptr     += 64;
+    max_len -= 64;
+  }
+
+  return vector_find_next_nl_generic (ptr, max_len);
+}
+#endif // __x86_64__ || _M_X64 || __i386__ || _M_IX86 || __aarch64__
+
+static vector_nl_scan_t cached_scan = vector_find_next_nl_generic;
+
+__attribute__((constructor))
+static void vector_scan_init (void)
+{
+  #if defined (__x86_64__) || defined (_M_X64) || defined (__i386__) || defined (_M_IX86)
+
+  if (cpu_supports_avx512f ())
+  {
+    cached_scan = vector_find_next_nl_avx512;
+    printf("\n%s, using avx512\n", __func__);
+  }
+  else if (cpu_supports_avx2 ())
+  {
+    cached_scan = vector_find_next_nl_avx2;
+    printf("\n%s, using avx2\n", __func__);
+  }
+  else
+  {
+    cached_scan = vector_find_next_nl_generic;
+    printf("\n%s, using generic\n", __func__);
+  }
+
+  #elif defined (__aarch64__)
+
+  // Use 64-byte NEON-mapped function for Apple Silicon
+  // cached_scan = vector_find_next_nl_avx512;
+  // printf("\n%s, using 64-byte NEON-mapped functions\n", __func__);
+
+  // Use 32-byte NEON-mapped function for Apple Silicon
+  cached_scan = vector_find_next_nl_avx2;
+  printf("\n%s, using 32-byte NEON-mapped functions\n", __func__);
+
+  #else
+
+  cached_scan = vector_find_next_nl_generic;
+  printf("\n%s, using generic\n", __func__);
+
+  #endif
+}
+
+vector_nl_scan_t vector_scan_get (void)
+{
+  return cached_scan;
+}


### PR DESCRIPTION
- Introduced vectorized newline scanning routines using AVX2, AVX512, or NEON intrinsics for faster wordlist parsing compared to memchr().
- thread_next() and thread_seek() now transparently use the optimized implementation when available:
    * On x86/x86_64: AVX512 or AVX2 selected at runtime.
    * On Apple Silicon (arm64): NEON via sse2neon.
    * Fallback to generic memchr() if no SIMD path is available.
- Ensures portability across Linux, Windows, and macOS (Intel + Apple Silicon) without requiring build-time AVX feature flags.

During development, I noticed that compiling hashcat using clang/clang++ even on Linux resulted in a performance increase on -a 8.

Thanks