### PR TITLE
Make Argon2 more robust

### DIFF
--- a/OpenCL/m34000-pure.cl
+++ b/OpenCL/m34000-pure.cl
@@ -14,6 +14,10 @@
 #define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
 #define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
 
+#ifndef ARGON2_PARALLELISM
+#define ARGON2_PARALLELISM 0
+#endif
+
 typedef struct argon2_tmp
 {
   u32 state[4];
@@ -64,7 +68,7 @@ KERNEL_FQ KERNEL_FA void m34000_loop (KERN_ATTR_TMPS_ESALT (argon2_tmp_t, merged
   const u32 argon2_thread = get_local_id (0);
   const u32 argon2_lsz = get_local_size (0);
 
-  #ifdef ARGON2_PARALLELISM
+  #if ARGON2_PARALLELISM > 0
   LOCAL_VK u64 shuffle_bufs[ARGON2_PARALLELISM][32];
   #else
   LOCAL_VK u64 shuffle_bufs[32][32];
@@ -92,7 +96,7 @@ KERNEL_FQ KERNEL_FA void m34000_loop (KERN_ATTR_TMPS_ESALT (argon2_tmp_t, merged
   #ifdef IS_APPLE
   // it doesn't work on Apple, so we won't set it up
   #else
-  #ifdef ARGON2_PARALLELISM
+  #if ARGON2_PARALLELISM > 0
   argon2_options.parallelism = ARGON2_PARALLELISM;
   #endif
   #endif

--- a/OpenCL/m34100-pure.cl
+++ b/OpenCL/m34100-pure.cl
@@ -18,6 +18,10 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
+#ifndef ARGON2_PARALLELISM
+#define ARGON2_PARALLELISM 0
+#endif
+
 #define LUKS_STRIPES    (                                   4000)
 #define LUKS_CT_LEN     (                                    512)
 #define LUKS_AF_MAX_LEN (HC_LUKS_KEY_SIZE_512 / 8 * LUKS_STRIPES)
@@ -149,7 +153,7 @@ KERNEL_FQ KERNEL_FA void m34100_loop (KERN_ATTR_TMPS_ESALT (luks_tmp_t, merged_o
   const u32 argon2_thread = get_local_id (0);
   const u32 argon2_lsz = get_local_size (0);
 
-  #ifdef ARGON2_PARALLELISM
+  #if ARGON2_PARALLELISM > 0
   LOCAL_VK u64 shuffle_bufs[ARGON2_PARALLELISM][32];
   #else
   LOCAL_VK u64 shuffle_bufs[32][32];
@@ -177,7 +181,7 @@ KERNEL_FQ KERNEL_FA void m34100_loop (KERN_ATTR_TMPS_ESALT (luks_tmp_t, merged_o
   #ifdef IS_APPLE
   // it doesn't work on Apple, so we won't set it up
   #else
-  #ifdef ARGON2_PARALLELISM
+  #if ARGON2_PARALLELISM > 0
   argon2_options.parallelism = ARGON2_PARALLELISM;
   #endif
   #endif

--- a/OpenCL/m34300-pure.cl
+++ b/OpenCL/m34300-pure.cl
@@ -23,6 +23,10 @@ Pseudocode:
 #include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
 #endif
 
+#ifndef ARGON2_PARALLELISM
+#define ARGON2_PARALLELISM 0
+#endif
+
 #define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
 #define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
 
@@ -167,7 +171,7 @@ KERNEL_FQ KERNEL_FA void m34300_loop (KERN_ATTR_TMPS_ESALT (argon2_tmp_t, merged
   const u32 argon2_thread = get_local_id (0);
   const u32 argon2_lsz = get_local_size (0);
 
-  #ifdef ARGON2_PARALLELISM
+  #if ARGON2_PARALLELISM > 0
   LOCAL_VK u64 shuffle_bufs[ARGON2_PARALLELISM][32];
   #else
   LOCAL_VK u64 shuffle_bufs[32][32];
@@ -195,7 +199,7 @@ KERNEL_FQ KERNEL_FA void m34300_loop (KERN_ATTR_TMPS_ESALT (argon2_tmp_t, merged
   #ifdef IS_APPLE
   // it doesn't work on Apple, so we won't set it up
   #else
-  #ifdef ARGON2_PARALLELISM
+  #if ARGON2_PARALLELISM > 0
   argon2_options.parallelism = ARGON2_PARALLELISM;
   #endif
   #endif

--- a/src/modules/argon2_common.c
+++ b/src/modules/argon2_common.c
@@ -64,7 +64,12 @@ const char *argon2_module_extra_tuningdb_block (MAYBE_UNUSED const hashconfig_t 
 
   const u64 available_mem = MIN (device_param->device_available_mem, (device_param->device_maxmem_alloc * 4)) - (fixed_mem + spill_mem);
 
-  const u32 kernel_accel_max = (device_param->device_host_unified_memory == true) ? (available_mem / 2) / size_per_accel : available_mem / size_per_accel;
+  u32 kernel_accel_max = (kernel_accel_user>0) ? kernel_accel_user : 1;
+
+  if (size_per_accel>0)
+  {
+     kernel_accel_max = (device_param->device_host_unified_memory == true) ? (available_mem / 2) / size_per_accel : available_mem / size_per_accel;
+  }
 
   u32 kernel_accel_new = device_processors;
 


### PR DESCRIPTION
 Prevent argon2 hashes with parameters all 0 to crash hashcat.

```
[ test_1756335826 ] > Init test for hash type 34000.
[ test_1756335826 ] [ Type 34000, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1756335826 ] [ Type 34000, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1756336403 ] > Init test for hash type 34000.
[ test_1756336403 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1756336403 ] [ Type 34000, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1756335826 ] > Init test for hash type 34300.
[ test_1756335826 ] [ Type 34300, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1756335826 ] [ Type 34300, Attack 0, Mode single, Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1756336445 ] > Init test for hash type 34300.
[ test_1756336445 ] [ Type 34300, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1756336445 ] [ Type 34300, Attack 0, Mode multi,  Device-Type Cpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
```