### PR TITLE
Fix cross-platform compatibility between POSIX and Windows threads

### DIFF
--- a/include/autotune.h
+++ b/include/autotune.h
@@ -8,6 +8,10 @@
 
 int find_tuning_function (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param);
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_autotune (void *p);
+#else
 HC_API_CALL void *thread_autotune (void *p);
+#endif
 
 #endif // HC_AUTOTUNE_H

--- a/include/backend.h
+++ b/include/backend.h
@@ -92,9 +92,12 @@ int run_kernel_decompress                   (hashcat_ctx_t *hashcat_ctx, hc_devi
 int run_copy                                (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 pws_cnt);
 int run_cracker                             (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 pws_pos, const u64 pws_cnt);
 
-HC_API_CALL
-void *hook12_thread (void *p);
-HC_API_CALL
-void *hook23_thread (void *p);
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD hook12_thread (void *p);
+HC_API_CALL DWORD hook23_thread (void *p);
+#else
+HC_API_CALL void *hook12_thread (void *p);
+HC_API_CALL void *hook23_thread (void *p);
+#endif
 
 #endif // HC_BACKEND_H

--- a/include/brain.h
+++ b/include/brain.h
@@ -240,10 +240,15 @@ int   brain_server_sort_hash_long       (const void *v1, const void *v2);
 int   brain_server_sort_hash_short      (const void *v1, const void *v2);
 int   brain_server_sort_hash_unique     (const void *v1, const void *v2);
 void  brain_server_handle_signal        (int signo);
-HC_API_CALL
-void *brain_server_handle_client        (void *p);
-HC_API_CALL
-void *brain_server_handle_dumps         (void *p);
+
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD brain_server_handle_client  (void *p);
+HC_API_CALL DWORD brain_server_handle_dumps   (void *p);
+#else
+HC_API_CALL void *brain_server_handle_client  (void *p);
+HC_API_CALL void *brain_server_handle_dumps   (void *p);
+#endif
+
 void  brain_server_db_hash_init         (brain_server_db_hash_t *brain_server_db_hash, const u32 brain_session);
 bool  brain_server_db_hash_realloc      (brain_server_db_hash_t *brain_server_db_hash, const i64 new_long_cnt);
 void  brain_server_db_hash_free         (brain_server_db_hash_t *brain_server_db_hash);

--- a/include/dispatch.h
+++ b/include/dispatch.h
@@ -22,7 +22,12 @@
 #endif
 #endif
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_calc_stdin (void *p);
+HC_API_CALL DWORD thread_calc (void *p);
+#else
 HC_API_CALL void *thread_calc_stdin (void *p);
 HC_API_CALL void *thread_calc (void *p);
+#endif
 
 #endif // HC_DISPATCH_H

--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -26,6 +26,14 @@
 //Define Performance Metrics Log max sensors number
 #define ADL_PMLOG_MAX_SENSORS  256
 
+#if defined (__MSC_VER)
+#define HC_ADL_API_CALL __cdecl
+#elif defined (_WIN32) || defined (__WIN32__)
+#define HC_ADL_API_CALL __stdcall
+#else
+#define HC_ADL_API_CALL
+#endif
+
 typedef enum ADLSensorType
 {
   SENSOR_MAXTYPES = 0,
@@ -642,7 +650,7 @@ typedef struct hm_adl_lib
 
 typedef hm_adl_lib_t ADL_PTR;
 
-void *HC_API_CALL ADL_Main_Memory_Alloc (const int iSize);
+void *HC_ADL_API_CALL ADL_Main_Memory_Alloc (const int iSize);
 
 int adl_init (void *hashcat_ctx);
 void adl_close (void *hashcat_ctx);

--- a/include/monitor.h
+++ b/include/monitor.h
@@ -10,6 +10,10 @@
 
 int get_runtime_left (const hashcat_ctx_t *hashcat_ctx);
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_monitor (void *p);
+#else
 HC_API_CALL void *thread_monitor (void *p);
+#endif
 
 #endif // HC_MONITOR_H

--- a/include/outfile_check.h
+++ b/include/outfile_check.h
@@ -11,7 +11,11 @@
 
 #define OUTFILES_DIR "outfiles"
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_outfile_remove (void *p);
+#else
 HC_API_CALL void *thread_outfile_remove (void *p);
+#endif
 
 int  outcheck_ctx_init    (hashcat_ctx_t *hashcat_ctx);
 void outcheck_ctx_destroy (hashcat_ctx_t *hashcat_ctx);

--- a/include/selftest.h
+++ b/include/selftest.h
@@ -6,6 +6,10 @@
 #ifndef HC_SELFTEST_H
 #define HC_SELFTEST_H
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_selftest (void *p);
+#else
 HC_API_CALL void *thread_selftest (void *p);
+#endif
 
 #endif // HC_SELFTEST_H

--- a/include/terminal.h
+++ b/include/terminal.h
@@ -39,7 +39,11 @@ int setup_console (void);
 void send_prompt  (hashcat_ctx_t *hashcat_ctx);
 void clear_prompt (hashcat_ctx_t *hashcat_ctx);
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_keypress (void *p);
+#else
 HC_API_CALL void *thread_keypress (void *p);
+#endif
 
 #if defined (_WIN)
 void SetConsoleWindowSize (const int x);

--- a/src/autotune.c
+++ b/src/autotune.c
@@ -696,19 +696,23 @@ static int autotune (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
   return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_autotune (void *p)
+#else
 HC_API_CALL void *thread_autotune (void *p)
+#endif
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 
   hashcat_ctx_t *hashcat_ctx = thread_param->hashcat_ctx;
   backend_ctx_t *backend_ctx = hashcat_ctx->backend_ctx;
 
-  if (backend_ctx->enabled == false) return NULL;
+  if (backend_ctx->enabled == false) return 0;
 
   hc_device_param_t *device_param = backend_ctx->devices_param + thread_param->tid;
 
-  if (device_param->skipped == true) return NULL;
-  if (device_param->skipped_warning == true) return NULL;
+  if (device_param->skipped == true) return 0;
+  if (device_param->skipped_warning == true) return 0;
 
   // init autotunes status and rc
 
@@ -717,12 +721,12 @@ HC_API_CALL void *thread_autotune (void *p)
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return 0;
   }
 
   if (device_param->is_hip == true)
   {
-    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return NULL;
+    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return 0;
   }
 
   // check for autotune failure
@@ -735,9 +739,9 @@ HC_API_CALL void *thread_autotune (void *p)
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return 0;
   }
 
-  return NULL;
+  return 0;
 }
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -17495,7 +17495,11 @@ int backend_session_update_mp_rl (hashcat_ctx_t *hashcat_ctx, const u32 css_cnt_
   return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD hook12_thread (void *p)
+#else
 HC_API_CALL void *hook12_thread (void *p)
+#endif
 {
   hook_thread_param_t *hook_thread_param = (hook_thread_param_t *) p;
 
@@ -17516,10 +17520,14 @@ HC_API_CALL void *hook12_thread (void *p)
     }
   }
 
-  return NULL;
+  return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD hook23_thread (void *p)
+#else
 HC_API_CALL void *hook23_thread (void *p)
+#endif
 {
   hook_thread_param_t *hook_thread_param = (hook_thread_param_t *) p;
 
@@ -17540,5 +17548,5 @@ HC_API_CALL void *hook23_thread (void *p)
     }
   }
 
-  return NULL;
+  return 0;
 }

--- a/src/brain.c
+++ b/src/brain.c
@@ -2063,7 +2063,11 @@ void brain_server_handle_signal (int signo)
   }
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD brain_server_handle_dumps (void *p)
+#else
 HC_API_CALL void *brain_server_handle_dumps (void *p)
+#endif
 {
   brain_server_dumper_options_t *brain_server_dumper_options = (brain_server_dumper_options_t *) p;
 
@@ -2071,7 +2075,7 @@ HC_API_CALL void *brain_server_handle_dumps (void *p)
 
   u32 brain_server_timer = brain_server_dumper_options->brain_server_timer;
 
-  if (brain_server_timer == 0) return NULL;
+  if (brain_server_timer == 0) return 0;
 
   u32 i = 0;
 
@@ -2092,10 +2096,14 @@ HC_API_CALL void *brain_server_handle_dumps (void *p)
     sleep (1);
   }
 
-  return NULL;
+  return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD brain_server_handle_client (void *p)
+#else
 HC_API_CALL void *brain_server_handle_client (void *p)
+#endif
 {
   brain_server_client_options_t *brain_server_client_options = (brain_server_client_options_t *) p;
 
@@ -2120,7 +2128,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
   #else
 
@@ -2136,7 +2144,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   u32 brain_link_version_ok = (brain_link_version >= (u32) BRAIN_LINK_VERSION_MIN) ? 1 : 0;
@@ -2149,7 +2157,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   if (brain_link_version_ok == 0)
@@ -2160,7 +2168,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   u32 challenge = brain_auth_challenge ();
@@ -2173,7 +2181,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   u64 response = 0;
@@ -2186,7 +2194,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   u64 auth_hash = brain_auth_hash (challenge, auth_password, strlen (auth_password));
@@ -2201,7 +2209,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   if (password_ok == 0)
@@ -2212,7 +2220,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   u32 brain_session = 0;
@@ -2225,7 +2233,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   if (session_whitelist_cnt > 0)
@@ -2250,7 +2258,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
       close (client_fd);
 
-      return NULL;
+      return 0;
     }
   }
 
@@ -2264,7 +2272,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   i64 passwords_max = 0;
@@ -2277,7 +2285,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   if (passwords_max >= BRAIN_LINK_CANDIDATES_MAX)
@@ -2288,7 +2296,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   brain_logging (stdout, client_idx, "Session: 0x%08x, Attack: 0x%08x, Kernel-power: %" PRIu64 "\n", brain_session, brain_attack, passwords_max);
@@ -2323,7 +2331,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
       close (client_fd);
 
-      return NULL;
+      return 0;
     }
 
     brain_server_db_hash = &brain_server_dbs->hash_buf[brain_server_dbs->hash_cnt];
@@ -2359,7 +2367,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
       close (client_fd);
 
-      return NULL;
+      return 0;
     }
 
     brain_server_db_attack = &brain_server_dbs->attack_buf[brain_server_dbs->attack_cnt];
@@ -2383,7 +2391,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   // recv
@@ -2400,7 +2408,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   // send
@@ -2417,7 +2425,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   // temp
@@ -2432,7 +2440,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   // short global alloc
@@ -2450,7 +2458,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
     close (client_fd);
 
-    return NULL;
+    return 0;
   }
 
   // main loop
@@ -3051,7 +3059,7 @@ HC_API_CALL void *brain_server_handle_client (void *p)
 
   close (client_fd);
 
-  return NULL;
+  return 0;
 }
 
 int brain_server (const char *listen_host, const int listen_port, const char *brain_password, const char *brain_session_whitelist, const u32 brain_server_timer)

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -351,7 +351,11 @@ static int calc_stdin (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_par
   return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_calc_stdin (void *p)
+#else
 HC_API_CALL void *thread_calc_stdin (void *p)
+#endif
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 
@@ -361,29 +365,29 @@ HC_API_CALL void *thread_calc_stdin (void *p)
   hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
   hashes_t      *hashes      = hashcat_ctx->hashes;
 
-  if (backend_ctx->enabled == false) return NULL;
+  if (backend_ctx->enabled == false) return 0;
 
   hc_device_param_t *device_param = backend_ctx->devices_param + thread_param->tid;
 
-  if (device_param->skipped) return NULL;
-  if (device_param->skipped_warning == true) return NULL;
+  if (device_param->skipped) return 0;
+  if (device_param->skipped_warning == true) return 0;
 
   if (bridge_ctx->enabled == true)
   {
     if (bridge_ctx->thread_init != BRIDGE_DEFAULT)
     {
-      if (bridge_ctx->thread_init (bridge_ctx->platform_context, device_param, hashconfig, hashes) == false) return NULL;
+      if (bridge_ctx->thread_init (bridge_ctx->platform_context, device_param, hashconfig, hashes) == false) return 0;
     }
   }
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return 0;
   }
 
   if (device_param->is_hip == true)
   {
-    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return NULL;
+    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return 0;
   }
 
   if (calc_stdin (hashcat_ctx, device_param) == -1)
@@ -395,7 +399,7 @@ HC_API_CALL void *thread_calc_stdin (void *p)
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return 0;
   }
 
   if (bridge_ctx->enabled == true)
@@ -406,7 +410,7 @@ HC_API_CALL void *thread_calc_stdin (void *p)
     }
   }
 
-  return NULL;
+  return 0;
 }
 
 static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
@@ -1869,7 +1873,11 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
   return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_calc (void *p)
+#else
 HC_API_CALL void *thread_calc (void *p)
+#endif
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 
@@ -1879,29 +1887,29 @@ HC_API_CALL void *thread_calc (void *p)
   hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
   hashes_t      *hashes      = hashcat_ctx->hashes;
 
-  if (backend_ctx->enabled == false) return NULL;
+  if (backend_ctx->enabled == false) return 0;
 
   hc_device_param_t *device_param = backend_ctx->devices_param + thread_param->tid;
 
-  if (device_param->skipped) return NULL;
-  if (device_param->skipped_warning == true) return NULL;
+  if (device_param->skipped) return 0;
+  if (device_param->skipped_warning == true) return 0;
 
   if (bridge_ctx->enabled == true)
   {
     if (bridge_ctx->thread_init != BRIDGE_DEFAULT)
     {
-      if (bridge_ctx->thread_init (bridge_ctx->platform_context, device_param, hashconfig, hashes) == false) return NULL;
+      if (bridge_ctx->thread_init (bridge_ctx->platform_context, device_param, hashconfig, hashes) == false) return 0;
     }
   }
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return 0;
   }
 
   if (device_param->is_hip == true)
   {
-    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return NULL;
+    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return 0;
   }
 
   if (calc (hashcat_ctx, device_param) == -1)
@@ -1913,7 +1921,7 @@ HC_API_CALL void *thread_calc (void *p)
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return 0;
   }
 
   if (bridge_ctx->enabled == true)
@@ -1924,5 +1932,5 @@ HC_API_CALL void *thread_calc (void *p)
     }
   }
 
-  return NULL;
+  return 0;
 }

--- a/src/ext_ADL.c
+++ b/src/ext_ADL.c
@@ -11,7 +11,7 @@
 
 #include "dynloader.h"
 
-void *HC_API_CALL ADL_Main_Memory_Alloc (const int iSize)
+void *HC_ADL_API_CALL ADL_Main_Memory_Alloc (const int iSize)
 {
   return malloc ((size_t) iSize);
 }

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -409,11 +409,15 @@ static int monitor (hashcat_ctx_t *hashcat_ctx)
   return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_monitor (void *p)
+#else
 HC_API_CALL void *thread_monitor (void *p)
+#endif
 {
   hashcat_ctx_t *hashcat_ctx = (hashcat_ctx_t *) p;
 
   monitor (hashcat_ctx); // we should give back some useful returncode
 
-  return NULL;
+  return 0;
 }

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -316,22 +316,24 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
   return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_outfile_remove (void *p)
+#else
 HC_API_CALL void *thread_outfile_remove (void *p)
+#endif
 {
   hashcat_ctx_t *hashcat_ctx = (hashcat_ctx_t *) p;
 
   const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const outcheck_ctx_t *outcheck_ctx = hashcat_ctx->outcheck_ctx;
 
-  if (hashconfig->outfile_check_disable == true) return NULL;
+  if (hashconfig->outfile_check_disable == true) return 0;
 
-  if (outcheck_ctx->enabled == false) return NULL;
+  if (outcheck_ctx->enabled == false) return 0;
 
-  const int rc = outfile_remove (hashcat_ctx);
+  outfile_remove (hashcat_ctx);
 
-  if (rc == -1) return NULL;
-
-  return NULL;
+  return 0;
 }
 
 int outcheck_ctx_init (hashcat_ctx_t *hashcat_ctx)

--- a/src/selftest.c
+++ b/src/selftest.c
@@ -1236,7 +1236,11 @@ static int process_selftest (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *devi
   return 0;
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_selftest (void *p)
+#else
 HC_API_CALL void *thread_selftest (void *p)
+#endif
 {
   thread_param_t *thread_param = (thread_param_t *) p;
 
@@ -1246,33 +1250,33 @@ HC_API_CALL void *thread_selftest (void *p)
   hashconfig_t  *hashconfig  = hashcat_ctx->hashconfig;
   hashes_t      *hashes      = hashcat_ctx->hashes;
 
-  if (backend_ctx->enabled == false) return NULL;
+  if (backend_ctx->enabled == false) return 0;
 
   user_options_t *user_options = hashcat_ctx->user_options;
 
-  if (user_options->self_test == false) return NULL;
+  if (user_options->self_test == false) return 0;
 
   hc_device_param_t *device_param = backend_ctx->devices_param + thread_param->tid;
 
-  if (device_param->skipped == true) return NULL;
-  if (device_param->skipped_warning == true) return NULL;
+  if (device_param->skipped == true) return 0;
+  if (device_param->skipped_warning == true) return 0;
 
   if (bridge_ctx->enabled == true)
   {
     if (bridge_ctx->thread_init != BRIDGE_DEFAULT)
     {
-      if (bridge_ctx->thread_init (bridge_ctx->platform_context, device_param, hashconfig, hashes) == false) return NULL;
+      if (bridge_ctx->thread_init (bridge_ctx->platform_context, device_param, hashconfig, hashes) == false) return 0;
     }
   }
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPushCurrent (hashcat_ctx, device_param->cuda_context) == -1) return 0;
   }
 
   if (device_param->is_hip == true)
   {
-    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return NULL;
+    if (hc_hipSetDevice (hashcat_ctx, device_param->hip_device) == -1) return 0;
   }
 
   const int rc_selftest = process_selftest (hashcat_ctx, device_param);
@@ -1295,14 +1299,14 @@ HC_API_CALL void *thread_selftest (void *p)
 
   if (device_param->is_cuda == true)
   {
-    if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return NULL;
+    if (hc_cuStreamSynchronize (hashcat_ctx, device_param->cuda_stream) == -1) return 0;
 
-    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return NULL;
+    if (hc_cuCtxPopCurrent (hashcat_ctx, &device_param->cuda_context) == -1) return 0;
   }
 
   if (device_param->is_hip == true)
   {
-    if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return NULL;
+    if (hc_hipStreamSynchronize (hashcat_ctx, device_param->hip_stream) == -1) return 0;
   }
 
   if (bridge_ctx->enabled == true)
@@ -1315,8 +1319,8 @@ HC_API_CALL void *thread_selftest (void *p)
 
   if (device_param->is_opencl == true)
   {
-    if (hc_clFinish (hashcat_ctx, device_param->opencl_command_queue) == -1) return NULL;
+    if (hc_clFinish (hashcat_ctx, device_param->opencl_command_queue) == -1) return 0;
   }
 
-  return NULL;
+  return 0;
 }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -424,13 +424,17 @@ static void keypress (hashcat_ctx_t *hashcat_ctx)
   tty_fix ();
 }
 
+#if defined (_WIN32) || defined (__WIN32__)
+HC_API_CALL DWORD thread_keypress (void *p)
+#else
 HC_API_CALL void *thread_keypress (void *p)
+#endif
 {
   hashcat_ctx_t *hashcat_ctx = (hashcat_ctx_t *) p;
 
   keypress (hashcat_ctx);
 
-  return NULL;
+  return 0;
 }
 
 #if defined (_WIN)


### PR DESCRIPTION
When compiling hashcat with clang, new warnings appeared, such as the following:

```
src/backend.c:1468:11: warning: cast from 'void *(*)(void *) __attribute__((stdcall))' to 'LPTHREAD_START_ROUTINE' (aka 'unsigned long (*)(void *)') converts to incompatible function type
      [-Wcast-function-type-mismatch]
 1468 |           hc_thread_create (c_threads[i], hook12_thread, hook_thread_param);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/thread.h:20:64: note: expanded from macro 'hc_thread_create'
   20 | #define hc_thread_create(t,f,a)     t = CreateThread (NULL, 0, (LPTHREAD_START_ROUTINE) &f, a, 0, NULL)
      |                                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This patch fixes all of these.

Thanks