### PR TITLE
Fix clang warning on unrar source code

### DIFF
--- a/deps/unrar/headers.cpp
+++ b/deps/unrar/headers.cpp
@@ -40,7 +40,7 @@ void FileHeader::Reset(size_t SubDataSize)
 FileHeader& FileHeader::operator = (FileHeader &hd)
 {
   SubData.Reset();
-  memcpy(this,&hd,sizeof(*this));
+  memcpy((void*)this,&hd,sizeof(*this));
   SubData.CleanData();
   SubData=hd.SubData;
   return *this;

--- a/deps/unrar/options.cpp
+++ b/deps/unrar/options.cpp
@@ -10,13 +10,13 @@ RAROptions::~RAROptions()
 {
   // It is important for security reasons, so we do not have the unnecessary
   // password data left in memory.
-  memset(this,0,sizeof(RAROptions));
+  memset((void*)this,0,sizeof(RAROptions));
 }
 
 
 void RAROptions::Init()
 {
-  memset(this,0,sizeof(RAROptions));
+  memset((void*)this,0,sizeof(RAROptions));
   WinSize=0x2000000;
   Overwrite=OVERWRITE_DEFAULT;
   Method=3;

--- a/deps/unrar/unpack50mt.cpp
+++ b/deps/unrar/unpack50mt.cpp
@@ -34,7 +34,7 @@ void Unpack::InitMT()
   {
     uint MaxItems=MaxUserThreads*UNP_BLOCKS_PER_THREAD;
     UnpThreadData=new UnpackThreadData[MaxItems];
-    memset(UnpThreadData,0,sizeof(UnpackThreadData)*MaxItems);
+    memset((void*)UnpThreadData,0,sizeof(UnpackThreadData)*MaxItems);
 
     for (uint I=0;I<MaxItems;I++)
     {


### PR DESCRIPTION
POC
```
deps/unrar/headers.cpp:43:10: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'FileHeader' [-Wnontrivial-memcall]
   43 |   memcpy(this,&hd,sizeof(*this));
      |          ^
deps/unrar/headers.cpp:43:10: note: explicitly cast the pointer to silence this warning
   43 |   memcpy(this,&hd,sizeof(*this));
      |          ^
      |          (void*)
1 warning generated.
```