### PR TITLE
Refactor is_valid_char()

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -3131,6 +3131,31 @@ DECLSPEC int is_valid_printable_32 (const u32 v)
   return 1;
 }
 
+DECLSPEC int is_valid_printable_8_incl_common_control (const u8 v)
+{
+  int valid=1;
+  // make sure only printables are allowed
+  if (v > (u8) 0x7e) valid=0;
+  if (v < (u8) 0x20) valid=0;
+
+  // but also allow some common control characters
+  if (v == (u8) 0x09) valid=1; // \t
+  if (v == (u8) 0x0a) valid=1; // \n
+  if (v == (u8) 0x0d) valid=1; // \r
+
+  return valid;
+}
+
+DECLSPEC int is_valid_printable_32_incl_common_control (const u32 v)
+{
+  if (is_valid_printable_8_incl_common_control ((u8) (v >>  0)) == 0) return 0;
+  if (is_valid_printable_8_incl_common_control ((u8) (v >>  8)) == 0) return 0;
+  if (is_valid_printable_8_incl_common_control ((u8) (v >> 16)) == 0) return 0;
+  if (is_valid_printable_8_incl_common_control ((u8) (v >> 24)) == 0) return 0;
+
+  return 1;
+}
+
 DECLSPEC int hc_find_keyboard_layout_map (const u32 search, const int search_len, LOCAL_AS keyboard_layout_mapping_t *s_keyboard_layout_mapping_buf, const int keyboard_layout_mapping_cnt)
 {
   for (int idx = 0; idx < keyboard_layout_mapping_cnt; idx++)

--- a/OpenCL/m34700_a0-pure.cl
+++ b/OpenCL/m34700_a0-pure.cl
@@ -17,20 +17,6 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-DECLSPEC int is_valid_char (const u32 v)
-{
-  if ((v & 0xff000000) < 0x09000000) return 0;
-  if ((v & 0xff000000) > 0x7e000000) return 0;
-  if ((v & 0x00ff0000) < 0x00090000) return 0;
-  if ((v & 0x00ff0000) > 0x007e0000) return 0;
-  if ((v & 0x0000ff00) < 0x00000900) return 0;
-  if ((v & 0x0000ff00) > 0x00007e00) return 0;
-  if ((v & 0x000000ff) < 0x00000009) return 0;
-  if ((v & 0x000000ff) > 0x0000007e) return 0;
-
-  return 1;
-}
-
 KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_RULES ())
 {
   const u64 gid = get_global_id (0);
@@ -209,10 +195,11 @@ KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_RULES ())
     pt[2] = ct[2] ^ out[2];
     pt[3] = ct[3] ^ out[3];
 
-    if (is_valid_char (pt[0]) == 0) continue;
-    if (is_valid_char (pt[1]) == 0) continue;
-    if (is_valid_char (pt[2]) == 0) continue;
-    if (is_valid_char (pt[3]) == 0) continue;
+    // decrypted data should be a string consisting only of ASCII chars (including newlines)
+    if (is_valid_printable_32_incl_common_control (pt[0]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[1]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[2]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[3]) == 0) continue;
 
     int i;
 
@@ -225,10 +212,10 @@ KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_RULES ())
       pt[2] = salt_bufs[SALT_POS_HOST].salt_buf[i + 2] ^ out[2];
       pt[3] = salt_bufs[SALT_POS_HOST].salt_buf[i + 3] ^ out[3];
 
-      if (is_valid_char (pt[0]) == 0) break;
-      if (is_valid_char (pt[1]) == 0) break;
-      if (is_valid_char (pt[2]) == 0) break;
-      if (is_valid_char (pt[3]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[0]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[1]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[2]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[3]) == 0) break;
     }
 
     if (i < 16) continue;
@@ -432,10 +419,10 @@ KERNEL_FQ KERNEL_FA void m34700_sxx (KERN_ATTR_RULES ())
     pt[2] = ct[2] ^ out[2];
     pt[3] = ct[3] ^ out[3];
 
-    if (is_valid_char (pt[0]) == 0) continue;
-    if (is_valid_char (pt[1]) == 0) continue;
-    if (is_valid_char (pt[2]) == 0) continue;
-    if (is_valid_char (pt[3]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[0]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[1]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[2]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[3]) == 0) continue;
 
     int i;
 
@@ -448,10 +435,10 @@ KERNEL_FQ KERNEL_FA void m34700_sxx (KERN_ATTR_RULES ())
       pt[2] = salt_bufs[SALT_POS_HOST].salt_buf[i + 2] ^ out[2];
       pt[3] = salt_bufs[SALT_POS_HOST].salt_buf[i + 3] ^ out[3];
 
-      if (is_valid_char (pt[0]) == 0) break;
-      if (is_valid_char (pt[1]) == 0) break;
-      if (is_valid_char (pt[2]) == 0) break;
-      if (is_valid_char (pt[3]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[0]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[1]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[2]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[3]) == 0) break;
     }
 
     if (i < 16) continue;

--- a/OpenCL/m34700_a1-pure.cl
+++ b/OpenCL/m34700_a1-pure.cl
@@ -15,20 +15,6 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-DECLSPEC int is_valid_char (const u32 v)
-{
-  if ((v & 0xff000000) < 0x09000000) return 0;
-  if ((v & 0xff000000) > 0x7e000000) return 0;
-  if ((v & 0x00ff0000) < 0x00090000) return 0;
-  if ((v & 0x00ff0000) > 0x007e0000) return 0;
-  if ((v & 0x0000ff00) < 0x00000900) return 0;
-  if ((v & 0x0000ff00) > 0x00007e00) return 0;
-  if ((v & 0x000000ff) < 0x00000009) return 0;
-  if ((v & 0x000000ff) > 0x0000007e) return 0;
-
-  return 1;
-}
-
 KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_BASIC ())
 {
   const u64 gid = get_global_id (0);
@@ -232,10 +218,10 @@ KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_BASIC ())
     pt[2] = ct[2] ^ out[2];
     pt[3] = ct[3] ^ out[3];
 
-    if (is_valid_char (pt[0]) == 0) continue;
-    if (is_valid_char (pt[1]) == 0) continue;
-    if (is_valid_char (pt[2]) == 0) continue;
-    if (is_valid_char (pt[3]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[0]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[1]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[2]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[3]) == 0) continue;
 
     int i;
 
@@ -248,10 +234,10 @@ KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_BASIC ())
       pt[2] = salt_bufs[SALT_POS_HOST].salt_buf[i + 2] ^ out[2];
       pt[3] = salt_bufs[SALT_POS_HOST].salt_buf[i + 3] ^ out[3];
 
-      if (is_valid_char (pt[0]) == 0) break;
-      if (is_valid_char (pt[1]) == 0) break;
-      if (is_valid_char (pt[2]) == 0) break;
-      if (is_valid_char (pt[3]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[0]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[1]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[2]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[3]) == 0) break;
     }
 
     if (i < 16) continue;
@@ -480,10 +466,11 @@ KERNEL_FQ KERNEL_FA void m34700_sxx (KERN_ATTR_BASIC ())
     pt[2] = ct[2] ^ out[2];
     pt[3] = ct[3] ^ out[3];
 
-    if (is_valid_char (pt[0]) == 0) continue;
-    if (is_valid_char (pt[1]) == 0) continue;
-    if (is_valid_char (pt[2]) == 0) continue;
-    if (is_valid_char (pt[3]) == 0) continue;
+    // decrypted data should be a string consisting only of ASCII chars (including newlines)
+    if (is_valid_printable_32_incl_common_control (pt[0]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[1]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[2]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[3]) == 0) continue;
 
     int i;
 
@@ -496,10 +483,10 @@ KERNEL_FQ KERNEL_FA void m34700_sxx (KERN_ATTR_BASIC ())
       pt[2] = salt_bufs[SALT_POS_HOST].salt_buf[i + 2] ^ out[2];
       pt[3] = salt_bufs[SALT_POS_HOST].salt_buf[i + 3] ^ out[3];
 
-      if (is_valid_char (pt[0]) == 0) break;
-      if (is_valid_char (pt[1]) == 0) break;
-      if (is_valid_char (pt[2]) == 0) break;
-      if (is_valid_char (pt[3]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[0]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[1]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[2]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[3]) == 0) break;
     }
 
     if (i < 16) continue;

--- a/OpenCL/m34700_a3-pure.cl
+++ b/OpenCL/m34700_a3-pure.cl
@@ -15,20 +15,6 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-DECLSPEC int is_valid_char (const u32 v)
-{
-  if ((v & 0xff000000) < 0x09000000) return 0;
-  if ((v & 0xff000000) > 0x7e000000) return 0;
-  if ((v & 0x00ff0000) < 0x00090000) return 0;
-  if ((v & 0x00ff0000) > 0x007e0000) return 0;
-  if ((v & 0x0000ff00) < 0x00000900) return 0;
-  if ((v & 0x0000ff00) > 0x00007e00) return 0;
-  if ((v & 0x000000ff) < 0x00000009) return 0;
-  if ((v & 0x000000ff) > 0x0000007e) return 0;
-
-  return 1;
-}
-
 KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_VECTOR ())
 {
   const u64 gid = get_global_id (0);
@@ -218,10 +204,10 @@ KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_VECTOR ())
     pt[2] = ct[2] ^ out[2];
     pt[3] = ct[3] ^ out[3];
 
-    if (is_valid_char (pt[0]) == 0) continue;
-    if (is_valid_char (pt[1]) == 0) continue;
-    if (is_valid_char (pt[2]) == 0) continue;
-    if (is_valid_char (pt[3]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[0]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[1]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[2]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[3]) == 0) continue;
 
     int i;
 
@@ -234,10 +220,10 @@ KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_VECTOR ())
       pt[2] = salt_bufs[SALT_POS_HOST].salt_buf[i + 2] ^ out[2];
       pt[3] = salt_bufs[SALT_POS_HOST].salt_buf[i + 3] ^ out[3];
 
-      if (is_valid_char (pt[0]) == 0) break;
-      if (is_valid_char (pt[1]) == 0) break;
-      if (is_valid_char (pt[2]) == 0) break;
-      if (is_valid_char (pt[3]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[0]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[1]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[2]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[3]) == 0) break;
     }
 
     if (i < 16) continue;
@@ -452,10 +438,11 @@ KERNEL_FQ KERNEL_FA void m34700_sxx (KERN_ATTR_VECTOR ())
     pt[2] = ct[2] ^ out[2];
     pt[3] = ct[3] ^ out[3];
 
-    if (is_valid_char (pt[0]) == 0) continue;
-    if (is_valid_char (pt[1]) == 0) continue;
-    if (is_valid_char (pt[2]) == 0) continue;
-    if (is_valid_char (pt[3]) == 0) continue;
+    // decrypted data should be a string consisting only of ASCII chars (including newlines)
+    if (is_valid_printable_32_incl_common_control (pt[0]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[1]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[2]) == 0) continue;
+    if (is_valid_printable_32_incl_common_control (pt[3]) == 0) continue;
 
     int i;
 
@@ -468,10 +455,10 @@ KERNEL_FQ KERNEL_FA void m34700_sxx (KERN_ATTR_VECTOR ())
       pt[2] = salt_bufs[SALT_POS_HOST].salt_buf[i + 2] ^ out[2];
       pt[3] = salt_bufs[SALT_POS_HOST].salt_buf[i + 3] ^ out[3];
 
-      if (is_valid_char (pt[0]) == 0) break;
-      if (is_valid_char (pt[1]) == 0) break;
-      if (is_valid_char (pt[2]) == 0) break;
-      if (is_valid_char (pt[3]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[0]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[1]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[2]) == 0) break;
+      if (is_valid_printable_32_incl_common_control (pt[3]) == 0) break;
     }
 
     if (i < 16) continue;

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -47,7 +47,7 @@ SLOW_ALGOS=$(   grep -l ATTACK_EXEC_OUTSIDE_KERNEL "${TDIR}"/../src/modules/modu
 # fake slow algos, due to specific password pattern (e.g. ?d from "mask_3" is invalid):
 # ("only" drawback is that just -a 0 is tested with this workaround)
 
-SLOW_ALGOS="${SLOW_ALGOS} 28501 28502 28503 28504 28505 28506 30901 30902 30903 30904 30905 30906"
+SLOW_ALGOS="${SLOW_ALGOS} 28501 28502 28503 28504 28505 28506 30901 30902 30903 30904 30905 30906 34700"
 
 OUTD="test_$(date +%s)"
 


### PR DESCRIPTION
I found `is_valid_char()` and thought it was a strange function because we have `is_valid_printable_32()`, however `is_valid_char()` is used specifically where 0x0a is also included in the plaintext e.g. with JSON. This PR is mainly focused to make sure people use common methods when reusing parts of kernels.

A different option would be to keep the 4 instances of `is_valid_char()` and just add some comments to the codes: we're not using `is_valid_printable_32()` because newlines (`0x0a`) need to be included.

This makes one wonder though, whether `is_valid_printable_32()` should also include `\n` `\r` and `\t`?

```
bash ./tools/test.sh -m 34700 -t all -a all
[ test_1758226294 ] > Init test for hash type 34700.
[ test_1758226294 ] [ Type 34700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1758226294 ] [ Type 34700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1758226294 ] [ Type 34700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1758226294 ] [ Type 34700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped

bash ./tools/test.sh -m 12700 -t all -a all
[ test_1758226467 ] > Init test for hash type 12700.
[ test_1758226467 ] [ Type 12700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1758226467 ] [ Type 12700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1758226467 ] [ Type 12700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1758226467 ] [ Type 12700, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
```


Whilst first trying the tests I found that for 34700 -a6 multi timed out because `?d?d?d?d?d?d?d?d` is attacked which takes ~45 minutes and thus times out on my pc, so I've added 34700 to SLOW_ALGOS in test.sh; same behavior on master branch.
