### PR TITLE
fix modules build warnings

### DIFF
--- a/src/modules/module_22600.c
+++ b/src/modules/module_22600.c
@@ -58,9 +58,10 @@ typedef struct telegram
 
 } telegram_t;
 
+#define DATA_LEN_TELEGRAM 288
+#define SALT_LEN_TELEGRAM 32
+
 static const char *SIGNATURE_TELEGRAM = "$telegram$";
-static const int   DATA_LEN_TELEGRAM  = 288;
-static const int   SALT_LEN_TELEGRAM  =  32;
 
 u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {

--- a/src/modules/module_24500.c
+++ b/src/modules/module_24500.c
@@ -59,9 +59,10 @@ typedef struct telegram
 
 } telegram_t;
 
+#define DATA_LEN_TELEGRAM 288
+#define SALT_LEN_TELEGRAM 32
+
 static const char *SIGNATURE_TELEGRAM = "$telegram$";
-static const int   DATA_LEN_TELEGRAM  = 288;
-static const int   SALT_LEN_TELEGRAM  =  32;
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_28501.c
+++ b/src/modules/module_28501.c
@@ -31,8 +31,6 @@ static const char *ST_PASS           = "KxhashcatxhXkULNJYF8Fu46G28SJrC7x2qwFtRu
 static const char *ST_HASH           = "1Jv6EonXm9x4Dw4QjEPAhGfmzFxTL7b3Zj";
 static const char *BENCHMARK_MASK    = "?1?1?1?1?1?1?1atxhXkULNJYF8Fu46G28SJrC7x2qwFtRuf38kVjkWxHg3";
 static const char *BENCHMARK_CHARSET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   WIF_LEN           = 52;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -50,6 +48,9 @@ const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
 const char *module_benchmark_charset (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_CHARSET;  }
+
+#define PUBKEY_MAXLEN 64 // our max is actually always 25 (21 + 4)
+#define WIF_LEN       52
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_28502.c
+++ b/src/modules/module_28502.c
@@ -31,8 +31,6 @@ static const char *ST_PASS           = "5KcL859EUnBDtVG76134U6DZWnVmpE996emJnWmT
 static const char *ST_HASH           = "1L9nr4GX4Zmd7gDL1UT75QPUqxSgNTvdHb";
 static const char *BENCHMARK_MASK    = "?1?1?1?1?1?1?1EUnBDtVG76134U6DZWnVmpE996emJnWmTLRW2hashcat";
 static const char *BENCHMARK_CHARSET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   WIF_LEN           = 51;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -50,6 +48,9 @@ const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
 const char *module_benchmark_charset (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_CHARSET;  }
+
+#define PUBKEY_MAXLEN 64 // our max is actually always 25 (21 + 4)
+#define WIF_LEN       51
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_28503.c
+++ b/src/modules/module_28503.c
@@ -29,7 +29,6 @@ static const char *ST_PASS           = "KyhashcatpL2CQmMUDVMVuEXqdLSvfQ6TBjkUuyt
 static const char *ST_HASH           = "bc1qxd76a5zamfyw0g2d2rxkdh0zt9m0uzmxmwjf0q";
 static const char *BENCHMARK_MASK    = "?1?1?1?1?1?1?1atpL2CQmMUDVMVuEXqdLSvfQ6TBjkUuyttSvBa7GMiuLi";
 static const char *BENCHMARK_CHARSET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-static const u32   WIF_LEN           = 52;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -47,6 +46,8 @@ const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
 const char *module_benchmark_charset (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_CHARSET;  }
+
+#define WIF_LEN 52
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_28504.c
+++ b/src/modules/module_28504.c
@@ -29,7 +29,6 @@ static const char *ST_PASS           = "5HzV19ffW9QTnmZHbwETRpPHm1d4hAP8PG1etUb3
 static const char *ST_HASH           = "bc1qv8e65p73gmp4w3z6fqnyu8t6ct69vetsda3snd";
 static const char *BENCHMARK_MASK    = "?1?1?1?1?1?1?1fW9QTnmZHbwETRpPHm1d4hAP8PG1etUb3T3jjhashcat";
 static const char *BENCHMARK_CHARSET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-static const u32   WIF_LEN           = 51;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -47,6 +46,8 @@ const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
 const char *module_benchmark_charset (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_CHARSET;  }
+
+#define WIF_LEN 51
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_28505.c
+++ b/src/modules/module_28505.c
@@ -31,8 +31,6 @@ static const char *ST_PASS           = "L4hashcat7q6HMnMFcukyvxxVJvpabXYjxXLey88
 static const char *ST_HASH           = "3H1YvmSdrjEfj9LvtiKJ8XiYq5htJRuejA";
 static const char *BENCHMARK_MASK    = "?1?1?1?1?1?1?1at7q6HMnMFcukyvxxVJvpabXYjxXLey8846NtWUyX4YLi";
 static const char *BENCHMARK_CHARSET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   WIF_LEN           = 52;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -50,6 +48,9 @@ const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
 const char *module_benchmark_charset (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_CHARSET;  }
+
+#define PUBKEY_MAXLEN 64 // our max is actually always 25 (21 + 4)
+#define WIF_LEN       52
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_28506.c
+++ b/src/modules/module_28506.c
@@ -31,8 +31,6 @@ static const char *ST_PASS           = "5JjDR424kMePbt5Uxnm2t1NizhdiVPcf8gCj68PQ
 static const char *ST_HASH           = "3LovFVx5zBRvusVcj7pf3JxV9V46kjKhKu";
 static const char *BENCHMARK_MASK    = "?1?1?1?1?1?1?14kMePbt5Uxnm2t1NizhdiVPcf8gCj68PQpP2ihashcat";
 static const char *BENCHMARK_CHARSET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   WIF_LEN           = 51;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -50,6 +48,9 @@ const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
 const char *module_benchmark_charset (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_CHARSET;  }
+
+#define PUBKEY_MAXLEN 64 // our max is actually always 25 (21 + 4)
+#define WIF_LEN       51
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_30901.c
+++ b/src/modules/module_30901.c
@@ -30,8 +30,6 @@ static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "59887ec9920239bd45b6a9f82b7c4e024f80beaf887e5ee6aac5de0a899d3068";
 static const char *ST_HASH           = "14Fqy5AGRehazZ4NLzxFWy2E4BiNFdH9Ut";
 static const char *BENCHMARK_MASK    = "?h?h?h?h?h?h?h9920239bd45b6a9f82b7c4e024f80beaf887e5ee6aac5de0a899d3068";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   RAW_LEN           = 64;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -48,6 +46,9 @@ u32         module_salt_type         (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
+
+#define PUBKEY_MAXLEN     64 // our max is actually always 25 (21 + 4)
+#define RAW_LEN           64
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_30902.c
+++ b/src/modules/module_30902.c
@@ -30,8 +30,6 @@ static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "2006a306cf8f61c18c4e78e5fc0f5a7aa473b5ffb41f34344a32f8e042786fa1";
 static const char *ST_HASH           = "12sLRz1TKPZurKCwVqeT5FkW3Y7usipPbZ";
 static const char *BENCHMARK_MASK    = "?h?h?h?h?h?h?h6cf8f61c18c4e78e5fc0f5a7aa473b5ffb41f34344a32f8e042786fa1";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   RAW_LEN           = 64;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -48,6 +46,9 @@ u32         module_salt_type         (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
+
+#define PUBKEY_MAXLEN     64 // our max is actually always 25 (21 + 4)
+#define RAW_LEN           64
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_30905.c
+++ b/src/modules/module_30905.c
@@ -30,8 +30,6 @@ static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "83b45ff8d85f37aafc05a8accd1f1cd5e50868b57e2ef0ef6f287bb4d8d17786";
 static const char *ST_HASH           = "3JqAMRQN3Gd6i8yV3Kw7v55RmFxW7iW2Aq";
 static const char *BENCHMARK_MASK    = "?h?h?h?h?h?h?h8d85f37aafc05a8accd1f1cd5e50868b57e2ef0ef6f287bb4d8d17786";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   RAW_LEN           = 64;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -48,6 +46,9 @@ u32         module_salt_type         (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
+
+#define PUBKEY_MAXLEN     64 // our max is actually always 25 (21 + 4)
+#define RAW_LEN           64
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {

--- a/src/modules/module_30906.c
+++ b/src/modules/module_30906.c
@@ -30,8 +30,6 @@ static const u32   SALT_TYPE         = SALT_TYPE_NONE;
 static const char *ST_PASS           = "4c969ccc86d9e1f557b4ff1f19badc9a99718dd2aec8fcf66460612e05f5f7dd";
 static const char *ST_HASH           = "3PmD8zdrFD8KVgLrguVDCP2RJB4Rh35G9Z";
 static const char *BENCHMARK_MASK    = "?h?h?h?h?h?h?hc86d9e1f557b4ff1f19badc9a99718dd2aec8fcf66460612e05f5f7dd";
-static const u32   PUBKEY_MAXLEN     = 64; // our max is actually always 25 (21 + 4)
-static const u32   RAW_LEN           = 64;
 
 u32         module_attack_exec       (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0         (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -48,6 +46,9 @@ u32         module_salt_type         (MAYBE_UNUSED const hashconfig_t *hashconfi
 const char *module_st_hash           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass           (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 const char *module_benchmark_mask    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BENCHMARK_MASK;  }
+
+#define PUBKEY_MAXLEN     64 // our max is actually always 25 (21 + 4)
+#define RAW_LEN           64
 
 bool module_unstable_warning (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra, MAYBE_UNUSED const hc_device_param_t *device_param)
 {


### PR DESCRIPTION
```
src/modules/module_22600.c:184:17: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  184 |   char salt_buf[SALT_BUF_LEN];
      |                 ^~~~~~~~~~~~
src/modules/module_22600.c:182:24: note: expanded from macro 'SALT_BUF_LEN'
  182 |   #define SALT_BUF_LEN (SALT_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/module_22600.c:197:16: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  197 |   char message[DATA_BUF_LEN];
      |                ^~~~~~~~~~~~
src/modules/module_22600.c:195:24: note: expanded from macro 'DATA_BUF_LEN'
  195 |   #define DATA_BUF_LEN (DATA_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
src/modules/module_22600.c:184:17: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  184 |   char salt_buf[SALT_BUF_LEN];
      |                 ^~~~~~~~~~~~
src/modules/module_22600.c:182:24: note: expanded from macro 'SALT_BUF_LEN'
  182 |   #define SALT_BUF_LEN (SALT_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/module_22600.c:197:16: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  197 |   char message[DATA_BUF_LEN];
      |                ^~~~~~~~~~~~
src/modules/module_22600.c:195:24: note: expanded from macro 'DATA_BUF_LEN'
  195 |   #define DATA_BUF_LEN (DATA_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
src/modules/module_24500.c:208:17: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  208 |   char salt_buf[SALT_BUF_LEN];
      |                 ^~~~~~~~~~~~
src/modules/module_24500.c:206:24: note: expanded from macro 'SALT_BUF_LEN'
  206 |   #define SALT_BUF_LEN (SALT_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/module_24500.c:221:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  221 |   char data[DATA_BUF_LEN];
      |             ^~~~~~~~~~~~
src/modules/module_24500.c:219:24: note: expanded from macro 'DATA_BUF_LEN'
  219 |   #define DATA_BUF_LEN (DATA_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
src/modules/module_24500.c:208:17: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  208 |   char salt_buf[SALT_BUF_LEN];
      |                 ^~~~~~~~~~~~
src/modules/module_24500.c:206:24: note: expanded from macro 'SALT_BUF_LEN'
  206 |   #define SALT_BUF_LEN (SALT_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/module_24500.c:221:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
  221 |   char data[DATA_BUF_LEN];
      |             ^~~~~~~~~~~~
src/modules/module_24500.c:219:24: note: expanded from macro 'DATA_BUF_LEN'
  219 |   #define DATA_BUF_LEN (DATA_LEN_TELEGRAM * 2 + 1)
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
src/modules/module_28501.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_28502.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_28501.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_28505.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
src/modules/module_28502.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
1 warning generated.
src/modules/module_28506.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_28505.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_28506.c:85:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   85 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_30901.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_30902.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_30901.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_30905.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_30906.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_30902.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
src/modules/module_30905.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
src/modules/module_30906.c:90:13: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
   90 |   u8 pubkey[PUBKEY_MAXLEN];
      |             ^~~~~~~~~~~~~
1 warning generated.
1 warning generated.

```