### PR TITLE
fixed kernel declarations for module 22800

### DIFF
--- a/OpenCL/m22800_a0-pure.cl
+++ b/OpenCL/m22800_a0-pure.cl
@@ -28,7 +28,7 @@
 #define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
 #endif
 
-KERNEL_FQ KERNEL_FA m22800_mxx (KERN_ATTR_RULES ())
+KERNEL_FQ KERNEL_FA void m22800_mxx (KERN_ATTR_RULES ())
 {
   /**
    * modifier
@@ -146,7 +146,7 @@ KERNEL_FQ KERNEL_FA m22800_mxx (KERN_ATTR_RULES ())
   }
 }
 
-KERNEL_FQ KERNEL_FA m22800_sxx (KERN_ATTR_RULES ())
+KERNEL_FQ KERNEL_FA void m22800_sxx (KERN_ATTR_RULES ())
 {
   /**
    * modifier

--- a/OpenCL/m22800_a1-pure.cl
+++ b/OpenCL/m22800_a1-pure.cl
@@ -26,7 +26,7 @@
 #define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
 #endif
 
-KERNEL_FQ KERNEL_FA m22800_mxx (KERN_ATTR_BASIC ())
+KERNEL_FQ KERNEL_FA void m22800_mxx (KERN_ATTR_BASIC ())
 {
   /**
    * modifier
@@ -146,7 +146,7 @@ KERNEL_FQ KERNEL_FA m22800_mxx (KERN_ATTR_BASIC ())
   }
 }
 
-KERNEL_FQ KERNEL_FA m22800_sxx (KERN_ATTR_BASIC ())
+KERNEL_FQ KERNEL_FA void m22800_sxx (KERN_ATTR_BASIC ())
 {
   /**
    * modifier

--- a/OpenCL/m22800_a3-pure.cl
+++ b/OpenCL/m22800_a3-pure.cl
@@ -28,7 +28,7 @@
 #define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
 #endif
 
-KERNEL_FQ KERNEL_FA m22800_mxx (KERN_ATTR_VECTOR ())
+KERNEL_FQ KERNEL_FA void m22800_mxx (KERN_ATTR_VECTOR ())
 {
   /**
    * modifier
@@ -157,7 +157,7 @@ KERNEL_FQ KERNEL_FA m22800_mxx (KERN_ATTR_VECTOR ())
   }
 }
 
-KERNEL_FQ KERNEL_FA m22800_sxx (KERN_ATTR_VECTOR ())
+KERNEL_FQ KERNEL_FA void m22800_sxx (KERN_ATTR_VECTOR ())
 {
   /**
    * modifier


### PR DESCRIPTION
```
hc_mtlCreateLibraryWithSource(): failed to create metal library, program_source:31:21: error: C++ requires a type specifier for all declarations
KERNEL_FQ KERNEL_FA m22800_mxx (KERN_ATTR_VECTOR ())
                    ^
program_source:160:21: error: C++ requires a type specifier for all declarations
KERNEL_FQ KERNEL_FA m22800_sxx (KERN_ATTR_VECTOR ())
```

reported here: #4462 