### PR TITLE
fix deprecated declarations warnings on sprintf

### DIFF
--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -345,44 +345,46 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (pkzip->version == 1)
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V1);
-    out_len += 7;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V1);
   }
   else
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V2);
-    out_len += 8;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V2);
   }
-  out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
 
-  out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hash.data_type_enum, pkzip->hash.magic_type_enum);
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
+
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hash.data_type_enum, pkzip->hash.magic_type_enum);
+
   if (pkzip->hash.data_type_enum > 1)
   {
-    out_len += sprintf (line_buf + out_len, "%x*%x*%x*%x*%x*", pkzip->hash.compressed_length, pkzip->hash.uncompressed_length, pkzip->hash.crc32, pkzip->hash.offset, pkzip->hash.additional_offset);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%x*%x*%x*%x*%x*", pkzip->hash.compressed_length, pkzip->hash.uncompressed_length, pkzip->hash.crc32, pkzip->hash.offset, pkzip->hash.additional_offset);
   }
 
-  out_len += sprintf (line_buf + out_len, "%i*%x*%04x*", pkzip->hash.compression_type, pkzip->hash.data_length, pkzip->hash.checksum_from_crc);
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%x*%04x*", pkzip->hash.compression_type, pkzip->hash.data_length, pkzip->hash.checksum_from_crc);
+
   if (pkzip->version == 2)
   {
-    out_len += sprintf (line_buf + out_len, "%04x*", pkzip->hash.checksum_from_timestamp);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%04x*", pkzip->hash.checksum_from_timestamp);
   }
 
   for (u32 i = 0; i < pkzip->hash.data_length / 4; i++)
   {
-    out_len += sprintf (line_buf + out_len, "%08x", byte_swap_32 (pkzip->hash.data[i]));
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%08x", byte_swap_32 (pkzip->hash.data[i]));
   }
+
   for (u32 i = 0; i < pkzip->hash.data_length % 4; i++)
   {
-    out_len += sprintf (line_buf + out_len, "%02x", (pkzip->hash.data[pkzip->hash.data_length / 4] >> i*8) & 0xff);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%02x", (pkzip->hash.data[pkzip->hash.data_length / 4] >> i*8) & 0xff);
   }
 
   if (pkzip->version == 1)
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip$");
   }
   else
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip2$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip2$");
   }
 
   return out_len;

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -313,44 +313,46 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (pkzip->version == 1)
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V1);
-    out_len += 7;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V1);
   }
   else
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V2);
-    out_len += 8;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V2);
   }
-  out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
 
-  out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hash.data_type_enum, pkzip->hash.magic_type_enum);
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
+
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hash.data_type_enum, pkzip->hash.magic_type_enum);
+
   if (pkzip->hash.data_type_enum > 1)
   {
-    out_len += sprintf (line_buf + out_len, "%x*%x*%x*%x*%x*", pkzip->hash.compressed_length, pkzip->hash.uncompressed_length, pkzip->hash.crc32, pkzip->hash.offset, pkzip->hash.additional_offset);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%x*%x*%x*%x*%x*", pkzip->hash.compressed_length, pkzip->hash.uncompressed_length, pkzip->hash.crc32, pkzip->hash.offset, pkzip->hash.additional_offset);
   }
 
-  out_len += sprintf (line_buf + out_len, "%i*%x*%04x*", pkzip->hash.compression_type, pkzip->hash.data_length, pkzip->hash.checksum_from_crc);
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%x*%04x*", pkzip->hash.compression_type, pkzip->hash.data_length, pkzip->hash.checksum_from_crc);
+
   if (pkzip->version == 2)
   {
-    out_len += sprintf (line_buf + out_len, "%04x*", pkzip->hash.checksum_from_timestamp);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%04x*", pkzip->hash.checksum_from_timestamp);
   }
 
   for (u32 i = 0; i < pkzip->hash.data_length / 4; i++)
   {
-    out_len += sprintf (line_buf + out_len, "%08x", byte_swap_32 (pkzip->hash.data[i]));
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%08x", byte_swap_32 (pkzip->hash.data[i]));
   }
+
   for (u32 i = 0; i < pkzip->hash.data_length % 4; i++)
   {
-    out_len += sprintf (line_buf + out_len, "%02x", (pkzip->hash.data[pkzip->hash.data_length / 4] >> i*8) & 0xff);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%02x", (pkzip->hash.data[pkzip->hash.data_length / 4] >> (i * 8)) & 0xff);
   }
 
   if (pkzip->version == 1)
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip$");
   }
   else
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip2$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip2$");
   }
 
   return out_len;

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -341,51 +341,54 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (pkzip->version == 1)
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V1);
-    out_len += 7;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V1);
   }
   else
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V2);
-    out_len += 8;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V2);
   }
-  out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
+
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
 
   for (int cnt = 0; cnt < pkzip->hash_count; cnt++)
   {
     if (cnt > 0)
     {
-      out_len += sprintf (line_buf + out_len, "*");
-    }
-    out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hashes[cnt].data_type_enum, pkzip->hashes[cnt].magic_type_enum);
-    if (pkzip->hashes[cnt].data_type_enum > 1)
-    {
-      out_len += sprintf (line_buf + out_len, "%x*%x*%x*%x*%x*", pkzip->hashes[cnt].compressed_length, pkzip->hashes[cnt].uncompressed_length, pkzip->hashes[cnt].crc32, pkzip->hashes[cnt].offset, pkzip->hashes[cnt].additional_offset);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "*");
     }
 
-    out_len += sprintf (line_buf + out_len, "%i*%x*%04x*", pkzip->hashes[cnt].compression_type, pkzip->hashes[cnt].data_length, pkzip->hashes[cnt].checksum_from_crc);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hashes[cnt].data_type_enum, pkzip->hashes[cnt].magic_type_enum);
+
+    if (pkzip->hashes[cnt].data_type_enum > 1)
+    {
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%x*%x*%x*%x*%x*", pkzip->hashes[cnt].compressed_length, pkzip->hashes[cnt].uncompressed_length, pkzip->hashes[cnt].crc32, pkzip->hashes[cnt].offset, pkzip->hashes[cnt].additional_offset);
+    }
+
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%x*%04x*", pkzip->hashes[cnt].compression_type, pkzip->hashes[cnt].data_length, pkzip->hashes[cnt].checksum_from_crc);
+
     if (pkzip->version == 2)
     {
-      out_len += sprintf (line_buf + out_len, "%04x*", pkzip->hashes[cnt].checksum_from_timestamp);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%04x*", pkzip->hashes[cnt].checksum_from_timestamp);
     }
 
     for (u32 i = 0; i < pkzip->hashes[cnt].data_length / 4; i++)
     {
-      out_len += sprintf (line_buf + out_len, "%08x", byte_swap_32 (pkzip->hashes[cnt].data[i]));
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%08x", byte_swap_32 (pkzip->hashes[cnt].data[i]));
     }
+
     for (u32 i = 0; i < pkzip->hashes[cnt].data_length % 4; i++)
     {
-      out_len += sprintf (line_buf + out_len, "%02x", (pkzip->hashes[cnt].data[pkzip->hashes[cnt].data_length / 4] >> i*8) & 0xff);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%02x", (pkzip->hashes[cnt].data[pkzip->hashes[cnt].data_length / 4] >> (i * 8)) & 0xff);
     }
   }
 
   if (pkzip->version == 1)
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip$");
   }
   else
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip2$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip2$");
   }
 
   return out_len;

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -341,51 +341,54 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (pkzip->version == 1)
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V1);
-    out_len += 7;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V1);
   }
   else
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V2);
-    out_len += 8;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V2);
   }
-  out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
+
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
 
   for (int cnt = 0; cnt < pkzip->hash_count; cnt++)
   {
     if (cnt > 0)
     {
-      out_len += sprintf (line_buf + out_len, "*");
-    }
-    out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hashes[cnt].data_type_enum, pkzip->hashes[cnt].magic_type_enum);
-    if (pkzip->hashes[cnt].data_type_enum > 1)
-    {
-      out_len += sprintf (line_buf + out_len, "%x*%x*%x*%x*%x*", pkzip->hashes[cnt].compressed_length, pkzip->hashes[cnt].uncompressed_length, pkzip->hashes[cnt].crc32, pkzip->hashes[cnt].offset, pkzip->hashes[cnt].additional_offset);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "*");
     }
 
-    out_len += sprintf (line_buf + out_len, "%i*%x*%04x*", pkzip->hashes[cnt].compression_type, pkzip->hashes[cnt].data_length, pkzip->hashes[cnt].checksum_from_crc);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hashes[cnt].data_type_enum, pkzip->hashes[cnt].magic_type_enum);
+
+    if (pkzip->hashes[cnt].data_type_enum > 1)
+    {
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%x*%x*%x*%x*%x*", pkzip->hashes[cnt].compressed_length, pkzip->hashes[cnt].uncompressed_length, pkzip->hashes[cnt].crc32, pkzip->hashes[cnt].offset, pkzip->hashes[cnt].additional_offset);
+    }
+
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%x*%04x*", pkzip->hashes[cnt].compression_type, pkzip->hashes[cnt].data_length, pkzip->hashes[cnt].checksum_from_crc);
+
     if (pkzip->version == 2)
     {
-      out_len += sprintf (line_buf + out_len, "%04x*", pkzip->hashes[cnt].checksum_from_timestamp);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%04x*", pkzip->hashes[cnt].checksum_from_timestamp);
     }
 
     for (u32 i = 0; i < pkzip->hashes[cnt].data_length / 4; i++)
     {
-      out_len += sprintf (line_buf + out_len, "%08x", byte_swap_32 (pkzip->hashes[cnt].data[i]));
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%08x", byte_swap_32(pkzip->hashes[cnt].data[i]));
     }
+
     for (u32 i = 0; i < pkzip->hashes[cnt].data_length % 4; i++)
     {
-      out_len += sprintf (line_buf + out_len, "%02x", (pkzip->hashes[cnt].data[pkzip->hashes[cnt].data_length / 4] >> i*8) & 0xff);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%02x", (pkzip->hashes[cnt].data[pkzip->hashes[cnt].data_length / 4] >> (i*8)) & 0xff);
     }
   }
 
   if (pkzip->version == 1)
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip$");
   }
   else
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip2$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip2$");
   }
 
   return out_len;

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -324,51 +324,54 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (pkzip->version == 1)
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V1);
-    out_len += 7;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V1);
   }
   else
   {
-    sprintf (line_buf, "%s", SIGNATURE_PKZIP_V2);
-    out_len += 8;
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%s", SIGNATURE_PKZIP_V2);
   }
-  out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
+
+  out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hash_count, pkzip->checksum_size);
 
   for (int cnt = 0; cnt < pkzip->hash_count; cnt++)
   {
     if (cnt > 0)
     {
-      out_len += sprintf (line_buf + out_len, "*");
-    }
-    out_len += sprintf (line_buf + out_len, "%i*%i*", pkzip->hashes[cnt].data_type_enum, pkzip->hashes[cnt].magic_type_enum);
-    if (pkzip->hashes[cnt].data_type_enum > 1)
-    {
-      out_len += sprintf (line_buf + out_len, "%x*%x*%x*%x*%x*", pkzip->hashes[cnt].compressed_length, pkzip->hashes[cnt].uncompressed_length, pkzip->hashes[cnt].crc32, pkzip->hashes[cnt].offset, pkzip->hashes[cnt].additional_offset);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "*");
     }
 
-    out_len += sprintf (line_buf + out_len, "%i*%x*%04x*", pkzip->hashes[cnt].compression_type, pkzip->hashes[cnt].data_length, pkzip->hashes[cnt].checksum_from_crc);
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%i*", pkzip->hashes[cnt].data_type_enum, pkzip->hashes[cnt].magic_type_enum);
+
+    if (pkzip->hashes[cnt].data_type_enum > 1)
+    {
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%x*%x*%x*%x*%x*", pkzip->hashes[cnt].compressed_length, pkzip->hashes[cnt].uncompressed_length, pkzip->hashes[cnt].crc32, pkzip->hashes[cnt].offset, pkzip->hashes[cnt].additional_offset);
+    }
+
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "%i*%x*%04x*", pkzip->hashes[cnt].compression_type, pkzip->hashes[cnt].data_length, pkzip->hashes[cnt].checksum_from_crc);
+
     if (pkzip->version == 2)
     {
-      out_len += sprintf (line_buf + out_len, "%04x*", pkzip->hashes[cnt].checksum_from_timestamp);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%04x*", pkzip->hashes[cnt].checksum_from_timestamp);
     }
 
     for (u32 i = 0; i < pkzip->hashes[cnt].data_length / 4; i++)
     {
-      out_len += sprintf (line_buf + out_len, "%08x", byte_swap_32 (pkzip->hashes[cnt].data[i]));
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%08x", byte_swap_32(pkzip->hashes[cnt].data[i]));
     }
+
     for (u32 i = 0; i < pkzip->hashes[cnt].data_length % 4; i++)
     {
-      out_len += sprintf (line_buf + out_len, "%02x", (pkzip->hashes[cnt].data[pkzip->hashes[cnt].data_length / 4] >> i*8) & 0xff);
+      out_len += snprintf (line_buf + out_len, line_size - out_len, "%02x", (pkzip->hashes[cnt].data[pkzip->hashes[cnt].data_length / 4] >> (i*8)) & 0xff);
     }
   }
 
   if (pkzip->version == 1)
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip$");
   }
   else
   {
-    out_len += sprintf (line_buf + out_len, "*$/pkzip2$");
+    out_len += snprintf (line_buf + out_len, line_size - out_len, "*$/pkzip2$");
   }
 
   return out_len;


### PR DESCRIPTION
```
$ make DEBUG=2 -s -j
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive library: obj/combined.NATIVE.a will be fat and ar(1) will not be able to operate on it
src/modules/module_17200.c:348:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  348 |     sprintf (line_buf, "%s", SIGNATURE_PKZIP_V1);
      |     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:278:1: note: 'sprintf' has been explicitly marked deprecated here
  278 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:227:48: note: expanded from macro '__deprecated_msg'
  227 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
src/modules/module_17200.c:353:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  353 |     sprintf (line_buf, "%s", SIGNATURE_PKZIP_V2);
      |     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:278:1: note: 'sprintf' has been explicitly marked deprecated here
  278 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
[...]
```