### PR TITLE
fix FIXED_LOCAL_SIZE undefined for module 18600

### DIFF
--- a/OpenCL/inc_cipher_blowfish.h
+++ b/OpenCL/inc_cipher_blowfish.h
@@ -6,6 +6,12 @@
 #ifndef INC_CIPHER_BLOWFISH_H
 #define INC_CIPHER_BLOWFISH_H
 
+#ifndef FIXED_LOCAL_SIZE
+#ifdef FIXED_LOCAL_SIZE_COMP
+#define FIXED_LOCAL_SIZE FIXED_LOCAL_SIZE_COMP
+#endif
+#endif
+
 DECLSPEC void expand_key            (PRIVATE_AS u32 *E, PRIVATE_AS u32 *W, const int len);
 DECLSPEC void blowfish_set_key      (PRIVATE_AS u32 *E, PRIVATE_AS u32 E_dim_size, PRIVATE_AS u32 *P, LOCAL_AS u32 *S0, LOCAL_AS u32 *S1, LOCAL_AS u32 *S2, LOCAL_AS u32 *S3);
 DECLSPEC void blowfish_set_key_salt (PRIVATE_AS u32 *E, PRIVATE_AS u32 E_dim_size, PRIVATE_AS u32 *salt_buf, PRIVATE_AS u32 *P, LOCAL_AS u32 *S0, LOCAL_AS u32 *S1, LOCAL_AS u32 *S2, LOCAL_AS u32 *S3);


### PR DESCRIPTION
Added workaround to prevent the following error

```
---------------------------------------------------------------------------------------
* Hash-Mode 18600 (Open Document Format (ODF) 1.1 (SHA-1, Blowfish)) [Iterations: 1023]
---------------------------------------------------------------------------------------

nvrtcCompileProgram(): NVRTC_ERROR_COMPILATION

[redacted]/hashcat/OpenCL/inc_cipher_blowfish.cl(319): error: identifier "FIXED_LOCAL_SIZE" is undefined
    return S[KEY32 (lid, key)];
             ^

[redacted]/hashcat/OpenCL/inc_cipher_blowfish.cl(326): error: identifier "FIXED_LOCAL_SIZE" is undefined
    S[KEY32 (lid, key)] = val;
      ^

2 errors detected in the compilation of "main_kernel".

* Device #1: Kernel [redacted]/hashcat/OpenCL/m18600-pure.cl build failed.

* Device #1: Kernel [redacted]/hashcat/OpenCL/m18600-pure.cl build failed.
```