### PR TITLE
Fixed bugs on multiple DES based modules when used with CPU devices

### DIFF
--- a/OpenCL/m01500_a0-pure.cl
+++ b/OpenCL/m01500_a0-pure.cl
@@ -30,6 +30,8 @@ KERNEL_FQ KERNEL_FA void m01500_mxx (KERN_ATTR_RULES ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -55,6 +57,13 @@ KERNEL_FQ KERNEL_FA void m01500_mxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -114,6 +123,8 @@ KERNEL_FQ KERNEL_FA void m01500_sxx (KERN_ATTR_RULES ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -139,6 +150,13 @@ KERNEL_FQ KERNEL_FA void m01500_sxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m01500_a1-pure.cl
+++ b/OpenCL/m01500_a1-pure.cl
@@ -28,6 +28,8 @@ KERNEL_FQ KERNEL_FA void m01500_mxx (KERN_ATTR_BASIC ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -53,6 +55,13 @@ KERNEL_FQ KERNEL_FA void m01500_mxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -191,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m01500_sxx (KERN_ATTR_BASIC ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -216,6 +227,13 @@ KERNEL_FQ KERNEL_FA void m01500_sxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m03000_a0-pure.cl
+++ b/OpenCL/m03000_a0-pure.cl
@@ -65,6 +65,8 @@ KERNEL_FQ KERNEL_FA void m03000_mxx (KERN_ATTR_RULES ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -90,6 +92,13 @@ KERNEL_FQ KERNEL_FA void m03000_mxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -153,6 +162,8 @@ KERNEL_FQ KERNEL_FA void m03000_sxx (KERN_ATTR_RULES ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -178,6 +189,13 @@ KERNEL_FQ KERNEL_FA void m03000_sxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m03000_a1-pure.cl
+++ b/OpenCL/m03000_a1-pure.cl
@@ -63,6 +63,8 @@ KERNEL_FQ KERNEL_FA void m03000_mxx (KERN_ATTR_BASIC ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -88,6 +90,13 @@ KERNEL_FQ KERNEL_FA void m03000_mxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -230,6 +239,8 @@ KERNEL_FQ KERNEL_FA void m03000_sxx (KERN_ATTR_BASIC ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -255,6 +266,13 @@ KERNEL_FQ KERNEL_FA void m03000_sxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m08500_a0-pure.cl
+++ b/OpenCL/m08500_a0-pure.cl
@@ -77,6 +77,8 @@ KERNEL_FQ KERNEL_FA void m08500_mxx (KERN_ATTR_RULES ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -102,6 +104,13 @@ KERNEL_FQ KERNEL_FA void m08500_mxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -175,6 +184,8 @@ KERNEL_FQ KERNEL_FA void m08500_sxx (KERN_ATTR_RULES ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -200,6 +211,13 @@ KERNEL_FQ KERNEL_FA void m08500_sxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m08500_a1-pure.cl
+++ b/OpenCL/m08500_a1-pure.cl
@@ -75,6 +75,8 @@ KERNEL_FQ KERNEL_FA void m08500_mxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -100,6 +102,13 @@ KERNEL_FQ KERNEL_FA void m08500_mxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -231,6 +240,8 @@ KERNEL_FQ KERNEL_FA void m08500_sxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -256,6 +267,13 @@ KERNEL_FQ KERNEL_FA void m08500_sxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m08500_a3-pure.cl
+++ b/OpenCL/m08500_a3-pure.cl
@@ -207,6 +207,8 @@ KERNEL_FQ KERNEL_FA void m08500_mxx (KERN_ATTR_VECTOR ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -232,6 +234,13 @@ KERNEL_FQ KERNEL_FA void m08500_mxx (KERN_ATTR_VECTOR ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -281,6 +290,8 @@ KERNEL_FQ KERNEL_FA void m08500_sxx (KERN_ATTR_VECTOR ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -306,6 +317,13 @@ KERNEL_FQ KERNEL_FA void m08500_sxx (KERN_ATTR_VECTOR ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m14000_a0-pure.cl
+++ b/OpenCL/m14000_a0-pure.cl
@@ -42,6 +42,8 @@ KERNEL_FQ KERNEL_FA void m14000_mxx (KERN_ATTR_RULES ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -67,6 +69,13 @@ KERNEL_FQ KERNEL_FA void m14000_mxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -147,6 +156,8 @@ KERNEL_FQ KERNEL_FA void m14000_sxx (KERN_ATTR_RULES ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -172,6 +183,13 @@ KERNEL_FQ KERNEL_FA void m14000_sxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m14000_a1-pure.cl
+++ b/OpenCL/m14000_a1-pure.cl
@@ -40,6 +40,8 @@ KERNEL_FQ KERNEL_FA void m14000_mxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -65,6 +67,13 @@ KERNEL_FQ KERNEL_FA void m14000_mxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -188,6 +197,8 @@ KERNEL_FQ KERNEL_FA void m14000_sxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -213,6 +224,13 @@ KERNEL_FQ KERNEL_FA void m14000_sxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m14100_a0-pure.cl
+++ b/OpenCL/m14100_a0-pure.cl
@@ -30,6 +30,8 @@ KERNEL_FQ KERNEL_FA void m14100_mxx (KERN_ATTR_RULES ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -55,6 +57,13 @@ KERNEL_FQ KERNEL_FA void m14100_mxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -165,6 +174,8 @@ KERNEL_FQ KERNEL_FA void m14100_sxx (KERN_ATTR_RULES ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -190,6 +201,13 @@ KERNEL_FQ KERNEL_FA void m14100_sxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m14100_a1-pure.cl
+++ b/OpenCL/m14100_a1-pure.cl
@@ -28,6 +28,8 @@ KERNEL_FQ KERNEL_FA void m14100_mxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -53,6 +55,13 @@ KERNEL_FQ KERNEL_FA void m14100_mxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -211,6 +220,8 @@ KERNEL_FQ KERNEL_FA void m14100_sxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -236,6 +247,13 @@ KERNEL_FQ KERNEL_FA void m14100_sxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m14100_a3-pure.cl
+++ b/OpenCL/m14100_a3-pure.cl
@@ -227,6 +227,8 @@ KERNEL_FQ KERNEL_FA void m14100_mxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -252,6 +254,13 @@ KERNEL_FQ KERNEL_FA void m14100_mxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -301,6 +310,8 @@ KERNEL_FQ KERNEL_FA void m14100_sxx (KERN_ATTR_BASIC ())
    * shared
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -326,6 +337,13 @@ KERNEL_FQ KERNEL_FA void m14100_sxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64] = c_SPtrans;
+  CONSTANT_AS u32a (*s_skb)[64]     = c_skb;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m16000_a0-pure.cl
+++ b/OpenCL/m16000_a0-pure.cl
@@ -42,6 +42,8 @@ KERNEL_FQ KERNEL_FA void m16000_mxx (KERN_ATTR_RULES ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -74,6 +76,15 @@ KERNEL_FQ KERNEL_FA void m16000_mxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64]   = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]       = c_skb;
+
+  CONSTANT_AS u32a (*s_tripcode_salt) = c_tripcode_salt;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -135,6 +146,8 @@ KERNEL_FQ KERNEL_FA void m16000_sxx (KERN_ATTR_RULES ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -167,6 +180,15 @@ KERNEL_FQ KERNEL_FA void m16000_sxx (KERN_ATTR_RULES ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64]   = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]       = c_skb;
+
+  CONSTANT_AS u32a (*s_tripcode_salt) = c_tripcode_salt;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m16000_a1-pure.cl
+++ b/OpenCL/m16000_a1-pure.cl
@@ -40,6 +40,8 @@ KERNEL_FQ KERNEL_FA void m16000_mxx (KERN_ATTR_BASIC ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -72,6 +74,15 @@ KERNEL_FQ KERNEL_FA void m16000_mxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64]   = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]       = c_skb;
+
+  CONSTANT_AS u32a (*s_tripcode_salt) = c_tripcode_salt;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -212,6 +223,8 @@ KERNEL_FQ KERNEL_FA void m16000_sxx (KERN_ATTR_BASIC ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -244,6 +257,15 @@ KERNEL_FQ KERNEL_FA void m16000_sxx (KERN_ATTR_BASIC ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64]   = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]       = c_skb;
+
+  CONSTANT_AS u32a (*s_tripcode_salt) = c_tripcode_salt;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/OpenCL/m16000_a3-pure.cl
+++ b/OpenCL/m16000_a3-pure.cl
@@ -40,6 +40,8 @@ KERNEL_FQ KERNEL_FA void m16000_mxx (KERN_ATTR_VECTOR ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -72,6 +74,15 @@ KERNEL_FQ KERNEL_FA void m16000_mxx (KERN_ATTR_VECTOR ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64]   = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]       = c_skb;
+
+  CONSTANT_AS u32a (*s_tripcode_salt) = c_tripcode_salt;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 
@@ -161,6 +172,8 @@ KERNEL_FQ KERNEL_FA void m16000_sxx (KERN_ATTR_VECTOR ())
    * sbox, kbox
    */
 
+  #ifdef REAL_SHM
+
   LOCAL_VK u32 s_SPtrans[8][64];
   LOCAL_VK u32 s_skb[8][64];
 
@@ -193,6 +206,15 @@ KERNEL_FQ KERNEL_FA void m16000_sxx (KERN_ATTR_VECTOR ())
   }
 
   SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a (*s_SPtrans)[64]   = c_SPtrans_opti;
+  CONSTANT_AS u32a (*s_skb)[64]       = c_skb;
+
+  CONSTANT_AS u32a (*s_tripcode_salt) = c_tripcode_salt;
+
+  #endif
 
   if (gid >= GID_CNT) return;
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -5,6 +5,7 @@
 ##
 
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
+- Fixed bugs on multiple DES based modules when used with CPU devices
 
 * changes v7.1.1 -> v7.1.2
 


### PR DESCRIPTION
POC of build errors with CPU device

```
Initializing backend runtime for device #6. Please be patient...4 errors generated.
clCompileProgram(): CL_COMPILE_PROGRAM_FAILURE

error: /home/matrix/.cache/pocl/kcache/tempfile_vrgJ9W.cl:109:57: passing '__local u32 (*)[64]' (aka '__local unsigned int (*)[64]') to parameter of type '__constant u32 (*)[64]' (aka '__constant unsigned int (*)[64]') changes address space of pointer
error: /home/matrix/.cache/pocl/kcache/tempfile_vrgJ9W.cl:113:48: passing '__local u32 (*)[64]' (aka '__local unsigned int (*)[64]') to parameter of type '__constant u32 (*)[64]' (aka '__constant unsigned int (*)[64]') changes address space of pointer
error: /home/matrix/.cache/pocl/kcache/tempfile_vrgJ9W.cl:214:57: passing '__local u32 (*)[64]' (aka '__local unsigned int (*)[64]') to parameter of type '__constant u32 (*)[64]' (aka '__constant unsigned int (*)[64]') changes address space of pointer
error: /home/matrix/.cache/pocl/kcache/tempfile_vrgJ9W.cl:218:48: passing '__local u32 (*)[64]' (aka '__local unsigned int (*)[64]') to parameter of type '__constant u32 (*)[64]' (aka '__constant unsigned int (*)[64]') changes address space of pointer
Device cpu-haswell-12th Gen Intel(R) Core(TM) i7-12700K failed to build the program

```

Thanks to jeffmcjunkin from Discord for pointing this out ;)