### PR TITLE
Fix hash category for mega.nz password-protected links

### DIFF
--- a/src/modules/module_33400.c
+++ b/src/modules/module_33400.c
@@ -22,8 +22,8 @@ static const u32   DGST_POS1      = 1;
 static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_8;
-// TODO: not sure about this choice
-static const u32   HASH_CATEGORY  = HASH_CATEGORY_ARCHIVE;
+// Mega.nz is a cloud storage service, categorized as network server
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_SERVER;
 static const char *HASH_NAME      = "mega.nz password-protected link (PBKDF2-HMAC-SHA512)";
 static const u64   KERN_TYPE      = 33400;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE


### PR DESCRIPTION
This PR resolves the TODO comment in module 33400 by correctly categorizing mega.nz password-protected links

- Change from HASH_CATEGORY_ARCHIVE to HASH_CATEGORY_NETWORK_SERVER
- Mega.nz is a cloud storage service, not an archive format
- Remove TODO comment as category is now correctly determined
- Builds cleanly with no warnings
- Module loads correctly  
- No breaking changes to existing functionality

Resolves categorization ambiguity in module 33400.

### Testing Results

```bash
$ ./hashcat -H -m 33400
Hash mode #33400
  Name................: mega.nz password-protected link (PBKDF2-HMAC-SHA512)
  Category............: FTP, HTTP, SMTP, LDAP Server  ✓  (changed from Archive)

$ ./hashcat -b -m 33400

Speed.#01........:      139 H/s (69.78ms) @ Accel:1024 Loops:1000 Thr:1 Vec:4
Started: Mon Sep 22 23:35:01 2025
Stopped: Mon Sep 22 23:35:52 2025
```