### PR TITLE
Update hashcat-toolchain to version 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ hashcat.dll
 *.log
 *.out
 *.dSYM
+*.su
 kernels/**
 seekdbs/**
 lib/*.a

--- a/docker/hashcatToolchain.ubuntu
+++ b/docker/hashcatToolchain.ubuntu
@@ -1,41 +1,23 @@
-ARG UBUNTU_VERSION=16.04
+ARG UBUNTU_VERSION=16.04 \
+    WD=/opt/toolchain \
+    HOST_ARCH=x86_64
 
-FROM ubuntu:${UBUNTU_VERSION}
+FROM ubuntu:${UBUNTU_VERSION} AS builder-toolchain
 
 LABEL org.opencontainers.image.authors="Gabriele 'matrix' Gristina <matrix@hashcat.net>" \
       org.opencontainers.image.title="Hashcat cross-build toolchain (Ubuntu based)" \
-      org.opencontainers.image.version="1.0" \
+      org.opencontainers.image.version="1.1" \
       org.opencontainers.image.description="Docker image based on Ubuntu (tested from version 16.04 onwards) for cross-compiling Hashcat (Windows and Linux) and optionally scanning for potential vulnerabilities using clang-tidy and scan-build." \
       org.opencontainers.image.source="https://github.com/hashcat/hashcat/blob/master/docker/hashcatToolchain.ubuntu" \
       org.opencontainers.image.licenses="MIT"
 
-ARG UBUNTU_VERSION
-ARG BINUTILS_VERSION=2_45
-ARG MINGW_VERSION=13.0.0
-ARG GCC_VERSION=15.2.0
-ARG CLANG_VERSION=21.1.1
-ARG CMAKE_VERSION=4.1.1
-ARG SEVEN_ZIP_VERSION=25.01
-ARG WIN_ICONV_VERSION=v0.0.10
-ARG LINUX_PYTHON_VERSION=3.13.5
-ARG WIN_PYTHON_VERSION=3.12.11-1
-ARG OPENSSL_VERSION=OpenSSL_1_1_1w
-ARG RUST_VERSION=1.89.0
 ARG MAX_CORES=12
-ARG WD=/root
+ARG UBUNTU_VERSION \
+    WD \
+    HOST_ARCH
 
 ENV UBUNTU_VERSION=${UBUNTU_VERSION} \
-    BINUTILS_VERSION=${BINUTILS_VERSION} \
-    MINGW_VERSION=${MINGW_VERSION} \
-    GCC_VERSION=${GCC_VERSION} \
-    CLANG_VERSION=${CLANG_VERSION} \
-    CMAKE_VERSION=${CMAKE_VERSION} \
-    SEVEN_ZIP_VERSION=${SEVEN_ZIP_VERSION} \
-    WIN_ICONV_VERSION=${WIN_ICONV_VERSION} \
-    LINUX_PYTHON_VERSION=${LINUX_PYTHON_VERSION} \
-    WIN_PYTHON_VERSION=${WIN_PYTHON_VERSION} \
-    OPENSSL_VERSION=${OPENSSL_VERSION} \
-    RUST_VERSION=${RUST_VERSION} \
+    HOST_ARCH=${HOST_ARCH} \
     MAX_CORES=${MAX_CORES} \
     WD=${WD}
 
@@ -44,69 +26,44 @@ ENV UBUNTU_VERSION=${UBUNTU_VERSION} \
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y --no-install-recommends install apt-utils && apt-get -y --no-install-recommends install \
-    apt-utils autoconf automake \
+    autoconf automake \
     bison build-essential \
-    ca-certificates curl \
-    dos2unix \
+    ca-certificates \
     flex \
     gawk git gperf \
     libtool \
     pkg-config \
-    texinfo time \
+    texinfo \
     unzip \
     wget \
-    zlib1g-dev zstd \
+    zlib1g-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ## Prepare directories
 
-RUN mkdir -p $WD/src $WD/build $WD/install/native $WD/install/cross /opt/win-python /opt/linux-python /root/out /root/patches
-
-## Download sources
-
-WORKDIR $WD/src
-
-# 7zip, win-iconv, OpenSSL, MinGW, GCC, Binutils, Clang, Python
-
-RUN git clone --depth 1 --branch ${SEVEN_ZIP_VERSION} https://github.com/ip7z/7zip.git && \
-    git clone --depth 1 --branch ${WIN_ICONV_VERSION} https://github.com/win-iconv/win-iconv.git && \
-    git clone --depth 1 --branch ${OPENSSL_VERSION} https://github.com/openssl/openssl && \
-    git clone --depth 1 --branch v${MINGW_VERSION} https://github.com/mingw-w64/mingw-w64 && \
-    git clone --depth 1 --branch releases/gcc-${GCC_VERSION} https://gcc.gnu.org/git/gcc.git gcc-${GCC_VERSION} && \
-    git clone --depth 1 --branch binutils-${BINUTILS_VERSION} https://sourceware.org/git/binutils-gdb.git binutils-${BINUTILS_VERSION} && \
-    git clone --depth 1 --branch llvmorg-${CLANG_VERSION} https://github.com/llvm/llvm-project && \
-    git clone --depth 1 --branch v${LINUX_PYTHON_VERSION} https://github.com/python/cpython python-${LINUX_PYTHON_VERSION}
-
-# CMake, Python (windows)
-
-RUN wget --no-verbose -t 3 -c --https-only https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
-    chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
-    cd /opt/win-python && \
-    wget --no-verbose -t 3 -c --https-only https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.tar.zst && \
-    unzstd mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.tar.zst && tar -xf mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.tar && \
-    rm -rf mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.*
+RUN mkdir -p $WD/src $WD/build $WD/native $WD/cross /opt/linux-python
 
 ## Build
 
 # OpenSSL
 
-WORKDIR $WD/src/openssl
+ARG OPENSSL_VERSION=OpenSSL_1_1_1w
+ENV OPENSSL_VERSION=${OPENSSL_VERSION}
 
-RUN ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl shared zlib \
+RUN cd $WD/src && git clone --depth 1 --branch ${OPENSSL_VERSION} https://github.com/openssl/openssl && cd openssl && \
+    ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared zlib \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
-    make -j${CORES} && make install_sw
-
-RUN echo "/usr/local/openssl/lib" > /etc/ld.so.conf.d/toolchain.conf && ldconfig
-
-WORKDIR $WD/src
-
-RUN rm -rf openssl
+    make -j${CORES} && make install_sw && \
+    echo "/opt/openssl/lib" > /etc/ld.so.conf.d/toolchain.conf && ldconfig && cd $WD/src && rm -rf openssl
 
 # Python (linux)
 
-WORKDIR $WD/src/python-${LINUX_PYTHON_VERSION}
+ARG LINUX_PYTHON_VERSION=3.13.5
+ENV LINUX_PYTHON_VERSION=${LINUX_PYTHON_VERSION}
 
-RUN ./configure --prefix=/opt/linux-python --with-openssl=/usr/local/openssl \
+RUN cd $WD/src && git clone --depth 1 --branch v${LINUX_PYTHON_VERSION} https://github.com/python/cpython python-${LINUX_PYTHON_VERSION} && \
+    cd python-${LINUX_PYTHON_VERSION} && \
+    ./configure --prefix=/opt/linux-python --with-openssl=/opt/openssl \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} && make install && cd $WD/src && rm -rf python-*
 
@@ -114,34 +71,39 @@ ENV PATH=/opt/linux-python/bin:$PATH
 
 # binutils (native, minimal)
 
-WORKDIR $WD/build/binutils-native-minimal
+ARG BINUTILS_VERSION=2_45
+ENV BINUTILS_VERSION=${BINUTILS_VERSION}
 
-RUN $WD/src/binutils-${BINUTILS_VERSION}/configure \
-    --prefix=$WD/install/native \
+RUN cd $WD/src && git clone --depth 1 --branch binutils-${BINUTILS_VERSION} https://sourceware.org/git/binutils-gdb.git binutils-${BINUTILS_VERSION} && \
+    mkdir -p $WD/build/binutils-native-minimal && cd $WD/build/binutils-native-minimal && \
+    $WD/src/binutils-${BINUTILS_VERSION}/configure \
+    --prefix=$WD/native \
     --disable-multilib \
     --disable-werror \
     --disable-gdb --disable-gdbserver \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} && make install
 
-ENV PATH=$WD/install/native/bin:$PATH
+ENV PATH=$WD/native/bin:$PATH
 
-RUN update-alternatives --install /usr/bin/ar ar $WD/install/native/bin/ar 100 && \
-    update-alternatives --install /usr/bin/ranlib ranlib $WD/install/native/bin/ranlib 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-ld x86_64-linux-gnu-ld $WD/install/native/bin/ld 100 && \
-    update-alternatives --set ar $WD/install/native/bin/ar && \
-    update-alternatives --set ranlib $WD/install/native/bin/ranlib && \
-    update-alternatives --set x86_64-linux-gnu-ld $WD/install/native/bin/ld
+RUN update-alternatives --install /usr/bin/ar ar $WD/native/bin/ar 100 && \
+    update-alternatives --install /usr/bin/ranlib ranlib $WD/native/bin/ranlib 100 && \
+    update-alternatives --install /usr/bin/${HOST_ARCH}-linux-gnu-ld ${HOST_ARCH}-linux-gnu-ld $WD/native/bin/ld 100 && \
+    update-alternatives --set ar $WD/native/bin/ar && \
+    update-alternatives --set ranlib $WD/native/bin/ranlib && \
+    update-alternatives --set ${HOST_ARCH}-linux-gnu-ld $WD/native/bin/ld
 
 # gcc (native)
 
-RUN cd $WD/src/gcc-${GCC_VERSION} && ./contrib/download_prerequisites
+ARG GCC_VERSION=15.2.0
+ENV GCC_VERSION=${GCC_VERSION}
 
-WORKDIR $WD/build/gcc-native
-
-RUN $WD/src/gcc-${GCC_VERSION}/configure \
-    --prefix=$WD/install/native \
-    --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu \
+RUN cd $WD/src && git clone --depth 1 --branch releases/gcc-${GCC_VERSION} https://gcc.gnu.org/git/gcc.git gcc-${GCC_VERSION} && \
+    cd gcc-${GCC_VERSION} && ./contrib/download_prerequisites && \
+    mkdir -p $WD/build/gcc-native && cd $WD/build/gcc-native && \
+    $WD/src/gcc-${GCC_VERSION}/configure \
+    --prefix=$WD/native \
+    --build=${HOST_ARCH}-linux-gnu --host=${HOST_ARCH}-linux-gnu --target=${HOST_ARCH}-linux-gnu \
     --enable-languages=c,c++,lto --disable-multilib --disable-werror \
     --enable-shared --enable-static \
     --enable-lto --enable-plugin \
@@ -152,24 +114,23 @@ RUN $WD/src/gcc-${GCC_VERSION}/configure \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} V=0 && make install V=0
 
-RUN echo "$WD/install/native/lib" >> /etc/ld.so.conf.d/toolchain.conf && \
-    echo "$WD/install/native/lib64" >> /etc/ld.so.conf.d/toolchain.conf && \
+RUN echo "$WD/native/lib" >> /etc/ld.so.conf.d/toolchain.conf && \
+    echo "$WD/native/lib64" >> /etc/ld.so.conf.d/toolchain.conf && \
     ldconfig && \
-    update-alternatives --install /usr/bin/gcc gcc $WD/install/native/bin/gcc 100 && \
-    update-alternatives --install /usr/bin/g++ g++ $WD/install/native/bin/g++ 100 && \
-    update-alternatives --install /usr/bin/cc cc $WD/install/native/bin/gcc 100 && \
-    update-alternatives --install /usr/bin/c++ c++ $WD/install/native/bin/g++ 100 && \
-    update-alternatives --set gcc $WD/install/native/bin/gcc && \
-    update-alternatives --set g++ $WD/install/native/bin/g++ && \
-    update-alternatives --set cc $WD/install/native/bin/gcc && \
-    update-alternatives --set c++ $WD/install/native/bin/g++
+    update-alternatives --install /usr/bin/gcc gcc $WD/native/bin/gcc 100 && \
+    update-alternatives --install /usr/bin/g++ g++ $WD/native/bin/g++ 100 && \
+    update-alternatives --install /usr/bin/cc cc $WD/native/bin/gcc 100 && \
+    update-alternatives --install /usr/bin/c++ c++ $WD/native/bin/g++ 100 && \
+    update-alternatives --set gcc $WD/native/bin/gcc && \
+    update-alternatives --set g++ $WD/native/bin/g++ && \
+    update-alternatives --set cc $WD/native/bin/gcc && \
+    update-alternatives --set c++ $WD/native/bin/g++
 
 # binutils (native, full with LTO)
 
-WORKDIR $WD/build/binutils-native-full
-
-RUN $WD/src/binutils-${BINUTILS_VERSION}/configure \
-    --prefix=$WD/install/native \
+RUN mkdir -p $WD/build/binutils-native-full && cd $WD/build/binutils-native-full && \
+    $WD/src/binutils-${BINUTILS_VERSION}/configure \
+    --prefix=$WD/native \
     --disable-multilib \
     --disable-werror \
     --disable-gdb --disable-gdbserver \
@@ -178,14 +139,13 @@ RUN $WD/src/binutils-${BINUTILS_VERSION}/configure \
     --enable-ld=default \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} && make install && \
-    ln -s $WD/install/native/libexec/gcc/x86_64-linux-gnu/15.2.0/liblto_plugin.so $WD/install/native/lib/bfd-plugins/
+    ln -s $WD/native/libexec/gcc/${HOST_ARCH}-linux-gnu/15.2.0/liblto_plugin.so $WD/native/lib/bfd-plugins/
 
 # binutils-cross (minimal)
 
-WORKDIR $WD/build/binutils-cross-minimal
-
-RUN $WD/src/binutils-${BINUTILS_VERSION}/configure \
-    --prefix=$WD/install/cross \
+RUN mkdir -p $WD/build/binutils-cross-minimal && cd $WD/build/binutils-cross-minimal && \
+    $WD/src/binutils-${BINUTILS_VERSION}/configure \
+    --prefix=$WD/cross \
     --target=x86_64-w64-mingw32 \
     --disable-multilib \
     --disable-werror \
@@ -195,36 +155,44 @@ RUN $WD/src/binutils-${BINUTILS_VERSION}/configure \
 
 # mingw-w64 headers
 
-WORKDIR $WD/build/mingw-w64-headers
+ARG MINGW_VERSION=13.0.0
+ENV MINGW_VERSION=${MINGW_VERSION}
 
-RUN $WD/src/mingw-w64/mingw-w64-headers/configure \
+RUN cd $WD/src && git clone --depth 1 --branch v${MINGW_VERSION} https://github.com/mingw-w64/mingw-w64 && \
+    mkdir -p $WD/build/mingw-w64-headers && cd $WD/build/mingw-w64-headers && \
+    $WD/src/mingw-w64/mingw-w64-headers/configure \
     --host=x86_64-w64-mingw32 \
-    --prefix=$WD/install/cross/x86_64-w64-mingw32 \
+    --prefix=$WD/cross/x86_64-w64-mingw32 \
+    --with-default-msvcrt=ucrt \
+    --with-default-win32-threads=win32 \
+    --enable-idl \
     --enable-sdk=all \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} && make install
 
 # GCC-cross (stage1)
 
-WORKDIR $WD/build/gcc-stage1
-
-RUN $WD/src/gcc-${GCC_VERSION}/configure \
-    --prefix=$WD/install/cross \
+RUN mkdir -p $WD/build/gcc-stage1 && cd $WD/build/gcc-stage1 && \
+    $WD/src/gcc-${GCC_VERSION}/configure \
+    --prefix=$WD/cross \
     --target=x86_64-w64-mingw32 \
-    --enable-languages=c,c++ \
+    --enable-languages=c \
     --disable-multilib \
-    --with-default-msvcrt=msvcrt \
+    --enable-threads=win32 \
+    --with-arch=x86-64 \
+    --with-tune=generic \
+    --with-seh \
+    --with-default-msvcrt=ucrt \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} V=0 all-gcc && make install-gcc V=0
 
-ENV PATH=$WD/install/cross/bin:$PATH
+ENV PATH=$WD/cross/bin:$PATH
 
 # binutils-cross (full, with LTO)
 
-WORKDIR $WD/build/binutils-cross-full
-
-RUN $WD/src/binutils-${BINUTILS_VERSION}/configure \
-    --prefix=$WD/install/cross \
+RUN mkdir -p $WD/build/binutils-cross-full && cd $WD/build/binutils-cross-full && \
+    $WD/src/binutils-${BINUTILS_VERSION}/configure \
+    --prefix=$WD/cross \
     --target=x86_64-w64-mingw32 \
     --disable-multilib \
     --disable-werror \
@@ -237,94 +205,81 @@ RUN $WD/src/binutils-${BINUTILS_VERSION}/configure \
 
 # mingw-w64 crt
 
-WORKDIR $WD/build/mingw-w64-crt
-
-RUN $WD/src/mingw-w64/mingw-w64-crt/configure \
+RUN mkdir -p $WD/build/mingw-w64-crt && cd $WD/build/mingw-w64-crt && \
+    $WD/src/mingw-w64/mingw-w64-crt/configure \
     --host=x86_64-w64-mingw32 \
-    --prefix=$WD/install/cross/x86_64-w64-mingw32 \
-    --with-default-msvcrt=msvcrt \
+    --prefix=$WD/cross/x86_64-w64-mingw32 \
+    --with-default-msvcrt=ucrt \
+    --enable-silent-rules \
+    --disable-lib32 --enable-lib64 \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} && make install
 
 # mingw-w64 winpthreads
 
-WORKDIR $WD/build/winpthreads
-
-RUN $WD/src/mingw-w64/mingw-w64-libraries/winpthreads/configure \
+RUN mkdir -p $WD/build/winpthreads && cd $WD/build/winpthreads && \
+    $WD/src/mingw-w64/mingw-w64-libraries/winpthreads/configure \
     --host=x86_64-w64-mingw32 \
-    --prefix=$WD/install/cross/x86_64-w64-mingw32 \
+    --prefix=$WD/cross/x86_64-w64-mingw32 \
+    --libdir=$WD/cross/x86_64-w64-mingw32/lib \
+    --enable-silent-rules \
     --disable-shared \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} && make install
 
 # GCC-cross (stage2, with LTO)
 
-WORKDIR $WD/build/gcc-stage2
-
-RUN $WD/src/gcc-${GCC_VERSION}/configure \
-    --prefix=$WD/install/cross \
+RUN mkdir -p $WD/build/gcc-stage2 && cd $WD/build/gcc-stage2 && \
+    $WD/src/gcc-${GCC_VERSION}/configure \
+    --prefix=$WD/cross \
     --target=x86_64-w64-mingw32 \
-    --enable-languages=c,c++,lto --disable-multilib --with-default-msvcrt=msvcrt \
+    --enable-languages=c,c++,lto \
     --enable-shared --enable-static \
     --enable-lto --enable-plugin \
+    --disable-multilib \
     --enable-threads=win32 \
-    --build=x86_64-linux-gnu --disable-option-checking --disable-silent-rules --disable-maintainer-mode --disable-dependency-tracking \
-    --with-headers --with-system-zlib --enable-libstdcxx-time=yes --with-tune=generic --enable-version-specific-runtime-libs \
+    --with-arch=x86-64 \
+    --with-tune=generic \
+    --with-seh \
+    --with-default-msvcrt=ucrt \
+    --build=${HOST_ARCH}-linux-gnu --disable-option-checking --disable-silent-rules --disable-maintainer-mode --disable-dependency-tracking \
+    --with-headers --with-system-zlib --enable-libstdcxx-time=yes --enable-version-specific-runtime-libs \
     --enable-fully-dynamic-string --enable-libatomic --enable-libstdcxx-filesystem-ts=yes \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} V=0 && make install V=0 && \
-    ln -s $WD/install/cross/libexec/gcc/x86_64-w64-mingw32/15.2.0/liblto_plugin.so $WD/install/cross/lib/bfd-plugins/
-
-# 7zip
-
-WORKDIR $WD/src/7zip/CPP/7zip/Bundles/Alone2
-
-RUN make -f makefile.gcc -j && cp _o/7zz /usr/local/bin/7z && cd $WD/src && rm -rf 7zip
+    ln -s $WD/cross/libexec/gcc/x86_64-w64-mingw32/15.2.0/liblto_plugin.so $WD/cross/lib/bfd-plugins/
 
 # CMake
 
-WORKDIR $WD/src
+ARG CMAKE_VERSION=4.1.1
+ENV CMAKE_VERSION=${CMAKE_VERSION}
 
-RUN ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/usr/local && rm -rf cmake-${CMAKE_VERSION}-linux-x86_64.sh
-
-# win-iconv
-
-WORKDIR $WD/src/win-iconv
-
-RUN cmake \
-    -D WIN_ICONV_BUILD_EXECUTABLE=OFF \
-    -D CMAKE_INSTALL_PREFIX=/opt/win-iconv-64 \
-    -D CMAKE_C_COMPILER=$(which x86_64-w64-mingw32-gcc) \
-    -D CMAKE_CXX_COMPILER=$(which x86_64-w64-mingw32-g++) \
-    -D CMAKE_SYSTEM_NAME=Windows \
-    -D CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
-    -D CMAKE_C_STANDARD_LIBRARIES="-static-libgcc" \
-    -D CMAKE_CXX_STANDARD_LIBRARIES="-static-libgcc -static-libstdc++" \
-    . && make install
-
-WORKDIR $WD/src
-
-RUN rm -rf win-iconv
-
-# rust
-
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}; /root/.cargo/bin/rustup target add x86_64-pc-windows-gnu
-
-ENV PATH=/root/.cargo/bin:$PATH
+RUN cd $WD/src && wget --no-verbose -t 3 -c --https-only https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh && \
+    chmod +x cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh && \
+    ./cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh --skip-license --prefix=/usr/local && rm -rf cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh
 
 # Clang and tools (with LTO)
 
-WORKDIR $WD/build/llvm
+ARG CLANG_VERSION=21.1.2
 
-RUN cmake -G "Unix Makefiles" \
+ENV CLANG_VERSION=${CLANG_VERSION}
+
+ENV LD_LIBRARY_PATH=$WD/native/lib64:$WD/native/lib
+
+RUN cd $WD/src && git clone --depth 1 --branch llvmorg-${CLANG_VERSION} https://github.com/llvm/llvm-project && \
+    mkdir -p $WD/build/llvm && cd $WD/build/llvm && \
+    cmake -G "Unix Makefiles" \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=$WD/install/clang \
+    -DCMAKE_INSTALL_PREFIX=$WD/clang \
+    -DCMAKE_C_COMPILER=$WD/native/bin/gcc \
+    -DCMAKE_CXX_COMPILER=$WD/native/bin/g++ \
     -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" \
     -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
+    -DLLVM_TARGETS_TO_BUILD="X86;AArch64" \
     -DLLVM_BUILD_LLVM_DYLIB=ON \
     -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_ENABLE_LTO=ON \
-    -DLLVM_BINUTILS_INCDIR=$WD/install/native/include \
+    -DLLVM_BINUTILS_INCDIR=$WD/native/include \
     -DLLVM_ENABLE_PLUGINS=ON \
     -DLLVM_ENABLE_LLD=OFF \
     -DLLVM_USE_LINKER=OFF \
@@ -339,37 +294,154 @@ RUN cmake -G "Unix Makefiles" \
     -DLIBCXX_ENABLE_EXCEPTIONS=ON \
     -DLIBCXX_ENABLE_RTTI=ON \
     -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath,'\$ORIGIN/../lib64:\$ORIGIN/../lib'" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,'\$ORIGIN/../lib64:\$ORIGIN/../lib'" \
     $WD/src/llvm-project/llvm \
     && CORES=$(nproc); if [ "$CORES" -gt "$MAX_CORES" ]; then CORES=$MAX_CORES; fi; \
     make -j${CORES} && make install && \
-    ln -s $WD/install/clang/lib/LLVMgold.so $WD/install/native/lib/bfd-plugins/ && \
-    ln -s $WD/install/clang/lib/LLVMgold.so $WD/install/cross/lib/bfd-plugins/
+    ln -s $WD/clang/lib/LLVMgold.so $WD/native/lib/bfd-plugins/ && \
+    ln -s $WD/clang/lib/LLVMgold.so $WD/cross/lib/bfd-plugins/
 
-ENV PATH=$WD/install/clang/bin:$PATH \
-    TERM=xterm-256color
+ENV PATH=$WD/clang/bin:$PATH
+
+RUN echo "Toolchain config: " > /root/toolchain-info.log && \
+    echo "WD: ${WD}" >> /root/toolchain-info.log && \
+    echo "MAX_CORES: ${MAX_CORES}" >> /root/toolchain-info.log && \
+    echo "HOST_ARCH: ${HOST_ARCH}" >> /root/toolchain-info.log && \
+    echo "UBUNTU_VERSION: ${UBUNTU_VERSION}" >> /root/toolchain-info.log && \
+    echo "BINUTILS_VERSION: ${BINUTILS_VERSION}" >> /root/toolchain-info.log && \
+    echo "MINGW_VERSION: ${MINGW_VERSION}" >> /root/toolchain-info.log && \
+    echo "GCC_VERSION: ${GCC_VERSION}" >> /root/toolchain-info.log && \
+    echo "CLANG_VERSION: ${CLANG_VERSION}" >> /root/toolchain-info.log && \
+    echo "CMAKE_VERSION: ${CMAKE_VERSION}" >> /root/toolchain-info.log && \
+    echo "LINUX_PYTHON_VERSION: ${LINUX_PYTHON_VERSION}" >> /root/toolchain-info.log && \
+    rm -rf $WD/build $WD/src
+
+CMD ["true"]
 
 ## hashcat cross-build section
 
-ARG CACHE_BUST=1
-ARG ENABLE_LTO=1
-ARG MAINTAINER_MODE=1
-ARG USE_CLANG=1
-ARG USE_GCC=0
+FROM ubuntu:${UBUNTU_VERSION} AS hashcat-builder
 
-ENV ENABLE_LTO=${ENABLE_LTO} \
+ARG UBUNTU_VERSION \
+    WD \
+    HOST_ARCH
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/opt/toolchain/native/bin:/opt/toolchain/cross/bin:/opt/toolchain/clang/bin:/opt/linux-python/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/toolchain/native/lib64:/opt/toolchain/native/lib \
+    TERM=xterm-256color \
+    UBUNTU_VERSION=${UBUNTU_VERSION} \
+    HOST_ARCH=${HOST_ARCH} \
+    WD=${WD}
+
+COPY --from=builder-toolchain /opt /opt
+COPY --from=builder-toolchain /root/toolchain-info.log /root/toolchain-info.log
+
+RUN apt-get update && apt-get -y --no-install-recommends install apt-utils && apt-get -y --no-install-recommends install \
+    build-essential \
+    ca-certificates curl \
+    dos2unix \
+    git \
+    libc6-dev \
+    make \
+    time \
+    wget \
+    zstd \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN echo "$WD/native/lib" > /etc/ld.so.conf.d/toolchain.conf && \
+    echo "$WD/native/lib64" >> /etc/ld.so.conf.d/toolchain.conf && \
+    echo "/opt/openssl/lib" >> /etc/ld.so.conf.d/toolchain.conf && \
+    ldconfig && \
+    update-alternatives --install /usr/bin/ar ar $WD/native/bin/ar 100 && \
+    update-alternatives --install /usr/bin/ranlib ranlib $WD/native/bin/ranlib 100 && \
+    update-alternatives --install /usr/bin/${HOST_ARCH}-linux-gnu-ld ${HOST_ARCH}-linux-gnu-ld $WD/native/bin/ld 100 && \
+    update-alternatives --set ar $WD/native/bin/ar && \
+    update-alternatives --set ranlib $WD/native/bin/ranlib && \
+    update-alternatives --set ${HOST_ARCH}-linux-gnu-ld $WD/native/bin/ld && \
+    update-alternatives --install /usr/bin/gcc gcc $WD/native/bin/gcc 100 && \
+    update-alternatives --install /usr/bin/g++ g++ $WD/native/bin/g++ 100 && \
+    update-alternatives --install /usr/bin/cc cc $WD/native/bin/gcc 100 && \
+    update-alternatives --install /usr/bin/c++ c++ $WD/native/bin/g++ 100 && \
+    update-alternatives --set gcc $WD/native/bin/gcc && \
+    update-alternatives --set g++ $WD/native/bin/g++ && \
+    update-alternatives --set cc $WD/native/bin/gcc && \
+    update-alternatives --set c++ $WD/native/bin/g++ && \
+    mkdir -p $WD/src /opt/win-python /root/out
+
+# 7zip
+
+ARG SEVEN_ZIP_VERSION=25.01
+ENV SEVEN_ZIP_VERSION=${SEVEN_ZIP_VERSION}
+
+RUN cd $WD/src && git clone --depth 1 --branch ${SEVEN_ZIP_VERSION} https://github.com/ip7z/7zip.git && \
+    cd 7zip/CPP/7zip/Bundles/Alone2 && make -f makefile.gcc -j && cp _o/7zz /usr/local/bin/7z && cd $WD/src && rm -rf 7zip
+
+# CMake
+
+ARG CMAKE_VERSION=4.1.1
+ENV CMAKE_VERSION=${CMAKE_VERSION}
+
+RUN cd $WD/src && wget --no-verbose -t 3 -c --https-only https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh && \
+    chmod +x cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh && \
+    ./cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh --skip-license --prefix=/usr/local && rm -rf cmake-${CMAKE_VERSION}-linux-${HOST_ARCH}.sh
+
+# win-iconv
+
+ARG WIN_ICONV_VERSION=v0.0.10
+ENV WIN_ICONV_VERSION=${WIN_ICONV_VERSION}
+
+RUN cd $WD/src && git clone --depth 1 --branch ${WIN_ICONV_VERSION} https://github.com/win-iconv/win-iconv.git && cd win-iconv && \
+    cmake \
+    -D WIN_ICONV_BUILD_EXECUTABLE=OFF \
+    -D CMAKE_INSTALL_PREFIX=/opt/win-iconv-64 \
+    -D CMAKE_C_COMPILER=$(which x86_64-w64-mingw32-gcc) \
+    -D CMAKE_CXX_COMPILER=$(which x86_64-w64-mingw32-g++) \
+    -D CMAKE_SYSTEM_NAME=Windows \
+    -D CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+    -D CMAKE_C_STANDARD_LIBRARIES="-static-libgcc" \
+    -D CMAKE_CXX_STANDARD_LIBRARIES="-static-libgcc -static-libstdc++" \
+    . && make install && cd $WD/src && rm -rf win-iconv
+
+# Python (windows)
+
+ARG WIN_PYTHON_VERSION=3.12.11-1
+ENV WIN_PYTHON_VERSION=${WIN_PYTHON_VERSION}
+
+RUN cd /opt/win-python && \
+    wget --no-verbose -t 3 -c --https-only https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.tar.zst && \
+    unzstd mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.tar.zst && tar -xf mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.tar && \
+    rm -rf mingw-w64-x86_64-python-${WIN_PYTHON_VERSION}-any.pkg.*
+
+# rust
+
+ARG RUST_VERSION=1.90.0
+ENV RUST_VERSION=${RUST_VERSION}
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}; /root/.cargo/bin/rustup target add x86_64-pc-windows-gnu
+
+ENV PATH=/root/.cargo/bin:$PATH
+
+# hashcat
+
+ARG CACHE_BUST=1 \
+    ENABLE_LTO=1 \
+    MAINTAINER_MODE=1 \
+    USE_CLANG=1 \
+    USE_GCC=0
+
+ENV CACHE_BUST=${CACHE_BUST} \
+    ENABLE_LTO=${ENABLE_LTO} \
     MAINTAINER_MODE=${MAINTAINER_MODE} \
     USE_CLANG=${USE_CLANG} \
     USE_GCC=${USE_GCC}
 
-WORKDIR /root
-
-RUN git clone https://github.com/hashcat/hashcat.git
+RUN cd /root && git clone https://github.com/hashcat/hashcat.git
 
 COPY docker/patches/ubuntu/ /root/patches/
 
-WORKDIR /root/hashcat
-
-RUN bash -c 'shopt -s nullglob; for p in /root/patches/*.patch /root/patches/*.diff; do git apply "$p"; done'
+RUN bash -c 'shopt -s nullglob; cd /root/hashcat; for p in /root/patches/*.patch /root/patches/*.diff; do git apply "$p"; done'
 
 RUN if [ "${USE_GCC}" = "1" ]; then \
       cp -af /root/hashcat /root/hashcat-gcc && cd /root/hashcat-gcc && \
@@ -410,34 +482,22 @@ RUN if [ "${USE_CLANG}" = "1" ]; then \
       fi; \
     fi
 
-WORKDIR /root
-
-RUN if [ "${USE_CLANG}" = "1" ] && [ "${USE_GCC}" = "1" ]; then mv /root/out/* /root/xy/ ; fi; rm -rf /root/out /root/hashcat-* $WD/src $WD/build /tmp/* /var/tmp/*
+RUN if [ "${USE_CLANG}" = "1" ] && [ "${USE_GCC}" = "1" ]; then mv /root/out/* /root/xy/; fi; cd /root && rm -rf /root/out /root/hashcat-* $WD/src /tmp/* /var/tmp/*
 
 ARG WITH_CODE_ANALYSIS=0
 ENV WITH_CODE_ANALYSIS=${WITH_CODE_ANALYSIS}
 
-RUN echo "Toolchain config: " | tee -a /root/toolchain-info.log && \
-    echo "UBUNTU_VERSION: ${UBUNTU_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "BINUTILS_VERSION: ${BINUTILS_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "MINGW_VERSION: ${MINGW_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "GCC_VERSION: ${GCC_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "CLANG_VERSION: ${CLANG_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "CMAKE_VERSION: ${CMAKE_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "SEVEN_ZIP_VERSION: ${SEVEN_ZIP_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "WIN_ICONV_VERSION: ${WIN_ICONV_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "LINUX_PYTHON_VERSION: ${LINUX_PYTHON_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "WIN_PYTHON_VERSION: ${WIN_PYTHON_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "RUST_VERSION: ${RUST_VERSION}" | tee -a /root/toolchain-info.log && \
-    echo "MAX_CORES: ${MAX_CORES}" | tee -a /root/toolchain-info.log && \
-    echo "ENABLE_LTO: ${ENABLE_LTO}" | tee -a /root/toolchain-info.log && \
-    echo "MAINTAINER_MODE: ${MAINTAINER_MODE}" | tee -a /root/toolchain-info.log && \
-    echo "USE_CLANG: ${USE_CLANG}" | tee -a /root/toolchain-info.log && \
-    echo "USE_GCC: ${USE_GCC}" | tee -a /root/toolchain-info.log && \
-    echo "WITH_CODE_ANALYSIS: ${WITH_CODE_ANALYSIS}" | tee -a /root/toolchain-info.log && \
-    echo "WD: ${WD}" | tee -a /root/toolchain-info.log && \
-    echo -n "GLIBC_VERSION: " | tee -a /root/toolchain-info.log && \
-    strings /root/xy/hashcat-*/hashcat.bin | grep -o 'GLIBC_[0-9]\+\.[0-9]\+' | sort -V | tail -1 | tee -a /root/toolchain-info.log && \
+RUN echo "WIN_PYTHON_VERSION: ${WIN_PYTHON_VERSION}" >> /root/toolchain-info.log && \
+    echo "WIN_ICONV_VERSION: ${WIN_ICONV_VERSION}" >> /root/toolchain-info.log && \
+    echo "SEVEN_ZIP_VERSION: ${SEVEN_ZIP_VERSION}" >> /root/toolchain-info.log && \
+    echo "RUST_VERSION: ${RUST_VERSION}" >> /root/toolchain-info.log && \
+    echo "ENABLE_LTO: ${ENABLE_LTO}" >> /root/toolchain-info.log && \
+    echo "MAINTAINER_MODE: ${MAINTAINER_MODE}" >> /root/toolchain-info.log && \
+    echo "USE_CLANG: ${USE_CLANG}" >> /root/toolchain-info.log && \
+    echo "USE_GCC: ${USE_GCC}" >> /root/toolchain-info.log && \
+    echo "WITH_CODE_ANALYSIS: ${WITH_CODE_ANALYSIS}" >> /root/toolchain-info.log && \
+    echo -n "GLIBC_VERSION: " >> tee -a /root/toolchain-info.log && \
+    strings /root/xy/hashcat-*/hashcat.bin | grep -o 'GLIBC_[0-9]\+\.[0-9]\+' | sort -V | tail -1 >> /root/toolchain-info.log && \
     ldd /root/xy/hashcat-*/hashcat.bin | tee -a /root/linux_libs_dump.log && \
     x86_64-w64-mingw32-objdump -p /root/xy/hashcat-*/hashcat.exe | grep 'DLL Name' | tee -a /root/win_libs_dump.log
 

--- a/docker/patches/ubuntu/001-Makefile.patch
+++ b/docker/patches/ubuntu/001-Makefile.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Makefile b/src/Makefile
-index 58719b999..39e224c64 100644
+index 1f1987fbe..05e2c34da 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -10,6 +10,7 @@ PRODUCTION_VERSION      := v7.1.2
@@ -10,13 +10,20 @@ index 58719b999..39e224c64 100644
  USE_SYSTEM_LZMA         ?= 0
  USE_SYSTEM_ZLIB         ?= 0
  USE_SYSTEM_OPENCL       ?= 0
-@@ -203,10 +204,16 @@ COMPTIME                := $(shell date +%s)
+@@ -201,12 +202,23 @@ COMPTIME                := $(shell date +%s)
+ ## General compiler and linker options
+ ##
  
++CFLAGS                  := $(CFLAGS)
  LFLAGS                  := $(LDFLAGS)
  
++#ifeq ($(DEBUG),1)
++CFLAGS                  += -fstack-usage
++#endif
++
 +ifeq ($(ENABLE_LTO),1)
-+CFLAGS += -flto=auto -Wno-unknown-warning-option
-+LFLAGS += -flto=auto -Wno-lto-type-mismatch
++CFLAGS                  += -flto=auto -Wno-unknown-warning-option
++LFLAGS                  += -flto=auto -Wno-lto-type-mismatch
 +endif
 +
  ifneq ($(UNAME),Darwin)
@@ -27,7 +34,7 @@ index 58719b999..39e224c64 100644
  endif
  endif
  endif
-@@ -284,7 +291,7 @@ endif
+@@ -284,7 +296,7 @@ endif
  endif
  
  ifeq ($(DEBUG),0)
@@ -36,7 +43,7 @@ index 58719b999..39e224c64 100644
  ifneq ($(UNAME),Darwin)
  LFLAGS                  += -s
  endif
-@@ -354,9 +361,11 @@ CFLAGS                  += -I$(DEPS_UNRAR_PATH)
+@@ -354,9 +366,11 @@ CFLAGS                  += -I$(DEPS_UNRAR_PATH)
  ifeq ($(UNAME),OpenBSD)
  LFLAGS                  += -lc++
  else
@@ -48,7 +55,7 @@ index 58719b999..39e224c64 100644
  
  ##
  ## Native compilation target
-@@ -916,24 +925,76 @@ WIN_PYTHON              := /opt/win-python
+@@ -917,24 +931,77 @@ WIN_PYTHON              := /opt/win-python
  CFLAGS_CROSS_LINUX      := $(CFLAGS)
  CFLAGS_CROSS_LINUX      += -fPIC
  CFLAGS_CROSS_LINUX      += -DWITH_HWMON
@@ -120,6 +127,7 @@ index 58719b999..39e224c64 100644
 +ifeq ($(ENABLE_LTO),1)
 +ifneq (,$(findstring clang, $(CC_WIN)))
 +LFLAGS_CROSS_WIN        += -fuse-ld=lld
++LFLAGS_CROSS_WIN        += -Wl,--stack,16777216
 +endif
 +endif
 +

--- a/docker/patches/ubuntu/001-Makefile.patch
+++ b/docker/patches/ubuntu/001-Makefile.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Makefile b/src/Makefile
-index 1f1987fbe..05e2c34da 100644
+index 1f1987fbe..4f89b8d63 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -10,6 +10,7 @@ PRODUCTION_VERSION      := v7.1.2
@@ -55,7 +55,45 @@ index 1f1987fbe..05e2c34da 100644
  
  ##
  ## Native compilation target
-@@ -917,24 +931,77 @@ WIN_PYTHON              := /opt/win-python
+@@ -552,23 +566,31 @@ clean:
+ 	$(RM) -rf modules/*.dSYM
+ 	$(RM) -rf bridges/*.dSYM
+ 	$(RM) -rf feeds/*.dSYM
+-	$(RM) -f modules/*.dll
+-	$(RM) -f bridges/*.dll
++	$(RM) -rf *.dSYM
+ 	$(RM) -f bridges/subs/*.dll
+-	$(RM) -f feeds/*.dll
+-	$(RM) -f modules/*.so
+-	$(RM) -f bridges/*.so
+ 	$(RM) -f bridges/subs/*.so
++	$(RM) -f bridges/subs/*.su
++	$(RM) -f bridges/*.dll
++	$(RM) -f bridges/*.so
++	$(RM) -f bridges/*.su
++	$(RM) -f feeds/*.dll
+ 	$(RM) -f feeds/*.so
++	$(RM) -f feeds/*.su
++	$(RM) -f modules/*.dll
++	$(RM) -f modules/*.so
++	$(RM) -f modules/*.su
+ 	$(RM) -f obj/*/*/*.o
++	$(RM) -f obj/*/*/*.su
+ 	$(RM) -f obj/*/*.o
++	$(RM) -f obj/*/*.su
+ 	$(RM) -f obj/*.o
++	$(RM) -f obj/*.su
+ 	$(RM) -f obj/*.a
+-	$(RM) -rf *.dSYM
+ 	$(RM) -f *.dylib
+ 	$(RM) -f *.bin *.exe
+ 	$(RM) -f *.pid
+ 	$(RM) -f *.log
++	$(RM) -f *.su
+ 	$(RM) -f core
+ 	$(RM) -rf *.induct
+ 	$(RM) -rf *.outfiles
+@@ -917,24 +939,77 @@ WIN_PYTHON              := /opt/win-python
  CFLAGS_CROSS_LINUX      := $(CFLAGS)
  CFLAGS_CROSS_LINUX      += -fPIC
  CFLAGS_CROSS_LINUX      += -DWITH_HWMON


### PR DESCRIPTION
Hi,

The new version uses a **multi-stage build**, so the final image **size will be 12.6 GB instead of** approximately **48 GB.**

In addition, the definitions of variables and also the download sections for all components have been moved to inside the file instead of at the beginning. This is to prevent the image from being rebuilt from scratch in case one of the component versions is modified.

Important info: in this release, I switched **from** compiling **MinGW with MSVCRT** **to** **MinGW-w64 with UCRT + SEH**.
This means that if the hashcat binary for Windows is run **on Windows < 10, you will need to install the latest supported Visual C++ Redistributable**. In theory, this new configuration should improve the overall performance of hashcat on Windows, but in practice, some benchmarks need to be done to understand if and by how much.

The docker has also been tested on macOS (aarch64) using colima. In this case, at the moment, MAINTAINER_MODE must be set to "1" and HOST_ARCH must be set to "aarch64" (using --build-arg).

Thanks