### PR TITLE
Add Wordpress bcrypt

### DIFF
--- a/OpenCL/m35500-pure.cl
+++ b/OpenCL/m35500-pure.cl
@@ -63,7 +63,6 @@ KERNEL_FQ KERNEL_FA void m35500_init (KERN_ATTR_TMPS (bcrypt_tmp_t))
   if (gid >= GID_CNT) return;
 
   // "wp-sha384" key
-  // Only works with 32-length array, unsure why
   const u32 key[32] = { 0x732D7077, 0x38336168, 0x00000034, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
   sha384_hmac_ctx_t ctx0;

--- a/OpenCL/m35500-pure.cl
+++ b/OpenCL/m35500-pure.cl
@@ -1,0 +1,502 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_blowfish.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha384.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+CONSTANT_VK u32 bin2base64[0x40] =
+{
+  0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50,
+  0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+  0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76,
+  0x77, 0x78, 0x79, 0x7a, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x2b, 0x2f,
+};
+
+#if   VECT_SIZE == 1
+#define int_to_base64(c) make_u32x (s_bin2base64[(c)])
+#elif VECT_SIZE == 2
+#define int_to_base64(c) make_u32x (s_bin2base64[(c).s0], s_bin2base64[(c).s1])
+#elif VECT_SIZE == 4
+#define int_to_base64(c) make_u32x (s_bin2base64[(c).s0], s_bin2base64[(c).s1], s_bin2base64[(c).s2], s_bin2base64[(c).s3])
+#elif VECT_SIZE == 8
+#define int_to_base64(c) make_u32x (s_bin2base64[(c).s0], s_bin2base64[(c).s1], s_bin2base64[(c).s2], s_bin2base64[(c).s3], s_bin2base64[(c).s4], s_bin2base64[(c).s5], s_bin2base64[(c).s6], s_bin2base64[(c).s7])
+#elif VECT_SIZE == 16
+#define int_to_base64(c) make_u32x (s_bin2base64[(c).s0], s_bin2base64[(c).s1], s_bin2base64[(c).s2], s_bin2base64[(c).s3], s_bin2base64[(c).s4], s_bin2base64[(c).s5], s_bin2base64[(c).s6], s_bin2base64[(c).s7], s_bin2base64[(c).s8], s_bin2base64[(c).s9], s_bin2base64[(c).sa], s_bin2base64[(c).sb], s_bin2base64[(c).sc], s_bin2base64[(c).sd], s_bin2base64[(c).se], s_bin2base64[(c).sf])
+#endif
+
+typedef struct bcrypt_tmp
+{
+  u32 E[18];
+
+  u32 P[18];
+
+  u32 S0[256];
+  u32 S1[256];
+  u32 S2[256];
+  u32 S3[256];
+
+} bcrypt_tmp_t;
+
+KERNEL_FQ KERNEL_FA void m35500_init (KERN_ATTR_TMPS (bcrypt_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  CONSTANT_AS u32a *s_bin2base64 = bin2base64;
+
+  if (gid >= GID_CNT) return;
+
+  // "wp-sha384" key
+  // Only works with 32-length array, unsure why
+  const u32 key[32] = { 0x732D7077, 0x38336168, 0x00000034, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+  sha384_hmac_ctx_t ctx0;
+
+  sha384_hmac_init_swap (&ctx0, key, 9);
+
+  sha384_hmac_update_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  sha384_hmac_final (&ctx0);
+
+  #define tmp_u8_00 ((ctx0.opad.h[0] >> 58) & 0x3f)
+  #define tmp_u8_01 ((ctx0.opad.h[0] >> 52) & 0x3f)
+  #define tmp_u8_02 ((ctx0.opad.h[0] >> 46) & 0x3f)
+  #define tmp_u8_03 ((ctx0.opad.h[0] >> 40) & 0x3f)
+  #define tmp_u8_04 ((ctx0.opad.h[0] >> 34) & 0x3f)
+  #define tmp_u8_05 ((ctx0.opad.h[0] >> 28) & 0x3f)
+  #define tmp_u8_06 ((ctx0.opad.h[0] >> 22) & 0x3f)
+  #define tmp_u8_07 ((ctx0.opad.h[0] >> 16) & 0x3f)
+  #define tmp_u8_08 ((ctx0.opad.h[0] >> 10) & 0x3f)
+  #define tmp_u8_09 ((ctx0.opad.h[0] >>  4) & 0x3f)
+  #define tmp_u8_10 ((ctx0.opad.h[0] <<  2) & 0x3c) | ((ctx0.opad.h[1] >> 62) & 0x03)
+
+  #define tmp_u8_11 ((ctx0.opad.h[1] >> 56) & 0x3f)
+  #define tmp_u8_12 ((ctx0.opad.h[1] >> 50) & 0x3f)
+  #define tmp_u8_13 ((ctx0.opad.h[1] >> 44) & 0x3f)
+  #define tmp_u8_14 ((ctx0.opad.h[1] >> 38) & 0x3f)
+  #define tmp_u8_15 ((ctx0.opad.h[1] >> 32) & 0x3f)
+  #define tmp_u8_16 ((ctx0.opad.h[1] >> 26) & 0x3f)
+  #define tmp_u8_17 ((ctx0.opad.h[1] >> 20) & 0x3f)
+  #define tmp_u8_18 ((ctx0.opad.h[1] >> 14) & 0x3f)
+  #define tmp_u8_19 ((ctx0.opad.h[1] >>  8) & 0x3f)
+  #define tmp_u8_20 ((ctx0.opad.h[1] >>  2) & 0x3f)
+  #define tmp_u8_21 ((ctx0.opad.h[1] <<  4) & 0x30) | ((ctx0.opad.h[2] >> 60) & 0x0f)
+
+  #define tmp_u8_22 ((ctx0.opad.h[2] >> 54) & 0x3f)
+  #define tmp_u8_23 ((ctx0.opad.h[2] >> 48) & 0x3f)
+  #define tmp_u8_24 ((ctx0.opad.h[2] >> 42) & 0x3f)
+  #define tmp_u8_25 ((ctx0.opad.h[2] >> 36) & 0x3f)
+  #define tmp_u8_26 ((ctx0.opad.h[2] >> 30) & 0x3f)
+  #define tmp_u8_27 ((ctx0.opad.h[2] >> 24) & 0x3f)
+  #define tmp_u8_28 ((ctx0.opad.h[2] >> 18) & 0x3f)
+  #define tmp_u8_29 ((ctx0.opad.h[2] >> 12) & 0x3f)
+  #define tmp_u8_30 ((ctx0.opad.h[2] >>  6) & 0x3f)
+  #define tmp_u8_31 ((ctx0.opad.h[2] >>  0) & 0x3f)
+
+  #define tmp_u8_32 ((ctx0.opad.h[3] >> 58) & 0x3f)
+  #define tmp_u8_33 ((ctx0.opad.h[3] >> 52) & 0x3f)
+  #define tmp_u8_34 ((ctx0.opad.h[3] >> 46) & 0x3f)
+  #define tmp_u8_35 ((ctx0.opad.h[3] >> 40) & 0x3f)
+  #define tmp_u8_36 ((ctx0.opad.h[3] >> 34) & 0x3f)
+  #define tmp_u8_37 ((ctx0.opad.h[3] >> 28) & 0x3f)
+  #define tmp_u8_38 ((ctx0.opad.h[3] >> 22) & 0x3f)
+  #define tmp_u8_39 ((ctx0.opad.h[3] >> 16) & 0x3f)
+  #define tmp_u8_40 ((ctx0.opad.h[3] >> 10) & 0x3f)
+  #define tmp_u8_41 ((ctx0.opad.h[3] >>  4) & 0x3f)
+  #define tmp_u8_42 ((ctx0.opad.h[3] <<  2) & 0x3c) | ((ctx0.opad.h[4] >> 62) & 0x03)
+
+  #define tmp_u8_43 ((ctx0.opad.h[4] >> 56) & 0x3f)
+  #define tmp_u8_44 ((ctx0.opad.h[4] >> 50) & 0x3f)
+  #define tmp_u8_45 ((ctx0.opad.h[4] >> 44) & 0x3f)
+  #define tmp_u8_46 ((ctx0.opad.h[4] >> 38) & 0x3f)
+  #define tmp_u8_47 ((ctx0.opad.h[4] >> 32) & 0x3f)
+  #define tmp_u8_48 ((ctx0.opad.h[4] >> 26) & 0x3f)
+  #define tmp_u8_49 ((ctx0.opad.h[4] >> 20) & 0x3f)
+  #define tmp_u8_50 ((ctx0.opad.h[4] >> 14) & 0x3f)
+  #define tmp_u8_51 ((ctx0.opad.h[4] >>  8) & 0x3f)
+  #define tmp_u8_52 ((ctx0.opad.h[4] >>  2) & 0x3f)
+  #define tmp_u8_53 ((ctx0.opad.h[4] <<  4) & 0x30) | ((ctx0.opad.h[5] >> 60) & 0x0f)
+
+  #define tmp_u8_54 ((ctx0.opad.h[5] >> 54) & 0x3f)
+  #define tmp_u8_55 ((ctx0.opad.h[5] >> 48) & 0x3f)
+  #define tmp_u8_56 ((ctx0.opad.h[5] >> 42) & 0x3f)
+  #define tmp_u8_57 ((ctx0.opad.h[5] >> 36) & 0x3f)
+  #define tmp_u8_58 ((ctx0.opad.h[5] >> 30) & 0x3f)
+  #define tmp_u8_59 ((ctx0.opad.h[5] >> 24) & 0x3f)
+  #define tmp_u8_60 ((ctx0.opad.h[5] >> 18) & 0x3f)
+  #define tmp_u8_61 ((ctx0.opad.h[5] >> 12) & 0x3f)
+  #define tmp_u8_62 ((ctx0.opad.h[5] >>  6) & 0x3f)
+  #define tmp_u8_63 ((ctx0.opad.h[5] >>  0) & 0x3f)
+
+  u32 w[18] = { 0 };
+
+  w[ 0] = int_to_base64 (tmp_u8_00) <<  0
+        | int_to_base64 (tmp_u8_01) <<  8
+        | int_to_base64 (tmp_u8_02) << 16
+        | int_to_base64 (tmp_u8_03) << 24;
+  w[ 1] = int_to_base64 (tmp_u8_04) <<  0
+        | int_to_base64 (tmp_u8_05) <<  8
+        | int_to_base64 (tmp_u8_06) << 16
+        | int_to_base64 (tmp_u8_07) << 24;
+  w[ 2] = int_to_base64 (tmp_u8_08) <<  0
+        | int_to_base64 (tmp_u8_09) <<  8
+        | int_to_base64 (tmp_u8_10) << 16
+        | int_to_base64 (tmp_u8_11) << 24;
+  w[ 3] = int_to_base64 (tmp_u8_12) <<  0
+        | int_to_base64 (tmp_u8_13) <<  8
+        | int_to_base64 (tmp_u8_14) << 16
+        | int_to_base64 (tmp_u8_15) << 24;
+  w[ 4] = int_to_base64 (tmp_u8_16) <<  0
+        | int_to_base64 (tmp_u8_17) <<  8
+        | int_to_base64 (tmp_u8_18) << 16
+        | int_to_base64 (tmp_u8_19) << 24;
+  w[ 5] = int_to_base64 (tmp_u8_20) <<  0
+        | int_to_base64 (tmp_u8_21) <<  8
+        | int_to_base64 (tmp_u8_22) << 16
+        | int_to_base64 (tmp_u8_23) << 24;
+  w[ 6] = int_to_base64 (tmp_u8_24) <<  0
+        | int_to_base64 (tmp_u8_25) <<  8
+        | int_to_base64 (tmp_u8_26) << 16
+        | int_to_base64 (tmp_u8_27) << 24;
+  w[ 7] = int_to_base64 (tmp_u8_28) <<  0
+        | int_to_base64 (tmp_u8_29) <<  8
+        | int_to_base64 (tmp_u8_30) << 16
+        | int_to_base64 (tmp_u8_31) << 24;
+  w[ 8] = int_to_base64 (tmp_u8_32) <<  0
+        | int_to_base64 (tmp_u8_33) <<  8
+        | int_to_base64 (tmp_u8_34) << 16
+        | int_to_base64 (tmp_u8_35) << 24;
+  w[ 9] = int_to_base64 (tmp_u8_36) <<  0
+        | int_to_base64 (tmp_u8_37) <<  8
+        | int_to_base64 (tmp_u8_38) << 16
+        | int_to_base64 (tmp_u8_39) << 24;
+  w[10] = int_to_base64 (tmp_u8_40) <<  0
+        | int_to_base64 (tmp_u8_41) <<  8
+        | int_to_base64 (tmp_u8_42) << 16
+        | int_to_base64 (tmp_u8_43) << 24;
+  w[11] = int_to_base64 (tmp_u8_44) <<  0
+        | int_to_base64 (tmp_u8_45) <<  8
+        | int_to_base64 (tmp_u8_46) << 16
+        | int_to_base64 (tmp_u8_47) << 24;
+  w[12] = int_to_base64 (tmp_u8_48) <<  0
+        | int_to_base64 (tmp_u8_49) <<  8
+        | int_to_base64 (tmp_u8_50) << 16
+        | int_to_base64 (tmp_u8_51) << 24;
+  w[13] = int_to_base64 (tmp_u8_52) <<  0
+        | int_to_base64 (tmp_u8_53) <<  8
+        | int_to_base64 (tmp_u8_54) << 16
+        | int_to_base64 (tmp_u8_55) << 24;
+  w[14] = int_to_base64 (tmp_u8_56) <<  0
+        | int_to_base64 (tmp_u8_57) <<  8
+        | int_to_base64 (tmp_u8_58) << 16
+        | int_to_base64 (tmp_u8_59) << 24;
+  w[15] = int_to_base64 (tmp_u8_60) <<  0
+        | int_to_base64 (tmp_u8_61) <<  8
+        | int_to_base64 (tmp_u8_62) << 16
+        | int_to_base64 (tmp_u8_63) << 24;
+
+  u32 E[18] = { 0 };
+
+  expand_key (E, w, 64);
+
+  E[ 0] = hc_swap32_S (E[ 0]);
+  E[ 1] = hc_swap32_S (E[ 1]);
+  E[ 2] = hc_swap32_S (E[ 2]);
+  E[ 3] = hc_swap32_S (E[ 3]);
+  E[ 4] = hc_swap32_S (E[ 4]);
+  E[ 5] = hc_swap32_S (E[ 5]);
+  E[ 6] = hc_swap32_S (E[ 6]);
+  E[ 7] = hc_swap32_S (E[ 7]);
+  E[ 8] = hc_swap32_S (E[ 8]);
+  E[ 9] = hc_swap32_S (E[ 9]);
+  E[10] = hc_swap32_S (E[10]);
+  E[11] = hc_swap32_S (E[11]);
+  E[12] = hc_swap32_S (E[12]);
+  E[13] = hc_swap32_S (E[13]);
+  E[14] = hc_swap32_S (E[14]);
+  E[15] = hc_swap32_S (E[15]);
+  E[16] = hc_swap32_S (E[16]);
+  E[17] = hc_swap32_S (E[17]);
+
+  for (u32 i = 0; i < 18; i++)
+  {
+    tmps[gid].E[i] = E[i];
+  }
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf[4];
+
+  salt_buf[0] = salt_bufs[SALT_POS_HOST].salt_buf[0];
+  salt_buf[1] = salt_bufs[SALT_POS_HOST].salt_buf[1];
+  salt_buf[2] = salt_bufs[SALT_POS_HOST].salt_buf[2];
+  salt_buf[3] = salt_bufs[SALT_POS_HOST].salt_buf[3];
+
+  #ifdef DYNAMIC_LOCAL
+  // from host
+  #else
+  LOCAL_VK u32 S0_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S1_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S2_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S3_all[FIXED_LOCAL_SIZE][256];
+  #endif
+
+  #ifdef BCRYPT_AVOID_BANK_CONFLICTS
+  LOCAL_AS u32 *S0 = S + (FIXED_LOCAL_SIZE * 256 * 0);
+  LOCAL_AS u32 *S1 = S + (FIXED_LOCAL_SIZE * 256 * 1);
+  LOCAL_AS u32 *S2 = S + (FIXED_LOCAL_SIZE * 256 * 2);
+  LOCAL_AS u32 *S3 = S + (FIXED_LOCAL_SIZE * 256 * 3);
+  #else
+  LOCAL_AS u32 *S0 = S0_all[lid];
+  LOCAL_AS u32 *S1 = S1_all[lid];
+  LOCAL_AS u32 *S2 = S2_all[lid];
+  LOCAL_AS u32 *S3 = S3_all[lid];
+  #endif
+
+  u32 P[18];
+
+  blowfish_set_key_salt (E, 18, salt_buf, P, S0, S1, S2, S3);
+
+  // store
+
+  for (u32 i = 0; i < 18; i++)
+  {
+    tmps[gid].P[i] = P[i];
+  }
+
+  for (u32 i = 0; i < 256; i++)
+  {
+    tmps[gid].S0[i] = GET_KEY32 (S0, i);
+    tmps[gid].S1[i] = GET_KEY32 (S1, i);
+    tmps[gid].S2[i] = GET_KEY32 (S2, i);
+    tmps[gid].S3[i] = GET_KEY32 (S3, i);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m35500_loop (KERN_ATTR_TMPS (bcrypt_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // load
+
+  u32 E[18];
+
+  for (u32 i = 0; i < 18; i++)
+  {
+    E[i] = tmps[gid].E[i];
+  }
+
+  u32 P[18];
+
+  for (u32 i = 0; i < 18; i++)
+  {
+    P[i] = tmps[gid].P[i];
+  }
+
+  #ifdef DYNAMIC_LOCAL
+  // from host
+  #else
+  LOCAL_VK u32 S0_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S1_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S2_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S3_all[FIXED_LOCAL_SIZE][256];
+  #endif
+
+  #ifdef BCRYPT_AVOID_BANK_CONFLICTS
+  LOCAL_AS u32 *S0 = S + (FIXED_LOCAL_SIZE * 256 * 0);
+  LOCAL_AS u32 *S1 = S + (FIXED_LOCAL_SIZE * 256 * 1);
+  LOCAL_AS u32 *S2 = S + (FIXED_LOCAL_SIZE * 256 * 2);
+  LOCAL_AS u32 *S3 = S + (FIXED_LOCAL_SIZE * 256 * 3);
+  #else
+  LOCAL_AS u32 *S0 = S0_all[lid];
+  LOCAL_AS u32 *S1 = S1_all[lid];
+  LOCAL_AS u32 *S2 = S2_all[lid];
+  LOCAL_AS u32 *S3 = S3_all[lid];
+  #endif
+
+  for (u32 i = 0; i < 256; i++)
+  {
+    SET_KEY32 (S0, i, tmps[gid].S0[i]);
+    SET_KEY32 (S1, i, tmps[gid].S1[i]);
+    SET_KEY32 (S2, i, tmps[gid].S2[i]);
+    SET_KEY32 (S3, i, tmps[gid].S3[i]);
+  }
+
+  /**
+   * salt
+   */
+
+  u32 salt_buf[4];
+
+  salt_buf[0] = salt_bufs[SALT_POS_HOST].salt_buf[0];
+  salt_buf[1] = salt_bufs[SALT_POS_HOST].salt_buf[1];
+  salt_buf[2] = salt_bufs[SALT_POS_HOST].salt_buf[2];
+  salt_buf[3] = salt_bufs[SALT_POS_HOST].salt_buf[3];
+
+  /**
+   * main loop
+   */
+
+  for (u32 i = 0; i < LOOP_CNT; i++)
+  {
+    for (u32 i = 0; i < 18; i++)
+    {
+      P[i] ^= E[i];
+    }
+
+    blowfish_encrypt (P, S0, S1, S2, S3);
+
+    P[ 0] ^= salt_buf[0];
+    P[ 1] ^= salt_buf[1];
+    P[ 2] ^= salt_buf[2];
+    P[ 3] ^= salt_buf[3];
+    P[ 4] ^= salt_buf[0];
+    P[ 5] ^= salt_buf[1];
+    P[ 6] ^= salt_buf[2];
+    P[ 7] ^= salt_buf[3];
+    P[ 8] ^= salt_buf[0];
+    P[ 9] ^= salt_buf[1];
+    P[10] ^= salt_buf[2];
+    P[11] ^= salt_buf[3];
+    P[12] ^= salt_buf[0];
+    P[13] ^= salt_buf[1];
+    P[14] ^= salt_buf[2];
+    P[15] ^= salt_buf[3];
+    P[16] ^= salt_buf[0];
+    P[17] ^= salt_buf[1];
+
+    blowfish_encrypt (P, S0, S1, S2, S3);
+  }
+
+  // store
+
+  for (u32 i = 0; i < 18; i++)
+  {
+    tmps[gid].P[i] = P[i];
+  }
+
+  for (u32 i = 0; i < 256; i++)
+  {
+    tmps[gid].S0[i] = GET_KEY32 (S0, i);
+    tmps[gid].S1[i] = GET_KEY32 (S1, i);
+    tmps[gid].S2[i] = GET_KEY32 (S2, i);
+    tmps[gid].S3[i] = GET_KEY32 (S3, i);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m35500_comp (KERN_ATTR_TMPS (bcrypt_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // load
+
+  u32 P[18];
+
+  for (u32 i = 0; i < 18; i++)
+  {
+    P[i] = tmps[gid].P[i];
+  }
+
+  #ifdef DYNAMIC_LOCAL
+  // from host
+  #else
+  LOCAL_VK u32 S0_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S1_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S2_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S3_all[FIXED_LOCAL_SIZE][256];
+  #endif
+
+  #ifdef BCRYPT_AVOID_BANK_CONFLICTS
+  LOCAL_AS u32 *S0 = S + (FIXED_LOCAL_SIZE * 256 * 0);
+  LOCAL_AS u32 *S1 = S + (FIXED_LOCAL_SIZE * 256 * 1);
+  LOCAL_AS u32 *S2 = S + (FIXED_LOCAL_SIZE * 256 * 2);
+  LOCAL_AS u32 *S3 = S + (FIXED_LOCAL_SIZE * 256 * 3);
+  #else
+  LOCAL_AS u32 *S0 = S0_all[lid];
+  LOCAL_AS u32 *S1 = S1_all[lid];
+  LOCAL_AS u32 *S2 = S2_all[lid];
+  LOCAL_AS u32 *S3 = S3_all[lid];
+  #endif
+
+  for (u32 i = 0; i < 256; i++)
+  {
+    SET_KEY32 (S0, i, tmps[gid].S0[i]);
+    SET_KEY32 (S1, i, tmps[gid].S1[i]);
+    SET_KEY32 (S2, i, tmps[gid].S2[i]);
+    SET_KEY32 (S3, i, tmps[gid].S3[i]);
+  }
+
+  /**
+   * main
+   */
+
+  u32 L0;
+  u32 R0;
+
+  L0 = BCRYPTM_0;
+  R0 = BCRYPTM_1;
+
+  for (u32 i = 0; i < 64; i++)
+  {
+    BF_ENCRYPT (L0, R0);
+  }
+
+  const u32 r0 = L0;
+  const u32 r1 = R0;
+
+  L0 = BCRYPTM_2;
+  R0 = BCRYPTM_3;
+
+  for (u32 i = 0; i < 64; i++)
+  {
+    BF_ENCRYPT (L0, R0);
+  }
+
+  const u32 r2 = L0;
+  const u32 r3 = R0;
+
+  /*
+  e = L0;
+  f = R0;
+
+  f &= ~0xff; // its just 23 not 24 !
+  */
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/src/modules/module_35500.c
+++ b/src/modules/module_35500.c
@@ -1,0 +1,264 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_6;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_FRAMEWORK;
+static const char *HASH_NAME      = "Wordpress bcrypt(hmac-sha384($pass))";
+static const u64   KERN_TYPE      = 35500;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_DYNAMIC_SHARED;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$wp$2y$10$lzlQrRRhLSjz486bA9CKHuZRPoKz4uviT251Sq/r5OzKUBbrXwnQW";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct bcrypt_tmp
+{
+  u32 E[18];
+
+  u32 P[18];
+
+  u32 S0[256];
+  u32 S1[256];
+  u32 S2[256];
+  u32 S3[256];
+
+} bcrypt_tmp_t;
+
+#include "blowfish_common.c"
+
+static const char *SIGNATURE_BCRYPT1 = "$wp$2a$";
+static const char *SIGNATURE_BCRYPT2 = "$wp$2b$";
+static const char *SIGNATURE_BCRYPT3 = "$wp$2x$";
+static const char *SIGNATURE_BCRYPT4 = "$wp$2y$";
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (bcrypt_tmp_t);
+
+  return tmp_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 4;
+
+  token.signatures_cnt    = 4;
+  token.signatures_buf[0] = SIGNATURE_BCRYPT1;
+  token.signatures_buf[1] = SIGNATURE_BCRYPT2;
+  token.signatures_buf[2] = SIGNATURE_BCRYPT3;
+  token.signatures_buf[3] = SIGNATURE_BCRYPT4;
+
+  token.len[0]     = 7;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '$';
+  token.len[1]     = 2;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len[2]     = 22;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64B;
+
+  token.len[3]     = 31;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64B;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *iter_pos = token.buf[1];
+  const u8 *salt_pos = token.buf[2];
+  const u8 *hash_pos = token.buf[3];
+
+  const int salt_len = token.len[2];
+  const int hash_len = token.len[3];
+
+  salt->salt_len  = 16;
+  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+  
+  memcpy ((char *) salt->salt_sign, line_buf, 6);
+
+  u8 *salt_buf_ptr = (u8 *) salt->salt_buf;
+
+  u8 tmp_buf[100];
+
+  memset (tmp_buf, 0, sizeof (tmp_buf));
+
+  base64_decode (bf64_to_int, salt_pos, salt_len, tmp_buf);
+
+  memcpy (salt_buf_ptr, tmp_buf, 16);
+
+  salt->salt_buf[0] = byte_swap_32 (salt->salt_buf[0]);
+  salt->salt_buf[1] = byte_swap_32 (salt->salt_buf[1]);
+  salt->salt_buf[2] = byte_swap_32 (salt->salt_buf[2]);
+  salt->salt_buf[3] = byte_swap_32 (salt->salt_buf[3]);
+
+  memset (tmp_buf, 0, sizeof (tmp_buf));
+
+  base64_decode (bf64_to_int, hash_pos, hash_len, tmp_buf);
+
+  memcpy (digest, tmp_buf, 24);
+
+  digest[0] = byte_swap_32 (digest[0]);
+  digest[1] = byte_swap_32 (digest[1]);
+  digest[2] = byte_swap_32 (digest[2]);
+  digest[3] = byte_swap_32 (digest[3]);
+  digest[4] = byte_swap_32 (digest[4]);
+  digest[5] = byte_swap_32 (digest[5]);
+
+  digest[5] &= ~0xffu; // its just 23 not 24 !
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  u32 tmp_digest[6];
+
+  tmp_digest[0] = byte_swap_32 (digest[0]);
+  tmp_digest[1] = byte_swap_32 (digest[1]);
+  tmp_digest[2] = byte_swap_32 (digest[2]);
+  tmp_digest[3] = byte_swap_32 (digest[3]);
+  tmp_digest[4] = byte_swap_32 (digest[4]);
+  tmp_digest[5] = byte_swap_32 (digest[5]);
+
+  u32 tmp_salt[4];
+
+  tmp_salt[0] = byte_swap_32 (salt->salt_buf[0]);
+  tmp_salt[1] = byte_swap_32 (salt->salt_buf[1]);
+  tmp_salt[2] = byte_swap_32 (salt->salt_buf[2]);
+  tmp_salt[3] = byte_swap_32 (salt->salt_buf[3]);
+
+  char tmp_buf[64];
+
+  base64_encode (int_to_bf64, (const u8 *) tmp_salt,   16, (u8 *) tmp_buf +  0);
+  base64_encode (int_to_bf64, (const u8 *) tmp_digest, 23, (u8 *) tmp_buf + 22);
+
+  tmp_buf[22 + 31] = 0; // base64_encode wants to pad
+
+  return snprintf (line_buf, line_size, "%s$%02d$%s", (const char *) salt->salt_sign, (int)log2(salt->salt_iter), tmp_buf);
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = blowfish_module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = blowfish_module_jit_cache_disable;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m35500.pm
+++ b/tools/test_modules/m35500.pm
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Crypt::Eksblowfish::Bcrypt qw (bcrypt en_base64);
+use MIME::Base64               qw (encode_base64 decode_base64);
+use Digest::SHA                qw (hmac_sha384);
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $iter = shift;
+
+  my $cost = "05";
+
+  if (length ($iter))
+  {
+    $cost = $iter;
+  }
+
+  my $hmac = hmac_sha384 ($word, "wp-sha384");
+  my $encoded_hmac = encode_base64($hmac, '');
+
+  my $hash = '$wp' . bcrypt ($encoded_hmac, sprintf ('$2a$%s$%s$', $cost, en_base64 ($salt)));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $index1 = index ($line, ":", 33);
+
+  return if $index1 < 1;
+
+  my $hash = substr ($line, 0, $index1);
+  my $word = substr ($line, $index1 + 1);
+
+  my $index2 = index ($hash, "\$", 4);
+
+  my $iter = substr ($hash, 4, $index2 - 4);
+
+  my $plain_base64 = substr ($hash, $index2 + 1, 22);
+
+  # base64 mapping
+
+  my $base64   = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  my $itoa64_2 = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  my $encoded = "";
+
+  for (my $i = 0; $i < length ($plain_base64); $i++)
+  {
+    my $char = substr ($plain_base64, $i, 1);
+
+    $encoded .= substr ($base64, index ($itoa64_2, $char), 1);
+  }
+
+  my $salt = decode_base64 ($encoded);
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $iter);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tunings/Modules_bcrypt.hctune
+++ b/tunings/Modules_bcrypt.hctune
@@ -10,3 +10,4 @@ DEVICE_TYPE_CPU                                 *       25800   1       N       
 DEVICE_TYPE_CPU                                 *       28400   1       N       A
 DEVICE_TYPE_CPU                                 *       30600   1       N       A
 DEVICE_TYPE_CPU                                 *       30601   1       N       A
+DEVICE_TYPE_CPU                                 *       35500   1       N       A


### PR DESCRIPTION
Apparently Wordpress have changed their hashing algorithms, with the new main choice being `bcrypt(base64(hmac-sha384_raw($plain)))`, using `wp-sha384` as the hmac key and a `$wp` prefix signature.
https://github.com/WordPress/WordPress/blob/6.8.1/wp-includes/pluggable.php#L2706-L2709
```
$ ./tools/test.sh -m 35500 -a all -t all -o win -P
[ test_1758841868 ] > Init test for hash type 35500.
[ test_1758841868 ] [ Type 35500, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1758841868 ] [ Type 35500, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1758841868 ] [ Type 35500, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1758841868 ] [ Type 35500, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
```

Satisfies: https://hashcat.net/forum/thread-13369-post-63813.html and additional user reports
