### PR TITLE
Disable setShouldMaximizeConcurrentCompilation on ext_metal.m, due to segfault on macos Tahoe

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -12,6 +12,7 @@ Docker: Add hashcat-toolchain
 
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
+- Disable setShouldMaximizeConcurrentCompilation on ext_metal.m, due to segfault on macos Tahoe
 
 * changes v7.1.1 -> v7.1.2
 

--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -339,12 +339,14 @@ int hc_mtlDeviceGet (void *hashcat_ctx, mtl_device_id *metal_device, int ordinal
     return -1;
   }
 
+  /*
   // parallelize pipeline state object (PSO) compilation internally
 
   if ([device respondsToSelector:@selector(setShouldMaximizeConcurrentCompilation:)])
   {
     ((void (*)(id, SEL, BOOL))objc_msgSend)(device, @selector(setShouldMaximizeConcurrentCompilation:), YES);
   }
+  */
 
   *metal_device = device;
 


### PR DESCRIPTION
fix #4511