### PR TITLE
Avoid generating invalid luks2 hashfiles

### DIFF
--- a/tools/luks2hashcat.py
+++ b/tools/luks2hashcat.py
@@ -327,6 +327,8 @@ def extract_version2(file):
     segment_offset = int(json_header['segments']['0']['offset'])
     file.seek(segment_offset)
     first_sector = file.read(512)
+    if len(first_sector) < 512:
+        raise ValueError("file contains less data than needed (invalid payload len)")
 
     for key in json_header['keyslots']:
         print(key)


### PR DESCRIPTION
Using `luks2hashcat.py` on luks2 header files which are too small may generate an invalid hashcat hash under certain circumstances.

Just add a small check if the desired 512 bytes can be read from the file or generate an error.

Example where the incorrect hashcat hash was generated can be reproduced as follows. First create a luks2 container:
```
$ dd if=/dev/zero of=/tmp/luks-container.img bs=1M count=1024 # create basefile
$ sudo cryptsetup luksFormat /tmp/luks-container.img --type luks2 -o 1536000  # encrypt with luks2, enter a password yourself
$ sudo cryptsetup open /tmp/luks-container.img luks-container # decrypt container
$ # now make a filesystem inside the container, mount it and place a file in it
$ sudo mkfs.ext4 /dev/mapper/luks-container
$ sudo mount /dev/mapper/luks-container /mnt/luks
$ echo "You found the password." | sudo tee /mnt/luks/hello.txt
$ # unmount and close container
$ sudo umount /mnt/luks
$ sudo cryptsetup close luks-container
```
Now create a too small luks2 header file to reproduce the error:
```
dd if=/tmp/luks-container.img of=/tmp/luks-container-too-small.img bs=1M count=16
```
Without this fix, `luks2hashcat.py` will generate a hash without error:
```
python3 /tmp/hashcat/tools/luks2hashcat.py /tmp/luks-container-too-small.img > /tmp/luks2.hash
``` 

Now calling hashcat:
```
hashcat -m 34100 /tmp/luks2.hash -a3 -1 't' 'hashca?1'
```
will generate a separator unmatched error because the segment size could not be read from the input file. Therefore I added a small check in the `luks2hashcat.py` script.