### PR TITLE
Fix typos in makefiles for bridge plugins

### DIFF
--- a/src/bridges/bridge_python_generic_hash_mp.mk
+++ b/src/bridges/bridge_python_generic_hash_mp.mk
@@ -56,7 +56,7 @@ RESET = \033[0m
 ifeq ($(REPORT_MISSING_DLL),true)
 bridges/bridge_python_generic_hash_mp.dll:
 	@echo ""
-	@echo "$(RED)WARNING$(RESET): Skipping regular plugin 70300: Python Windows headers not found."
+	@echo "$(RED)WARNING$(RESET): Skipping regular plugin 73000: Python Windows headers not found."
 	@echo "         To use -m 73000, you must install the required Python headers."
 	@echo "         Otherwise, you can safely ignore this warning."
 	@echo "         See BUILD_WSL.md how to prepare $(WIN_PYTHON)."
@@ -66,7 +66,7 @@ endif
 ifeq ($(REPORT_MISSING_SO),true)
 bridges/bridge_python_generic_hash_mp.so:
 	@echo ""
-	@echo "$(RED)WARNING$(RESET): Skipping regular plugin 70300: Python headers not found."
+	@echo "$(RED)WARNING$(RESET): Skipping regular plugin 73000: Python headers not found."
 	@echo "         To use -m 73000, you must install the required Python headers."
 	@echo "         Otherwise, you can safely ignore this warning."
 	@echo "         For more information, see 'docs/hashcat-python-plugin-requirements.md'."

--- a/src/bridges/bridge_python_generic_hash_sp.mk
+++ b/src/bridges/bridge_python_generic_hash_sp.mk
@@ -68,7 +68,7 @@ RESET = \033[0m
 ifeq ($(REPORT_MISSING_DLL),true)
 bridges/bridge_python_generic_hash_sp.dll:
 	@echo ""
-	@echo "$(RED)WARNING$(RESET): Skipping freethreaded plugin 70200: Python Windows headers not found."
+	@echo "$(RED)WARNING$(RESET): Skipping freethreaded plugin 72000: Python Windows headers not found."
 	@echo "         To use -m 72000, you must install the required Python headers."
 	@echo "         Otherwise, you can safely ignore this warning."
 	@echo "         See BUILD_WSL.md how to prepare $(WIN_PYTHON)."
@@ -78,7 +78,7 @@ endif
 ifeq ($(REPORT_MISSING_SO),true)
 bridges/bridge_python_generic_hash_sp.so:
 	@echo ""
-	@echo "$(RED)WARNING$(RESET): Skipping freethreaded plugin 70200: Python 3.12+ headers not found."
+	@echo "$(RED)WARNING$(RESET): Skipping freethreaded plugin 72000: Python 3.12+ headers not found."
 	@echo "         To use -m 72000, you must install the required Python headers."
 	@echo "         Otherwise, you can safely ignore this warning."
 	@echo "         For more information, see 'docs/hashcat-python-plugin-requirements.md'."


### PR DESCRIPTION
In the two python binding plugins, the makefile error (when not supported) shows the wrong module number.
In the lines below, the correct number is used. This PR simply changes the plugin number in the error string.