### PR TITLE
Add missing length set in mask_ctx_parse_maskfile

### DIFF
--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -1829,6 +1829,7 @@ int mask_ctx_parse_maskfile (hashcat_ctx_t *hashcat_ctx)
   mfs_buf[5].mf_len = 0;
   mfs_buf[6].mf_len = 0;
   mfs_buf[7].mf_len = 0;
+  mfs_buf[8].mf_len = 0;
 
   size_t mfs_cnt = 0;
 


### PR DESCRIPTION
Setting 8 custom charsets in a mask file causes bad behavior, seems like an out of bounds. Previous mpsp.c had lengths set to 0 on each iter for all fields charsets+mask, but the recent expansion to 8 custom charsets only sets lengths to 0 for 8 of the 8+1 fields. 