### PR TITLE
Add a github action to run checks and tests for Rust code

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches:
       - "master"
-      - "feat/*"
     tags:
       - v*
     paths:
@@ -50,7 +49,6 @@ jobs:
         with:
           toolchain: ${{ env.rust_stable }}
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
       # Check fmt
       - name: "rustfmt --check"
         # Workaround for rust-lang/cargo#7732
@@ -60,10 +58,39 @@ jobs:
             exit 1
           fi
 
-  # test all rust bridges
-  test-bridges:
+  minrust:
+    name: minrust
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust ${{ env.rust_min }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_min }}
+      - name: "cargo check hashcat-sys"
+        run: cargo check
+        working-directory: Rust/hashcat-sys
+      - name: "cargo check bridges"
+        run: |
+          for b in `ls`; do
+            cd ${b}
+            cargo check
+            cd ..
+          done
+        working-directory: Rust/bridges
+      - name: "cargo check feeds"
+        run: |
+          for b in `ls`; do
+            cd ${b}
+            cargo check
+            cd ..
+          done
+        working-directory: Rust/feeds
+
+  # test all rust code
+  test-rust:
     needs: basics
-    name: test all Rust bridges
+    name: test all Rust crates
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -77,36 +104,24 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
             toolchain: ${{ env.rust_stable }}
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-      - uses: Swatinem/rust-cache@v2
+      - name: test hashcat-sys
+        run: cargo test
+        working-directory: Rust/hashcat-sys
       - name: test all bridges
         run: |
           set -euxo pipefail
           for b in `ls`; do
             cd ${b}
-            cargo nextest run
+            cargo test
             cd ..
           done
         working-directory: Rust/bridges
-
-  minrust:
-    name: minrust
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install Rust ${{ env.rust_min }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.rust_min }}
-      - uses: Swatinem/rust-cache@v2
-      - name: "cargo check"
+      - name: test all feeds
         run: |
+          set -euxo pipefail
           for b in `ls`; do
             cd ${b}
-            cargo check
+            cargo test
             cd ..
           done
-        working-directory: Rust/bridges
+        working-directory: Rust/feeds

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,112 @@
+name: Rust tests
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+  RUSTUP_WINDOWS_PATH_ADD_BIN: 1
+  # Change to specific Rust release to pin
+  rust_stable: stable
+  rust_nightly: nightly-2025-01-25
+  rust_edition: '2021'
+  rust_clippy: '1.88'
+  rust_min: '1.88'
+
+on:
+  push:
+    branches:
+      - "master"
+      - "feat/*"
+    tags:
+      - v*
+    paths:
+      - 'Rust/**'
+      - '.github/workflows/rust.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'Rust/**'
+      - '.github/workflows/rust.yml'
+
+jobs:
+  # Basic actions that must pass before we kick off more expensive tests.
+  basics:
+    name: basic checks
+    runs-on: ubuntu-latest
+    needs:
+      - fmt
+      - minrust
+    steps:
+      - run: exit 0
+
+  # enforce standard Rust formating (rustfmt)
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      # Check fmt
+      - name: "rustfmt --check"
+        # Workaround for rust-lang/cargo#7732
+        run: |
+          if ! rustfmt --check --edition ${{ env.rust_edition }} $(git ls-files '*.rs'); then
+            printf "Please run \`rustfmt --edition ${{ env.rust_edition }} \$(git ls-files '*.rs')\` to fix rustfmt errors.\nSee CONTRIBUTING.md for more details.\n" >&2
+            exit 1
+          fi
+
+  # test all rust bridges
+  test-bridges:
+    needs: basics
+    name: test all Rust bridges
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # - windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+            toolchain: ${{ env.rust_stable }}
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - uses: Swatinem/rust-cache@v2
+      - name: test all bridges
+        run: |
+          set -euxo pipefail
+          for b in `ls`; do
+            cd ${b}
+            cargo nextest run
+            cd ..
+          done
+        working-directory: Rust/bridges
+
+  minrust:
+    name: minrust
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust ${{ env.rust_min }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_min }}
+      - uses: Swatinem/rust-cache@v2
+      - name: "cargo check"
+        run: |
+          for b in `ls`; do
+            cd ${b}
+            cargo check
+            cd ..
+          done
+        working-directory: Rust/bridges

--- a/Rust/bridges/dynamic_hash/src/eval.rs
+++ b/Rust/bridges/dynamic_hash/src/eval.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use crate::{DataDecoder, Expr, ExtraParams, OutputFormat};
 
-use base64::{Engine, prelude::BASE64_STANDARD};
+use base64::{prelude::BASE64_STANDARD, Engine};
 use hmac::{Hmac, Mac};
 use md2::Md2;
 use md4::Md4;

--- a/Rust/bridges/dynamic_hash/src/interop.rs
+++ b/Rust/bridges/dynamic_hash/src/interop.rs
@@ -13,8 +13,7 @@ use std::{
 
 use hashcat_sys::{bridge_context_t, generic_io_t, generic_io_tmp_t, salt_t};
 
-use crate::Expr;
-use crate::{eval::EvalContext, parse};
+use crate::{eval::EvalContext, parse, Expr};
 
 thread_local! {
     static AST: OnceCell<Expr> = OnceCell::new();

--- a/Rust/bridges/dynamic_hash/src/parse.rs
+++ b/Rust/bridges/dynamic_hash/src/parse.rs
@@ -2,7 +2,7 @@
  * Author......: See docs/credits.txt
  * License.....: MIT
  */
-use base64::{Engine, prelude::BASE64_STANDARD};
+use base64::{prelude::BASE64_STANDARD, Engine};
 use std::fmt;
 
 use crate::{DataDecoder, Expr, ExtraParams, OutputFormat};

--- a/Rust/bridges/generic_hash/Cargo.lock
+++ b/Rust/bridges/generic_hash/Cargo.lock
@@ -121,7 +121,6 @@ dependencies = [
 name = "generic_hash"
 version = "0.1.0"
 dependencies = [
- "bindgen",
  "hashcat-sys",
  "hex",
  "sha2",

--- a/Rust/bridges/generic_hash/src/lib.rs
+++ b/Rust/bridges/generic_hash/src/lib.rs
@@ -2,6 +2,5 @@
  * Author......: See docs/credits.txt
  * License.....: MIT
  */
-
 mod generic_hash;
 mod interop;

--- a/Rust/feeds/dummy/src/lib.rs
+++ b/Rust/feeds/dummy/src/lib.rs
@@ -6,82 +6,97 @@ pub static GENERIC_PLUGIN_OPTIONS: u32 = 0;
 #[unsafe(no_mangle)]
 pub static GENERIC_PLUGIN_VERSION: u32 = 712;
 
-#[repr (C)]
-pub struct generic_global_ctx_t
-{
-  pub quiet: bool,
+#[repr(C)]
+pub struct generic_global_ctx_t {
+    pub quiet: bool,
 
-  pub workc: i32,
-  pub workv: *mut *mut c_char,
+    pub workc: i32,
+    pub workv: *mut *mut c_char,
 
-  pub profile_dir: *mut c_char,
-  pub cache_dir: *mut c_char,
+    pub profile_dir: *mut c_char,
+    pub cache_dir: *mut c_char,
 
-  pub error: bool,
-  pub error_msg: [c_char; 256],
+    pub error: bool,
+    pub error_msg: [c_char; 256],
 
-  pub gbldata: *mut c_void,
+    pub gbldata: *mut c_void,
 }
 
-#[repr (C)]
-pub struct generic_thread_ctx_t
-{
-  pub thrdata: *mut c_void,
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn global_init (_global_ctx: *mut generic_global_ctx_t, _thread_ctx: *mut *mut generic_thread_ctx_t, _hashcat_ctx: *mut c_void) -> bool
-{
-  true
+#[repr(C)]
+pub struct generic_thread_ctx_t {
+    pub thrdata: *mut c_void,
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn global_term (_global_ctx: *mut generic_global_ctx_t, _thread_ctx: *mut *mut generic_thread_ctx_t, _hashcat_ctx: *mut c_void)
-{
+pub extern "C" fn global_init(
+    _global_ctx: *mut generic_global_ctx_t,
+    _thread_ctx: *mut *mut generic_thread_ctx_t,
+    _hashcat_ctx: *mut c_void,
+) -> bool {
+    true
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn global_keyspace (_global_ctx: *mut generic_global_ctx_t, _thread_ctx: *mut *mut generic_thread_ctx_t, _hashcat_ctx: *mut c_void) -> u64
-{
-  0xffff_ffff_ffff_ffff
+pub extern "C" fn global_term(
+    _global_ctx: *mut generic_global_ctx_t,
+    _thread_ctx: *mut *mut generic_thread_ctx_t,
+    _hashcat_ctx: *mut c_void,
+) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn thread_init (_global_ctx: *mut generic_global_ctx_t, _thread_ctx: *mut generic_thread_ctx_t) -> bool
-{
-  unsafe
-  {
-    let buf: Box<[u8; 256]> = Box::new ([0; 256]);
-
-    (*_thread_ctx).thrdata = Box::into_raw (buf) as *mut c_void;
-  }
-
-  true
+pub extern "C" fn global_keyspace(
+    _global_ctx: *mut generic_global_ctx_t,
+    _thread_ctx: *mut *mut generic_thread_ctx_t,
+    _hashcat_ctx: *mut c_void,
+) -> u64 {
+    0xffff_ffff_ffff_ffff
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn thread_term (_global_ctx: *mut generic_global_ctx_t, _thread_ctx: *mut generic_thread_ctx_t)
-{
-  unsafe
-  {
-    let ptr = (*_thread_ctx).thrdata as *mut [u8; 256];
+pub extern "C" fn thread_init(
+    _global_ctx: *mut generic_global_ctx_t,
+    _thread_ctx: *mut generic_thread_ctx_t,
+) -> bool {
+    unsafe {
+        let buf: Box<[u8; 256]> = Box::new([0; 256]);
 
-    let _ = Box::from_raw (ptr);
+        (*_thread_ctx).thrdata = Box::into_raw(buf) as *mut c_void;
+    }
 
-    (*_thread_ctx).thrdata = std::ptr::null_mut ();
-  }
+    true
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn thread_seek (_global_ctx: *mut generic_global_ctx_t, _thread_ctx: *mut generic_thread_ctx_t, _offset: u64) -> bool
-{
-  true
+pub extern "C" fn thread_term(
+    _global_ctx: *mut generic_global_ctx_t,
+    _thread_ctx: *mut generic_thread_ctx_t,
+) {
+    unsafe {
+        let ptr = (*_thread_ctx).thrdata as *mut [u8; 256];
+
+        let _ = Box::from_raw(ptr);
+
+        (*_thread_ctx).thrdata = std::ptr::null_mut();
+    }
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn thread_next (_global_ctx: *mut generic_global_ctx_t, _thread_ctx: *mut generic_thread_ctx_t, out_buf: *mut u8) -> c_int
-{
-  unsafe { std::ptr::copy_nonoverlapping(b"Password1".as_ptr(), out_buf, 9) }
+pub extern "C" fn thread_seek(
+    _global_ctx: *mut generic_global_ctx_t,
+    _thread_ctx: *mut generic_thread_ctx_t,
+    _offset: u64,
+) -> bool {
+    true
+}
 
-  9
+#[unsafe(no_mangle)]
+pub extern "C" fn thread_next(
+    _global_ctx: *mut generic_global_ctx_t,
+    _thread_ctx: *mut generic_thread_ctx_t,
+    out_buf: *mut u8,
+) -> c_int {
+    unsafe { std::ptr::copy_nonoverlapping(b"Password1".as_ptr(), out_buf, 9) }
+
+    9
 }

--- a/Rust/hashcat-sys/src/lib.rs
+++ b/Rust/hashcat-sys/src/lib.rs
@@ -8,3 +8,14 @@
 pub mod bindings;
 
 pub use bindings::*;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// test that bindings.rs exists by asserting some very basic things
+    #[test]
+    fn test_bindings_exists() {
+        assert_eq!(bindings::INT8_MIN, -128);
+    }
+}

--- a/Rust/hashcat-sys/src/lib.rs
+++ b/Rust/hashcat-sys/src/lib.rs
@@ -4,6 +4,7 @@
     non_snake_case,
     non_upper_case_globals
 )]
+#[rustfmt::skip]
 pub mod bindings;
 
 pub use bindings::*;

--- a/src/Makefile
+++ b/src/Makefile
@@ -575,7 +575,6 @@ clean:
 	$(RM) -rf kernels
 	$(RM) -rf Rust/bridges/*/target
 	$(RM) -rf Rust/feeds/*/target
-	$(RM) -rf Rust/hashcat-sys/target
 	$(RM) -rf Rust/hashcat-sys/src/bindings.rs
 
 .PHONY: distclean

--- a/src/Makefile
+++ b/src/Makefile
@@ -575,6 +575,8 @@ clean:
 	$(RM) -rf kernels
 	$(RM) -rf Rust/bridges/*/target
 	$(RM) -rf Rust/feeds/*/target
+	$(RM) -rf Rust/hashcat-sys/target
+	$(RM) -rf Rust/hashcat-sys/src/bindings.rs
 
 .PHONY: distclean
 distclean: clean


### PR DESCRIPTION
Since using Rust in hashcat is quite new, it's still easy to start running unit tests automatically without generating a lot of work for previous contributors. This pull request adds a github action to automatically execute common formatting checks using `rustfmt` and to run unit tests in all crates (currently `hashcat-sys`, all bridges and all feeds).

Various Rust source files were changed slightly to meet the `rustfmt` specification.

Currently only works on mac and linux.