### PR TITLE
Fix MSYS2 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,25 +79,39 @@ jobs:
             libiconv
             libiconv-devel
             make
+            mingw-w64-x86_64-rustup
             python
+
+      - name: Setup Rustup (Windows only)
+        if: matrix.os_name_lowercase == 'windows'
+        shell: msys2 {0}
+        env:
+          PATH: /mingw64/bin:$PATH
+        run: |
+          rustup default stable
+          rustup target add x86_64-pc-windows-gnu
 
       - name: Build (Windows)
         if: matrix.os_name_lowercase == 'windows'
         shell: msys2 {0}
         env:
           SHARED: ${{ matrix.shared }}
+          PATH: /mingw64/bin:$PATH
+          WIN_PYTHON: ""
         run: make
 
       - name: Build (Linux/macOS)
         if: matrix.os_name_lowercase != 'windows'
         env:
           SHARED: ${{ matrix.shared }}
+          TERM: xterm
         run: make
 
       - name: Generate documentation
         if: matrix.os_name_lowercase == 'linux' && matrix.shared == 0
         env:
           SHARED: ${{ matrix.shared }}
+          TERM: xterm
         run: |
          cd .github/workflows/
          bash -v ./generate_docs.sh || true # make sure return code of generate docs is always successful (we don't want a build to break because of it..)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,9 @@ jobs:
             libiconv
             libiconv-devel
             make
+            mingw-w64-x86_64-clang
             mingw-w64-x86_64-rustup
+            mingw-w64-x86_64-toolchain
             python
 
       - name: Setup Rustup (Windows only)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
         if: matrix.os_name_lowercase == 'windows'
         uses: msys2/setup-msys2@v2
         with:
+          msystem: MINGW64
           update: true
           install: |
             gcc

--- a/BUILD_MSYS2.md
+++ b/BUILD_MSYS2.md
@@ -14,6 +14,10 @@ $ pacman -S make
 $ pacman -S gcc
 $ pacman -S libiconv-devel
 $ pacman -S python3
+$ pacman -S mingw-w64-x86_64-rustup
+$ export PATH="/mingw64/bin:$PATH"
+$ rustup default stable
+$ rustup target add x86_64-pc-windows-gnu
 ```
 
 ### Building ###
@@ -33,7 +37,7 @@ $ cd hashcat
 Now type "make" to start compiling hashcat
 
 ```
-$ make
+$ make WIN_PYTHON=""
 ```
 
 The process may take a while, please be patient. Once it's finished, run hashcat by typing "./hashcat.exe"

--- a/BUILD_MSYS2.md
+++ b/BUILD_MSYS2.md
@@ -14,7 +14,9 @@ $ pacman -S make
 $ pacman -S gcc
 $ pacman -S libiconv-devel
 $ pacman -S python3
+$ pacman -S mingw-w64-x86_64-clang
 $ pacman -S mingw-w64-x86_64-rustup
+$ pacman -S mingw-w64-x86_64-toolchain
 $ export PATH="/mingw64/bin:$PATH"
 $ rustup default stable
 $ rustup target add x86_64-pc-windows-gnu

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -12,6 +12,7 @@ Docker: Add hashcat-toolchain
 
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
+- Fixed MSYS2 build
 - Disable setShouldMaximizeConcurrentCompilation on ext_metal.m, due to segfault on macos Tahoe
 
 * changes v7.1.1 -> v7.1.2

--- a/src/bridges/bridge_python_generic_hash_mp.mk
+++ b/src/bridges/bridge_python_generic_hash_mp.mk
@@ -41,6 +41,11 @@ bridges/bridge_python_generic_hash_mp.so:  src/bridges/bridge_python_generic_has
 bridges/bridge_python_generic_hash_mp.dll: src/bridges/bridge_python_generic_hash_mp.c src/cpu_features.c obj/combined.WIN.a
 	$(CC_WIN)    $(CCFLAGS) $(CFLAGS_CROSS_WIN)   $^ -o $@ $(LFLAGS_CROSS_WIN)   -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(PYTHON_CFLAGS_WIN)
 else
+
+ifeq ($(BRIDGE_SUFFIX),dll)
+PYTHON_CFLAGS := $(PYTHON_CFLAGS_WIN)
+endif
+
 ifeq ($(SHARED),1)
 bridges/bridge_python_generic_hash_mp.$(BRIDGE_SUFFIX): src/bridges/bridge_python_generic_hash_mp.c src/cpu_features.c $(HASHCAT_LIBRARY)
 	$(CC)       $(CCFLAGS) $(CFLAGS_NATIVE)       $^ -o $@ $(LFLAGS_NATIVE)      -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(PYTHON_CFLAGS)

--- a/src/bridges/bridge_python_generic_hash_sp.mk
+++ b/src/bridges/bridge_python_generic_hash_sp.mk
@@ -53,6 +53,11 @@ bridges/bridge_python_generic_hash_sp.so:  src/bridges/bridge_python_generic_has
 bridges/bridge_python_generic_hash_sp.dll: src/bridges/bridge_python_generic_hash_sp.c src/cpu_features.c obj/combined.WIN.a
 	$(CC_WIN)    $(CCFLAGS) $(CFLAGS_CROSS_WIN)   $^ -o $@ $(LFLAGS_CROSS_WIN)   -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(PYTHON_CFLAGS_WIN)
 else
+
+ifeq ($(BRIDGE_SUFFIX),dll)
+PYTHON_CFLAGS := $(PYTHON_CFLAGS_WIN)
+endif
+
 ifeq ($(SHARED),1)
 bridges/bridge_python_generic_hash_sp.$(BRIDGE_SUFFIX): src/bridges/bridge_python_generic_hash_sp.c src/cpu_features.c $(HASHCAT_LIBRARY)
 	$(CC)       $(CCFLAGS) $(CFLAGS_NATIVE)       $^ -o $@ $(LFLAGS_NATIVE)      -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(PYTHON_CFLAGS)


### PR DESCRIPTION
This patch fix the current MSYS2 build procedure, that fail for rust and python bridges

- Updated build.yml
- Updated BUILD_MSYS2.md
- Updated src/bridges/bridge_python_generic_hash_mp.mk and src/bridges/bridge_python_generic_hash_sp.mk