### PR TITLE
Replace deprecated Bitcoin::Crypto symbols with supported counterparts

### DIFF
--- a/tools/test_modules/m30901.pm
+++ b/tools/test_modules/m30901.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto::Util   qw (to_format);
 use Bitcoin::Crypto::Base58 qw (decode_base58check);
 
 sub module_constraints { [[64, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
@@ -27,7 +28,7 @@ sub module_generate_hash
 
   my @is_valid_hex = eval
   {
-    $priv = btc_prv->from_hex ($word);
+    $priv = btc_prv->from_serialized ([hex => $word]);
   };
 
   return if (! @is_valid_hex);
@@ -79,7 +80,8 @@ sub module_get_random_password
 
   my $priv = $derived_key->get_basic_key ();
 
-  return $priv->to_hex (); # the result is padded (32 raw bytes)
+  return to_format [hex => $priv->to_serialized ()]; # the result is padded (32 raw bytes)
 }
 
 1;
+

--- a/tools/test_modules/m30902.pm
+++ b/tools/test_modules/m30902.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto::Util   qw (to_format);
 use Bitcoin::Crypto::Base58 qw (decode_base58check);
 
 sub module_constraints { [[64, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
@@ -27,7 +28,7 @@ sub module_generate_hash
 
   my @is_valid_hex = eval
   {
-    $priv = btc_prv->from_hex ($word);
+    $priv = btc_prv->from_serialized ([hex => $word]);
   };
 
   return if (! @is_valid_hex);
@@ -79,7 +80,8 @@ sub module_get_random_password
 
   my $priv = $derived_key->get_basic_key ();
 
-  return $priv->to_hex (); # the result is padded (32 raw bytes)
+  return to_format [hex => $priv->to_serialized ()]; # the result is padded (32 raw bytes)
 }
 
 1;
+

--- a/tools/test_modules/m30903.pm
+++ b/tools/test_modules/m30903.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto::Util   qw (to_format);
 use Bitcoin::Crypto::Base58 qw (decode_base58check);
 
 sub module_constraints { [[64, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
@@ -27,7 +28,7 @@ sub module_generate_hash
 
   my @is_valid_hex = eval
   {
-    $priv = btc_prv->from_hex ($word);
+    $priv = btc_prv->from_serialized ([hex => $word]);
   };
 
   return if (! @is_valid_hex);
@@ -74,7 +75,8 @@ sub module_get_random_password
 
   my $priv = $derived_key->get_basic_key ();
 
-  return $priv->to_hex (); # the result is padded (32 raw bytes)
+  return to_format [hex => $priv->to_serialized ()]; # the result is padded (32 raw bytes)
 }
 
 1;
+

--- a/tools/test_modules/m30904.pm
+++ b/tools/test_modules/m30904.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto::Util   qw (to_format);
 use Bitcoin::Crypto::Base58 qw (decode_base58check);
 
 sub module_constraints { [[64, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
@@ -27,7 +28,7 @@ sub module_generate_hash
 
   my @is_valid_hex = eval
   {
-    $priv = btc_prv->from_hex ($word);
+    $priv = btc_prv->from_serialized ([hex => $word]);
   };
 
   return if (! @is_valid_hex);
@@ -77,7 +78,8 @@ sub module_get_random_password
 
   my $priv = $derived_key->get_basic_key ();
 
-  return $priv->to_hex (); # the result is padded (32 raw bytes)
+  return to_format [hex => $priv->to_serialized ()]; # the result is padded (32 raw bytes)
 }
 
 1;
+

--- a/tools/test_modules/m30905.pm
+++ b/tools/test_modules/m30905.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 
 use Bitcoin::Crypto         qw (btc_prv btc_extprv);
+use Bitcoin::Crypto::Util   qw (to_format);
 use Bitcoin::Crypto::Base58 qw (decode_base58check);
 
 sub module_constraints { [[64, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
@@ -27,7 +28,7 @@ sub module_generate_hash
 
   my @is_valid_hex = eval
   {
-    $priv = btc_prv->from_hex ($word);
+    $priv = btc_prv->from_serialized ([hex => $word]);
   };
 
   return if (! @is_valid_hex);
@@ -79,7 +80,8 @@ sub module_get_random_password
 
   my $priv = $derived_key->get_basic_key ();
 
-  return $priv->to_hex (); # the result is padded (32 raw bytes)
+  return to_format [hex => $priv->to_serialized ()]; # the result is padded (32 raw bytes)
 }
 
 1;
+


### PR DESCRIPTION
Resolves #3894

I am the author of Bitcoin::Crypto. I am planning to remove the deprecated symbols from the module in the very near future. They've been deprecated for around 24 months.

I don't intend to break compatibility of any public code that depends on my module, and so merging this PR will ensure using syntax that will be supported for the foreseeable future. I've searched the repository for other code that may use deprecated symbols and found none.

I didn't run these tests myself since I don't know much about hashcat, but I have sanity-checked the code with `perl -c`.