### PR TITLE
fix: Skip unencrypted data info in luks2hashcat.py

### DIFF
--- a/tools/luks2hashcat.py
+++ b/tools/luks2hashcat.py
@@ -331,7 +331,8 @@ def extract_version2(file):
         raise ValueError("file contains less data than needed (invalid payload len)")
 
     for key in json_header['keyslots']:
-        print(key)
+        if json_header['keyslots'][key]['type'] == 'reencrypt':
+            continue
         keyslot_offset = int(json_header['keyslots'][key]['area']['offset'])
         encryption = json_header['keyslots'][key]['area']['encryption']
         stripes = int(json_header['keyslots'][key]['af']['stripes'])


### PR DESCRIPTION
Example affected keyslots:
```json
{"0": {"type": "luks2", "key_size": 64, "af": {"type": "luks1", "stripes": 4000, "hash": "sha256"}, "area": {"type": "raw", "offset": "32768", "size": "258048", "encryption": "aes-xts-plain64", "key_size": 64}, "kdf": {"type": "argon2id", "time": 13, "memory": 1048576, "cpus": 4, "salt": "..."}}, "1": {"area": {"offset": "290816", "size": "4096", "type": "datashift", "shift_size": "16777216"}, "type": "reencrypt", "key_size": 1, "mode": "encrypt", "direction": "backward", "priority": 0}}
```