### PR TITLE
docs: fix Android build issues and add ARM Illegal instruction fix

### DIFF
--- a/BUILD_Android.md
+++ b/BUILD_Android.md
@@ -6,7 +6,7 @@ Author: See `docs/credits.txt`
 
 ---
 
-## ✅ Android Requirements
+## Android Requirements
 
 - Android 8.0 or higher (OpenCL 3.0 support)
 
@@ -14,7 +14,7 @@ Author: See `docs/credits.txt`
 
 ---
 
-## 🛠️ Building Hashcat on Android
+## Building Hashcat on Android
 
 ### Step 1: Install Dependencies
 
@@ -115,7 +115,7 @@ Verify the fix worked:
 
 ---
 
-## 🔧 OpenCL Troubleshooting
+## OpenCL Troubleshooting
 
 If Library Not Found on Device
 
@@ -151,7 +151,7 @@ clinfo | grep "Number of platforms"
 
 ---
 
-## 🚀 Usage Examples
+## Usage Examples
 
 Safe Benchmark (Skips Memory-Intensive Algorithms)
 
@@ -173,7 +173,7 @@ Brute Force
 
 ---
 
-## ⚠️ Known Limitations
+## Known Limitations
 
 Memory-Intensive Algorithms
 
@@ -199,21 +199,21 @@ Recommended for Mobile
 
 ---
 
-## 🚀 Performance Results (POCO X6 Pro)
+## Performance Results (POCO X6 Pro)
 
-| Algorithm | Speed     | Status |
-|-----------|-----------|--------|
-| MD4       | 1179 MH/s | ✅     |
-| MD5       | 853 MH/s  | ✅     |
-| SHA1      | 282 MH/s  | ✅     |
-| SHA256    | 111 MH/s  | ✅     |
-| WPA2      | OOM       | ❌     |
+| Algorithm | Speed     | Status  |
+|-----------|-----------|---------|
+| MD4       | 1179 MH/s | Working |
+| MD5       | 853 MH/s  | Working |
+| SHA1      | 282 MH/s  | Working |
+| SHA256    | 111 MH/s  | Working |
+| WPA2      | OOM       | Crashed |
 
 Real-world: 9-character password cracked in 90 seconds at 694 MH/s
 
 ---
 
-## 🎉 Done
+## Done
 
 Your Android device is now ready for **hashcat!** Perfect for:
 
@@ -227,4 +227,4 @@ Your Android device is now ready for **hashcat!** Perfect for:
 
 ---
 
-Tested on **POCO X6 Pro** • **Android 16** • **Termux 0.119.0-beta.3**
+Tested on **POCO X6 Pro** | **Android 16** | **Termux 0.119.0-beta.3**

--- a/BUILD_Android.md
+++ b/BUILD_Android.md
@@ -23,7 +23,7 @@ Step 1: Install Dependencies
 ```bash
 apt update
 apt install git make clang python rust libiconv sse2neon
-apt install libbz2 liblzma libsqlite openssl readline ncurses
+apt install libbz2 liblzma libsqlite openssl readline ncurses ncurses-utils
 ```
 
 Install OpenCL Vendor Driver:

--- a/BUILD_Android.md
+++ b/BUILD_Android.md
@@ -22,18 +22,24 @@ Step 1: Install Dependencies
 
 ```bash
 apt update
-apt install git make clang python rust libiconv sse2neon opencl-vendor-driver
+apt install git make clang python rust libiconv sse2neon
 apt install libbz2 liblzma libsqlite openssl readline ncurses
+```
+
+Install OpenCL Vendor Driver:
+
+```bash
+apt install -y opencl-vendor-driver
 ```
 
 Step 2: Verify OpenCL Support
 
 ```bash
 apt install -y clinfo
-clinfo
+clinfo -l
 ```
 
-If clinfo shows 0 platforms, you need to fix OpenCL libraries.
+If clinfo shows nothing, you will need to fix OpenCL libraries.
 
 Step 3: Fix OpenCL Libraries (If Needed)
 
@@ -104,7 +110,7 @@ If the vendor driver doesn't work:
 
 ```bash
 apt remove opencl-vendor-driver
-apt install mesa-opencl-icd
+apt install mesa-opencl-icd-rusticl
 ```
 
 Verify OpenCL Fix

--- a/BUILD_Android.md
+++ b/BUILD_Android.md
@@ -96,6 +96,23 @@ make clean; make
 ./hashcat --version
 ```
 
+> [!IMPORTANT]
+> If you encounter an `Illegal instruction` error, you may need to adjust the target architecture. This is a known issue for some ARM devices ([#4579](https://github.com/hashcat/hashcat/issues/4579)).
+
+```bash
+sed -i 's/-march=native/-march=armv8-a/g' src/Makefile
+sed -i 's/-mtune=native/-mtune=generic/g' src/Makefile
+
+make clean
+make
+```
+
+Verify the fix worked:
+
+```bash
+./hashcat -I
+```
+
 ---
 
 ## 🔧 OpenCL Troubleshooting

--- a/BUILD_Android.md
+++ b/BUILD_Android.md
@@ -6,19 +6,17 @@ Author: See `docs/credits.txt`
 
 ---
 
-✅ Android Requirements
+## ✅ Android Requirements
 
-· Android 8.0 or higher (OpenCL 3.0 support)
+- Android 8.0 or higher (OpenCL 3.0 support)
 
-· Termux app installed from F-Droid or [GitHub](https://github.com/termux/termux-app/releases/latest)
-
-· ARM64 device with OpenCL-capable GPU
+- Termux app installed from [GitHub](https://github.com/termux/termux-app/releases/latest) or F-Droid
 
 ---
 
-🛠️ Building Hashcat on Android
+## 🛠️ Building Hashcat on Android
 
-Step 1: Install Dependencies
+### Step 1: Install Dependencies
 
 ```bash
 apt update
@@ -32,7 +30,7 @@ Install OpenCL Vendor Driver:
 apt install -y opencl-vendor-driver
 ```
 
-Step 2: Verify OpenCL Support
+### Step 2: Verify OpenCL Support
 
 ```bash
 apt install -y clinfo
@@ -41,12 +39,19 @@ clinfo -l
 
 If clinfo shows nothing, you will need to fix OpenCL libraries.
 
-Step 3: Fix OpenCL Libraries (If Needed)
+### Step 3: Fix OpenCL Libraries (If Needed)
 
 Auto-Fix (Try This First):
 
 ```bash
-lib_path=$(find /system /vendor -name "android.hardware.graphics.common-V*-ndk.so" 2>/dev/null | head -1) && if [ -n "$lib_path" ]; then mkdir -p $PREFIX/opt/vendor/lib && ln -sf "$lib_path" "$PREFIX/opt/vendor/lib/android.hardware.graphics.common-V4-ndk.so" && echo "✅ OpenCL linked: $lib_path"; else echo "❌ Auto-fix failed - try manual linking"; fi
+lib_path=$(find /system/lib64 /vendor/lib64 /system/lib /vendor/lib -name "android.hardware.graphics.common-V*-ndk.so" 2>/dev/null | head -1) && \
+if [ -n "$lib_path" ]; then \
+    mkdir -p $PREFIX/opt/vendor/lib && \
+    ln -sf "$lib_path" "$PREFIX/opt/vendor/lib/android.hardware.graphics.common-V4-ndk.so" && \
+    echo "[+] OpenCL linked: $lib_path"; \
+else \
+    echo "[-] Auto-fix failed - try manual linking"; \
+fi
 ```
 
 Manual Solution (If Auto-Fix Failed):
@@ -61,15 +66,22 @@ Link the library:
 
 ```bash
 mkdir -p $PREFIX/opt/vendor/lib
-ln -s /path/to/found/library $PREFIX/opt/vendor/lib/android.hardware.graphics.common-V4-ndk.so
+ln -s /path/to/found/library.so $PREFIX/opt/vendor/lib/android.hardware.graphics.common-V4-ndk.so
 ```
 
-Example:
+Example (64-bit):
 
 ```bash
 ln -s /system/lib64/android.hardware.graphics.common-V5-ndk.so $PREFIX/opt/vendor/lib/android.hardware.graphics.common-V4-ndk.so
 ```
-Step 4: Clone and Build Hashcat
+
+Example (32-bit):
+
+```bash
+ln -s /system/lib/android.hardware.graphics.common-V5-ndk.so $PREFIX/opt/vendor/lib/android.hardware.graphics.common-V4-ndk.so
+```
+
+### Step 4: Clone and Build Hashcat
 
 ```bash
 git clone --depth 1 https://github.com/hashcat/hashcat.git
@@ -77,7 +89,7 @@ cd hashcat
 make clean; make
 ```
 
-Step 5: Verify Build
+### Step 5: Verify Build
 
 ```bash
 ./hashcat -I
@@ -86,7 +98,7 @@ Step 5: Verify Build
 
 ---
 
-🔧 OpenCL Troubleshooting
+## 🔧 OpenCL Troubleshooting
 
 If Library Not Found on Device
 
@@ -122,7 +134,7 @@ clinfo | grep "Number of platforms"
 
 ---
 
-🚀 Usage Examples
+## 🚀 Usage Examples
 
 Safe Benchmark (Skips Memory-Intensive Algorithms)
 
@@ -144,29 +156,29 @@ Brute Force
 
 ---
 
-⚠️ Known Limitations
+## ⚠️ Known Limitations
 
 Memory-Intensive Algorithms
 
 These algorithms exceed mobile memory limits and will crash:
 
-· WPA2 (22000) - PBKDF2 memory requirements
+- WPA2 (22000) - PBKDF2 memory requirements
 
-· Bitcoin (11300) - Large kernel needs
+- Bitcoin (11300) - Large kernel needs
 
-· SHA512 (1700) - 512-bit operations
+- SHA512 (1700) - 512-bit operations
 
 Recommended for Mobile
 
-· MD4/MD5 (800-1200 MH/s)
+- MD4/MD5 (800-1200 MH/s)
 
-· SHA1 (200-400 MH/s)
+- SHA1 (200-400 MH/s)
 
-· SHA256 (80-150 MH/s)
+- SHA256 (80-150 MH/s)
 
-· Dictionary attacks
+- Dictionary attacks
 
-· Educational use
+- Educational use
 
 ---
 
@@ -184,18 +196,18 @@ Real-world: 9-character password cracked in 90 seconds at 694 MH/s
 
 ---
 
-🎉 Done
+## 🎉 Done
 
-Your Android device is now ready for hashcat! Perfect for:
+Your Android device is now ready for **hashcat!** Perfect for:
 
-· Educational password security
+- Educational password security
 
-· Portable penetration testing
+- Portable penetration testing
 
-· On-the-go hash verification
+- On-the-go hash verification
 
-· Security research and learning
+- Security research and learning
 
 ---
 
-Tested on POCO X6 Pro • Android 15 • Termux 0.119.0
+Tested on **POCO X6 Pro** • **Android 16** • **Termux 0.119.0-beta.3**

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -35,6 +35,11 @@ Gabriele "matrix" Gristina <matrix@hashcat.net> (@gm4tr1x)
 * Benchmarks initial code base
 * hashcat-toolchain docker
 
+Ahmed "ahmed-alnassif" Al-Nassif <mr.ahmed.nassif@gmail.com> (@ahmed-alnassif)
+
+* Android port with Termux support
+* Android build documentation and setup guide
+
 Jean-Christophe "Fist0urs" Delaunay <jean-christophe.delaunay@synacktiv.com> (@Fist0urs)
 
 * Kerberos TGS Rep enctype 23 kernel module


### PR DESCRIPTION
## Summary
Fixes building hashcat on Android devices.

## Issues Fixed
- Fixes #3632
- Fixes #4579

## Changes
- Include /system/lib64 and /vendor/lib64 in auto-fix OpenCL library search
- Add ARM architecture workaround for "Illegal instruction" error
- Update manual linking examples with 64-bit and 32-bit paths
- Fix formatting and documentation inconsistencies
- Add credit for Android support and documentation