### PR TITLE
Fix for issue #4610

### DIFF
--- a/src/modules/module_03710.c
+++ b/src/modules/module_03710.c
@@ -45,6 +45,18 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
+u32 module_salt_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);
+
+  // optimized kernel uses single-block MD5: 64 - 9 (overhead) = 55 bytes payload
+  // inner md5 hex output = 32 bytes, leaving 55 - 32 = 23 bytes for salt
+
+  const u32 salt_max = (optimized_kernel == true) ? 23 : hashconfig->salt_max;
+
+  return salt_max;
+}
+
 int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
 {
   u32 *digest = (u32 *) digest_buf;
@@ -212,7 +224,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_pwdump_column            = MODULE_DEFAULT;
   module_ctx->module_pw_max                   = MODULE_DEFAULT;
   module_ctx->module_pw_min                   = MODULE_DEFAULT;
-  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = module_salt_max;
   module_ctx->module_salt_min                 = MODULE_DEFAULT;
   module_ctx->module_salt_type                = module_salt_type;
   module_ctx->module_separator                = MODULE_DEFAULT;


### PR DESCRIPTION
Problem: Hash mode 3710 (md5($salt.md5($pass))) with the optimized kernel (-O) reported a maximum salt length of 51 bytes, but silently failed to crack hashes with salts longer than 23 bytes.                                                                                                                             
                                                                                                                                                                
Root cause: The optimized kernel uses single-block MD5 (64 bytes). With 9 bytes of overhead (0x80 padding + 8-byte length field), 55 bytes remain for payload.
The inner MD5 hex output consumes 32 bytes, leaving only 23 bytes for the salt. The module had no custom module_salt_max(), so it fell through to default_salt_max() which returned SALT_MAX_OLD = 51.                                                                                                          
                                                                                                                                                                
Fix in src/modules/module_03710.c:                                                                                                                            
 1. Added a module_salt_max() function (lines 48-58) that returns 23 when using optimized kernels, and the default hashconfig->salt_max otherwise              
2. Wired it up in module_init() at line 227: module_salt_max instead of MODULE_DEFAULT                                                                        
                                                                                                                                                                
This follows the same pattern used by mode 4710 (src/modules/module_04710.c:50-59), which also overrides module_salt_max() for its optimized kernel constraints.                                                                                                                                                  
                                                                                                                                                                
Effect: With -O, hashcat will now correctly report "Maximum salt length supported by kernel: 23" and reject hashes with salts > 23 bytes upfront, instead of silently failing to crack them.                           

fix #4610 