### PR TITLE
fix: prevent out of bounds write in build_debugdata

### DIFF
--- a/src/hashes.c
+++ b/src/hashes.c
@@ -462,7 +462,7 @@ int check_hash (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pla
   u8  debug_rule_buf[RP_PASSWORD_SIZE] = { 0 };
   int debug_rule_len  = 0; // -1 error
 
-  u8  debug_plain_ptr[RP_PASSWORD_SIZE] = { 0 };
+  u8  debug_plain_ptr[RP_PASSWORD_SIZE + 1] = { 0 };
   int debug_plain_len = 0;
 
   build_debugdata (hashcat_ctx, device_param, plain, debug_rule_buf, &debug_rule_len, debug_plain_ptr, &debug_plain_len);


### PR DESCRIPTION
This fixes an out of bound write in `build_debugdata()`. The `debug_plain_ptr` buffer size didn't consider the null terminator. When a plaintext is exactly 256 bytes long the null terminator will corrupt the first byte of `plain_ptr` and thus writing a wrong solution to the output file. This happens because `plain_ptr` on the stack is located just after `debug_plain_ptr`. At least that's the case on Linux x64 compiled with gcc. I couldn't reproduce this bug on a Mac M2 compiled with clang. I haven't investigated why but my guess would be due to a different stack layout.

The bug only happens when `--debug-mode` is 2, 3, 4 or 5 and was introduced with https://github.com/hashcat/hashcat/commit/73b8cda1764353ece4699708ed8fa32ec0632563. The bug is older than this commit but it was hidden due to `memcpy` writing the the correct data again to `plain_ptr`.

To reproduce:
```
$ cat /tmp/noop.rule
:

$ cat /tmp/dict
6Y8jBZwYVV6rXlmEf4rfrO4aOgccTEJkR2cNY3ZAqtqYm4jI9jaiJaXUHk96dAeefmurEzhsqJ6W54PdbwKbGDypp7AM9FW5ajDgMNUOdcSGZ3jZBCpUb2rx0VAPWaHsCIn72KiI6xtW1xwSmOni6EnpceQE8CiZVmNxkMC7z93GAjjtynz7IxquuZL11v138tpUhWOwv6Dw2fMqqXWYH4SMPr3X5pYfl1zH6Ky9tE9msAT21KZ0OA12fiUkxurM

$ ./hashcat -m 100 -r /tmp/noop.rule --debug-file /tmp/debug-file --debug-mode=4 -o /tmp/outfile --potfile-disable 85ec7318c85383dc19a7311690ff1308ed6a46f9 /tmp/dict

$ cat /tmp/outfile
85ec7318c85383dc19a7311690ff1308ed6a46f9:$HEX[0059386a425a775956563672586c6d4566347266724f34614f67636354454a6b5232634e59335a41717471596d346a49396a61694a615855486b393664416565666d7572457a6873714a36573534506462774b62474479707037414d39465735616a44674d4e554f646353475a336a5a4243705562327278305641505761487343496e37324b694936787457317877536d4f6e6936456e70636551453843695a566d4e786b4d43377a393347416a6a74796e7a3749787175755a4c31317631333874705568574f777636447732664d71715857594834534d50723358357059666c317a48364b79397445396d73415432314b5a304f4131326669556b7875724d]
```