### PR TITLE
Bridge Module for Bcrypt on FPGAs via LiteX

### DIFF
--- a/OpenCL/m70300-pure.cl
+++ b/OpenCL/m70300-pure.cl
@@ -3,11 +3,6 @@
  * License.....: MIT
  *
  * bcrypt $2*$, Blowfish (Unix) - LiteX FPGA Accelerated
- *
- * This kernel is minimal as the LiteX-Bcrypt FPGA bridge handles
- * the actual bcrypt computation. The _init kernel copies passwords
- * to the tmp structure, _loop is empty (bridge handles it), and
- * _comp checks if the bridge marked the hash as cracked.
  */
 
 #ifdef KERNEL_STATIC
@@ -20,24 +15,13 @@
 #define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
 #define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
 
-/**
- * FPGA tmp structure - must match module_70300.c and bridge_litex_bcrypt.c
- */
-
 typedef struct bcrypt_fpga_tmp
 {
-  u32 pw_buf[18];   // Password buffer (up to 72 bytes for bcrypt)
+  u32 pw_buf[18];   // Password buffer (up to 72 bytes)
   u32 pw_len;
-  u32 digest[6];    // Output from FPGA (24 bytes, 6 words)
   u32 cracked;      // Flag set by bridge when FPGA reports match
 
 } bcrypt_fpga_tmp_t;
-
-/**
- * _init kernel: Copy password from pws[] to tmps[]
- *
- * This prepares the password data for the bridge to send to the FPGA.
- */
 
 KERNEL_FQ KERNEL_FA void m70300_init (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
 {
@@ -47,7 +31,6 @@ KERNEL_FQ KERNEL_FA void m70300_init (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
 
   const u32 pw_len = pws[gid].pw_len;
 
-  // Copy password buffer (up to 72 bytes = 18 u32s)
   for (u32 i = 0; i < 18; i++)
   {
     tmps[gid].pw_buf[i] = pws[gid].i[i];
@@ -55,32 +38,12 @@ KERNEL_FQ KERNEL_FA void m70300_init (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
 
   tmps[gid].pw_len = pw_len;
   tmps[gid].cracked = 0;
-
-  // Clear digest
-  for (u32 i = 0; i < 6; i++)
-  {
-    tmps[gid].digest[i] = 0;
-  }
 }
-
-/**
- * _loop kernel: Empty - bridge handles FPGA computation
- *
- * The LiteX-Bcrypt bridge sends passwords to the FPGA and receives
- * results. This kernel is not used but must exist for hashcat.
- */
 
 KERNEL_FQ KERNEL_FA void m70300_loop (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
 {
   // Empty - bridge replaces this kernel
 }
-
-/**
- * _comp kernel: Check if bridge marked this candidate as cracked
- *
- * The bridge sets tmps[gid].cracked = 1 when the FPGA reports a match.
- * We check this flag and mark the hash as cracked if set.
- */
 
 KERNEL_FQ KERNEL_FA void m70300_comp (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
 {
@@ -88,12 +51,8 @@ KERNEL_FQ KERNEL_FA void m70300_comp (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
 
   if (gid >= GID_CNT) return;
 
-  // Check if the bridge marked this as cracked
-  // The FPGA compares internally and tells us which password matched
-  // We use the target digest values directly since FPGA already confirmed the match
   if (tmps[gid].cracked == 1)
   {
-    // Use the target digest values - FPGA already confirmed this is the match
     const u32 r0 = digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0];
     const u32 r1 = digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1];
     const u32 r2 = digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2];

--- a/OpenCL/m70300-pure.cl
+++ b/OpenCL/m70300-pure.cl
@@ -1,0 +1,108 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ *
+ * bcrypt $2*$, Blowfish (Unix) - LiteX FPGA Accelerated
+ *
+ * This kernel is minimal as the LiteX-Bcrypt FPGA bridge handles
+ * the actual bcrypt computation. The _init kernel copies passwords
+ * to the tmp structure, _loop is empty (bridge handles it), and
+ * _comp checks if the bridge marked the hash as cracked.
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+/**
+ * FPGA tmp structure - must match module_70300.c and bridge_litex_bcrypt.c
+ */
+
+typedef struct bcrypt_fpga_tmp
+{
+  u32 pw_buf[18];   // Password buffer (up to 72 bytes for bcrypt)
+  u32 pw_len;
+  u32 digest[6];    // Output from FPGA (24 bytes, 6 words)
+  u32 cracked;      // Flag set by bridge when FPGA reports match
+
+} bcrypt_fpga_tmp_t;
+
+/**
+ * _init kernel: Copy password from pws[] to tmps[]
+ *
+ * This prepares the password data for the bridge to send to the FPGA.
+ */
+
+KERNEL_FQ KERNEL_FA void m70300_init (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  // Copy password buffer (up to 72 bytes = 18 u32s)
+  for (u32 i = 0; i < 18; i++)
+  {
+    tmps[gid].pw_buf[i] = pws[gid].i[i];
+  }
+
+  tmps[gid].pw_len = pw_len;
+  tmps[gid].cracked = 0;
+
+  // Clear digest
+  for (u32 i = 0; i < 6; i++)
+  {
+    tmps[gid].digest[i] = 0;
+  }
+}
+
+/**
+ * _loop kernel: Empty - bridge handles FPGA computation
+ *
+ * The LiteX-Bcrypt bridge sends passwords to the FPGA and receives
+ * results. This kernel is not used but must exist for hashcat.
+ */
+
+KERNEL_FQ KERNEL_FA void m70300_loop (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
+{
+  // Empty - bridge replaces this kernel
+}
+
+/**
+ * _comp kernel: Check if bridge marked this candidate as cracked
+ *
+ * The bridge sets tmps[gid].cracked = 1 when the FPGA reports a match.
+ * We check this flag and mark the hash as cracked if set.
+ */
+
+KERNEL_FQ KERNEL_FA void m70300_comp (KERN_ATTR_TMPS (bcrypt_fpga_tmp_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // Check if the bridge marked this as cracked
+  // The FPGA compares internally and tells us which password matched
+  // We use the target digest values directly since FPGA already confirmed the match
+  if (tmps[gid].cracked == 1)
+  {
+    // Use the target digest values - FPGA already confirmed this is the match
+    const u32 r0 = digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0];
+    const u32 r1 = digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1];
+    const u32 r2 = digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2];
+    const u32 r3 = digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3];
+
+    #define il_pos 0
+
+    #ifdef KERNEL_STATIC
+    #include COMPARE_M
+    #endif
+  }
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 ##
 
 SHARED                  ?= 0
-DEBUG                   := 1
+DEBUG                   := 0
 PRODUCTION              := 0
 PRODUCTION_VERSION      := v7.1.2
 MACOS_UNIVERSAL_BINARY  ?= 0

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 ##
 
 SHARED                  ?= 0
-DEBUG                   := 0
+DEBUG                   := 1
 PRODUCTION              := 0
 PRODUCTION_VERSION      := v7.1.2
 MACOS_UNIVERSAL_BINARY  ?= 0

--- a/src/bridges/bridge_litex_bcrypt.c
+++ b/src/bridges/bridge_litex_bcrypt.c
@@ -91,7 +91,7 @@ struct litepcie_ioctl_reg {
 
 #define MAX_FPGA_DEVICES    64
 #define BASE_WORKITEM_COUNT 128
-#define MAX_WORKITEM_COUNT  512
+#define MAX_WORKITEM_COUNT  65536
 #define MAX_PASSWORD_LEN    72
 #define FPGA_TIMEOUT        10000000
 #define DRAIN_SHORT_TIMEOUT 5000
@@ -561,7 +561,7 @@ static bool detect_fpga_config (unit_t *unit)
  * Calculate sub-batch size based on password lengths
  */
 
-static u32 calculate_sub_batch_size (const bcrypt_fpga_tmp_t *bcrypt_tmp, u64 pws_cnt)
+static u32 calculate_sub_batch_size (const bcrypt_fpga_tmp_t *bcrypt_tmp, u64 pws_cnt, size_t max_wl_payload)
 {
   u32 sub_batch = 0;
   size_t payload_size = 0;
@@ -570,7 +570,7 @@ static u32 calculate_sub_batch_size (const bcrypt_fpga_tmp_t *bcrypt_tmp, u64 pw
   {
     size_t pw_packet_size = bcrypt_tmp[i].pw_len + 1;  // +1 for null terminator
 
-    if (payload_size + pw_packet_size > MAX_PAYLOAD_SIZE) break;
+    if (payload_size + pw_packet_size > max_wl_payload) break;
 
     payload_size += pw_packet_size;
     sub_batch++;
@@ -699,13 +699,10 @@ void salt_destroy (MAYBE_UNUSED void *platform_context, MAYBE_UNUSED hashconfig_
 /**
  * Main launch loop - process passwords against FPGA
  *
- * Protocol (from cleanup2_test.c):
- * 1. Start recorder (kick toggle: write 0, then write 1)
- * 2. Send CMP_CONFIG packet
- * 3. Send WORD_GEN packet (empty for -a0 mode)
- * 4. Send WORD_LIST packet
- * 5. Wait for recorder done
- * 6. Read response
+ * Optimized protocol:
+ * - Sub-batch 1: CMP_CONFIG + WORD_GEN + WORD_LIST concatenated in single SRAM kick
+ * - Sub-batch 2+: WORD_GEN + WORD_LIST only (CMP_CONFIG persists, no RESET needed)
+ * - Burst IOCTL writes entire buffer to SRAM in one syscall
  */
 
 bool launch_loop (void *platform_context, hc_device_param_t *device_param,
@@ -718,7 +715,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
   unit_t *unit = &bridge->units_buf[unit_idx];
 
-  // Pre-build RESET packet (reused for initial reset and between sub-batches)
+  // Pre-build RESET packet (used for initial reset only)
   uint8_t reset_pl[1] = {0xCC};
   uint8_t reset_hdr[10];
 
@@ -790,7 +787,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     target_hashes[i] = digest[0];
   }
 
-  // Build CMP_CONFIG packet
+  // Build CMP_CONFIG payload once (reused only in first sub-batch)
   uint8_t cmp_pl[512];
   size_t cmp_pl_len = 0;
 
@@ -801,7 +798,17 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
   hcfree (target_hashes);
 
-  // Build WORD_GEN packet (empty for -a0 mode)
+  // Build CMP_CONFIG packet (header + checksums)
+  uint8_t cmp_hdr[10];
+
+  build_header (cmp_hdr, PKT_TYPE_CMP_CONFIG, unit->next_pkt_id++, cmp_pl_len);
+
+  uint8_t pkt_cmp[1024];
+  size_t pkt_cmp_len = 0;
+
+  add_checksums_around_payload (pkt_cmp, &pkt_cmp_len, cmp_hdr, 10, cmp_pl, cmp_pl_len);
+
+  // Build WORD_GEN payload once (empty for -a0 mode)
   // NOTE: word_gen_b FSM resets to CONF_NUM_RANGES after each WORD_LIST completes
   // (conf_full=0 on word_list_end), so WORD_GEN must be resent before EVERY WORD_LIST.
   uint8_t wg_pl[16];
@@ -809,19 +816,36 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
   build_empty_word_gen_payload (wg_pl, &wg_pl_len);
 
-  // Process passwords in sub-batches (1KB buffer limit)
+  // WORD_GEN packet overhead: header(10) + hdr_csum(4) + payload + payload_csum(4) = 24 bytes
+  size_t wg_pkt_overhead = 10 + 4 + wg_pl_len + 4;
+
+  // WORD_LIST packet overhead (excluding payload): header(10) + hdr_csum(4) + payload_csum(4) = 18 bytes
+  size_t wl_pkt_overhead = 10 + 4 + 4;
+
+  // Calculate available WORD_LIST payload space for first sub-batch vs subsequent
+  // SRAM is 1024 bytes total
+  size_t first_batch_wl_payload = STREAMER_MEM_SIZE - pkt_cmp_len - wg_pkt_overhead - wl_pkt_overhead;
+  size_t later_batch_wl_payload = STREAMER_MEM_SIZE - wg_pkt_overhead - wl_pkt_overhead;
+
+  // Concatenation buffer (1KB SRAM)
+  uint8_t concat_buf[STREAMER_MEM_SIZE];
+
+  // Process passwords in sub-batches
   u64 processed = 0;
+  bool first_sub_batch = true;
 
   while (processed < pws_cnt)
   {
-    u32 sub_batch = calculate_sub_batch_size (&bcrypt_tmp[processed], pws_cnt - processed);
+    size_t max_wl_payload = first_sub_batch ? first_batch_wl_payload : later_batch_wl_payload;
+
+    u32 sub_batch = calculate_sub_batch_size (&bcrypt_tmp[processed], pws_cnt - processed, max_wl_payload);
 
     if (sub_batch > MAX_SUB_BATCH_SIZE)
     {
       sub_batch = MAX_SUB_BATCH_SIZE;
     }
 
-    // Build WORD_LIST packet for this sub-batch
+    // Build WORD_LIST payload for this sub-batch
     const u8 *words[MAX_SUB_BATCH_SIZE];
     u32 word_lens[MAX_SUB_BATCH_SIZE];
 
@@ -836,6 +860,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
     build_word_list_payload (wl_pl, &wl_pl_len, words, word_lens, sub_batch);
 
+    // Build WORD_LIST packet
     uint8_t wl_hdr[10];
 
     build_header (wl_hdr, PKT_TYPE_WORD_LIST, unit->next_pkt_id++, wl_pl_len);
@@ -845,7 +870,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
     add_checksums_around_payload (pkt_wl, &pkt_wl_len, wl_hdr, 10, wl_pl, wl_pl_len);
 
-    // Build fresh WORD_GEN packet for this sub-batch (new pkt_id each time)
+    // Build WORD_GEN packet (fresh pkt_id each time)
     uint8_t wg_hdr[10];
 
     build_header (wg_hdr, PKT_TYPE_WORD_GEN, unit->next_pkt_id++, wg_pl_len);
@@ -855,42 +880,29 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
     add_checksums_around_payload (pkt_wg, &pkt_wg_len, wg_hdr, 10, wg_pl, wg_pl_len);
 
-    // Between sub-batches: RESET FPGA to clean state (no drain needed -
-    // we already read the previous response so FIFO should be empty)
-    if (processed > 0)
+    // Concatenate packets into single SRAM buffer
+    size_t concat_len = 0;
+
+    if (first_sub_batch)
     {
-      litepcie_writel (unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
-      kick_streamer (unit, pkt_reset, pkt_reset_len);
-      litepcie_writel (unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
+      // First sub-batch: CMP_CONFIG + WORD_GEN + WORD_LIST
+      memcpy (concat_buf + concat_len, pkt_cmp, pkt_cmp_len);
+      concat_len += pkt_cmp_len;
     }
 
-    // Build CMP_CONFIG packet for this sub-batch
-    uint8_t cmp_hdr2[10];
+    // WORD_GEN (always needed — conf_full resets after each WORD_LIST)
+    memcpy (concat_buf + concat_len, pkt_wg, pkt_wg_len);
+    concat_len += pkt_wg_len;
 
-    build_header (cmp_hdr2, PKT_TYPE_CMP_CONFIG, unit->next_pkt_id++, cmp_pl_len);
-
-    uint8_t pkt_cmp2[1024];
-    size_t pkt_cmp2_len = 0;
-
-    add_checksums_around_payload (pkt_cmp2, &pkt_cmp2_len, cmp_hdr2, 10, cmp_pl, cmp_pl_len);
+    // WORD_LIST
+    memcpy (concat_buf + concat_len, pkt_wl, pkt_wl_len);
+    concat_len += pkt_wl_len;
 
     // Protocol: start recorder BEFORE sending packets
     start_recorder (unit);
 
-    // Send CMP_CONFIG + WORD_GEN + WORD_LIST for every sub-batch
-    if (!kick_streamer (unit, pkt_cmp2, pkt_cmp2_len))
-    {
-      drain_output_fifo (unit);
-      return false;
-    }
-
-    if (!kick_streamer (unit, pkt_wg, pkt_wg_len))
-    {
-      drain_output_fifo (unit);
-      return false;
-    }
-
-    if (!kick_streamer (unit, pkt_wl, pkt_wl_len))
+    // Single kick for all concatenated packets
+    if (!kick_streamer (unit, concat_buf, concat_len))
     {
       drain_output_fifo (unit);
       return false;
@@ -955,6 +967,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     }
 
     processed += sub_batch;
+    first_sub_batch = false;
   }
 
   // Check for FPGA errors

--- a/src/bridges/bridge_litex_bcrypt.c
+++ b/src/bridges/bridge_litex_bcrypt.c
@@ -27,7 +27,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <errno.h>
 
 /**
  * LitePCIe IOCTL definitions (from litepcie.h)
@@ -91,8 +90,8 @@ struct litepcie_ioctl_reg {
  */
 
 #define MAX_FPGA_DEVICES    64
-#define BASE_WORKITEM_COUNT 16   // Must not exceed hashcat's kernel_power
-#define MAX_WORKITEM_COUNT  256
+#define BASE_WORKITEM_COUNT 128
+#define MAX_WORKITEM_COUNT  512
 #define MAX_PASSWORD_LEN    72
 #define FPGA_TIMEOUT        10000000
 #define DRAIN_SHORT_TIMEOUT 5000
@@ -110,8 +109,7 @@ typedef struct bcrypt_fpga_tmp
 {
   u32 pw_buf[18];
   u32 pw_len;
-  u32 cracked;      // Must be right after pw_len to match OpenCL struct!
-  // Note: NO digest field here - that was wrong and caused offset mismatch
+  u32 cracked;
 
 } bcrypt_fpga_tmp_t;
 
@@ -125,14 +123,12 @@ typedef struct
   char      device_path[64];
 
   char      unit_info_buf[1024];
-  int       unit_info_len;
   u64       workitem_count;
 
   int       num_proxies;
   int       cores_per_proxy;
   int       total_cores;
 
-  uint8_t  *streamer_buf;
   uint8_t  *recorder_buf;
   uint16_t  next_pkt_id;
 
@@ -241,11 +237,6 @@ static void le32_encode (uint32_t x, uint8_t *out)
   out[1] = (x >> 8) & 0xFF;
   out[2] = (x >> 16) & 0xFF;
   out[3] = (x >> 24) & 0xFF;
-}
-
-static uint16_t le16_decode (const uint8_t *data)
-{
-  return data[0] | (data[1] << 8);
 }
 
 /**
@@ -482,7 +473,7 @@ static uint32_t drain_output_fifo (unit_t *unit)
 
       if (cnt >= DRAIN_SHORT_TIMEOUT)
       {
-            return total_drained;
+        return total_drained;
       }
     }
 
@@ -547,8 +538,8 @@ static bool detect_fpga_config (unit_t *unit)
         unit->workitem_count = MAX_WORKITEM_COUNT;
       }
 
-      unit->unit_info_len = snprintf (unit->unit_info_buf, sizeof (unit->unit_info_buf),
-                                      "LiteX bcrypt FPGA: %s", ident);
+      snprintf (unit->unit_info_buf, sizeof (unit->unit_info_buf),
+                "LiteX bcrypt FPGA: %s", ident);
 
       return true;
     }
@@ -560,8 +551,8 @@ static bool detect_fpga_config (unit_t *unit)
   unit->total_cores = 1;
   unit->workitem_count = BASE_WORKITEM_COUNT;
 
-  unit->unit_info_len = snprintf (unit->unit_info_buf, sizeof (unit->unit_info_buf),
-                                  "LiteX bcrypt FPGA: %s", ident);
+  snprintf (unit->unit_info_buf, sizeof (unit->unit_info_buf),
+            "LiteX bcrypt FPGA: %s", ident);
 
   return true;
 }
@@ -612,13 +603,11 @@ static bool units_init (bridge_litex_bcrypt_t *bridge)
     unit->fd = fd;
     strncpy (unit->device_path, path, sizeof (unit->device_path) - 1);
 
-    unit->streamer_buf = (uint8_t *) hcmalloc (STREAMER_MEM_SIZE);
     unit->recorder_buf = (uint8_t *) hcmalloc (RECORDER_MEM_SIZE);
     unit->next_pkt_id = 0;
 
     if (!detect_fpga_config (unit))
     {
-      hcfree (unit->streamer_buf);
       hcfree (unit->recorder_buf);
       close (fd);
       continue;
@@ -665,7 +654,6 @@ void platform_term (void *platform_context)
         close (unit->fd);
       }
 
-      hcfree (unit->streamer_buf);
       hcfree (unit->recorder_buf);
     }
 
@@ -730,25 +718,28 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
   unit_t *unit = &bridge->units_buf[unit_idx];
 
+  // Pre-build RESET packet (reused for initial reset and between sub-batches)
+  uint8_t reset_pl[1] = {0xCC};
+  uint8_t reset_hdr[10];
+
+  build_header (reset_hdr, PKT_TYPE_RESET, 0x0000, 1);
+
+  uint8_t pkt_reset[32];
+  size_t pkt_reset_len = 0;
+
+  add_checksums_around_payload (pkt_reset, &pkt_reset_len, reset_hdr, 10, reset_pl, 1);
+
   // Force-reset FPGA via clear_error CSR (unsticks inpkt_header if in PKT_STATE_ERROR)
-  litepcie_writel(unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
+  litepcie_writel (unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
 
   // Send reset and drain any stale data (like cleanup2_test does)
-  {
-    uint8_t reset_pl[1] = {0xCC};
-    uint8_t reset_hdr[10];
-    // Use packet ID 0x0000 for reset (like cleanup2_test)
-    build_header(reset_hdr, PKT_TYPE_RESET, 0x0000, 1);
-    uint8_t pkt_reset[32];
-    size_t pkt_reset_len = 0;
-    add_checksums_around_payload(pkt_reset, &pkt_reset_len, reset_hdr, 10, reset_pl, 1);
-    kick_streamer(unit, pkt_reset, pkt_reset_len);
-  }
+  kick_streamer (unit, pkt_reset, pkt_reset_len);
+
   // Drain AFTER reset, BEFORE starting work
-  drain_output_fifo(unit);
+  drain_output_fifo (unit);
 
   // Clear error latch after reset (in case error_r was latched from a previous run)
-  litepcie_writel(unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
+  litepcie_writel (unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
 
   // Reset packet ID counter after reset
   unit->next_pkt_id = 1;
@@ -808,35 +799,18 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
                                    salt16, subtype,
                                    digests_cnt, target_hashes);
 
-  uint8_t cmp_hdr[10];
-
-  build_header (cmp_hdr, PKT_TYPE_CMP_CONFIG, unit->next_pkt_id++, cmp_pl_len);
-
-  uint8_t pkt_cmp[1024];
-  size_t pkt_cmp_len = 0;
-
-  add_checksums_around_payload (pkt_cmp, &pkt_cmp_len, cmp_hdr, 10, cmp_pl, cmp_pl_len);
-
-  // target_hashes freed at cleanup label
+  hcfree (target_hashes);
 
   // Build WORD_GEN packet (empty for -a0 mode)
+  // NOTE: word_gen_b FSM resets to CONF_NUM_RANGES after each WORD_LIST completes
+  // (conf_full=0 on word_list_end), so WORD_GEN must be resent before EVERY WORD_LIST.
   uint8_t wg_pl[16];
   size_t wg_pl_len = 0;
 
   build_empty_word_gen_payload (wg_pl, &wg_pl_len);
 
-  uint8_t wg_hdr[10];
-
-  build_header (wg_hdr, PKT_TYPE_WORD_GEN, unit->next_pkt_id++, wg_pl_len);
-
-  uint8_t pkt_wg[64];
-  size_t pkt_wg_len = 0;
-
-  add_checksums_around_payload (pkt_wg, &pkt_wg_len, wg_hdr, 10, wg_pl, wg_pl_len);
-
   // Process passwords in sub-batches (1KB buffer limit)
   u64 processed = 0;
-  bool first_batch = true;
 
   while (processed < pws_cnt)
   {
@@ -871,28 +845,51 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
     add_checksums_around_payload (pkt_wl, &pkt_wl_len, wl_hdr, 10, wl_pl, wl_pl_len);
 
+    // Build fresh WORD_GEN packet for this sub-batch (new pkt_id each time)
+    uint8_t wg_hdr[10];
+
+    build_header (wg_hdr, PKT_TYPE_WORD_GEN, unit->next_pkt_id++, wg_pl_len);
+
+    uint8_t pkt_wg[64];
+    size_t pkt_wg_len = 0;
+
+    add_checksums_around_payload (pkt_wg, &pkt_wg_len, wg_hdr, 10, wg_pl, wg_pl_len);
+
+    // Between sub-batches: RESET FPGA to clean state (no drain needed -
+    // we already read the previous response so FIFO should be empty)
+    if (processed > 0)
+    {
+      litepcie_writel (unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
+      kick_streamer (unit, pkt_reset, pkt_reset_len);
+      litepcie_writel (unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
+    }
+
+    // Build CMP_CONFIG packet for this sub-batch
+    uint8_t cmp_hdr2[10];
+
+    build_header (cmp_hdr2, PKT_TYPE_CMP_CONFIG, unit->next_pkt_id++, cmp_pl_len);
+
+    uint8_t pkt_cmp2[1024];
+    size_t pkt_cmp2_len = 0;
+
+    add_checksums_around_payload (pkt_cmp2, &pkt_cmp2_len, cmp_hdr2, 10, cmp_pl, cmp_pl_len);
+
     // Protocol: start recorder BEFORE sending packets
     start_recorder (unit);
 
-    // First batch: send CMP_CONFIG, WORD_GEN, then WORD_LIST
-    if (first_batch)
+    // Send CMP_CONFIG + WORD_GEN + WORD_LIST for every sub-batch
+    if (!kick_streamer (unit, pkt_cmp2, pkt_cmp2_len))
     {
-      if (!kick_streamer (unit, pkt_cmp, pkt_cmp_len))
-      {
-        drain_output_fifo (unit);
-        return false;
-      }
-
-      if (!kick_streamer (unit, pkt_wg, pkt_wg_len))
-      {
-        drain_output_fifo (unit);
-        return false;
-      }
-
-      first_batch = false;
+      drain_output_fifo (unit);
+      return false;
     }
 
-    // Send WORD_LIST
+    if (!kick_streamer (unit, pkt_wg, pkt_wg_len))
+    {
+      drain_output_fifo (unit);
+      return false;
+    }
+
     if (!kick_streamer (unit, pkt_wl, pkt_wl_len))
     {
       drain_output_fifo (unit);
@@ -950,7 +947,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
               read_bytes (unit->fd, RECORDER_MEM_BASE, drain_buf, read_len);
             }
           }
-          
+
           // Found a match - stop processing this batch
           goto cleanup;
         }
@@ -969,7 +966,6 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
   }
 
 cleanup:
-  hcfree(target_hashes);
   return true;
 }
 

--- a/src/bridges/bridge_litex_bcrypt.c
+++ b/src/bridges/bridge_litex_bcrypt.c
@@ -87,7 +87,7 @@ struct litepcie_ioctl_reg {
  */
 
 #define MAX_FPGA_DEVICES    64
-#define BASE_WORKITEM_COUNT 32
+#define BASE_WORKITEM_COUNT 16   // Must not exceed hashcat's kernel_power
 #define MAX_WORKITEM_COUNT  256
 #define MAX_PASSWORD_LEN    72
 #define FPGA_TIMEOUT        10000000
@@ -106,8 +106,8 @@ typedef struct bcrypt_fpga_tmp
 {
   u32 pw_buf[18];
   u32 pw_len;
-  u32 digest[6];
-  u32 cracked;
+  u32 cracked;      // Must be right after pw_len to match OpenCL struct!
+  // Note: NO digest field here - that was wrong and caused offset mismatch
 
 } bcrypt_fpga_tmp_t;
 
@@ -785,7 +785,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
   add_checksums_around_payload (pkt_cmp, &pkt_cmp_len, cmp_hdr, 10, cmp_pl, cmp_pl_len);
 
-  hcfree (target_hashes);
+  // target_hashes freed at cleanup label
 
   // Build WORD_GEN packet (empty for -a0 mode)
   uint8_t wg_pl[16];
@@ -909,6 +909,9 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
           uint32_t drain_len = 0;
 
           wait_recorder (unit, &drain_len);
+          
+          // Found a match - stop processing this batch
+          goto cleanup;
         }
       }
     }
@@ -924,6 +927,8 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     drain_output_fifo (unit);
   }
 
+cleanup:
+  hcfree(target_hashes);
   return true;
 }
 

--- a/src/bridges/bridge_litex_bcrypt.c
+++ b/src/bridges/bridge_litex_bcrypt.c
@@ -1,0 +1,948 @@
+/**
+ * Hashcat bridge for LiteX bcrypt FPGA accelerator
+ *
+ * This bridge interfaces hashcat with custom bcrypt FPGA hardware built using
+ * LiteX/Migen, accessed via the LitePCIe driver.
+ *
+ * Hardware requirements:
+ * - FPGA with LitePCIe interface
+ * - Bcrypt core with packet-based protocol (compatible with JtR ZTEX format)
+ * - Linux with litepcie kernel module loaded
+ *
+ * Protocol:
+ * - Packets sent to streamer memory region
+ * - Results captured in recorder memory region
+ * - Packet format: [header][hdr_checksum][payload][payload_checksum]
+ *
+ * Reference implementation: litex_bcrypt/software/user/cleanup2_test.c
+ */
+
+#include "common.h"
+#include "types.h"
+#include "bridges.h"
+#include "memory.h"
+#include "shared.h"
+#include "event.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+
+/**
+ * LitePCIe IOCTL definitions (from litepcie.h)
+ */
+
+struct litepcie_ioctl_reg {
+  uint32_t addr;
+  uint32_t val;
+  uint8_t  is_write;
+};
+
+#define LITEPCIE_IOCTL      'S'
+#define LITEPCIE_IOCTL_REG  _IOWR(LITEPCIE_IOCTL, 0, struct litepcie_ioctl_reg)
+
+/**
+ * CSR addresses (from csr.h - CSR_BASE is 0x0)
+ */
+
+#define CSR_IDENTIFIER_MEM_BASE     0x00001000
+
+#define CSR_BCRYPT_CTRL_ADDR        0x00000000
+#define CSR_BCRYPT_ERROR_ADDR       0x00000010
+
+#define CSR_STREAMER_LENGTH_ADDR    0x00004800
+#define CSR_STREAMER_KICK_ADDR      0x00004804
+#define CSR_STREAMER_DONE_ADDR      0x00004808
+
+#define CSR_RECORDER_KICK_ADDR      0x00004000
+#define CSR_RECORDER_DONE_ADDR      0x00004004
+#define CSR_RECORDER_COUNT_ADDR     0x00004008
+
+/**
+ * Memory addresses (from mem.h)
+ */
+
+#define STREAMER_MEM_BASE           0x00040000
+#define STREAMER_MEM_SIZE           0x00000400
+
+#define RECORDER_MEM_BASE           0x00080000
+#define RECORDER_MEM_SIZE           0x00000400
+
+/**
+ * Packet protocol definitions (from cleanup2_test.c)
+ */
+
+#define PKT_VERSION           2
+#define PKT_TYPE_WORD_LIST    0x01
+#define PKT_TYPE_WORD_GEN     0x02
+#define PKT_TYPE_CMP_CONFIG   0x03
+#define PKT_TYPE_RESET        0x05
+
+#define PKT_RESP_CMP_RESULT   0xd4
+#define PKT_RESP_PACKET_DONE  0xd2
+
+/**
+ * Bridge configuration
+ */
+
+#define MAX_FPGA_DEVICES    64
+#define BASE_WORKITEM_COUNT 32
+#define MAX_WORKITEM_COUNT  256
+#define MAX_PASSWORD_LEN    72
+#define FPGA_TIMEOUT        10000000
+#define DRAIN_SHORT_TIMEOUT 5000
+#define DRAIN_MAX_PACKETS   10
+
+// Payload size limit: 1KB buffer - header(10) - checksums(8)
+#define MAX_PAYLOAD_SIZE    1006
+#define MAX_SUB_BATCH_SIZE  512
+
+/**
+ * FPGA tmp structure (must match module_70300.c)
+ */
+
+typedef struct bcrypt_fpga_tmp
+{
+  u32 pw_buf[18];
+  u32 pw_len;
+  u32 digest[6];
+  u32 cracked;
+
+} bcrypt_fpga_tmp_t;
+
+/**
+ * Per-FPGA unit context
+ */
+
+typedef struct
+{
+  int       fd;
+  char      device_path[64];
+
+  char      unit_info_buf[1024];
+  int       unit_info_len;
+  u64       workitem_count;
+
+  int       num_proxies;
+  int       cores_per_proxy;
+  int       total_cores;
+
+  uint8_t  *streamer_buf;
+  uint8_t  *recorder_buf;
+  uint16_t  next_pkt_id;
+
+} unit_t;
+
+/**
+ * Platform-wide context
+ */
+
+typedef struct
+{
+  unit_t   *units_buf;
+  int       units_cnt;
+
+} bridge_litex_bcrypt_t;
+
+/**
+ * LitePCIe helper functions
+ */
+
+static uint32_t litepcie_readl (int fd, uint32_t addr)
+{
+  struct litepcie_ioctl_reg reg;
+
+  reg.addr = addr;
+  reg.is_write = 0;
+
+  if (ioctl (fd, LITEPCIE_IOCTL_REG, &reg) < 0)
+  {
+    return 0xFFFFFFFF;
+  }
+
+  return reg.val;
+}
+
+static void litepcie_writel (int fd, uint32_t addr, uint32_t val)
+{
+  struct litepcie_ioctl_reg reg;
+
+  reg.addr = addr;
+  reg.val = val;
+  reg.is_write = 1;
+
+  ioctl (fd, LITEPCIE_IOCTL_REG, &reg);
+}
+
+/**
+ * Write multiple bytes to LitePCIe memory region (from cleanup2_test.c)
+ */
+
+static void write_bytes (int fd, uint32_t base, const uint8_t *data, size_t len)
+{
+  uint8_t buf[4] = {0};
+
+  for (size_t i = 0; i < len; i += 4)
+  {
+    memset (buf, 0, 4);
+
+    size_t rem = len - i > 4 ? 4 : len - i;
+
+    memcpy (buf, data + i, rem);
+
+    litepcie_writel (fd, base + i, buf[0] | (buf[1] << 8) | (buf[2] << 16) | (buf[3] << 24));
+  }
+}
+
+/**
+ * Read multiple bytes from LitePCIe memory region (from cleanup2_test.c)
+ */
+
+static void read_bytes (int fd, uint32_t base, uint8_t *data, size_t len)
+{
+  for (size_t i = 0; i < len; i += 4)
+  {
+    uint32_t w = litepcie_readl (fd, base + i);
+
+    size_t rem = len - i > 4 ? 4 : len - i;
+
+    for (size_t j = 0; j < rem; j++)
+    {
+      data[i + j] = (w >> (8 * j)) & 0xFF;
+    }
+  }
+}
+
+/**
+ * Encoding helpers (from cleanup2_test.c)
+ */
+
+static void le16_encode (uint16_t x, uint8_t *out)
+{
+  out[0] = x & 0xFF;
+  out[1] = (x >> 8) & 0xFF;
+}
+
+static void le24_encode (uint32_t x, uint8_t *out)
+{
+  out[0] = x & 0xFF;
+  out[1] = (x >> 8) & 0xFF;
+  out[2] = (x >> 16) & 0xFF;
+}
+
+static void le32_encode (uint32_t x, uint8_t *out)
+{
+  out[0] = x & 0xFF;
+  out[1] = (x >> 8) & 0xFF;
+  out[2] = (x >> 16) & 0xFF;
+  out[3] = (x >> 24) & 0xFF;
+}
+
+static uint16_t le16_decode (const uint8_t *data)
+{
+  return data[0] | (data[1] << 8);
+}
+
+/**
+ * Checksum calculation (from cleanup2_test.c)
+ */
+
+static uint32_t csum32_le (const uint8_t *data, size_t len)
+{
+  uint32_t sum = 0;
+
+  for (size_t i = 0; i < len; i += 4)
+  {
+    uint32_t w = 0;
+
+    for (int j = 0; j < 4 && i + j < len; j++)
+    {
+      w |= data[i + j] << (8 * j);
+    }
+
+    sum = (sum + w) & 0xFFFFFFFF;
+  }
+
+  return sum ^ 0xFFFFFFFF;
+}
+
+/**
+ * Build packet header (from cleanup2_test.c - EXACT format)
+ *
+ * Header layout (10 bytes):
+ *   [0]     = version (PKT_VERSION = 2)
+ *   [1]     = pkt_type
+ *   [2]     = 0x00 (reserved)
+ *   [3]     = 0x00 (reserved)
+ *   [4-6]   = payload_len (3 bytes little-endian)
+ *   [7]     = 0x00 (reserved)
+ *   [8-9]   = pkt_id (2 bytes little-endian)
+ */
+
+static void build_header (uint8_t *out, uint8_t pkt_type, uint16_t pkt_id, uint32_t payload_len)
+{
+  out[0] = PKT_VERSION;
+  out[1] = pkt_type;
+  out[2] = 0x00;
+  out[3] = 0x00;
+  le24_encode (payload_len, out + 4);
+  out[7] = 0x00;
+  le16_encode (pkt_id, out + 8);
+}
+
+/**
+ * Add checksums around payload (from cleanup2_test.c)
+ *
+ * Output: [header][hdr_checksum][payload][payload_checksum]
+ */
+
+static void add_checksums_around_payload (uint8_t *pkt, size_t *pkt_len,
+                                          const uint8_t *header, size_t hlen,
+                                          const uint8_t *payload, size_t plen)
+{
+  uint8_t hsum[4], psum[4];
+
+  uint32_t h = csum32_le (header, hlen);
+  uint32_t p = csum32_le (payload, plen);
+
+  le32_encode (h, hsum);
+  le32_encode (p, psum);
+
+  memcpy (pkt, header, hlen);
+  memcpy (pkt + hlen, hsum, 4);
+  memcpy (pkt + hlen + 4, payload, plen);
+  memcpy (pkt + hlen + 4 + plen, psum, 4);
+
+  *pkt_len = hlen + 4 + plen + 4;
+}
+
+/**
+ * Build CMP_CONFIG payload for bcrypt (from cleanup2_test.c)
+ */
+
+static void build_cmp_config_payload_bcrypt (uint8_t *out, size_t *len,
+                                             uint32_t iter_count,
+                                             const uint8_t *salt16,
+                                             uint8_t subtype,
+                                             size_t nhashes,
+                                             const uint32_t *hashes)
+{
+  uint8_t *p = out;
+
+  // Salt (16 bytes)
+  memcpy (p, salt16, 16);
+  p += 16;
+
+  // Subtype (1 byte)
+  *p++ = subtype;
+
+  // Iteration count (4 bytes little-endian)
+  le32_encode (iter_count, p);
+  p += 4;
+
+  // Number of hashes (2 bytes little-endian)
+  le16_encode ((uint16_t) nhashes, p);
+  p += 2;
+
+  // Hash comparison values (4 bytes each)
+  for (size_t i = 0; i < nhashes; i++)
+  {
+    le32_encode (hashes[i], p);
+    p += 4;
+  }
+
+  // Magic terminator
+  *p++ = 0xCC;
+
+  *len = p - out;
+}
+
+/**
+ * Build WORD_LIST payload (from cleanup2_test.c)
+ */
+
+static void build_word_list_payload (uint8_t *out, size_t *len,
+                                     const u8 **words, const u32 *word_lens,
+                                     size_t nwords)
+{
+  uint8_t *p = out;
+
+  for (size_t i = 0; i < nwords; i++)
+  {
+    const u8 *w = words[i];
+    u32 wlen = word_lens[i];
+
+    memcpy (p, w, wlen);
+    p += wlen;
+    *p++ = 0x00;  // null terminator
+  }
+
+  *len = p - out;
+}
+
+/**
+ * Build empty WORD_GEN payload (from cleanup2_test.c)
+ */
+
+static void build_empty_word_gen_payload (uint8_t *out, size_t *len)
+{
+  uint8_t payload[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0xBB};
+
+  memcpy (out, payload, sizeof (payload));
+
+  *len = sizeof (payload);
+}
+
+/**
+ * Kick streamer (from cleanup2_test.c)
+ */
+
+static bool kick_streamer (unit_t *unit, const uint8_t *pkt_bytes, size_t pkt_len)
+{
+  write_bytes (unit->fd, STREAMER_MEM_BASE, pkt_bytes, pkt_len);
+
+  litepcie_writel (unit->fd, CSR_STREAMER_LENGTH_ADDR, pkt_len);
+  litepcie_writel (unit->fd, CSR_STREAMER_KICK_ADDR, 0);
+  litepcie_writel (unit->fd, CSR_STREAMER_KICK_ADDR, 1);
+
+  uint32_t cnt = 0;
+
+  while (!(litepcie_readl (unit->fd, CSR_STREAMER_DONE_ADDR) & 1))
+  {
+    cnt++;
+
+    if (cnt >= FPGA_TIMEOUT)
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Start recorder (from cleanup2_test.c)
+ */
+
+static void start_recorder (unit_t *unit)
+{
+  litepcie_writel (unit->fd, CSR_RECORDER_KICK_ADDR, 0);
+  litepcie_writel (unit->fd, CSR_RECORDER_KICK_ADDR, 1);
+}
+
+/**
+ * Wait for recorder (from cleanup2_test.c)
+ */
+
+static bool wait_recorder (unit_t *unit, uint32_t *len)
+{
+  uint32_t cnt = 0;
+
+  while (!(litepcie_readl (unit->fd, CSR_RECORDER_DONE_ADDR) & 1))
+  {
+    cnt++;
+
+    if (cnt >= FPGA_TIMEOUT)
+    {
+      *len = 0;
+      return false;
+    }
+  }
+
+  *len = litepcie_readl (unit->fd, CSR_RECORDER_COUNT_ADDR);
+
+  return true;
+}
+
+/**
+ * Drain output FIFO (from cleanup2_test.c)
+ */
+
+static uint32_t drain_output_fifo (unit_t *unit)
+{
+  uint32_t total_drained = 0;
+  int packets_drained = 0;
+
+  while (packets_drained < DRAIN_MAX_PACKETS)
+  {
+    litepcie_writel (unit->fd, CSR_RECORDER_KICK_ADDR, 0);
+    litepcie_writel (unit->fd, CSR_RECORDER_KICK_ADDR, 1);
+
+    uint32_t cnt = 0;
+
+    while (!(litepcie_readl (unit->fd, CSR_RECORDER_DONE_ADDR) & 1))
+    {
+      cnt++;
+
+      if (cnt >= DRAIN_SHORT_TIMEOUT)
+      {
+        return total_drained;
+      }
+    }
+
+    uint32_t captured = litepcie_readl (unit->fd, CSR_RECORDER_COUNT_ADDR);
+
+    if (captured == 0)
+    {
+      return total_drained;
+    }
+
+    packets_drained++;
+    total_drained += captured;
+  }
+
+  return total_drained;
+}
+
+/**
+ * Detect FPGA configuration from identifier string
+ *
+ * CRITICAL: Read identifier one character per 32-bit read
+ * (from kernel module behavior)
+ */
+
+static bool detect_fpga_config (unit_t *unit)
+{
+  char ident[256];
+
+  // Read identifier: one character per 32-bit read
+  for (int i = 0; i < 256; i++)
+  {
+    uint32_t w = litepcie_readl (unit->fd, CSR_IDENTIFIER_MEM_BASE + i * 4);
+
+    ident[i] = (char) (w & 0xFF);
+
+    if (ident[i] == 0) break;
+  }
+
+  ident[255] = 0;
+
+  // Parse identifier for proxy/core counts: "(pN x cM)"
+  char *p = strstr (ident, "(p");
+
+  if (p != NULL)
+  {
+    int proxies = 0, cores = 0;
+
+    if (sscanf (p, "(p%d x c%d)", &proxies, &cores) == 2)
+    {
+      unit->num_proxies = proxies;
+      unit->cores_per_proxy = cores;
+      unit->total_cores = proxies * cores;
+
+      unit->workitem_count = BASE_WORKITEM_COUNT * unit->total_cores;
+
+      if (unit->workitem_count > MAX_WORKITEM_COUNT)
+      {
+        unit->workitem_count = MAX_WORKITEM_COUNT;
+      }
+
+      unit->unit_info_len = snprintf (unit->unit_info_buf, sizeof (unit->unit_info_buf),
+                                      "LiteX bcrypt FPGA: %s", ident);
+
+      return true;
+    }
+  }
+
+  // Fallback
+  unit->num_proxies = 1;
+  unit->cores_per_proxy = 1;
+  unit->total_cores = 1;
+  unit->workitem_count = BASE_WORKITEM_COUNT;
+
+  unit->unit_info_len = snprintf (unit->unit_info_buf, sizeof (unit->unit_info_buf),
+                                  "LiteX bcrypt FPGA: %s", ident);
+
+  return true;
+}
+
+/**
+ * Calculate sub-batch size based on password lengths
+ */
+
+static u32 calculate_sub_batch_size (const bcrypt_fpga_tmp_t *bcrypt_tmp, u64 pws_cnt)
+{
+  u32 sub_batch = 0;
+  size_t payload_size = 0;
+
+  for (u64 i = 0; i < pws_cnt; i++)
+  {
+    size_t pw_packet_size = bcrypt_tmp[i].pw_len + 1;  // +1 for null terminator
+
+    if (payload_size + pw_packet_size > MAX_PAYLOAD_SIZE) break;
+
+    payload_size += pw_packet_size;
+    sub_batch++;
+  }
+
+  return sub_batch > 0 ? sub_batch : 1;
+}
+
+/**
+ * Initialize FPGA units
+ */
+
+static bool units_init (bridge_litex_bcrypt_t *bridge)
+{
+  bridge->units_buf = (unit_t *) hccalloc (MAX_FPGA_DEVICES, sizeof (unit_t));
+  bridge->units_cnt = 0;
+
+  for (int i = 0; i < MAX_FPGA_DEVICES; i++)
+  {
+    char path[64];
+
+    snprintf (path, sizeof (path), "/dev/litepcie%d", i);
+
+    int fd = open (path, O_RDWR);
+
+    if (fd < 0) continue;
+
+    unit_t *unit = &bridge->units_buf[bridge->units_cnt];
+
+    unit->fd = fd;
+    strncpy (unit->device_path, path, sizeof (unit->device_path) - 1);
+
+    unit->streamer_buf = (uint8_t *) hcmalloc (STREAMER_MEM_SIZE);
+    unit->recorder_buf = (uint8_t *) hcmalloc (RECORDER_MEM_SIZE);
+    unit->next_pkt_id = 0;
+
+    if (!detect_fpga_config (unit))
+    {
+      hcfree (unit->streamer_buf);
+      hcfree (unit->recorder_buf);
+      close (fd);
+      continue;
+    }
+
+    // Drain any leftover packets
+    drain_output_fifo (unit);
+
+    bridge->units_cnt++;
+  }
+
+  return bridge->units_cnt > 0;
+}
+
+/**
+ * Bridge interface functions
+ */
+
+void *platform_init (MAYBE_UNUSED user_options_t *user_options)
+{
+  bridge_litex_bcrypt_t *bridge = (bridge_litex_bcrypt_t *) hcmalloc (sizeof (bridge_litex_bcrypt_t));
+
+  if (units_init (bridge) == false)
+  {
+    hcfree (bridge);
+    return NULL;
+  }
+
+  return bridge;
+}
+
+void platform_term (void *platform_context)
+{
+  bridge_litex_bcrypt_t *bridge = platform_context;
+
+  if (bridge != NULL)
+  {
+    for (int i = 0; i < bridge->units_cnt; i++)
+    {
+      unit_t *unit = &bridge->units_buf[i];
+
+      if (unit->fd >= 0)
+      {
+        close (unit->fd);
+      }
+
+      hcfree (unit->streamer_buf);
+      hcfree (unit->recorder_buf);
+    }
+
+    hcfree (bridge->units_buf);
+    hcfree (bridge);
+  }
+}
+
+int get_unit_count (void *platform_context)
+{
+  bridge_litex_bcrypt_t *bridge = platform_context;
+
+  return bridge->units_cnt;
+}
+
+char *get_unit_info (void *platform_context, const int unit_idx)
+{
+  bridge_litex_bcrypt_t *bridge = platform_context;
+
+  unit_t *unit = &bridge->units_buf[unit_idx];
+
+  return unit->unit_info_buf;
+}
+
+int get_workitem_count (void *platform_context, const int unit_idx)
+{
+  bridge_litex_bcrypt_t *bridge = platform_context;
+
+  unit_t *unit = &bridge->units_buf[unit_idx];
+
+  return unit->workitem_count;
+}
+
+bool salt_prepare (MAYBE_UNUSED void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig, MAYBE_UNUSED hashes_t *hashes)
+{
+  return true;
+}
+
+void salt_destroy (MAYBE_UNUSED void *platform_context, MAYBE_UNUSED hashconfig_t *hashconfig, MAYBE_UNUSED hashes_t *hashes)
+{
+}
+
+/**
+ * Main launch loop - process passwords against FPGA
+ *
+ * Protocol (from cleanup2_test.c):
+ * 1. Start recorder (kick toggle: write 0, then write 1)
+ * 2. Send CMP_CONFIG packet
+ * 3. Send WORD_GEN packet (empty for -a0 mode)
+ * 4. Send WORD_LIST packet
+ * 5. Wait for recorder done
+ * 6. Read response
+ */
+
+bool launch_loop (void *platform_context, hc_device_param_t *device_param,
+                  MAYBE_UNUSED hashconfig_t *hashconfig, hashes_t *hashes,
+                  const u32 salt_pos, const u64 pws_cnt)
+{
+  bridge_litex_bcrypt_t *bridge = platform_context;
+
+  const int unit_idx = device_param->bridge_link_device;
+
+  unit_t *unit = &bridge->units_buf[unit_idx];
+
+  // Get salt information
+  salt_t *salts_buf = (salt_t *) hashes->salts_buf;
+  salt_t *salt_buf = &salts_buf[salt_pos];
+
+  // Get digests for this salt
+  u32 *digests_buf = (u32 *) hashes->digests_buf;
+  u32 digests_offset = salt_buf->digests_offset;
+  u32 digests_cnt = salt_buf->digests_cnt;
+
+  // Workaround: During self-test, salt_buf->digests_cnt may be 0
+  if (digests_cnt == 0 && hashes->salts_cnt == 1 && hashes->digests_cnt > 0)
+  {
+    digests_cnt = hashes->digests_cnt;
+  }
+
+  bcrypt_fpga_tmp_t *bcrypt_tmp = (bcrypt_fpga_tmp_t *) device_param->h_tmps;
+
+  // Clear cracked flags
+  for (u64 i = 0; i < pws_cnt; i++)
+  {
+    bcrypt_tmp[i].cracked = 0;
+  }
+
+  // Build salt16 from salt_buf
+  uint8_t salt16[16];
+
+  memcpy (salt16, salt_buf->salt_buf, 16);
+
+  // Get bcrypt subtype from salt_sign
+  const char *salt_sign_str = (const char *) salt_buf->salt_sign;
+  uint8_t subtype = 'a';
+
+  if (salt_sign_str[2] != 0)
+  {
+    subtype = salt_sign_str[2];
+  }
+
+  // Build target hashes array (first 4 bytes of each hash for comparison)
+  uint32_t *target_hashes = (uint32_t *) hcmalloc (digests_cnt * sizeof (uint32_t));
+
+  for (u32 i = 0; i < digests_cnt; i++)
+  {
+    u32 *digest = &digests_buf[(digests_offset + i) * 6];
+    target_hashes[i] = digest[0];
+  }
+
+  // Build CMP_CONFIG packet
+  uint8_t cmp_pl[512];
+  size_t cmp_pl_len = 0;
+
+  build_cmp_config_payload_bcrypt (cmp_pl, &cmp_pl_len,
+                                   salt_buf->salt_iter,
+                                   salt16, subtype,
+                                   digests_cnt, target_hashes);
+
+  uint8_t cmp_hdr[10];
+
+  build_header (cmp_hdr, PKT_TYPE_CMP_CONFIG, unit->next_pkt_id++, cmp_pl_len);
+
+  uint8_t pkt_cmp[1024];
+  size_t pkt_cmp_len = 0;
+
+  add_checksums_around_payload (pkt_cmp, &pkt_cmp_len, cmp_hdr, 10, cmp_pl, cmp_pl_len);
+
+  hcfree (target_hashes);
+
+  // Build WORD_GEN packet (empty for -a0 mode)
+  uint8_t wg_pl[16];
+  size_t wg_pl_len = 0;
+
+  build_empty_word_gen_payload (wg_pl, &wg_pl_len);
+
+  uint8_t wg_hdr[10];
+
+  build_header (wg_hdr, PKT_TYPE_WORD_GEN, unit->next_pkt_id++, wg_pl_len);
+
+  uint8_t pkt_wg[64];
+  size_t pkt_wg_len = 0;
+
+  add_checksums_around_payload (pkt_wg, &pkt_wg_len, wg_hdr, 10, wg_pl, wg_pl_len);
+
+  // Process passwords in sub-batches (1KB buffer limit)
+  u64 processed = 0;
+  bool first_batch = true;
+
+  while (processed < pws_cnt)
+  {
+    u32 sub_batch = calculate_sub_batch_size (&bcrypt_tmp[processed], pws_cnt - processed);
+
+    if (sub_batch > MAX_SUB_BATCH_SIZE)
+    {
+      sub_batch = MAX_SUB_BATCH_SIZE;
+    }
+
+    // Build WORD_LIST packet for this sub-batch
+    const u8 *words[MAX_SUB_BATCH_SIZE];
+    u32 word_lens[MAX_SUB_BATCH_SIZE];
+
+    for (u32 i = 0; i < sub_batch; i++)
+    {
+      words[i] = (const u8 *) bcrypt_tmp[processed + i].pw_buf;
+      word_lens[i] = bcrypt_tmp[processed + i].pw_len;
+    }
+
+    uint8_t wl_pl[MAX_PAYLOAD_SIZE + 64];
+    size_t wl_pl_len = 0;
+
+    build_word_list_payload (wl_pl, &wl_pl_len, words, word_lens, sub_batch);
+
+    uint8_t wl_hdr[10];
+
+    build_header (wl_hdr, PKT_TYPE_WORD_LIST, unit->next_pkt_id++, wl_pl_len);
+
+    uint8_t pkt_wl[MAX_PAYLOAD_SIZE + 64];
+    size_t pkt_wl_len = 0;
+
+    add_checksums_around_payload (pkt_wl, &pkt_wl_len, wl_hdr, 10, wl_pl, wl_pl_len);
+
+    // Protocol: start recorder BEFORE sending packets
+    start_recorder (unit);
+
+    // First batch: send CMP_CONFIG, WORD_GEN, then WORD_LIST
+    if (first_batch)
+    {
+      if (!kick_streamer (unit, pkt_cmp, pkt_cmp_len))
+      {
+        drain_output_fifo (unit);
+        return false;
+      }
+
+      if (!kick_streamer (unit, pkt_wg, pkt_wg_len))
+      {
+        drain_output_fifo (unit);
+        return false;
+      }
+
+      first_batch = false;
+    }
+
+    // Send WORD_LIST
+    if (!kick_streamer (unit, pkt_wl, pkt_wl_len))
+    {
+      drain_output_fifo (unit);
+      return false;
+    }
+
+    // Wait for recorder
+    uint32_t recorder_len = 0;
+
+    if (!wait_recorder (unit, &recorder_len))
+    {
+      drain_output_fifo (unit);
+      return false;
+    }
+
+    // Process response
+    if (recorder_len > 0 && recorder_len <= RECORDER_MEM_SIZE)
+    {
+      read_bytes (unit->fd, RECORDER_MEM_BASE, unit->recorder_buf, recorder_len);
+
+      if (recorder_len >= 2)
+      {
+        uint8_t version = unit->recorder_buf[0];
+        uint8_t pkt_type = unit->recorder_buf[1];
+
+        if (version == PKT_VERSION && pkt_type == PKT_RESP_CMP_RESULT)
+        {
+          // Match found - extract word_id from response
+          // word_id is a single byte at offset 14 (from cleanup2_test.c)
+          if (recorder_len >= 15)
+          {
+            uint8_t local_word_id = unit->recorder_buf[14];
+
+            if (local_word_id < sub_batch)
+            {
+              u64 global_word_id = processed + local_word_id;
+
+              // FPGA already confirmed the match - trust it
+              bcrypt_tmp[global_word_id].cracked = 1;
+            }
+          }
+
+          // Drain PACKET_DONE that follows CMP_RESULT
+          start_recorder (unit);
+
+          uint32_t drain_len = 0;
+
+          wait_recorder (unit, &drain_len);
+        }
+      }
+    }
+
+    processed += sub_batch;
+  }
+
+  // Check for FPGA errors
+  uint32_t err = litepcie_readl (unit->fd, CSR_BCRYPT_ERROR_ADDR);
+
+  if (err != 0)
+  {
+    drain_output_fifo (unit);
+  }
+
+  return true;
+}
+
+void bridge_init (bridge_ctx_t *bridge_ctx)
+{
+  bridge_ctx->bridge_context_size       = BRIDGE_CONTEXT_SIZE_CURRENT;
+  bridge_ctx->bridge_interface_version  = BRIDGE_INTERFACE_VERSION_CURRENT;
+
+  bridge_ctx->platform_init       = platform_init;
+  bridge_ctx->platform_term       = platform_term;
+  bridge_ctx->get_unit_count      = get_unit_count;
+  bridge_ctx->get_unit_info       = get_unit_info;
+  bridge_ctx->get_workitem_count  = get_workitem_count;
+  bridge_ctx->thread_init         = BRIDGE_DEFAULT;
+  bridge_ctx->thread_term         = BRIDGE_DEFAULT;
+  bridge_ctx->salt_prepare        = salt_prepare;
+  bridge_ctx->salt_destroy        = salt_destroy;
+  bridge_ctx->launch_loop         = launch_loop;
+  bridge_ctx->launch_loop2        = BRIDGE_DEFAULT;
+  bridge_ctx->st_update_hash      = BRIDGE_DEFAULT;
+  bridge_ctx->st_update_pass      = BRIDGE_DEFAULT;
+}

--- a/src/bridges/bridge_litex_bcrypt.c
+++ b/src/bridges/bridge_litex_bcrypt.c
@@ -48,8 +48,12 @@ struct litepcie_ioctl_reg {
 
 #define CSR_IDENTIFIER_MEM_BASE     0x00001000
 
-#define CSR_BCRYPT_CTRL_ADDR        0x00000000
-#define CSR_BCRYPT_ERROR_ADDR       0x00000010
+#define CSR_BCRYPT_CTRL_ADDR            0x00000000
+#define CSR_BCRYPT_APP_STATUS_ADDR      0x00000004
+#define CSR_BCRYPT_PKT_COMM_STATUS_ADDR 0x00000008
+#define CSR_BCRYPT_IDLE_ADDR            0x0000000C
+#define CSR_BCRYPT_ERROR_ADDR           0x00000010
+#define CSR_BCRYPT_CLEAR_ERROR_ADDR     0x00000014
 
 #define CSR_STREAMER_LENGTH_ADDR    0x00004800
 #define CSR_STREAMER_KICK_ADDR      0x00004804
@@ -478,10 +482,7 @@ static uint32_t drain_output_fifo (unit_t *unit)
 
       if (cnt >= DRAIN_SHORT_TIMEOUT)
       {
-        if (total_drained > 0) {
-          fprintf(stderr, "[BRIDGE] drain: timeout after %d packets, %u bytes\n", packets_drained, total_drained);
-        }
-        return total_drained;
+            return total_drained;
       }
     }
 
@@ -489,19 +490,12 @@ static uint32_t drain_output_fifo (unit_t *unit)
 
     if (captured == 0)
     {
-      if (total_drained > 0) {
-        fprintf(stderr, "[BRIDGE] drain: done, %d packets, %u bytes\n", packets_drained, total_drained);
-      }
       return total_drained;
     }
 
     // MUST read the data to fully clear the FIFO
     size_t read_len = captured < sizeof(discard_buf) ? captured : sizeof(discard_buf);
     read_bytes (unit->fd, RECORDER_MEM_BASE, discard_buf, read_len);
-    
-    // Print what we're draining
-    uint8_t pkt_type = (read_len > 1) ? discard_buf[1] : 0;
-    fprintf(stderr, "[BRIDGE] drain: packet %d, %u bytes, type=0x%02x\n", packets_drained, captured, pkt_type);
 
     packets_drained++;
     total_drained += captured;
@@ -730,13 +724,14 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
                   MAYBE_UNUSED hashconfig_t *hashconfig, hashes_t *hashes,
                   const u32 salt_pos, const u64 pws_cnt)
 {
-  fprintf(stderr, "[BRIDGE] launch_loop called: pws_cnt=%llu\n", (unsigned long long)pws_cnt);
-  
   bridge_litex_bcrypt_t *bridge = platform_context;
 
   const int unit_idx = device_param->bridge_link_device;
 
   unit_t *unit = &bridge->units_buf[unit_idx];
+
+  // Force-reset FPGA via clear_error CSR (unsticks inpkt_header if in PKT_STATE_ERROR)
+  litepcie_writel(unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
 
   // Send reset and drain any stale data (like cleanup2_test does)
   {
@@ -751,6 +746,10 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
   }
   // Drain AFTER reset, BEFORE starting work
   drain_output_fifo(unit);
+
+  // Clear error latch after reset (in case error_r was latched from a previous run)
+  litepcie_writel(unit->fd, CSR_BCRYPT_CLEAR_ERROR_ADDR, 1);
+
   // Reset packet ID counter after reset
   unit->next_pkt_id = 1;
 
@@ -856,8 +855,6 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     {
       words[i] = (const u8 *) bcrypt_tmp[processed + i].pw_buf;
       word_lens[i] = bcrypt_tmp[processed + i].pw_len;
-      fprintf(stderr, "[BRIDGE] Password[%u]: len=%u, bytes='%.*s'\n", 
-              i, word_lens[i], (int)word_lens[i], (const char*)words[i]);
     }
 
     uint8_t wl_pl[MAX_PAYLOAD_SIZE + 64];
@@ -880,18 +877,14 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     // First batch: send CMP_CONFIG, WORD_GEN, then WORD_LIST
     if (first_batch)
     {
-      fprintf(stderr, "[BRIDGE] Sending CMP_CONFIG (%zu bytes)\n", pkt_cmp_len);
       if (!kick_streamer (unit, pkt_cmp, pkt_cmp_len))
       {
-        fprintf(stderr, "[BRIDGE] CMP_CONFIG kick FAILED\n");
         drain_output_fifo (unit);
         return false;
       }
 
-      fprintf(stderr, "[BRIDGE] Sending WORD_GEN (%zu bytes)\n", pkt_wg_len);
       if (!kick_streamer (unit, pkt_wg, pkt_wg_len))
       {
-        fprintf(stderr, "[BRIDGE] WORD_GEN kick FAILED\n");
         drain_output_fifo (unit);
         return false;
       }
@@ -900,41 +893,25 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     }
 
     // Send WORD_LIST
-    fprintf(stderr, "[BRIDGE] Sending WORD_LIST (%zu bytes), sub_batch=%u: ", pkt_wl_len, sub_batch);
-    for (size_t i = 0; i < (pkt_wl_len < 32 ? pkt_wl_len : 32); i++) {
-      fprintf(stderr, "%02x ", pkt_wl[i]);
-    }
-    fprintf(stderr, "\n");
     if (!kick_streamer (unit, pkt_wl, pkt_wl_len))
     {
-      fprintf(stderr, "[BRIDGE] kick_streamer for WORD_LIST FAILED\n");
       drain_output_fifo (unit);
       return false;
     }
-    fprintf(stderr, "[BRIDGE] WORD_LIST sent successfully, waiting for recorder...\n");
 
     // Wait for recorder
     uint32_t recorder_len = 0;
 
     if (!wait_recorder (unit, &recorder_len))
     {
-      fprintf(stderr, "[BRIDGE] wait_recorder FAILED - draining and returning false\n");
       drain_output_fifo (unit);
       return false;
     }
-    fprintf(stderr, "[BRIDGE] wait_recorder OK, recorder_len=%u\n", recorder_len);
 
     // Process response
     if (recorder_len > 0 && recorder_len <= RECORDER_MEM_SIZE)
     {
       read_bytes (unit->fd, RECORDER_MEM_BASE, unit->recorder_buf, recorder_len);
-      
-      // Debug: print first bytes of response
-      fprintf(stderr, "[BRIDGE] Response bytes: ");
-      for (uint32_t i = 0; i < (recorder_len < 16 ? recorder_len : 16); i++) {
-        fprintf(stderr, "%02x ", unit->recorder_buf[i]);
-      }
-      fprintf(stderr, "\n");
 
       if (recorder_len >= 2)
       {
@@ -963,12 +940,15 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
           uint32_t drain_len = 0;
 
-          if (wait_recorder (unit, &drain_len) && drain_len > 0)
+          if (wait_recorder (unit, &drain_len))
           {
-            // MUST read the data to clear the FIFO
-            uint8_t drain_buf[64];
-            size_t read_len = drain_len < sizeof(drain_buf) ? drain_len : sizeof(drain_buf);
-            read_bytes (unit->fd, RECORDER_MEM_BASE, drain_buf, read_len);
+            if (drain_len > 0)
+            {
+              // MUST read the data to clear the FIFO
+              uint8_t drain_buf[64];
+              size_t read_len = drain_len < sizeof(drain_buf) ? drain_len : sizeof(drain_buf);
+              read_bytes (unit->fd, RECORDER_MEM_BASE, drain_buf, read_len);
+            }
           }
           
           // Found a match - stop processing this batch
@@ -989,7 +969,6 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
   }
 
 cleanup:
-  fprintf(stderr, "[BRIDGE] launch_loop returning true (cleanup path)\n");
   hcfree(target_hashes);
   return true;
 }

--- a/src/bridges/bridge_litex_bcrypt.c.bak
+++ b/src/bridges/bridge_litex_bcrypt.c.bak
@@ -58,6 +58,7 @@ struct litepcie_ioctl_reg {
 #define CSR_RECORDER_KICK_ADDR      0x00004000
 #define CSR_RECORDER_DONE_ADDR      0x00004004
 #define CSR_RECORDER_COUNT_ADDR     0x00004008
+#define CSR_CTRL_RESET_ADDR         0x00000800
 
 /**
  * Memory addresses (from mem.h)
@@ -87,7 +88,7 @@ struct litepcie_ioctl_reg {
  */
 
 #define MAX_FPGA_DEVICES    64
-#define BASE_WORKITEM_COUNT 16   // Must not exceed hashcat's kernel_power
+#define BASE_WORKITEM_COUNT 32
 #define MAX_WORKITEM_COUNT  256
 #define MAX_PASSWORD_LEN    72
 #define FPGA_TIMEOUT        10000000
@@ -106,8 +107,8 @@ typedef struct bcrypt_fpga_tmp
 {
   u32 pw_buf[18];
   u32 pw_len;
-  u32 cracked;      // Must be right after pw_len to match OpenCL struct!
-  // Note: NO digest field here - that was wrong and caused offset mismatch
+  u32 digest[6];
+  u32 cracked;
 
 } bcrypt_fpga_tmp_t;
 
@@ -174,6 +175,16 @@ static void litepcie_writel (int fd, uint32_t addr, uint32_t val)
 
   ioctl (fd, LITEPCIE_IOCTL_REG, &reg);
 }
+
+/**
+ * Reset the SoC to clear any stuck state
+ */
+static void soc_reset (int fd)
+{
+  litepcie_writel (fd, CSR_CTRL_RESET_ADDR, 1);
+  usleep (10000);  // 10ms settling time
+}
+
 
 /**
  * Write multiple bytes to LitePCIe memory region (from cleanup2_test.c)
@@ -435,6 +446,32 @@ static void start_recorder (unit_t *unit)
  * Wait for recorder (from cleanup2_test.c)
  */
 
+/**
+ * Send a PKT_TYPE_RESET packet to clear module errors
+ * This is needed because err_inpkt_checksum can be set on powerup by garbage data
+ */
+static bool send_reset_packet (unit_t *unit)
+{
+  uint8_t hdr[10];
+  uint8_t pkt[32];
+  size_t pkt_len = 0;
+  uint8_t empty_payload[1] = {0};
+
+  // Build reset packet header (empty payload)
+  build_header (hdr, PKT_TYPE_RESET, unit->next_pkt_id++, 0);
+
+  // Add checksums - even with 0 length payload, checksums are required
+  add_checksums_around_payload (pkt, &pkt_len, hdr, 10, empty_payload, 0);
+
+  // Send the reset packet
+  if (!kick_streamer (unit, pkt, pkt_len))
+    return false;
+
+  // Wait a bit for reset to complete
+  usleep (1000);
+  return true;
+}
+
 static bool wait_recorder (unit_t *unit, uint32_t *len)
 {
   uint32_t cnt = 0;
@@ -451,6 +488,7 @@ static bool wait_recorder (unit_t *unit, uint32_t *len)
   }
 
   *len = litepcie_readl (unit->fd, CSR_RECORDER_COUNT_ADDR);
+#define CSR_CTRL_RESET_ADDR         0x00000800
 
   return true;
 }
@@ -463,7 +501,6 @@ static uint32_t drain_output_fifo (unit_t *unit)
 {
   uint32_t total_drained = 0;
   int packets_drained = 0;
-  uint8_t discard_buf[256];
 
   while (packets_drained < DRAIN_MAX_PACKETS)
   {
@@ -478,30 +515,17 @@ static uint32_t drain_output_fifo (unit_t *unit)
 
       if (cnt >= DRAIN_SHORT_TIMEOUT)
       {
-        if (total_drained > 0) {
-          fprintf(stderr, "[BRIDGE] drain: timeout after %d packets, %u bytes\n", packets_drained, total_drained);
-        }
         return total_drained;
       }
     }
 
     uint32_t captured = litepcie_readl (unit->fd, CSR_RECORDER_COUNT_ADDR);
+#define CSR_CTRL_RESET_ADDR         0x00000800
 
     if (captured == 0)
     {
-      if (total_drained > 0) {
-        fprintf(stderr, "[BRIDGE] drain: done, %d packets, %u bytes\n", packets_drained, total_drained);
-      }
       return total_drained;
     }
-
-    // MUST read the data to fully clear the FIFO
-    size_t read_len = captured < sizeof(discard_buf) ? captured : sizeof(discard_buf);
-    read_bytes (unit->fd, RECORDER_MEM_BASE, discard_buf, read_len);
-    
-    // Print what we're draining
-    uint8_t pkt_type = (read_len > 1) ? discard_buf[1] : 0;
-    fprintf(stderr, "[BRIDGE] drain: packet %d, %u bytes, type=0x%02x\n", packets_drained, captured, pkt_type);
 
     packets_drained++;
     total_drained += captured;
@@ -616,6 +640,9 @@ static bool units_init (bridge_litex_bcrypt_t *bridge)
     unit_t *unit = &bridge->units_buf[bridge->units_cnt];
 
     unit->fd = fd;
+
+    // Reset FPGA to clean state
+    soc_reset (fd);
     strncpy (unit->device_path, path, sizeof (unit->device_path) - 1);
 
     unit->streamer_buf = (uint8_t *) hcmalloc (STREAMER_MEM_SIZE);
@@ -632,6 +659,12 @@ static bool units_init (bridge_litex_bcrypt_t *bridge)
 
     // Drain any leftover packets
     drain_output_fifo (unit);
+
+    // Send reset packet to clear any latched errors from powerup garbage
+    if (!send_reset_packet (unit))
+    {
+      fprintf(stderr, "[BRIDGE] Warning: Failed to send reset packet to %s\n", path);
+    }
 
     bridge->units_cnt++;
   }
@@ -667,6 +700,9 @@ void platform_term (void *platform_context)
       unit_t *unit = &bridge->units_buf[i];
 
       if (unit->fd >= 0)
+
+        // Reset FPGA before closing
+        soc_reset (unit->fd);
       {
         close (unit->fd);
       }
@@ -730,29 +766,11 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
                   MAYBE_UNUSED hashconfig_t *hashconfig, hashes_t *hashes,
                   const u32 salt_pos, const u64 pws_cnt)
 {
-  fprintf(stderr, "[BRIDGE] launch_loop called: pws_cnt=%llu\n", (unsigned long long)pws_cnt);
-  
   bridge_litex_bcrypt_t *bridge = platform_context;
 
   const int unit_idx = device_param->bridge_link_device;
 
   unit_t *unit = &bridge->units_buf[unit_idx];
-
-  // Send reset and drain any stale data (like cleanup2_test does)
-  {
-    uint8_t reset_pl[1] = {0xCC};
-    uint8_t reset_hdr[10];
-    // Use packet ID 0x0000 for reset (like cleanup2_test)
-    build_header(reset_hdr, PKT_TYPE_RESET, 0x0000, 1);
-    uint8_t pkt_reset[32];
-    size_t pkt_reset_len = 0;
-    add_checksums_around_payload(pkt_reset, &pkt_reset_len, reset_hdr, 10, reset_pl, 1);
-    kick_streamer(unit, pkt_reset, pkt_reset_len);
-  }
-  // Drain AFTER reset, BEFORE starting work
-  drain_output_fifo(unit);
-  // Reset packet ID counter after reset
-  unit->next_pkt_id = 1;
 
   // Get salt information
   salt_t *salts_buf = (salt_t *) hashes->salts_buf;
@@ -818,7 +836,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
   add_checksums_around_payload (pkt_cmp, &pkt_cmp_len, cmp_hdr, 10, cmp_pl, cmp_pl_len);
 
-  // target_hashes freed at cleanup label
+  hcfree (target_hashes);
 
   // Build WORD_GEN packet (empty for -a0 mode)
   uint8_t wg_pl[16];
@@ -856,8 +874,6 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     {
       words[i] = (const u8 *) bcrypt_tmp[processed + i].pw_buf;
       word_lens[i] = bcrypt_tmp[processed + i].pw_len;
-      fprintf(stderr, "[BRIDGE] Password[%u]: len=%u, bytes='%.*s'\n", 
-              i, word_lens[i], (int)word_lens[i], (const char*)words[i]);
     }
 
     uint8_t wl_pl[MAX_PAYLOAD_SIZE + 64];
@@ -880,18 +896,14 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     // First batch: send CMP_CONFIG, WORD_GEN, then WORD_LIST
     if (first_batch)
     {
-      fprintf(stderr, "[BRIDGE] Sending CMP_CONFIG (%zu bytes)\n", pkt_cmp_len);
       if (!kick_streamer (unit, pkt_cmp, pkt_cmp_len))
       {
-        fprintf(stderr, "[BRIDGE] CMP_CONFIG kick FAILED\n");
         drain_output_fifo (unit);
         return false;
       }
 
-      fprintf(stderr, "[BRIDGE] Sending WORD_GEN (%zu bytes)\n", pkt_wg_len);
       if (!kick_streamer (unit, pkt_wg, pkt_wg_len))
       {
-        fprintf(stderr, "[BRIDGE] WORD_GEN kick FAILED\n");
         drain_output_fifo (unit);
         return false;
       }
@@ -900,41 +912,31 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     }
 
     // Send WORD_LIST
-    fprintf(stderr, "[BRIDGE] Sending WORD_LIST (%zu bytes), sub_batch=%u: ", pkt_wl_len, sub_batch);
-    for (size_t i = 0; i < (pkt_wl_len < 32 ? pkt_wl_len : 32); i++) {
-      fprintf(stderr, "%02x ", pkt_wl[i]);
-    }
-    fprintf(stderr, "\n");
     if (!kick_streamer (unit, pkt_wl, pkt_wl_len))
     {
-      fprintf(stderr, "[BRIDGE] kick_streamer for WORD_LIST FAILED\n");
       drain_output_fifo (unit);
       return false;
     }
-    fprintf(stderr, "[BRIDGE] WORD_LIST sent successfully, waiting for recorder...\n");
 
     // Wait for recorder
     uint32_t recorder_len = 0;
 
     if (!wait_recorder (unit, &recorder_len))
     {
-      fprintf(stderr, "[BRIDGE] wait_recorder FAILED - draining and returning false\n");
+      fprintf(stderr, "[BRIDGE] wait_recorder TIMEOUT - draining and returning false\n");
       drain_output_fifo (unit);
       return false;
     }
-    fprintf(stderr, "[BRIDGE] wait_recorder OK, recorder_len=%u\n", recorder_len);
 
     // Process response
     if (recorder_len > 0 && recorder_len <= RECORDER_MEM_SIZE)
     {
-      read_bytes (unit->fd, RECORDER_MEM_BASE, unit->recorder_buf, recorder_len);
-      
-      // Debug: print first bytes of response
-      fprintf(stderr, "[BRIDGE] Response bytes: ");
-      for (uint32_t i = 0; i < (recorder_len < 16 ? recorder_len : 16); i++) {
+      fprintf(stderr, "[BRIDGE] Recorder got %u bytes: ", recorder_len);
+      for (uint32_t i = 0; i < (recorder_len < 20 ? recorder_len : 20); i++) {
         fprintf(stderr, "%02x ", unit->recorder_buf[i]);
       }
       fprintf(stderr, "\n");
+      read_bytes (unit->fd, RECORDER_MEM_BASE, unit->recorder_buf, recorder_len);
 
       if (recorder_len >= 2)
       {
@@ -963,16 +965,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
           uint32_t drain_len = 0;
 
-          if (wait_recorder (unit, &drain_len) && drain_len > 0)
-          {
-            // MUST read the data to clear the FIFO
-            uint8_t drain_buf[64];
-            size_t read_len = drain_len < sizeof(drain_buf) ? drain_len : sizeof(drain_buf);
-            read_bytes (unit->fd, RECORDER_MEM_BASE, drain_buf, read_len);
-          }
-          
-          // Found a match - stop processing this batch
-          goto cleanup;
+          wait_recorder (unit, &drain_len);
         }
       }
     }
@@ -988,9 +981,6 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     drain_output_fifo (unit);
   }
 
-cleanup:
-  fprintf(stderr, "[BRIDGE] launch_loop returning true (cleanup path)\n");
-  hcfree(target_hashes);
   return true;
 }
 

--- a/src/bridges/bridge_litex_bcrypt.c.orig
+++ b/src/bridges/bridge_litex_bcrypt.c.orig
@@ -87,7 +87,7 @@ struct litepcie_ioctl_reg {
  */
 
 #define MAX_FPGA_DEVICES    64
-#define BASE_WORKITEM_COUNT 16   // Must not exceed hashcat's kernel_power
+#define BASE_WORKITEM_COUNT 32
 #define MAX_WORKITEM_COUNT  256
 #define MAX_PASSWORD_LEN    72
 #define FPGA_TIMEOUT        10000000
@@ -106,8 +106,8 @@ typedef struct bcrypt_fpga_tmp
 {
   u32 pw_buf[18];
   u32 pw_len;
-  u32 cracked;      // Must be right after pw_len to match OpenCL struct!
-  // Note: NO digest field here - that was wrong and caused offset mismatch
+  u32 digest[6];
+  u32 cracked;
 
 } bcrypt_fpga_tmp_t;
 
@@ -463,7 +463,6 @@ static uint32_t drain_output_fifo (unit_t *unit)
 {
   uint32_t total_drained = 0;
   int packets_drained = 0;
-  uint8_t discard_buf[256];
 
   while (packets_drained < DRAIN_MAX_PACKETS)
   {
@@ -478,9 +477,6 @@ static uint32_t drain_output_fifo (unit_t *unit)
 
       if (cnt >= DRAIN_SHORT_TIMEOUT)
       {
-        if (total_drained > 0) {
-          fprintf(stderr, "[BRIDGE] drain: timeout after %d packets, %u bytes\n", packets_drained, total_drained);
-        }
         return total_drained;
       }
     }
@@ -489,19 +485,8 @@ static uint32_t drain_output_fifo (unit_t *unit)
 
     if (captured == 0)
     {
-      if (total_drained > 0) {
-        fprintf(stderr, "[BRIDGE] drain: done, %d packets, %u bytes\n", packets_drained, total_drained);
-      }
       return total_drained;
     }
-
-    // MUST read the data to fully clear the FIFO
-    size_t read_len = captured < sizeof(discard_buf) ? captured : sizeof(discard_buf);
-    read_bytes (unit->fd, RECORDER_MEM_BASE, discard_buf, read_len);
-    
-    // Print what we're draining
-    uint8_t pkt_type = (read_len > 1) ? discard_buf[1] : 0;
-    fprintf(stderr, "[BRIDGE] drain: packet %d, %u bytes, type=0x%02x\n", packets_drained, captured, pkt_type);
 
     packets_drained++;
     total_drained += captured;
@@ -730,29 +715,11 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
                   MAYBE_UNUSED hashconfig_t *hashconfig, hashes_t *hashes,
                   const u32 salt_pos, const u64 pws_cnt)
 {
-  fprintf(stderr, "[BRIDGE] launch_loop called: pws_cnt=%llu\n", (unsigned long long)pws_cnt);
-  
   bridge_litex_bcrypt_t *bridge = platform_context;
 
   const int unit_idx = device_param->bridge_link_device;
 
   unit_t *unit = &bridge->units_buf[unit_idx];
-
-  // Send reset and drain any stale data (like cleanup2_test does)
-  {
-    uint8_t reset_pl[1] = {0xCC};
-    uint8_t reset_hdr[10];
-    // Use packet ID 0x0000 for reset (like cleanup2_test)
-    build_header(reset_hdr, PKT_TYPE_RESET, 0x0000, 1);
-    uint8_t pkt_reset[32];
-    size_t pkt_reset_len = 0;
-    add_checksums_around_payload(pkt_reset, &pkt_reset_len, reset_hdr, 10, reset_pl, 1);
-    kick_streamer(unit, pkt_reset, pkt_reset_len);
-  }
-  // Drain AFTER reset, BEFORE starting work
-  drain_output_fifo(unit);
-  // Reset packet ID counter after reset
-  unit->next_pkt_id = 1;
 
   // Get salt information
   salt_t *salts_buf = (salt_t *) hashes->salts_buf;
@@ -818,7 +785,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
   add_checksums_around_payload (pkt_cmp, &pkt_cmp_len, cmp_hdr, 10, cmp_pl, cmp_pl_len);
 
-  // target_hashes freed at cleanup label
+  hcfree (target_hashes);
 
   // Build WORD_GEN packet (empty for -a0 mode)
   uint8_t wg_pl[16];
@@ -856,8 +823,6 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     {
       words[i] = (const u8 *) bcrypt_tmp[processed + i].pw_buf;
       word_lens[i] = bcrypt_tmp[processed + i].pw_len;
-      fprintf(stderr, "[BRIDGE] Password[%u]: len=%u, bytes='%.*s'\n", 
-              i, word_lens[i], (int)word_lens[i], (const char*)words[i]);
     }
 
     uint8_t wl_pl[MAX_PAYLOAD_SIZE + 64];
@@ -880,18 +845,14 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     // First batch: send CMP_CONFIG, WORD_GEN, then WORD_LIST
     if (first_batch)
     {
-      fprintf(stderr, "[BRIDGE] Sending CMP_CONFIG (%zu bytes)\n", pkt_cmp_len);
       if (!kick_streamer (unit, pkt_cmp, pkt_cmp_len))
       {
-        fprintf(stderr, "[BRIDGE] CMP_CONFIG kick FAILED\n");
         drain_output_fifo (unit);
         return false;
       }
 
-      fprintf(stderr, "[BRIDGE] Sending WORD_GEN (%zu bytes)\n", pkt_wg_len);
       if (!kick_streamer (unit, pkt_wg, pkt_wg_len))
       {
-        fprintf(stderr, "[BRIDGE] WORD_GEN kick FAILED\n");
         drain_output_fifo (unit);
         return false;
       }
@@ -900,41 +861,25 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     }
 
     // Send WORD_LIST
-    fprintf(stderr, "[BRIDGE] Sending WORD_LIST (%zu bytes), sub_batch=%u: ", pkt_wl_len, sub_batch);
-    for (size_t i = 0; i < (pkt_wl_len < 32 ? pkt_wl_len : 32); i++) {
-      fprintf(stderr, "%02x ", pkt_wl[i]);
-    }
-    fprintf(stderr, "\n");
     if (!kick_streamer (unit, pkt_wl, pkt_wl_len))
     {
-      fprintf(stderr, "[BRIDGE] kick_streamer for WORD_LIST FAILED\n");
       drain_output_fifo (unit);
       return false;
     }
-    fprintf(stderr, "[BRIDGE] WORD_LIST sent successfully, waiting for recorder...\n");
 
     // Wait for recorder
     uint32_t recorder_len = 0;
 
     if (!wait_recorder (unit, &recorder_len))
     {
-      fprintf(stderr, "[BRIDGE] wait_recorder FAILED - draining and returning false\n");
       drain_output_fifo (unit);
       return false;
     }
-    fprintf(stderr, "[BRIDGE] wait_recorder OK, recorder_len=%u\n", recorder_len);
 
     // Process response
     if (recorder_len > 0 && recorder_len <= RECORDER_MEM_SIZE)
     {
       read_bytes (unit->fd, RECORDER_MEM_BASE, unit->recorder_buf, recorder_len);
-      
-      // Debug: print first bytes of response
-      fprintf(stderr, "[BRIDGE] Response bytes: ");
-      for (uint32_t i = 0; i < (recorder_len < 16 ? recorder_len : 16); i++) {
-        fprintf(stderr, "%02x ", unit->recorder_buf[i]);
-      }
-      fprintf(stderr, "\n");
 
       if (recorder_len >= 2)
       {
@@ -963,16 +908,7 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
 
           uint32_t drain_len = 0;
 
-          if (wait_recorder (unit, &drain_len) && drain_len > 0)
-          {
-            // MUST read the data to clear the FIFO
-            uint8_t drain_buf[64];
-            size_t read_len = drain_len < sizeof(drain_buf) ? drain_len : sizeof(drain_buf);
-            read_bytes (unit->fd, RECORDER_MEM_BASE, drain_buf, read_len);
-          }
-          
-          // Found a match - stop processing this batch
-          goto cleanup;
+          wait_recorder (unit, &drain_len);
         }
       }
     }
@@ -988,9 +924,6 @@ bool launch_loop (void *platform_context, hc_device_param_t *device_param,
     drain_output_fifo (unit);
   }
 
-cleanup:
-  fprintf(stderr, "[BRIDGE] launch_loop returning true (cleanup path)\n");
-  hcfree(target_hashes);
   return true;
 }
 

--- a/src/bridges/bridge_litex_bcrypt.mk
+++ b/src/bridges/bridge_litex_bcrypt.mk
@@ -1,0 +1,17 @@
+
+LITEX_BCRYPT_CFLAGS :=
+
+ifeq ($(BUILD_MODE),cross)
+bridges/bridge_litex_bcrypt.so:  src/bridges/bridge_litex_bcrypt.c obj/combined.LINUX.a
+	$(CC_LINUX) $(CCFLAGS) $(CFLAGS_CROSS_LINUX)  $^ -o $@ $(LFLAGS_CROSS_LINUX) -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(LITEX_BCRYPT_CFLAGS)
+bridges/bridge_litex_bcrypt.dll: src/bridges/bridge_litex_bcrypt.c obj/combined.WIN.a
+	$(CC_WIN)   $(CCFLAGS) $(CFLAGS_CROSS_WIN)    $^ -o $@ $(LFLAGS_CROSS_WIN)   -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(LITEX_BCRYPT_CFLAGS)
+else
+ifeq ($(SHARED),1)
+bridges/bridge_litex_bcrypt.$(BRIDGE_SUFFIX): src/bridges/bridge_litex_bcrypt.c $(HASHCAT_LIBRARY)
+	$(CC)       $(CCFLAGS) $(CFLAGS_NATIVE)       $^ -o $@ $(LFLAGS_NATIVE)      -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(LITEX_BCRYPT_CFLAGS)
+else
+bridges/bridge_litex_bcrypt.$(BRIDGE_SUFFIX): src/bridges/bridge_litex_bcrypt.c obj/combined.NATIVE.a
+	$(CC)       $(CCFLAGS) $(CFLAGS_NATIVE)       $^ -o $@ $(LFLAGS_NATIVE)      -shared -fPIC -D BRIDGE_INTERFACE_VERSION_CURRENT=$(BRIDGE_INTERFACE_VERSION) $(LITEX_BCRYPT_CFLAGS)
+endif
+endif

--- a/src/modules/module_70300.c
+++ b/src/modules/module_70300.c
@@ -1,0 +1,290 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ *
+ * bcrypt $2*$, Blowfish (Unix) - LiteX FPGA Accelerated
+ *
+ * This module uses a hardware bridge to LiteX-Bcrypt FPGAs for
+ * hardware-accelerated bcrypt cracking.
+ *
+ * Hash format is identical to mode 3200 ($2a$, $2b$, $2x$, $2y$)
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_6;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_OS;
+static const char *HASH_NAME      = "bcrypt $2*$, Blowfish (Unix) [LiteX FPGA]";
+static const u64   KERN_TYPE      = 70300;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_NATIVE_THREADS
+                                  | OPTS_TYPE_MP_MULTI_DISABLE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const u64   BRIDGE_TYPE    = BRIDGE_TYPE_MATCH_TUNINGS
+                                  | BRIDGE_TYPE_REPLACE_LOOP;
+static const char *BRIDGE_NAME    = "litex_bcrypt";
+static const char *ST_PASS        = "testpass";
+static const char *ST_HASH        = "$2b$04$1VldY2zfWJR8BMfnYHEik..MCB9ARWzoHfe3fFFKfP6xes3sODPqe";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+const char *module_bridge_name    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BRIDGE_NAME;     }
+u64         module_bridge_type    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return BRIDGE_TYPE;     }
+
+/**
+ * FPGA tmp structure - used to pass passwords to bridge and receive results
+ */
+
+typedef struct bcrypt_fpga_tmp
+{
+  u32 pw_buf[18];   // Password buffer (up to 72 bytes for bcrypt)
+  u32 pw_len;
+  u32 digest[6];    // Output from FPGA (24 bytes, 6 words)
+  u32 cracked;      // Flag set by bridge when FPGA reports match
+
+} bcrypt_fpga_tmp_t;
+
+static const char *SIGNATURE_BCRYPT1 = "$2a$";
+static const char *SIGNATURE_BCRYPT2 = "$2b$";
+static const char *SIGNATURE_BCRYPT3 = "$2x$";
+static const char *SIGNATURE_BCRYPT4 = "$2y$";
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 pw_max = 72; // Bcrypt max password length
+
+  return pw_max;
+}
+
+u32 module_kernel_threads_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return 1;
+}
+
+u32 module_kernel_threads_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return 1;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return (const u64) sizeof (bcrypt_fpga_tmp_t);
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 4;
+
+  token.signatures_cnt    = 4;
+  token.signatures_buf[0] = SIGNATURE_BCRYPT1;
+  token.signatures_buf[1] = SIGNATURE_BCRYPT2;
+  token.signatures_buf[2] = SIGNATURE_BCRYPT3;
+  token.signatures_buf[3] = SIGNATURE_BCRYPT4;
+
+  token.len[0]     = 4;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '$';
+  token.len[1]     = 2;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.len[2]     = 22;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64B;
+
+  token.len[3]     = 31;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_BASE64B;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *iter_pos = token.buf[1];
+  const u8 *salt_pos = token.buf[2];
+  const u8 *hash_pos = token.buf[3];
+
+  const int salt_len = token.len[2];
+  const int hash_len = token.len[3];
+
+  salt->salt_len  = 16;
+  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  memcpy ((char *) salt->salt_sign, line_buf, 6);
+
+  u8 *salt_buf_ptr = (u8 *) salt->salt_buf;
+
+  u8 tmp_buf[100];
+
+  memset (tmp_buf, 0, sizeof (tmp_buf));
+
+  base64_decode (bf64_to_int, salt_pos, salt_len, tmp_buf);
+
+  memcpy (salt_buf_ptr, tmp_buf, 16);
+
+  salt->salt_buf[0] = byte_swap_32 (salt->salt_buf[0]);
+  salt->salt_buf[1] = byte_swap_32 (salt->salt_buf[1]);
+  salt->salt_buf[2] = byte_swap_32 (salt->salt_buf[2]);
+  salt->salt_buf[3] = byte_swap_32 (salt->salt_buf[3]);
+
+  memset (tmp_buf, 0, sizeof (tmp_buf));
+
+  base64_decode (bf64_to_int, hash_pos, hash_len, tmp_buf);
+
+  memcpy (digest, tmp_buf, 24);
+
+  digest[0] = byte_swap_32 (digest[0]);
+  digest[1] = byte_swap_32 (digest[1]);
+  digest[2] = byte_swap_32 (digest[2]);
+  digest[3] = byte_swap_32 (digest[3]);
+  digest[4] = byte_swap_32 (digest[4]);
+  digest[5] = byte_swap_32 (digest[5]);
+
+  digest[5] &= ~0xffu; // its just 23 not 24 bytes!
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  u32 tmp_digest[6];
+
+  tmp_digest[0] = byte_swap_32 (digest[0]);
+  tmp_digest[1] = byte_swap_32 (digest[1]);
+  tmp_digest[2] = byte_swap_32 (digest[2]);
+  tmp_digest[3] = byte_swap_32 (digest[3]);
+  tmp_digest[4] = byte_swap_32 (digest[4]);
+  tmp_digest[5] = byte_swap_32 (digest[5]);
+
+  u32 tmp_salt[4];
+
+  tmp_salt[0] = byte_swap_32 (salt->salt_buf[0]);
+  tmp_salt[1] = byte_swap_32 (salt->salt_buf[1]);
+  tmp_salt[2] = byte_swap_32 (salt->salt_buf[2]);
+  tmp_salt[3] = byte_swap_32 (salt->salt_buf[3]);
+
+  char tmp_buf[64];
+
+  base64_encode (int_to_bf64, (const u8 *) tmp_salt,   16, (u8 *) tmp_buf +  0);
+  base64_encode (int_to_bf64, (const u8 *) tmp_digest, 23, (u8 *) tmp_buf + 22);
+
+  tmp_buf[22 + 31] = 0; // base64_encode wants to pad
+
+  return snprintf (line_buf, line_size, "%s$%s", (const char *) salt->salt_sign, tmp_buf);
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = module_bridge_name;
+  module_ctx->module_bridge_type              = module_bridge_type;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = module_kernel_threads_max;
+  module_ctx->module_kernel_threads_min       = module_kernel_threads_min;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_70300.c
+++ b/src/modules/module_70300.c
@@ -63,7 +63,7 @@ typedef struct bcrypt_fpga_tmp
 {
   u32 pw_buf[18];   // Password buffer (up to 72 bytes for bcrypt)
   u32 pw_len;
-  u32 digest[6];    // Output from FPGA (24 bytes, 6 words)
+  
   u32 cracked;      // Flag set by bridge when FPGA reports match
 
 } bcrypt_fpga_tmp_t;


### PR DESCRIPTION
This accompanies https://github.com/blurbdust/litex_bcrypt to have modern FPGAs use the old [jtr FPGA modules](https://github.com/openwall/john/tree/bleeding-jumbo/src/ztex/fpga-bcrypt) with an easy to port and extensible framework through LiteX. As long as a board is supported in LiteX and has PCIe, this module should work with them. 

I am completely open to changing the module number, I chose one at random. The other md5crypt, descrypt, sha256crypt, and sha512crypt are working in simulations with LiteX and I will get the real hardware ports working soon so plans for a couple more module numbers should be made. I hope to have more, such as those housed in [OpenCiphers](https://openciphers.sourceforge.net/oc.html), to eventually be added as well. 

The YPCB-00338-1P1 boards are now very well supported but there are many other boards already supported. I also included instructions on how to [port to other boards](https://github.com/blurbdust/litex_bcrypt/blob/main/example_port.md) that are [supported by LiteX](https://github.com/blurbdust/litex_bcrypt/blob/main/possible_boards.md). The YPCB can squeeze in 450 bcrypt cores running at 137MHz across the board. I'm sure some additional optimizations can be found but for now, it's still great performance. 139MHz is/was possible but some reset signals made timing slip in some areas. 

I look forward to the roast of the proposed code!