### PR TITLE
Reapply shuffle-before-salsa optimization for scrypt kernels

### DIFF
--- a/OpenCL/inc_hash_scrypt.cl
+++ b/OpenCL/inc_hash_scrypt.cl
@@ -41,6 +41,23 @@ DECLSPEC void scrypt_shuffle (PRIVATE_AS u32 *TI)
     for (int j = 0; j < SALSA_CNT4; j++) TI[dst_off + j] = TT[src_off + j];
   }
 }
+
+DECLSPEC void scrypt_shuffle_inv (PRIVATE_AS u32 *TI)
+{
+  u32 TT[STATE_CNT4];
+
+  for (int j = 0; j < STATE_CNT4; j++) TT[j] = TI[j];
+
+  for (int dst_off = SALSA_CNT4 * 2, src_off = SALSA_CNT4; dst_off < STATE_CNT4; dst_off += SALSA_CNT4 * 2, src_off += SALSA_CNT4)
+  {
+    for (int j = 0; j < SALSA_CNT4; j++) TI[dst_off + j] = TT[src_off + j];
+  }
+
+  for (int dst_off = SALSA_CNT4, src_off = STATE_CNT4 / 2; dst_off < STATE_CNT4; dst_off += SALSA_CNT4 * 2, src_off += SALSA_CNT4)
+  {
+    for (int j = 0; j < SALSA_CNT4; j++) TI[dst_off + j] = TT[src_off + j];
+  }
+}
 #endif
 
 DECLSPEC void salsa_r (PRIVATE_AS u32 *TI)
@@ -172,6 +189,10 @@ DECLSPEC void scrypt_smix_init (GLOBAL_AS u32 *P, PRIVATE_AS u32 *X, GLOBAL_AS v
 
   for (u32 i = 0; i < STATE_CNT4; i++) X[i] = P[i];
 
+  #if SCRYPT_R > 1
+  scrypt_shuffle_inv (X);
+  #endif
+
   for (u32 y = 0; y < ySIZE; y++)
   {
     GLOBAL_AS hc_uint4_t *Vxx = Vx + (y * zSIZE);
@@ -180,13 +201,17 @@ DECLSPEC void scrypt_smix_init (GLOBAL_AS u32 *P, PRIVATE_AS u32 *X, GLOBAL_AS v
 
     for (u32 i = 0; i < (1 << SCRYPT_TMTO); i++)
     {
-      salsa_r (X);
-
       #if SCRYPT_R > 1
       scrypt_shuffle (X);
       #endif
+
+      salsa_r (X);
     }
   }
+
+  #if SCRYPT_R > 1
+  scrypt_shuffle (X);
+  #endif
 
   for (u32 i = 0; i < STATE_CNT4; i++) P[i] = X[i];
 }
@@ -216,6 +241,10 @@ DECLSPEC void scrypt_smix_loop (GLOBAL_AS u32 *P, PRIVATE_AS u32 *X, PRIVATE_AS 
 
   for (u32 i = 0; i < STATE_CNT4; i++) X[i] = P[i];
 
+  #if SCRYPT_R > 1
+  scrypt_shuffle_inv (X);
+  #endif
+
   // note: max 1024 iterations = forced -u 2048
 
   const u32 N_max = (SCRYPT_N < 2048) ? SCRYPT_N : 2048;
@@ -234,21 +263,25 @@ DECLSPEC void scrypt_smix_loop (GLOBAL_AS u32 *P, PRIVATE_AS u32 *X, PRIVATE_AS 
 
     for (u32 i = 0; i < km; i++)
     {
-      salsa_r (T);
-
       #if SCRYPT_R > 1
       scrypt_shuffle (T);
       #endif
+
+      salsa_r (T);
     }
 
     for (u32 z = 0; z < zSIZE; z++) X4[z] = xor_uint4 (X4[z], T4[z]);
 
-    salsa_r (X);
-
     #if SCRYPT_R > 1
     scrypt_shuffle (X);
     #endif
+
+    salsa_r (X);
   }
+
+  #if SCRYPT_R > 1
+  scrypt_shuffle (X);
+  #endif
 
   for (u32 i = 0; i < STATE_CNT4; i++) P[i] = X[i];
 }


### PR DESCRIPTION
The v7.0.0 refactoring (c231b2ec5) rewrote `salsa_r()` from `uint4` to `u32` and extracted the scrypt kernel code into the shared `inc_hash_scrypt.cl`. During this rewrite, the shuffle/salsa reordering from PR #3950 was inadvertently lost. `scrypt_shuffle()` ended up back after `salsa_r()` at all three call sites.

This PR restores the optimization in the new shared code structure.

The approach operates in an "inverse-shuffle domain" throughout the SMix computation. 

### Cross-architecture benchmark (5 runs per mode, hashcat v7.1.2 master)

| GPU       | Arch   | Before (H/s) | After (H/s) | Change   |
|-----------|--------|---------------|--------------|----------|
| RTX 3070  | Ampere | 1743          | 2060         | **+18.2%** |
| RTX 4070  | Ada    | 3424          | 4040         | **+18.0%** |
| RTX 4090  | Ada    | 7986          | 8910         | **+11.6%** |

Averages across modes 8900, 22700, 27700, 28200 (all R=8).

The RTX 4090 shows slightly lower improvement (+11.6% vs +18%) likely because its larger L2 cache (72 MB) better absorbs stack spill traffic.

### Kernel resources (m08900_loop, same across all GPUs)

| Metric | Before | After  |
|--------|--------|--------|
| REG    | 255    | 255    |
| STACK  | 3216   | 2208 (-31%) |

The speedup compared to the original PR #3950 (+12-14%) is larger because the new `u32` salsa code benefits more from the reordering. The compiler achieves better register scheduling with reduced stack spill.

### Per-mode detail (RTX 3070)

| Mode  | Before (H/s) | After (H/s) | Change |
|-------|-------------|------------|--------|
| 8900  | 1744        | 2064       | +18.3% |
| 15700 | 6           | 6          | R=1    |
| 22700 | 1742        | 2057       | +18.1% |
| 27700 | 1743        | 2059       | +18.2% |
| 28200 | 1745        | 2059       | +18.0% |
