### PR TITLE
Significant performance improvement for poor workload in hybrid2 (-a 7) and combinator (-a 1) attacks

### DIFF
--- a/OpenCL/m00000_a1-pure.cl
+++ b/OpenCL/m00000_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m00000_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m00000_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m00000_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m00000_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 

--- a/OpenCL/m00010_a1-pure.cl
+++ b/OpenCL/m00010_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m00010_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m00010_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m00010_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m00010_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 

--- a/OpenCL/m00020_a1-pure.cl
+++ b/OpenCL/m00020_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m00020_mxx (KERN_ATTR_BASIC ())
 
   md5_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m00020_mxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m00020_sxx (KERN_ATTR_BASIC ())
 
   md5_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m00020_sxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 

--- a/OpenCL/m00030_a1-pure.cl
+++ b/OpenCL/m00030_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m00030_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m00030_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m00030_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m00030_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 

--- a/OpenCL/m00040_a1-pure.cl
+++ b/OpenCL/m00040_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m00040_mxx (KERN_ATTR_BASIC ())
 
   md5_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m00040_mxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m00040_sxx (KERN_ATTR_BASIC ())
 
   md5_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m00040_sxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 

--- a/OpenCL/m00050_a1-pure.cl
+++ b/OpenCL/m00050_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m00050_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     md5_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m00050_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     md5_hmac_ctx_t ctx;

--- a/OpenCL/m00060_a1-pure.cl
+++ b/OpenCL/m00060_a1-pure.cl
@@ -69,14 +69,39 @@ KERNEL_FQ KERNEL_FA void m00060_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     md5_hmac_ctx_t ctx = ctx0;
@@ -161,14 +186,39 @@ KERNEL_FQ KERNEL_FA void m00060_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     md5_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m00070_a1-pure.cl
+++ b/OpenCL/m00070_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m00070_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m00070_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m00070_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m00070_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 

--- a/OpenCL/m00100_a1-pure.cl
+++ b/OpenCL/m00100_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m00100_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m00100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m00100_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m00100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m00110_a1-pure.cl
+++ b/OpenCL/m00110_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m00110_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m00110_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 

--- a/OpenCL/m00120_a1-pure.cl
+++ b/OpenCL/m00120_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m00120_mxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m00120_mxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m00120_sxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m00120_sxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m00130_a1-pure.cl
+++ b/OpenCL/m00130_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m00130_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m00130_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m00130_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m00130_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 

--- a/OpenCL/m00140_a1-pure.cl
+++ b/OpenCL/m00140_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m00140_mxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m00140_mxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m00140_sxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m00140_sxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m00150_a1-pure.cl
+++ b/OpenCL/m00150_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m00150_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m00150_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx;

--- a/OpenCL/m00160_a1-pure.cl
+++ b/OpenCL/m00160_a1-pure.cl
@@ -69,14 +69,39 @@ KERNEL_FQ KERNEL_FA void m00160_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx = ctx0;
@@ -161,14 +186,39 @@ KERNEL_FQ KERNEL_FA void m00160_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m00170_a1-pure.cl
+++ b/OpenCL/m00170_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m00170_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m00170_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m00170_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m00170_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m00300_a1-pure.cl
+++ b/OpenCL/m00300_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m00300_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m00300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -108,9 +124,12 @@ KERNEL_FQ KERNEL_FA void m00300_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -118,9 +137,22 @@ KERNEL_FQ KERNEL_FA void m00300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m00600_a1-pure.cl
+++ b/OpenCL/m00600_a1-pure.cl
@@ -30,9 +30,12 @@ KERNEL_FQ KERNEL_FA void m00600_mxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -40,9 +43,22 @@ KERNEL_FQ KERNEL_FA void m00600_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 
@@ -83,9 +99,12 @@ KERNEL_FQ KERNEL_FA void m00600_sxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -93,9 +112,22 @@ KERNEL_FQ KERNEL_FA void m00600_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 

--- a/OpenCL/m00610_a1-pure.cl
+++ b/OpenCL/m00610_a1-pure.cl
@@ -39,9 +39,12 @@ KERNEL_FQ KERNEL_FA void m00610_mxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -49,9 +52,22 @@ KERNEL_FQ KERNEL_FA void m00610_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_update (&ctx, s, salt_len);
 
@@ -102,9 +118,12 @@ KERNEL_FQ KERNEL_FA void m00610_sxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -112,9 +131,22 @@ KERNEL_FQ KERNEL_FA void m00610_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_update (&ctx, s, salt_len);
 

--- a/OpenCL/m00620_a1-pure.cl
+++ b/OpenCL/m00620_a1-pure.cl
@@ -34,7 +34,10 @@ KERNEL_FQ KERNEL_FA void m00620_mxx (KERN_ATTR_BASIC ())
 
   blake2b_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -45,6 +48,11 @@ KERNEL_FQ KERNEL_FA void m00620_mxx (KERN_ATTR_BASIC ())
     blake2b_ctx_t ctx = ctx0;
 
     blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 
@@ -89,7 +97,10 @@ KERNEL_FQ KERNEL_FA void m00620_sxx (KERN_ATTR_BASIC ())
 
   blake2b_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -100,6 +111,11 @@ KERNEL_FQ KERNEL_FA void m00620_sxx (KERN_ATTR_BASIC ())
     blake2b_ctx_t ctx = ctx0;
 
     blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 

--- a/OpenCL/m00900_a1-pure.cl
+++ b/OpenCL/m00900_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m00900_mxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m00900_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m00900_sxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m00900_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 

--- a/OpenCL/m01000_a1-pure.cl
+++ b/OpenCL/m01000_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m01000_mxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m01000_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m01000_sxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m01000_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 

--- a/OpenCL/m01100_a1-pure.cl
+++ b/OpenCL/m01100_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m01100_mxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m01100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx1 = ctx0;
+    md4_ctx_t ctx1;
 
-    md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx1);
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx1);
 
@@ -118,9 +134,12 @@ KERNEL_FQ KERNEL_FA void m01100_sxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -128,9 +147,22 @@ KERNEL_FQ KERNEL_FA void m01100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx1 = ctx0;
+    md4_ctx_t ctx1;
 
-    md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx1);
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx1);
 

--- a/OpenCL/m01300_a1-pure.cl
+++ b/OpenCL/m01300_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m01300_mxx (KERN_ATTR_BASIC ())
 
   sha224_ctx_t ctx0;
 
-  sha224_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_init (&ctx0);
 
-  sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m01300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha224_ctx_t ctx = ctx0;
+    sha224_ctx_t ctx;
 
-    sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha224_init (&ctx);
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha224_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m01300_sxx (KERN_ATTR_BASIC ())
 
   sha224_ctx_t ctx0;
 
-  sha224_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_init (&ctx0);
 
-  sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m01300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha224_ctx_t ctx = ctx0;
+    sha224_ctx_t ctx;
 
-    sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha224_init (&ctx);
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha224_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_final (&ctx);
 

--- a/OpenCL/m01310_a1-pure.cl
+++ b/OpenCL/m01310_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m01310_mxx (KERN_ATTR_BASIC ())
 
   sha224_ctx_t ctx0;
 
-  sha224_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_init (&ctx0);
 
-  sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m01310_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha224_ctx_t ctx = ctx0;
+    sha224_ctx_t ctx;
 
-    sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha224_init (&ctx);
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha224_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m01310_sxx (KERN_ATTR_BASIC ())
 
   sha224_ctx_t ctx0;
 
-  sha224_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_init (&ctx0);
 
-  sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m01310_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha224_ctx_t ctx = ctx0;
+    sha224_ctx_t ctx;
 
-    sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha224_init (&ctx);
+
+      sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha224_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_update (&ctx, s, salt_len);
 

--- a/OpenCL/m01320_a1-pure.cl
+++ b/OpenCL/m01320_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m01320_mxx (KERN_ATTR_BASIC ())
 
   sha224_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m01320_mxx (KERN_ATTR_BASIC ())
     sha224_ctx_t ctx = ctx0;
 
     sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha224_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m01320_sxx (KERN_ATTR_BASIC ())
 
   sha224_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m01320_sxx (KERN_ATTR_BASIC ())
     sha224_ctx_t ctx = ctx0;
 
     sha224_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha224_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_final (&ctx);
 

--- a/OpenCL/m01400_a1-pure.cl
+++ b/OpenCL/m01400_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m01400_mxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m01400_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m01400_sxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m01400_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m01410_a1-pure.cl
+++ b/OpenCL/m01410_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m01410_mxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m01410_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m01410_sxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m01410_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update (&ctx, s, salt_len);
 

--- a/OpenCL/m01420_a1-pure.cl
+++ b/OpenCL/m01420_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m01420_mxx (KERN_ATTR_BASIC ())
 
   sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m01420_mxx (KERN_ATTR_BASIC ())
     sha256_ctx_t ctx = ctx0;
 
     sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m01420_sxx (KERN_ATTR_BASIC ())
 
   sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m01420_sxx (KERN_ATTR_BASIC ())
     sha256_ctx_t ctx = ctx0;
 
     sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m01430_a1-pure.cl
+++ b/OpenCL/m01430_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m01430_mxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m01430_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m01430_sxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m01430_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update (&ctx, s, salt_len);
 

--- a/OpenCL/m01440_a1-pure.cl
+++ b/OpenCL/m01440_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m01440_mxx (KERN_ATTR_BASIC ())
 
   sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m01440_mxx (KERN_ATTR_BASIC ())
     sha256_ctx_t ctx = ctx0;
 
     sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m01440_sxx (KERN_ATTR_BASIC ())
 
   sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m01440_sxx (KERN_ATTR_BASIC ())
     sha256_ctx_t ctx = ctx0;
 
     sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m01450_a1-pure.cl
+++ b/OpenCL/m01450_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m01450_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha256_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m01450_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha256_hmac_ctx_t ctx;

--- a/OpenCL/m01460_a1-pure.cl
+++ b/OpenCL/m01460_a1-pure.cl
@@ -69,14 +69,39 @@ KERNEL_FQ KERNEL_FA void m01460_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha256_hmac_ctx_t ctx = ctx0;
@@ -161,14 +186,39 @@ KERNEL_FQ KERNEL_FA void m01460_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha256_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m01470_a1-pure.cl
+++ b/OpenCL/m01470_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m01470_mxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m01470_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m01470_sxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m01470_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m01700_a1-pure.cl
+++ b/OpenCL/m01700_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m01700_mxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m01700_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m01700_sxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m01700_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 

--- a/OpenCL/m01710_a1-pure.cl
+++ b/OpenCL/m01710_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m01710_mxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m01710_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m01710_sxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m01710_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, s, salt_len);
 

--- a/OpenCL/m01720_a1-pure.cl
+++ b/OpenCL/m01720_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m01720_mxx (KERN_ATTR_BASIC ())
 
   sha512_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m01720_mxx (KERN_ATTR_BASIC ())
     sha512_ctx_t ctx = ctx0;
 
     sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m01720_sxx (KERN_ATTR_BASIC ())
 
   sha512_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m01720_sxx (KERN_ATTR_BASIC ())
     sha512_ctx_t ctx = ctx0;
 
     sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 

--- a/OpenCL/m01730_a1-pure.cl
+++ b/OpenCL/m01730_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m01730_mxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m01730_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m01730_sxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m01730_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, s, salt_len);
 

--- a/OpenCL/m01740_a1-pure.cl
+++ b/OpenCL/m01740_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m01740_mxx (KERN_ATTR_BASIC ())
 
   sha512_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m01740_mxx (KERN_ATTR_BASIC ())
     sha512_ctx_t ctx = ctx0;
 
     sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha512_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m01740_sxx (KERN_ATTR_BASIC ())
 
   sha512_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m01740_sxx (KERN_ATTR_BASIC ())
     sha512_ctx_t ctx = ctx0;
 
     sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha512_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 

--- a/OpenCL/m01750_a1-pure.cl
+++ b/OpenCL/m01750_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m01750_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha512_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m01750_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha512_hmac_ctx_t ctx;

--- a/OpenCL/m01760_a1-pure.cl
+++ b/OpenCL/m01760_a1-pure.cl
@@ -69,14 +69,39 @@ KERNEL_FQ KERNEL_FA void m01760_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha512_hmac_ctx_t ctx = ctx0;
@@ -161,14 +186,39 @@ KERNEL_FQ KERNEL_FA void m01760_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha512_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m01770_a1-pure.cl
+++ b/OpenCL/m01770_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m01770_mxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m01770_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m01770_sxx (KERN_ATTR_BASIC ())
 
   sha512_ctx_t ctx0;
 
-  sha512_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_init (&ctx0);
 
-  sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha512_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m01770_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 

--- a/OpenCL/m02610_a1-pure.cl
+++ b/OpenCL/m02610_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m02610_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m02610_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -183,9 +199,12 @@ KERNEL_FQ KERNEL_FA void m02610_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -193,9 +212,22 @@ KERNEL_FQ KERNEL_FA void m02610_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m02630_a1-pure.cl
+++ b/OpenCL/m02630_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m02630_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m02630_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, s, salt_len);
 
@@ -191,9 +207,12 @@ KERNEL_FQ KERNEL_FA void m02630_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -201,9 +220,22 @@ KERNEL_FQ KERNEL_FA void m02630_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, s, salt_len);
 

--- a/OpenCL/m02810_a1-pure.cl
+++ b/OpenCL/m02810_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m02810_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m02810_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -206,9 +222,12 @@ KERNEL_FQ KERNEL_FA void m02810_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -216,9 +235,22 @@ KERNEL_FQ KERNEL_FA void m02810_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m03500_a1-pure.cl
+++ b/OpenCL/m03500_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m03500_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m03500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -213,9 +229,12 @@ KERNEL_FQ KERNEL_FA void m03500_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -223,9 +242,22 @@ KERNEL_FQ KERNEL_FA void m03500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m03610_a1-pure.cl
+++ b/OpenCL/m03610_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m03610_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m03610_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -213,9 +229,12 @@ KERNEL_FQ KERNEL_FA void m03610_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -223,9 +242,22 @@ KERNEL_FQ KERNEL_FA void m03610_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m03710_a1-pure.cl
+++ b/OpenCL/m03710_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m03710_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m03710_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -196,9 +212,12 @@ KERNEL_FQ KERNEL_FA void m03710_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -206,9 +225,22 @@ KERNEL_FQ KERNEL_FA void m03710_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m03730_a1-pure.cl
+++ b/OpenCL/m03730_a1-pure.cl
@@ -84,7 +84,10 @@ KERNEL_FQ KERNEL_FA void m03730_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,6 +98,11 @@ KERNEL_FQ KERNEL_FA void m03730_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
     md5_ctx_t ctx1 = ctx0;
 
     md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -212,7 +220,10 @@ KERNEL_FQ KERNEL_FA void m03730_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -223,6 +234,11 @@ KERNEL_FQ KERNEL_FA void m03730_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
     md5_ctx_t ctx1 = ctx0;
 
     md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m03800_a1-pure.cl
+++ b/OpenCL/m03800_a1-pure.cl
@@ -44,7 +44,10 @@ KERNEL_FQ KERNEL_FA void m03800_mxx (KERN_ATTR_BASIC ())
 
   md5_update (&ctx0, s, salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -55,6 +58,11 @@ KERNEL_FQ KERNEL_FA void m03800_mxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 
@@ -111,7 +119,10 @@ KERNEL_FQ KERNEL_FA void m03800_sxx (KERN_ATTR_BASIC ())
 
   md5_update (&ctx0, s, salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -122,6 +133,11 @@ KERNEL_FQ KERNEL_FA void m03800_sxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 

--- a/OpenCL/m03910_a1-pure.cl
+++ b/OpenCL/m03910_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m03910_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m03910_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -206,9 +222,12 @@ KERNEL_FQ KERNEL_FA void m03910_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -216,9 +235,22 @@ KERNEL_FQ KERNEL_FA void m03910_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m04010_a1-pure.cl
+++ b/OpenCL/m04010_a1-pure.cl
@@ -67,7 +67,10 @@ KERNEL_FQ KERNEL_FA void m04010_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0t = ctx0;
 
-  md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -78,6 +81,11 @@ KERNEL_FQ KERNEL_FA void m04010_mxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx1 = ctx0t;
 
     md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -184,7 +192,10 @@ KERNEL_FQ KERNEL_FA void m04010_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0t = ctx0;
 
-  md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -195,6 +206,11 @@ KERNEL_FQ KERNEL_FA void m04010_sxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx1 = ctx0t;
 
     md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m04110_a1-pure.cl
+++ b/OpenCL/m04110_a1-pure.cl
@@ -76,9 +76,12 @@ KERNEL_FQ KERNEL_FA void m04110_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0t;
 
-  md5_init (&ctx0t);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0t);
 
-  md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,9 +89,22 @@ KERNEL_FQ KERNEL_FA void m04110_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0t;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0t;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, s, salt_len);
 
@@ -206,9 +222,12 @@ KERNEL_FQ KERNEL_FA void m04110_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0t;
 
-  md5_init (&ctx0t);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0t);
 
-  md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -216,9 +235,22 @@ KERNEL_FQ KERNEL_FA void m04110_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0t;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0t;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, s, salt_len);
 

--- a/OpenCL/m04310_a1-pure.cl
+++ b/OpenCL/m04310_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m04310_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m04310_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -183,9 +199,12 @@ KERNEL_FQ KERNEL_FA void m04310_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -193,9 +212,22 @@ KERNEL_FQ KERNEL_FA void m04310_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m04400_a1-pure.cl
+++ b/OpenCL/m04400_a1-pure.cl
@@ -62,9 +62,12 @@ KERNEL_FQ KERNEL_FA void m04400_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -72,9 +75,22 @@ KERNEL_FQ KERNEL_FA void m04400_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -169,9 +185,12 @@ KERNEL_FQ KERNEL_FA void m04400_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -179,9 +198,22 @@ KERNEL_FQ KERNEL_FA void m04400_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m04410_a1-pure.cl
+++ b/OpenCL/m04410_a1-pure.cl
@@ -71,9 +71,12 @@ KERNEL_FQ KERNEL_FA void m04410_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,9 +89,22 @@ KERNEL_FQ KERNEL_FA void m04410_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -200,9 +216,12 @@ KERNEL_FQ KERNEL_FA void m04410_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -215,9 +234,22 @@ KERNEL_FQ KERNEL_FA void m04410_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m04420_a1-pure.cl
+++ b/OpenCL/m04420_a1-pure.cl
@@ -71,9 +71,12 @@ KERNEL_FQ KERNEL_FA void m04420_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,9 +89,22 @@ KERNEL_FQ KERNEL_FA void m04420_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx1, s, salt_len);
 
@@ -200,9 +216,12 @@ KERNEL_FQ KERNEL_FA void m04420_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -215,9 +234,22 @@ KERNEL_FQ KERNEL_FA void m04420_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx1, s, salt_len);
 

--- a/OpenCL/m04430_a1-pure.cl
+++ b/OpenCL/m04430_a1-pure.cl
@@ -66,7 +66,10 @@ KERNEL_FQ KERNEL_FA void m04430_mxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -82,6 +85,11 @@ KERNEL_FQ KERNEL_FA void m04430_mxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx1 = ctx0;
 
     sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -195,7 +203,10 @@ KERNEL_FQ KERNEL_FA void m04430_sxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -211,6 +222,11 @@ KERNEL_FQ KERNEL_FA void m04430_sxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx1 = ctx0;
 
     sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m04500_a1-pure.cl
+++ b/OpenCL/m04500_a1-pure.cl
@@ -61,9 +61,12 @@ KERNEL_FQ KERNEL_FA void m04500_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -71,9 +74,22 @@ KERNEL_FQ KERNEL_FA void m04500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -168,9 +184,12 @@ KERNEL_FQ KERNEL_FA void m04500_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -178,9 +197,22 @@ KERNEL_FQ KERNEL_FA void m04500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m04510_a1-pure.cl
+++ b/OpenCL/m04510_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m04510_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -85,9 +88,22 @@ KERNEL_FQ KERNEL_FA void m04510_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -182,9 +198,12 @@ KERNEL_FQ KERNEL_FA void m04510_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -197,9 +216,22 @@ KERNEL_FQ KERNEL_FA void m04510_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m04520_a1-pure.cl
+++ b/OpenCL/m04520_a1-pure.cl
@@ -67,9 +67,12 @@ KERNEL_FQ KERNEL_FA void m04520_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -77,9 +80,22 @@ KERNEL_FQ KERNEL_FA void m04520_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -189,9 +205,12 @@ KERNEL_FQ KERNEL_FA void m04520_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -199,9 +218,22 @@ KERNEL_FQ KERNEL_FA void m04520_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m04700_a1-pure.cl
+++ b/OpenCL/m04700_a1-pure.cl
@@ -62,9 +62,12 @@ KERNEL_FQ KERNEL_FA void m04700_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -72,9 +75,22 @@ KERNEL_FQ KERNEL_FA void m04700_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -164,9 +180,12 @@ KERNEL_FQ KERNEL_FA void m04700_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -174,9 +193,22 @@ KERNEL_FQ KERNEL_FA void m04700_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m04710_a1-pure.cl
+++ b/OpenCL/m04710_a1-pure.cl
@@ -71,9 +71,12 @@ KERNEL_FQ KERNEL_FA void m04710_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,9 +89,22 @@ KERNEL_FQ KERNEL_FA void m04710_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -198,9 +214,12 @@ KERNEL_FQ KERNEL_FA void m04710_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -213,9 +232,22 @@ KERNEL_FQ KERNEL_FA void m04710_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m04800_a1-pure.cl
+++ b/OpenCL/m04800_a1-pure.cl
@@ -46,7 +46,10 @@ KERNEL_FQ KERNEL_FA void m04800_mxx (KERN_ATTR_BASIC ())
 
   ctx0.len = 1;
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -57,6 +60,11 @@ KERNEL_FQ KERNEL_FA void m04800_mxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 
@@ -115,7 +123,10 @@ KERNEL_FQ KERNEL_FA void m04800_sxx (KERN_ATTR_BASIC ())
 
   ctx0.len = 1;
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -126,6 +137,11 @@ KERNEL_FQ KERNEL_FA void m04800_sxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, salt_len);
 

--- a/OpenCL/m04900_a1-pure.cl
+++ b/OpenCL/m04900_a1-pure.cl
@@ -44,7 +44,10 @@ KERNEL_FQ KERNEL_FA void m04900_mxx (KERN_ATTR_BASIC ())
 
   sha1_update (&ctx0, s, salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -55,6 +58,11 @@ KERNEL_FQ KERNEL_FA void m04900_mxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 
@@ -111,7 +119,10 @@ KERNEL_FQ KERNEL_FA void m04900_sxx (KERN_ATTR_BASIC ())
 
   sha1_update (&ctx0, s, salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -122,6 +133,11 @@ KERNEL_FQ KERNEL_FA void m04900_sxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 

--- a/OpenCL/m05000_a1-pure.cl
+++ b/OpenCL/m05000_a1-pure.cl
@@ -74,7 +74,10 @@ KERNEL_FQ KERNEL_FA void m05000_mxx (KERN_ATTR_BASIC ())
 
   sha1_update (&ctx0, s, salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -85,6 +88,11 @@ KERNEL_FQ KERNEL_FA void m05000_mxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 
@@ -194,7 +202,10 @@ KERNEL_FQ KERNEL_FA void m05000_sxx (KERN_ATTR_BASIC ())
 
   sha1_update (&ctx0, s, salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -205,6 +216,11 @@ KERNEL_FQ KERNEL_FA void m05000_sxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 

--- a/OpenCL/m05100_a1-pure.cl
+++ b/OpenCL/m05100_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m05100_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m05100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 
@@ -89,9 +105,12 @@ KERNEL_FQ KERNEL_FA void m05100_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -99,9 +118,22 @@ KERNEL_FQ KERNEL_FA void m05100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 

--- a/OpenCL/m05300_a1-pure.cl
+++ b/OpenCL/m05300_a1-pure.cl
@@ -66,14 +66,39 @@ KERNEL_FQ KERNEL_FA void m05300_mxx (KERN_ATTR_ESALT (ikepsk_t))
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     md5_hmac_ctx_t ctx0;
@@ -177,14 +202,39 @@ KERNEL_FQ KERNEL_FA void m05300_sxx (KERN_ATTR_ESALT (ikepsk_t))
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     md5_hmac_ctx_t ctx0;

--- a/OpenCL/m05400_a1-pure.cl
+++ b/OpenCL/m05400_a1-pure.cl
@@ -66,14 +66,39 @@ KERNEL_FQ KERNEL_FA void m05400_mxx (KERN_ATTR_ESALT (ikepsk_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx0;
@@ -177,14 +202,39 @@ KERNEL_FQ KERNEL_FA void m05400_sxx (KERN_ATTR_ESALT (ikepsk_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx0;

--- a/OpenCL/m05500_a1-pure.cl
+++ b/OpenCL/m05500_a1-pure.cl
@@ -127,9 +127,12 @@ KERNEL_FQ KERNEL_FA void m05500_mxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -137,9 +140,22 @@ KERNEL_FQ KERNEL_FA void m05500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 
@@ -270,9 +286,12 @@ KERNEL_FQ KERNEL_FA void m05500_sxx (KERN_ATTR_BASIC ())
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -280,9 +299,22 @@ KERNEL_FQ KERNEL_FA void m05500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 

--- a/OpenCL/m05600_a1-pure.cl
+++ b/OpenCL/m05600_a1-pure.cl
@@ -44,9 +44,12 @@ KERNEL_FQ KERNEL_FA void m05600_mxx (KERN_ATTR_ESALT (netntlm_t))
 
   md4_ctx_t ctx10;
 
-  md4_init (&ctx10);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx10);
 
-  md4_update_global_utf16le (&ctx10, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx10, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -54,9 +57,22 @@ KERNEL_FQ KERNEL_FA void m05600_mxx (KERN_ATTR_ESALT (netntlm_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx1 = ctx10;
+    md4_ctx_t ctx1;
 
-    md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx10;
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx1);
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx1);
 
@@ -153,9 +169,12 @@ KERNEL_FQ KERNEL_FA void m05600_sxx (KERN_ATTR_ESALT (netntlm_t))
 
   md4_ctx_t ctx10;
 
-  md4_init (&ctx10);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx10);
 
-  md4_update_global_utf16le (&ctx10, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx10, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -163,9 +182,22 @@ KERNEL_FQ KERNEL_FA void m05600_sxx (KERN_ATTR_ESALT (netntlm_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx1 = ctx10;
+    md4_ctx_t ctx1;
 
-    md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx10;
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx1);
+
+      md4_update_global_utf16le (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx1);
 

--- a/OpenCL/m05720_a1-pure.cl
+++ b/OpenCL/m05720_a1-pure.cl
@@ -37,7 +37,10 @@ KERNEL_FQ KERNEL_FA void m05720_mxx (KERN_ATTR_BASIC ())
 
   sha256_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -48,6 +51,11 @@ KERNEL_FQ KERNEL_FA void m05720_mxx (KERN_ATTR_BASIC ())
     sha256_ctx_t ctx = ctx0;
 
     sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -144,7 +152,10 @@ KERNEL_FQ KERNEL_FA void m05720_sxx (KERN_ATTR_BASIC ())
 
   sha256_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -155,6 +166,11 @@ KERNEL_FQ KERNEL_FA void m05720_sxx (KERN_ATTR_BASIC ())
     sha256_ctx_t ctx = ctx0;
 
     sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m06000_a1-pure.cl
+++ b/OpenCL/m06000_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m06000_mxx (KERN_ATTR_BASIC ())
 
   ripemd160_ctx_t ctx0;
 
-  ripemd160_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    ripemd160_init (&ctx0);
 
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m06000_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ripemd160_init (&ctx);
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     ripemd160_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m06000_sxx (KERN_ATTR_BASIC ())
 
   ripemd160_ctx_t ctx0;
 
-  ripemd160_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    ripemd160_init (&ctx0);
 
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m06000_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ripemd160_init (&ctx);
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     ripemd160_final (&ctx);
 

--- a/OpenCL/m06050_a1-pure.cl
+++ b/OpenCL/m06050_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m06050_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     ripemd160_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m06050_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     ripemd160_hmac_ctx_t ctx;

--- a/OpenCL/m06060_a1-pure.cl
+++ b/OpenCL/m06060_a1-pure.cl
@@ -69,14 +69,39 @@ KERNEL_FQ KERNEL_FA void m06060_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     ripemd160_hmac_ctx_t ctx = ctx0;
@@ -161,14 +186,39 @@ KERNEL_FQ KERNEL_FA void m06060_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     ripemd160_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m06100_a1-pure.cl
+++ b/OpenCL/m06100_a1-pure.cl
@@ -74,9 +74,12 @@ KERNEL_FQ KERNEL_FA void m06100_mxx (KERN_ATTR_BASIC ())
 
   whirlpool_ctx_t ctx0;
 
-  whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -84,9 +87,22 @@ KERNEL_FQ KERNEL_FA void m06100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 
@@ -171,9 +187,12 @@ KERNEL_FQ KERNEL_FA void m06100_sxx (KERN_ATTR_BASIC ())
 
   whirlpool_ctx_t ctx0;
 
-  whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -181,9 +200,22 @@ KERNEL_FQ KERNEL_FA void m06100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 

--- a/OpenCL/m07000_a1-pure.cl
+++ b/OpenCL/m07000_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m07000_mxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m07000_mxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     /**
      * pepper
@@ -119,7 +127,10 @@ KERNEL_FQ KERNEL_FA void m07000_sxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -130,6 +141,11 @@ KERNEL_FQ KERNEL_FA void m07000_sxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     /**
      * pepper

--- a/OpenCL/m07300_a1-pure.cl
+++ b/OpenCL/m07300_a1-pure.cl
@@ -63,14 +63,39 @@ KERNEL_FQ KERNEL_FA void m07300_mxx (KERN_ATTR_ESALT (rakp_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx;
@@ -144,14 +169,39 @@ KERNEL_FQ KERNEL_FA void m07300_sxx (KERN_ATTR_ESALT (rakp_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx;

--- a/OpenCL/m07350_a1-pure.cl
+++ b/OpenCL/m07350_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m07350_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     md5_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m07350_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     md5_hmac_ctx_t ctx;

--- a/OpenCL/m07500_a1-pure.cl
+++ b/OpenCL/m07500_a1-pure.cl
@@ -192,9 +192,12 @@ KERNEL_FQ KERNEL_FA void m07500_mxx (KERN_ATTR_ESALT (krb5pa_t))
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -202,9 +205,22 @@ KERNEL_FQ KERNEL_FA void m07500_mxx (KERN_ATTR_ESALT (krb5pa_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 
@@ -259,9 +275,12 @@ KERNEL_FQ KERNEL_FA void m07500_sxx (KERN_ATTR_ESALT (krb5pa_t))
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -269,9 +288,22 @@ KERNEL_FQ KERNEL_FA void m07500_sxx (KERN_ATTR_ESALT (krb5pa_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 

--- a/OpenCL/m08100_a1-pure.cl
+++ b/OpenCL/m08100_a1-pure.cl
@@ -37,7 +37,10 @@ KERNEL_FQ KERNEL_FA void m08100_mxx (KERN_ATTR_BASIC ())
 
   sha1_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -48,6 +51,11 @@ KERNEL_FQ KERNEL_FA void m08100_mxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, z, 1);
 
@@ -98,7 +106,10 @@ KERNEL_FQ KERNEL_FA void m08100_sxx (KERN_ATTR_BASIC ())
 
   sha1_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -109,6 +120,11 @@ KERNEL_FQ KERNEL_FA void m08100_sxx (KERN_ATTR_BASIC ())
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, z, 1);
 

--- a/OpenCL/m08300_a1-pure.cl
+++ b/OpenCL/m08300_a1-pure.cl
@@ -101,20 +101,40 @@ KERNEL_FQ KERNEL_FA void m08300_mxx (KERN_ATTR_BASIC ())
 
     if (pw_len > 0)
     {
-      pw_t combs;
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        pw_t combs;
 
-      const u32 first_len_combs = replace_dot_by_len (&combs, &combs_buf[il_pos], 0);
+        const u32 first_len_combs = replace_dot_by_len (&combs, &combs_buf[il_pos], 0);
 
-      pw_t pw;
+        pw_t pw;
 
-      const u32 first_len_pw = replace_dot_by_len (&pw, &pws[gid], first_len_combs);
+        const u32 first_len_pw = replace_dot_by_len (&pw, &pws[gid], first_len_combs);
 
-      ctx1.w0[0] = (first_len_pw & 0xff) << 24;
+        ctx1.w0[0] = (first_len_pw & 0xff) << 24;
 
-      ctx1.len = 1;
+        ctx1.len = 1;
 
-      sha1_update_swap (&ctx1, pw.i,    pw.pw_len);
-      sha1_update_swap (&ctx1, combs.i, combs.pw_len);
+        sha1_update_swap (&ctx1, pw.i,    pw.pw_len);
+        sha1_update_swap (&ctx1, combs.i, combs.pw_len);
+      }
+      else
+      {
+        pw_t pw;
+
+        const u32 first_len_pw = replace_dot_by_len (&pw, &pws[gid], 0);
+
+        pw_t combs;
+
+        const u32 first_len_combs = replace_dot_by_len (&combs, &combs_buf[il_pos], first_len_pw);
+
+        ctx1.w0[0] = (first_len_combs & 0xff) << 24;
+
+        ctx1.len = 1;
+
+        sha1_update_swap (&ctx1, combs.i, combs.pw_len);
+        sha1_update_swap (&ctx1, pw.i,    pw.pw_len);
+      }
     }
 
     sha1_update (&ctx1, s_pc, salt_len_pc + 1);
@@ -230,20 +250,40 @@ KERNEL_FQ KERNEL_FA void m08300_sxx (KERN_ATTR_BASIC ())
 
     if (pw_len > 0)
     {
-      pw_t combs;
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        pw_t combs;
 
-      const u32 first_len_combs = replace_dot_by_len (&combs, &combs_buf[il_pos], 0);
+        const u32 first_len_combs = replace_dot_by_len (&combs, &combs_buf[il_pos], 0);
 
-      pw_t pw;
+        pw_t pw;
 
-      const u32 first_len_pw = replace_dot_by_len (&pw, &pws[gid], first_len_combs);
+        const u32 first_len_pw = replace_dot_by_len (&pw, &pws[gid], first_len_combs);
 
-      ctx1.w0[0] = (first_len_pw & 0xff) << 24;
+        ctx1.w0[0] = (first_len_pw & 0xff) << 24;
 
-      ctx1.len = 1;
+        ctx1.len = 1;
 
-      sha1_update_swap (&ctx1, pw.i,    pw.pw_len);
-      sha1_update_swap (&ctx1, combs.i, combs.pw_len);
+        sha1_update_swap (&ctx1, pw.i,    pw.pw_len);
+        sha1_update_swap (&ctx1, combs.i, combs.pw_len);
+      }
+      else
+      {
+        pw_t pw;
+
+        const u32 first_len_pw = replace_dot_by_len (&pw, &pws[gid], 0);
+
+        pw_t combs;
+
+        const u32 first_len_combs = replace_dot_by_len (&combs, &combs_buf[il_pos], first_len_pw);
+
+        ctx1.w0[0] = (first_len_combs & 0xff) << 24;
+
+        ctx1.len = 1;
+
+        sha1_update_swap (&ctx1, combs.i, combs.pw_len);
+        sha1_update_swap (&ctx1, pw.i,    pw.pw_len);
+      }
     }
 
     sha1_update (&ctx1, s_pc, salt_len_pc + 1);

--- a/OpenCL/m08400_a1-pure.cl
+++ b/OpenCL/m08400_a1-pure.cl
@@ -67,9 +67,12 @@ KERNEL_FQ KERNEL_FA void m08400_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -77,9 +80,22 @@ KERNEL_FQ KERNEL_FA void m08400_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -228,9 +244,12 @@ KERNEL_FQ KERNEL_FA void m08400_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -238,9 +257,22 @@ KERNEL_FQ KERNEL_FA void m08400_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m09900_a1-pure.cl
+++ b/OpenCL/m09900_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m09900_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m09900_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, 100 - pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, 100 - pws[gid].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, 100 - pws[gid].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m09900_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m09900_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, 100 - pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, 100 - pws[gid].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, 100 - pws[gid].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 

--- a/OpenCL/m10800_a1-pure.cl
+++ b/OpenCL/m10800_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m10800_mxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m10800_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m10800_sxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m10800_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 

--- a/OpenCL/m10810_a1-pure.cl
+++ b/OpenCL/m10810_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m10810_mxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m10810_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m10810_sxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m10810_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_update (&ctx, s, salt_len);
 

--- a/OpenCL/m10820_a1-pure.cl
+++ b/OpenCL/m10820_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m10820_mxx (KERN_ATTR_BASIC ())
 
   sha384_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m10820_mxx (KERN_ATTR_BASIC ())
     sha384_ctx_t ctx = ctx0;
 
     sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha384_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 
@@ -100,7 +108,10 @@ KERNEL_FQ KERNEL_FA void m10820_sxx (KERN_ATTR_BASIC ())
 
   sha384_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -111,6 +122,11 @@ KERNEL_FQ KERNEL_FA void m10820_sxx (KERN_ATTR_BASIC ())
     sha384_ctx_t ctx = ctx0;
 
     sha384_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha384_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 

--- a/OpenCL/m10830_a1-pure.cl
+++ b/OpenCL/m10830_a1-pure.cl
@@ -40,9 +40,12 @@ KERNEL_FQ KERNEL_FA void m10830_mxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m10830_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_update (&ctx, s, salt_len);
 
@@ -105,9 +121,12 @@ KERNEL_FQ KERNEL_FA void m10830_sxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m10830_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_update (&ctx, s, salt_len);
 

--- a/OpenCL/m10840_a1-pure.cl
+++ b/OpenCL/m10840_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m10840_mxx (KERN_ATTR_BASIC ())
 
   sha384_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m10840_mxx (KERN_ATTR_BASIC ())
     sha384_ctx_t ctx = ctx0;
 
     sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha384_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m10840_sxx (KERN_ATTR_BASIC ())
 
   sha384_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m10840_sxx (KERN_ATTR_BASIC ())
     sha384_ctx_t ctx = ctx0;
 
     sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha384_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 

--- a/OpenCL/m10870_a1-pure.cl
+++ b/OpenCL/m10870_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m10870_mxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m10870_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 
@@ -85,9 +101,12 @@ KERNEL_FQ KERNEL_FA void m10870_sxx (KERN_ATTR_BASIC ())
 
   sha384_ctx_t ctx0;
 
-  sha384_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha384_init (&ctx0);
 
-  sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha384_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m10870_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha384_ctx_t ctx = ctx0;
+    sha384_ctx_t ctx;
 
-    sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha384_init (&ctx);
+
+      sha384_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha384_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha384_final (&ctx);
 

--- a/OpenCL/m11000_a1-pure.cl
+++ b/OpenCL/m11000_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m11000_mxx (KERN_ATTR_BASIC ())
 
   md5_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,6 +49,11 @@ KERNEL_FQ KERNEL_FA void m11000_mxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 
@@ -91,7 +99,10 @@ KERNEL_FQ KERNEL_FA void m11000_sxx (KERN_ATTR_BASIC ())
 
   md5_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -102,6 +113,11 @@ KERNEL_FQ KERNEL_FA void m11000_sxx (KERN_ATTR_BASIC ())
     md5_ctx_t ctx = ctx0;
 
     md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx);
 

--- a/OpenCL/m11100_a1-pure.cl
+++ b/OpenCL/m11100_a1-pure.cl
@@ -83,9 +83,12 @@ KERNEL_FQ KERNEL_FA void m11100_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0t;
 
-  md5_init (&ctx0t);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0t);
 
-  md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -93,9 +96,22 @@ KERNEL_FQ KERNEL_FA void m11100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0t;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0t;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 s0[4];
     u32 s1[4];
@@ -239,9 +255,12 @@ KERNEL_FQ KERNEL_FA void m11100_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0t;
 
-  md5_init (&ctx0t);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0t);
 
-  md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0t, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -249,9 +268,22 @@ KERNEL_FQ KERNEL_FA void m11100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0t;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0t;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 s0[4];
     u32 s1[4];

--- a/OpenCL/m11200_a1-pure.cl
+++ b/OpenCL/m11200_a1-pure.cl
@@ -37,9 +37,12 @@ KERNEL_FQ KERNEL_FA void m11200_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx2l;
 
-  sha1_init (&ctx2l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx2l);
 
-  sha1_update_global_swap (&ctx2l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx2l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -47,9 +50,22 @@ KERNEL_FQ KERNEL_FA void m11200_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx2 = ctx2l;
+    sha1_ctx_t ctx2;
 
-    sha1_update_global_swap (&ctx2, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx2 = ctx2l;
+
+      sha1_update_global_swap (&ctx2, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx2);
+
+      sha1_update_global_swap (&ctx2, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx2, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx2);
 
@@ -163,9 +179,12 @@ KERNEL_FQ KERNEL_FA void m11200_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx2l;
 
-  sha1_init (&ctx2l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx2l);
 
-  sha1_update_global_swap (&ctx2l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx2l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -173,9 +192,22 @@ KERNEL_FQ KERNEL_FA void m11200_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx2 = ctx2l;
+    sha1_ctx_t ctx2;
 
-    sha1_update_global_swap (&ctx2, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx2 = ctx2l;
+
+      sha1_update_global_swap (&ctx2, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx2);
+
+      sha1_update_global_swap (&ctx2, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx2, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx2);
 

--- a/OpenCL/m11400_a1-pure.cl
+++ b/OpenCL/m11400_a1-pure.cl
@@ -75,7 +75,10 @@ KERNEL_FQ KERNEL_FA void m11400_mxx (KERN_ATTR_ESALT (sip_t))
 
   md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,6 +89,11 @@ KERNEL_FQ KERNEL_FA void m11400_mxx (KERN_ATTR_ESALT (sip_t))
     md5_ctx_t ctx1 = ctx0;
 
     md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -181,7 +189,10 @@ KERNEL_FQ KERNEL_FA void m11400_sxx (KERN_ATTR_ESALT (sip_t))
 
   md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -192,6 +203,11 @@ KERNEL_FQ KERNEL_FA void m11400_sxx (KERN_ATTR_ESALT (sip_t))
     md5_ctx_t ctx1 = ctx0;
 
     md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m11500_a1-pure.cl
+++ b/OpenCL/m11500_a1-pure.cl
@@ -41,7 +41,12 @@ KERNEL_FQ KERNEL_FA void m11500_mxx (KERN_ATTR_BASIC ())
    * base
    */
 
-  u32x a_ref = crc32_global (pws[gid].i, pws[gid].pw_len, iv);
+  u32x a_ref;
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    a_ref = crc32_global (pws[gid].i, pws[gid].pw_len, iv);
+  }
 
   /**
    * loop
@@ -49,7 +54,18 @@ KERNEL_FQ KERNEL_FA void m11500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    u32x a = crc32_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    u32x a;
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      a = crc32_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    }
+    else
+    {
+      a = crc32_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, iv);
+
+      a = crc32_global (pws[gid].i, pws[gid].pw_len, a);
+    }
 
     u32x z = 0;
 
@@ -95,7 +111,12 @@ KERNEL_FQ KERNEL_FA void m11500_sxx (KERN_ATTR_BASIC ())
    * base
    */
 
-  const u32x a_ref = crc32_global (pws[gid].i, pws[gid].pw_len, iv);
+  u32x a_ref;
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    a_ref = crc32_global (pws[gid].i, pws[gid].pw_len, iv);
+  }
 
   /**
    * loop
@@ -103,7 +124,18 @@ KERNEL_FQ KERNEL_FA void m11500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    u32x a = crc32_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    u32x a;
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      a = crc32_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    }
+    else
+    {
+      a = crc32_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, iv);
+
+      a = crc32_global (pws[gid].i, pws[gid].pw_len, a);
+    }
 
     u32x z = 0;
 

--- a/OpenCL/m11700_a1-pure.cl
+++ b/OpenCL/m11700_a1-pure.cl
@@ -60,9 +60,12 @@ KERNEL_FQ KERNEL_FA void m11700_mxx (KERN_ATTR_BASIC ())
 
   streebog256_ctx_t ctx0;
 
-  streebog256_init (&ctx0, s_sbob_sl64);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    streebog256_init (&ctx0, s_sbob_sl64);
 
-  streebog256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    streebog256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -70,9 +73,22 @@ KERNEL_FQ KERNEL_FA void m11700_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    streebog256_ctx_t ctx = ctx0;
+    streebog256_ctx_t ctx;
 
-    streebog256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      streebog256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      streebog256_init (&ctx, s_sbob_sl64);
+
+      streebog256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      streebog256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     streebog256_final (&ctx);
 
@@ -143,9 +159,12 @@ KERNEL_FQ KERNEL_FA void m11700_sxx (KERN_ATTR_BASIC ())
 
   streebog256_ctx_t ctx0;
 
-  streebog256_init (&ctx0, s_sbob_sl64);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    streebog256_init (&ctx0, s_sbob_sl64);
 
-  streebog256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    streebog256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -153,9 +172,22 @@ KERNEL_FQ KERNEL_FA void m11700_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    streebog256_ctx_t ctx = ctx0;
+    streebog256_ctx_t ctx;
 
-    streebog256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      streebog256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      streebog256_init (&ctx, s_sbob_sl64);
+
+      streebog256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      streebog256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     streebog256_final (&ctx);
 

--- a/OpenCL/m11750_a1-pure.cl
+++ b/OpenCL/m11750_a1-pure.cl
@@ -94,14 +94,39 @@ KERNEL_FQ KERNEL_FA void m11750_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog256_hmac_ctx_t ctx;
@@ -213,14 +238,39 @@ KERNEL_FQ KERNEL_FA void m11750_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog256_hmac_ctx_t ctx;

--- a/OpenCL/m11760_a1-pure.cl
+++ b/OpenCL/m11760_a1-pure.cl
@@ -98,14 +98,39 @@ KERNEL_FQ KERNEL_FA void m11760_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog256_hmac_ctx_t ctx = ctx0;
@@ -219,14 +244,39 @@ KERNEL_FQ KERNEL_FA void m11760_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog256_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m11800_a1-pure.cl
+++ b/OpenCL/m11800_a1-pure.cl
@@ -60,9 +60,12 @@ KERNEL_FQ KERNEL_FA void m11800_mxx (KERN_ATTR_BASIC ())
 
   streebog512_ctx_t ctx0;
 
-  streebog512_init (&ctx0, s_sbob_sl64);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    streebog512_init (&ctx0, s_sbob_sl64);
 
-  streebog512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    streebog512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -70,9 +73,22 @@ KERNEL_FQ KERNEL_FA void m11800_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    streebog512_ctx_t ctx = ctx0;
+    streebog512_ctx_t ctx;
 
-    streebog512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      streebog512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      streebog512_init (&ctx, s_sbob_sl64);
+
+      streebog512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      streebog512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     streebog512_final (&ctx);
 
@@ -143,9 +159,12 @@ KERNEL_FQ KERNEL_FA void m11800_sxx (KERN_ATTR_BASIC ())
 
   streebog512_ctx_t ctx0;
 
-  streebog512_init (&ctx0, s_sbob_sl64);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    streebog512_init (&ctx0, s_sbob_sl64);
 
-  streebog512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    streebog512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -153,9 +172,22 @@ KERNEL_FQ KERNEL_FA void m11800_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    streebog512_ctx_t ctx = ctx0;
+    streebog512_ctx_t ctx;
 
-    streebog512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      streebog512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      streebog512_init (&ctx, s_sbob_sl64);
+
+      streebog512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      streebog512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     streebog512_final (&ctx);
 

--- a/OpenCL/m11850_a1-pure.cl
+++ b/OpenCL/m11850_a1-pure.cl
@@ -94,14 +94,39 @@ KERNEL_FQ KERNEL_FA void m11850_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog512_hmac_ctx_t ctx;
@@ -213,14 +238,39 @@ KERNEL_FQ KERNEL_FA void m11850_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog512_hmac_ctx_t ctx;

--- a/OpenCL/m11860_a1-pure.cl
+++ b/OpenCL/m11860_a1-pure.cl
@@ -98,14 +98,39 @@ KERNEL_FQ KERNEL_FA void m11860_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog512_hmac_ctx_t ctx = ctx0;
@@ -219,14 +244,39 @@ KERNEL_FQ KERNEL_FA void m11860_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 t[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        t[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (t, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= t[i];
+      }
     }
 
     streebog512_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m12600_a1-pure.cl
+++ b/OpenCL/m12600_a1-pure.cl
@@ -77,9 +77,12 @@ KERNEL_FQ KERNEL_FA void m12600_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -87,9 +90,22 @@ KERNEL_FQ KERNEL_FA void m12600_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -223,9 +239,12 @@ KERNEL_FQ KERNEL_FA void m12600_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -233,9 +252,22 @@ KERNEL_FQ KERNEL_FA void m12600_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx0;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m13100_a1-pure.cl
+++ b/OpenCL/m13100_a1-pure.cl
@@ -290,9 +290,12 @@ KERNEL_FQ KERNEL_FA void m13100_mxx (KERN_ATTR_ESALT (krb5tgs_t))
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -300,9 +303,22 @@ KERNEL_FQ KERNEL_FA void m13100_mxx (KERN_ATTR_ESALT (krb5tgs_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 
@@ -348,9 +364,12 @@ KERNEL_FQ KERNEL_FA void m13100_sxx (KERN_ATTR_ESALT (krb5tgs_t))
 
   md4_ctx_t ctx0;
 
-  md4_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -358,9 +377,22 @@ KERNEL_FQ KERNEL_FA void m13100_sxx (KERN_ATTR_ESALT (krb5tgs_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx);
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 

--- a/OpenCL/m13300_a1-pure.cl
+++ b/OpenCL/m13300_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m13300_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m13300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -87,9 +103,12 @@ KERNEL_FQ KERNEL_FA void m13300_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -97,9 +116,22 @@ KERNEL_FQ KERNEL_FA void m13300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m13500_a1-pure.cl
+++ b/OpenCL/m13500_a1-pure.cl
@@ -72,7 +72,10 @@ KERNEL_FQ KERNEL_FA void m13500_mxx (KERN_ATTR_ESALT (pstoken_t))
    * base
    */
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -83,6 +86,11 @@ KERNEL_FQ KERNEL_FA void m13500_mxx (KERN_ATTR_ESALT (pstoken_t))
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -155,7 +163,10 @@ KERNEL_FQ KERNEL_FA void m13500_sxx (KERN_ATTR_ESALT (pstoken_t))
    * base
    */
 
-  sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -166,6 +177,11 @@ KERNEL_FQ KERNEL_FA void m13500_sxx (KERN_ATTR_ESALT (pstoken_t))
     sha1_ctx_t ctx = ctx0;
 
     sha1_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_RIGHT)
+    {
+      sha1_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m13800_a1-pure.cl
+++ b/OpenCL/m13800_a1-pure.cl
@@ -37,9 +37,12 @@ KERNEL_FQ KERNEL_FA void m13800_mxx (KERN_ATTR_ESALT (win8phone_t))
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -47,9 +50,22 @@ KERNEL_FQ KERNEL_FA void m13800_mxx (KERN_ATTR_ESALT (win8phone_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update_global (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, 128);
 
@@ -93,9 +109,12 @@ KERNEL_FQ KERNEL_FA void m13800_sxx (KERN_ATTR_ESALT (win8phone_t))
 
   sha256_ctx_t ctx0;
 
-  sha256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx0);
 
-  sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_utf16le_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -103,9 +122,22 @@ KERNEL_FQ KERNEL_FA void m13800_sxx (KERN_ATTR_ESALT (win8phone_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_utf16le_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_utf16le_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update_global (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, 128);
 

--- a/OpenCL/m13900_a1-pure.cl
+++ b/OpenCL/m13900_a1-pure.cl
@@ -67,9 +67,12 @@ KERNEL_FQ KERNEL_FA void m13900_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -77,9 +80,22 @@ KERNEL_FQ KERNEL_FA void m13900_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -228,9 +244,12 @@ KERNEL_FQ KERNEL_FA void m13900_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -238,9 +257,22 @@ KERNEL_FQ KERNEL_FA void m13900_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m14400_a1-pure.cl
+++ b/OpenCL/m14400_a1-pure.cl
@@ -140,9 +140,18 @@ KERNEL_FQ KERNEL_FA void m14400_mxx (KERN_ATTR_BASIC ())
 
     sha1_update_64 (&ctx1, d20, d21, d22, d23, 2);
 
-    sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     d40[0] = 0x2d2d2d2d;
     d40[1] = 0;
@@ -230,9 +239,18 @@ KERNEL_FQ KERNEL_FA void m14400_mxx (KERN_ATTR_BASIC ())
 
       sha1_update_64 (&ctx, d20, d21, d22, d23, 2);
 
-      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
 
-      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      }
+      else
+      {
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+      }
 
       d40[0] = 0x2d2d2d2d;
       d40[1] = 0;
@@ -397,9 +415,18 @@ KERNEL_FQ KERNEL_FA void m14400_sxx (KERN_ATTR_BASIC ())
 
     sha1_update_64 (&ctx1, d20, d21, d22, d23, 2);
 
-    sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     d40[0] = 0x2d2d2d2d;
     d40[1] = 0;
@@ -487,9 +514,18 @@ KERNEL_FQ KERNEL_FA void m14400_sxx (KERN_ATTR_BASIC ())
 
       sha1_update_64 (&ctx, d20, d21, d22, d23, 2);
 
-      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
 
-      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      }
+      else
+      {
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+      }
 
       d40[0] = 0x2d2d2d2d;
       d40[1] = 0;

--- a/OpenCL/m14511_a1-pure.cl
+++ b/OpenCL/m14511_a1-pure.cl
@@ -82,22 +82,25 @@ KERNEL_FQ KERNEL_FA void m14511_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (aes_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (aes_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x41000000;
+      ctx0_padding.w0[0] = 0x41000000;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    sha1_update_swap (&ctx0_padding, w, w_len);
+      sha1_update_swap (&ctx0_padding, w, w_len);
+    }
+
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -105,16 +108,36 @@ KERNEL_FQ KERNEL_FA void m14511_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    if (aes_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (aes_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      sha1_init (&ctx);
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (aes_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     sha1_final (&ctx);
 
@@ -129,9 +152,26 @@ KERNEL_FQ KERNEL_FA void m14511_mxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      sha1_ctx_t ctx0_tmp = ctx0_padding;
+      sha1_ctx_t ctx0_tmp;
 
-      sha1_update_swap (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        sha1_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x41000000;
+
+        ctx0_tmp.len = 1;
+
+        sha1_update_global_swap (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
 
       sha1_final (&ctx0_tmp);
 
@@ -282,22 +322,25 @@ KERNEL_FQ KERNEL_FA void m14511_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (aes_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (aes_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x41000000;
+      ctx0_padding.w0[0] = 0x41000000;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    sha1_update_swap (&ctx0_padding, w, w_len);
+      sha1_update_swap (&ctx0_padding, w, w_len);
+    }
+
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -305,16 +348,36 @@ KERNEL_FQ KERNEL_FA void m14511_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    if (aes_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (aes_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      sha1_init (&ctx);
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (aes_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     sha1_final (&ctx);
 
@@ -329,9 +392,26 @@ KERNEL_FQ KERNEL_FA void m14511_sxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      sha1_ctx_t ctx0_tmp = ctx0_padding;
+      sha1_ctx_t ctx0_tmp;
 
-      sha1_update_swap (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        sha1_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x41000000;
+
+        ctx0_tmp.len = 1;
+
+        sha1_update_global_swap (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
 
       sha1_final (&ctx0_tmp);
 

--- a/OpenCL/m14512_a1-pure.cl
+++ b/OpenCL/m14512_a1-pure.cl
@@ -46,22 +46,25 @@ KERNEL_FQ KERNEL_FA void m14512_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (serpent_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (serpent_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x41000000;
+      ctx0_padding.w0[0] = 0x41000000;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    sha1_update_swap (&ctx0_padding, w, w_len);
+      sha1_update_swap (&ctx0_padding, w, w_len);
+    }
+
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -69,16 +72,36 @@ KERNEL_FQ KERNEL_FA void m14512_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    if (serpent_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (serpent_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      sha1_init (&ctx);
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (serpent_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     sha1_final (&ctx);
 
@@ -93,9 +116,26 @@ KERNEL_FQ KERNEL_FA void m14512_mxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      sha1_ctx_t ctx0_tmp = ctx0_padding;
+      sha1_ctx_t ctx0_tmp;
 
-      sha1_update_swap (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        sha1_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x41000000;
+
+        ctx0_tmp.len = 1;
+
+        sha1_update_global_swap (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
 
       sha1_final (&ctx0_tmp);
 
@@ -210,22 +250,25 @@ KERNEL_FQ KERNEL_FA void m14512_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (serpent_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (serpent_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x41000000;
+      ctx0_padding.w0[0] = 0x41000000;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    sha1_update_swap (&ctx0_padding, w, w_len);
+      sha1_update_swap (&ctx0_padding, w, w_len);
+    }
+
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -233,16 +276,36 @@ KERNEL_FQ KERNEL_FA void m14512_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    if (serpent_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (serpent_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      sha1_init (&ctx);
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (serpent_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     sha1_final (&ctx);
 
@@ -257,9 +320,26 @@ KERNEL_FQ KERNEL_FA void m14512_sxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      sha1_ctx_t ctx0_tmp = ctx0_padding;
+      sha1_ctx_t ctx0_tmp;
 
-      sha1_update_swap (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        sha1_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x41000000;
+
+        ctx0_tmp.len = 1;
+
+        sha1_update_global_swap (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
 
       sha1_final (&ctx0_tmp);
 

--- a/OpenCL/m14513_a1-pure.cl
+++ b/OpenCL/m14513_a1-pure.cl
@@ -46,22 +46,25 @@ KERNEL_FQ KERNEL_FA void m14513_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (twofish_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (twofish_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x41000000;
+      ctx0_padding.w0[0] = 0x41000000;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    sha1_update_swap (&ctx0_padding, w, w_len);
+      sha1_update_swap (&ctx0_padding, w, w_len);
+    }
+
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -69,16 +72,36 @@ KERNEL_FQ KERNEL_FA void m14513_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    if (twofish_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (twofish_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      sha1_init (&ctx);
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (twofish_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     sha1_final (&ctx);
 
@@ -93,9 +116,26 @@ KERNEL_FQ KERNEL_FA void m14513_mxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      sha1_ctx_t ctx0_tmp = ctx0_padding;
+      sha1_ctx_t ctx0_tmp;
 
-      sha1_update_swap (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        sha1_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x41000000;
+
+        ctx0_tmp.len = 1;
+
+        sha1_update_global_swap (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
 
       sha1_final (&ctx0_tmp);
 
@@ -211,22 +251,25 @@ KERNEL_FQ KERNEL_FA void m14513_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (twofish_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (twofish_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x41000000;
+      ctx0_padding.w0[0] = 0x41000000;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    sha1_update_swap (&ctx0_padding, w, w_len);
+      sha1_update_swap (&ctx0_padding, w, w_len);
+    }
+
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -234,16 +277,36 @@ KERNEL_FQ KERNEL_FA void m14513_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    if (twofish_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (twofish_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      sha1_init (&ctx);
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (twofish_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     sha1_final (&ctx);
 
@@ -258,9 +321,26 @@ KERNEL_FQ KERNEL_FA void m14513_sxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      sha1_ctx_t ctx0_tmp = ctx0_padding;
+      sha1_ctx_t ctx0_tmp;
 
-      sha1_update_swap (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        sha1_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x41000000;
+
+        ctx0_tmp.len = 1;
+
+        sha1_update_global_swap (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        sha1_update_swap (&ctx0_tmp, w, w_len);
+      }
 
       sha1_final (&ctx0_tmp);
 

--- a/OpenCL/m14521_a1-pure.cl
+++ b/OpenCL/m14521_a1-pure.cl
@@ -78,7 +78,10 @@ KERNEL_FQ KERNEL_FA void m14521_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,9 +89,22 @@ KERNEL_FQ KERNEL_FA void m14521_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -245,7 +261,10 @@ KERNEL_FQ KERNEL_FA void m14521_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -253,9 +272,22 @@ KERNEL_FQ KERNEL_FA void m14521_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m14522_a1-pure.cl
+++ b/OpenCL/m14522_a1-pure.cl
@@ -42,7 +42,10 @@ KERNEL_FQ KERNEL_FA void m14522_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m14522_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -173,7 +189,10 @@ KERNEL_FQ KERNEL_FA void m14522_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -181,9 +200,22 @@ KERNEL_FQ KERNEL_FA void m14522_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m14523_a1-pure.cl
+++ b/OpenCL/m14523_a1-pure.cl
@@ -42,7 +42,10 @@ KERNEL_FQ KERNEL_FA void m14523_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m14523_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -174,7 +190,10 @@ KERNEL_FQ KERNEL_FA void m14523_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -182,9 +201,22 @@ KERNEL_FQ KERNEL_FA void m14523_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m14531_a1-pure.cl
+++ b/OpenCL/m14531_a1-pure.cl
@@ -78,7 +78,10 @@ KERNEL_FQ KERNEL_FA void m14531_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,9 +89,22 @@ KERNEL_FQ KERNEL_FA void m14531_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 
@@ -245,7 +261,10 @@ KERNEL_FQ KERNEL_FA void m14531_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -253,9 +272,22 @@ KERNEL_FQ KERNEL_FA void m14531_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 

--- a/OpenCL/m14532_a1-pure.cl
+++ b/OpenCL/m14532_a1-pure.cl
@@ -42,7 +42,10 @@ KERNEL_FQ KERNEL_FA void m14532_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m14532_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 
@@ -173,7 +189,10 @@ KERNEL_FQ KERNEL_FA void m14532_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -181,9 +200,22 @@ KERNEL_FQ KERNEL_FA void m14532_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 

--- a/OpenCL/m14533_a1-pure.cl
+++ b/OpenCL/m14533_a1-pure.cl
@@ -42,7 +42,10 @@ KERNEL_FQ KERNEL_FA void m14533_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m14533_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 
@@ -174,7 +190,10 @@ KERNEL_FQ KERNEL_FA void m14533_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -182,9 +201,22 @@ KERNEL_FQ KERNEL_FA void m14533_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx);
 

--- a/OpenCL/m14541_a1-pure.cl
+++ b/OpenCL/m14541_a1-pure.cl
@@ -82,22 +82,25 @@ KERNEL_FQ KERNEL_FA void m14541_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (aes_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (aes_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x00000041;
+      ctx0_padding.w0[0] = 0x00000041;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    ripemd160_update (&ctx0_padding, w, w_len);
+      ripemd160_update (&ctx0_padding, w, w_len);
+    }
+
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -105,16 +108,36 @@ KERNEL_FQ KERNEL_FA void m14541_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    if (aes_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (aes_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      ripemd160_init (&ctx);
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (aes_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     ripemd160_final (&ctx);
 
@@ -129,9 +152,26 @@ KERNEL_FQ KERNEL_FA void m14541_mxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = hc_swap32_S (ctx.h[4]);
 
-      ripemd160_ctx_t ctx0_tmp = ctx0_padding;
+      ripemd160_ctx_t ctx0_tmp;
 
-      ripemd160_update (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        ripemd160_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x00000041;
+
+        ctx0_tmp.len = 1;
+
+        ripemd160_update_global (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
 
       ripemd160_final (&ctx0_tmp);
 
@@ -282,22 +322,25 @@ KERNEL_FQ KERNEL_FA void m14541_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (aes_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (aes_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x00000041;
+      ctx0_padding.w0[0] = 0x00000041;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    ripemd160_update (&ctx0_padding, w, w_len);
+      ripemd160_update (&ctx0_padding, w, w_len);
+    }
+
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -305,16 +348,36 @@ KERNEL_FQ KERNEL_FA void m14541_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    if (aes_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (aes_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      ripemd160_init (&ctx);
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (aes_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     ripemd160_final (&ctx);
 
@@ -329,9 +392,26 @@ KERNEL_FQ KERNEL_FA void m14541_sxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = hc_swap32_S (ctx.h[4]);
 
-      ripemd160_ctx_t ctx0_tmp = ctx0_padding;
+      ripemd160_ctx_t ctx0_tmp;
 
-      ripemd160_update (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        ripemd160_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x00000041;
+
+        ctx0_tmp.len = 1;
+
+        ripemd160_update_global (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
 
       ripemd160_final (&ctx0_tmp);
 

--- a/OpenCL/m14542_a1-pure.cl
+++ b/OpenCL/m14542_a1-pure.cl
@@ -46,22 +46,25 @@ KERNEL_FQ KERNEL_FA void m14542_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (serpent_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (serpent_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x00000041;
+      ctx0_padding.w0[0] = 0x00000041;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    ripemd160_update (&ctx0_padding, w, w_len);
+      ripemd160_update (&ctx0_padding, w, w_len);
+    }
+
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -69,16 +72,36 @@ KERNEL_FQ KERNEL_FA void m14542_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    if (serpent_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (serpent_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      ripemd160_init (&ctx);
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (serpent_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     ripemd160_final (&ctx);
 
@@ -93,9 +116,26 @@ KERNEL_FQ KERNEL_FA void m14542_mxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      ripemd160_ctx_t ctx0_tmp = ctx0_padding;
+      ripemd160_ctx_t ctx0_tmp;
 
-      ripemd160_update (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        ripemd160_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x00000041;
+
+        ctx0_tmp.len = 1;
+
+        ripemd160_update_global (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
 
       ripemd160_final (&ctx0_tmp);
 
@@ -210,22 +250,25 @@ KERNEL_FQ KERNEL_FA void m14542_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (serpent_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (serpent_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x00000041;
+      ctx0_padding.w0[0] = 0x00000041;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    ripemd160_update (&ctx0_padding, w, w_len);
+      ripemd160_update (&ctx0_padding, w, w_len);
+    }
+
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -233,16 +276,36 @@ KERNEL_FQ KERNEL_FA void m14542_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    if (serpent_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (serpent_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      ripemd160_init (&ctx);
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (serpent_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     ripemd160_final (&ctx);
 
@@ -257,9 +320,26 @@ KERNEL_FQ KERNEL_FA void m14542_sxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      ripemd160_ctx_t ctx0_tmp = ctx0_padding;
+      ripemd160_ctx_t ctx0_tmp;
 
-      ripemd160_update (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        ripemd160_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x00000041;
+
+        ctx0_tmp.len = 1;
+
+        ripemd160_update_global (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
 
       ripemd160_final (&ctx0_tmp);
 

--- a/OpenCL/m14543_a1-pure.cl
+++ b/OpenCL/m14543_a1-pure.cl
@@ -46,22 +46,25 @@ KERNEL_FQ KERNEL_FA void m14543_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (twofish_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (twofish_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x00000041;
+      ctx0_padding.w0[0] = 0x00000041;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    ripemd160_update (&ctx0_padding, w, w_len);
+      ripemd160_update (&ctx0_padding, w, w_len);
+    }
+
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -69,16 +72,36 @@ KERNEL_FQ KERNEL_FA void m14543_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    if (twofish_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (twofish_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      ripemd160_init (&ctx);
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (twofish_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     ripemd160_final (&ctx);
 
@@ -93,9 +116,26 @@ KERNEL_FQ KERNEL_FA void m14543_mxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      ripemd160_ctx_t ctx0_tmp = ctx0_padding;
+      ripemd160_ctx_t ctx0_tmp;
 
-      ripemd160_update (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        ripemd160_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x00000041;
+
+        ctx0_tmp.len = 1;
+
+        ripemd160_update_global (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
 
       ripemd160_final (&ctx0_tmp);
 
@@ -211,22 +251,25 @@ KERNEL_FQ KERNEL_FA void m14543_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   u32 w_len = 0;
 
-  if (twofish_key_len > 128)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    w_len = pws[gid].pw_len;
+    if (twofish_key_len > 128)
+    {
+      w_len = pws[gid].pw_len;
 
-    for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
 
-    ctx0_padding = ctx0;
+      ctx0_padding = ctx0;
 
-    ctx0_padding.w0[0] = 0x00000041;
+      ctx0_padding.w0[0] = 0x00000041;
 
-    ctx0_padding.len = 1;
+      ctx0_padding.len = 1;
 
-    ripemd160_update (&ctx0_padding, w, w_len);
+      ripemd160_update (&ctx0_padding, w, w_len);
+    }
+
+    ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
   }
-
-  ripemd160_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
 
   /**
    * loop
@@ -234,16 +277,36 @@ KERNEL_FQ KERNEL_FA void m14543_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd160_ctx_t ctx = ctx0;
+    ripemd160_ctx_t ctx;
 
-    if (twofish_key_len > 128)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      w_len = combs_buf[il_pos].pw_len;
+      ctx = ctx0;
 
-      for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      if (twofish_key_len > 128)
+      {
+        w_len = combs_buf[il_pos].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = combs_buf[il_pos].i[i];
+      }
+
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
     }
+    else
+    {
+      ripemd160_init (&ctx);
 
-    ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      ripemd160_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd160_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+
+      if (twofish_key_len > 128)
+      {
+        w_len = pws[gid].pw_len;
+
+        for (u32 i = 0; i < 64; i++) w[i] = pws[gid].i[i];
+      }
+    }
 
     ripemd160_final (&ctx);
 
@@ -258,9 +321,26 @@ KERNEL_FQ KERNEL_FA void m14543_sxx (KERN_ATTR_ESALT (cryptoapi_t))
     {
       k4 = ctx.h[4];
 
-      ripemd160_ctx_t ctx0_tmp = ctx0_padding;
+      ripemd160_ctx_t ctx0_tmp;
 
-      ripemd160_update (&ctx0_tmp, w, w_len);
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        ctx0_tmp = ctx0_padding;
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
+      else
+      {
+        ripemd160_init (&ctx0_tmp);
+
+        ctx0_tmp.w0[0] = 0x00000041;
+
+        ctx0_tmp.len = 1;
+
+        ripemd160_update_global (&ctx0_tmp, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+        ripemd160_update (&ctx0_tmp, w, w_len);
+      }
 
       ripemd160_final (&ctx0_tmp);
 

--- a/OpenCL/m14551_a1-pure.cl
+++ b/OpenCL/m14551_a1-pure.cl
@@ -105,7 +105,10 @@ KERNEL_FQ KERNEL_FA void m14551_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -113,9 +116,22 @@ KERNEL_FQ KERNEL_FA void m14551_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 
@@ -299,7 +315,10 @@ KERNEL_FQ KERNEL_FA void m14551_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -307,9 +326,22 @@ KERNEL_FQ KERNEL_FA void m14551_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 

--- a/OpenCL/m14552_a1-pure.cl
+++ b/OpenCL/m14552_a1-pure.cl
@@ -87,7 +87,10 @@ KERNEL_FQ KERNEL_FA void m14552_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +98,22 @@ KERNEL_FQ KERNEL_FA void m14552_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 
@@ -263,7 +279,10 @@ KERNEL_FQ KERNEL_FA void m14552_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -271,9 +290,22 @@ KERNEL_FQ KERNEL_FA void m14552_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 

--- a/OpenCL/m14553_a1-pure.cl
+++ b/OpenCL/m14553_a1-pure.cl
@@ -87,7 +87,10 @@ KERNEL_FQ KERNEL_FA void m14553_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +98,22 @@ KERNEL_FQ KERNEL_FA void m14553_mxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 
@@ -264,7 +280,10 @@ KERNEL_FQ KERNEL_FA void m14553_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   whirlpool_init (&ctx0, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -272,9 +291,22 @@ KERNEL_FQ KERNEL_FA void m14553_sxx (KERN_ATTR_ESALT (cryptoapi_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      whirlpool_init (&ctx, s_MT0, s_MT1, s_MT2, s_MT3, s_MT4, s_MT5, s_MT6, s_MT7);
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_final (&ctx);
 

--- a/OpenCL/m15000_a1-pure.cl
+++ b/OpenCL/m15000_a1-pure.cl
@@ -42,7 +42,10 @@ KERNEL_FQ KERNEL_FA void m15000_mxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m15000_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, s, salt_len);
 
@@ -107,7 +123,10 @@ KERNEL_FQ KERNEL_FA void m15000_sxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +134,22 @@ KERNEL_FQ KERNEL_FA void m15000_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx);
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, s, salt_len);
 

--- a/OpenCL/m15500_a1-pure.cl
+++ b/OpenCL/m15500_a1-pure.cl
@@ -42,7 +42,10 @@ KERNEL_FQ KERNEL_FA void m15500_mxx (KERN_ATTR_BASIC ())
 
   sha1_init (&ctx0);
 
-  sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m15500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16be_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 
@@ -113,7 +129,10 @@ KERNEL_FQ KERNEL_FA void m15500_sxx (KERN_ATTR_BASIC ())
 
   sha1_init (&ctx0);
 
-  sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -121,9 +140,22 @@ KERNEL_FQ KERNEL_FA void m15500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16be_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s, salt_len);
 

--- a/OpenCL/m16100_a1-pure.cl
+++ b/OpenCL/m16100_a1-pure.cl
@@ -67,7 +67,10 @@ KERNEL_FQ KERNEL_FA void m16100_mxx (KERN_ATTR_ESALT (tacacs_plus_t))
 
   md5_update_64 (&ctx0, session0, session1, session2, session3, 4);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   u32 ct_buf[2];
 
@@ -84,9 +87,22 @@ KERNEL_FQ KERNEL_FA void m16100_mxx (KERN_ATTR_ESALT (tacacs_plus_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 sequence0[4];
     u32 sequence1[4];
@@ -225,7 +241,10 @@ KERNEL_FQ KERNEL_FA void m16100_sxx (KERN_ATTR_ESALT (tacacs_plus_t))
 
   md5_update_64 (&ctx0, session0, session1, session2, session3, 4);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   u32 ct_buf[2];
 
@@ -242,9 +261,22 @@ KERNEL_FQ KERNEL_FA void m16100_sxx (KERN_ATTR_ESALT (tacacs_plus_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 sequence0[4];
     u32 sequence1[4];

--- a/OpenCL/m16400_a1-pure.cl
+++ b/OpenCL/m16400_a1-pure.cl
@@ -193,7 +193,10 @@ KERNEL_FQ KERNEL_FA void m16400_mxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  cram_md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    cram_md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -201,9 +204,22 @@ KERNEL_FQ KERNEL_FA void m16400_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    cram_md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      cram_md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      cram_md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      cram_md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     cram_md5_final (&ctx);
 
@@ -247,7 +263,10 @@ KERNEL_FQ KERNEL_FA void m16400_sxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  cram_md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    cram_md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -255,9 +274,22 @@ KERNEL_FQ KERNEL_FA void m16400_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    cram_md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      cram_md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      cram_md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      cram_md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     cram_md5_final (&ctx);
 

--- a/OpenCL/m16511_a1-pure.cl
+++ b/OpenCL/m16511_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m16511_mxx (KERN_ATTR_ESALT (jwt_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha256_hmac_ctx_t ctx;
@@ -146,14 +171,39 @@ KERNEL_FQ KERNEL_FA void m16511_sxx (KERN_ATTR_ESALT (jwt_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha256_hmac_ctx_t ctx;

--- a/OpenCL/m16512_a1-pure.cl
+++ b/OpenCL/m16512_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m16512_mxx (KERN_ATTR_ESALT (jwt_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha384_hmac_ctx_t ctx;
@@ -146,14 +171,39 @@ KERNEL_FQ KERNEL_FA void m16512_sxx (KERN_ATTR_ESALT (jwt_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha384_hmac_ctx_t ctx;

--- a/OpenCL/m16513_a1-pure.cl
+++ b/OpenCL/m16513_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m16513_mxx (KERN_ATTR_ESALT (jwt_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha512_hmac_ctx_t ctx;
@@ -146,14 +171,39 @@ KERNEL_FQ KERNEL_FA void m16513_sxx (KERN_ATTR_ESALT (jwt_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha512_hmac_ctx_t ctx;

--- a/OpenCL/m16600_a1-pure.cl
+++ b/OpenCL/m16600_a1-pure.cl
@@ -94,7 +94,10 @@ KERNEL_FQ KERNEL_FA void m16600_mxx (KERN_ATTR_ESALT (electrum_wallet_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * data
@@ -122,9 +125,22 @@ KERNEL_FQ KERNEL_FA void m16600_mxx (KERN_ATTR_ESALT (electrum_wallet_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -318,7 +334,10 @@ KERNEL_FQ KERNEL_FA void m16600_sxx (KERN_ATTR_ESALT (electrum_wallet_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * data
@@ -346,9 +365,22 @@ KERNEL_FQ KERNEL_FA void m16600_sxx (KERN_ATTR_ESALT (electrum_wallet_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m17200_a1-pure.cl
+++ b/OpenCL/m17200_a1-pure.cl
@@ -524,12 +524,15 @@ KERNEL_FQ KERNEL_FA void m17200_sxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -538,12 +541,33 @@ KERNEL_FQ KERNEL_FA void m17200_sxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1 = key1init;
     u32x key2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;
@@ -754,12 +778,15 @@ KERNEL_FQ KERNEL_FA void m17200_mxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -768,12 +795,33 @@ KERNEL_FQ KERNEL_FA void m17200_mxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1 = key1init;
     u32x key2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;

--- a/OpenCL/m17210_a1-pure.cl
+++ b/OpenCL/m17210_a1-pure.cl
@@ -215,12 +215,15 @@ KERNEL_FQ KERNEL_FA void m17210_sxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -229,12 +232,33 @@ KERNEL_FQ KERNEL_FA void m17210_sxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1 = key1init;
     u32x key2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;
@@ -444,12 +468,15 @@ KERNEL_FQ KERNEL_FA void m17210_mxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -458,12 +485,33 @@ KERNEL_FQ KERNEL_FA void m17210_mxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1 = key1init;
     u32x key2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;

--- a/OpenCL/m17220_a1-pure.cl
+++ b/OpenCL/m17220_a1-pure.cl
@@ -507,12 +507,15 @@ KERNEL_FQ KERNEL_FA void m17220_sxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -521,12 +524,33 @@ KERNEL_FQ KERNEL_FA void m17220_sxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1init2 = key1init;
     u32x key2init2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;
@@ -774,12 +798,15 @@ KERNEL_FQ KERNEL_FA void m17220_mxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -788,12 +815,33 @@ KERNEL_FQ KERNEL_FA void m17220_mxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1init2 = key1init;
     u32x key2init2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;

--- a/OpenCL/m17225_a1-pure.cl
+++ b/OpenCL/m17225_a1-pure.cl
@@ -507,12 +507,15 @@ KERNEL_FQ KERNEL_FA void m17225_sxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -521,12 +524,33 @@ KERNEL_FQ KERNEL_FA void m17225_sxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1init2 = key1init;
     u32x key2init2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;
@@ -836,12 +860,15 @@ KERNEL_FQ KERNEL_FA void m17225_mxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -850,12 +877,33 @@ KERNEL_FQ KERNEL_FA void m17225_mxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1init2 = key1init;
     u32x key2init2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;

--- a/OpenCL/m17230_a1-pure.cl
+++ b/OpenCL/m17230_a1-pure.cl
@@ -200,12 +200,15 @@ KERNEL_FQ KERNEL_FA void m17230_sxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -214,12 +217,33 @@ KERNEL_FQ KERNEL_FA void m17230_sxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1init2 = key1init;
     u32x key2init2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;
@@ -372,12 +396,15 @@ KERNEL_FQ KERNEL_FA void m17230_mxx (KERN_ATTR_ESALT (pkzip_t))
   u32x key1init = 0x23456789;
   u32x key2init = 0x34567890;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
@@ -386,12 +413,33 @@ KERNEL_FQ KERNEL_FA void m17230_mxx (KERN_ATTR_ESALT (pkzip_t))
     u32x key1init2 = key1init;
     u32x key2init2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init2, key1init2, key2init2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init2, key1init2, key2init2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init2, key1init2, key2init2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init2, key1init2, key2init2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     u32 plain;

--- a/OpenCL/m18100_a1-pure.cl
+++ b/OpenCL/m18100_a1-pure.cl
@@ -109,14 +109,39 @@ KERNEL_FQ KERNEL_FA void m18100_mxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0;
@@ -142,14 +167,39 @@ KERNEL_FQ KERNEL_FA void m18100_mxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0, otp_code1;
@@ -176,14 +226,39 @@ KERNEL_FQ KERNEL_FA void m18100_mxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0, otp_code1, otp_code2;
@@ -211,14 +286,39 @@ KERNEL_FQ KERNEL_FA void m18100_mxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0, otp_code1, otp_code2, otp_code3;
@@ -299,14 +399,39 @@ KERNEL_FQ KERNEL_FA void m18100_sxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0;
@@ -332,14 +457,39 @@ KERNEL_FQ KERNEL_FA void m18100_sxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0, otp_code1;
@@ -370,14 +520,39 @@ KERNEL_FQ KERNEL_FA void m18100_sxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0, otp_code1, otp_code2;
@@ -413,14 +588,39 @@ KERNEL_FQ KERNEL_FA void m18100_sxx (KERN_ATTR_BASIC ())
         c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
       }
 
-      switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-      #ifdef _unroll
-      #pragma unroll
-      #endif
-      for (int i = 0; i < 64; i++)
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
       {
-        c[i] |= w[i];
+        switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w[i];
+        }
+      }
+      else
+      {
+        u32 w_tmp[64];
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          w_tmp[i] = w[i];
+        }
+
+        switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+        #ifdef _unroll
+        #pragma unroll
+        #endif
+        for (int i = 0; i < 64; i++)
+        {
+          c[i] |= w_tmp[i];
+        }
       }
 
       u32 otp_code0, otp_code1, otp_code2, otp_code3;

--- a/OpenCL/m18200_a1-pure.cl
+++ b/OpenCL/m18200_a1-pure.cl
@@ -290,7 +290,10 @@ KERNEL_FQ KERNEL_FA void m18200_mxx (KERN_ATTR_ESALT (krb5asrep_t))
 
   md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -298,9 +301,22 @@ KERNEL_FQ KERNEL_FA void m18200_mxx (KERN_ATTR_ESALT (krb5asrep_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 
@@ -348,7 +364,10 @@ KERNEL_FQ KERNEL_FA void m18200_sxx (KERN_ATTR_ESALT (krb5asrep_t))
 
   md4_init (&ctx0);
 
-  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -356,9 +375,22 @@ KERNEL_FQ KERNEL_FA void m18200_sxx (KERN_ATTR_ESALT (krb5asrep_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx = ctx0;
+    md4_ctx_t ctx;
 
-    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx);
 

--- a/OpenCL/m18500_a1-pure.cl
+++ b/OpenCL/m18500_a1-pure.cl
@@ -62,7 +62,10 @@ KERNEL_FQ KERNEL_FA void m18500_mxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx);
 
-  md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -70,10 +73,22 @@ KERNEL_FQ KERNEL_FA void m18500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
+    md5_ctx_t ctx0;
 
-    md5_ctx_t ctx0 = ctx;
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx;
 
-    md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx;
+
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx0);
 
@@ -189,7 +204,10 @@ KERNEL_FQ KERNEL_FA void m18500_sxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx);
 
-  md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -197,10 +215,22 @@ KERNEL_FQ KERNEL_FA void m18500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
+    md5_ctx_t ctx0;
 
-    md5_ctx_t ctx0 = ctx;
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx;
 
-    md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx;
+
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx0);
 

--- a/OpenCL/m19300_a1-pure.cl
+++ b/OpenCL/m19300_a1-pure.cl
@@ -54,7 +54,10 @@ KERNEL_FQ KERNEL_FA void m19300_mxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   sha1_update_global_swap (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -62,9 +65,22 @@ KERNEL_FQ KERNEL_FA void m19300_mxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s2, salt2_len);
 
@@ -121,7 +137,10 @@ KERNEL_FQ KERNEL_FA void m19300_sxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   sha1_update_global_swap (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -129,9 +148,22 @@ KERNEL_FQ KERNEL_FA void m19300_sxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update (&ctx, s2, salt2_len);
 

--- a/OpenCL/m19500_a1-pure.cl
+++ b/OpenCL/m19500_a1-pure.cl
@@ -98,7 +98,11 @@ KERNEL_FQ KERNEL_FA void m19500_mxx (KERN_ATTR_ESALT (devise_hash_t))
   sha1_update             (&ctx0, glue, 2);
   sha1_update             (&ctx0, s, salt_len);
   sha1_update             (&ctx0, glue, 2);
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -106,9 +110,23 @@ KERNEL_FQ KERNEL_FA void m19500_mxx (KERN_ATTR_ESALT (devise_hash_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
+
     sha1_update             (&ctx, glue, 2);
     sha1_update             (&ctx, k, site_key_len);
 
@@ -150,8 +168,18 @@ KERNEL_FQ KERNEL_FA void m19500_mxx (KERN_ATTR_ESALT (devise_hash_t))
 
       sha1_update (&ctx, s, salt_len);
       sha1_update (&ctx, glue, 2);
-      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
-      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      }
+      else
+      {
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+      }
+
       sha1_update (&ctx, glue, 2);
       sha1_update (&ctx, k, site_key_len);
 
@@ -241,7 +269,11 @@ KERNEL_FQ KERNEL_FA void m19500_sxx (KERN_ATTR_ESALT (devise_hash_t))
   sha1_update             (&ctx0, glue, 2);
   sha1_update             (&ctx0, s, salt_len);
   sha1_update             (&ctx0, glue, 2);
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -249,9 +281,23 @@ KERNEL_FQ KERNEL_FA void m19500_sxx (KERN_ATTR_ESALT (devise_hash_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
+
     sha1_update             (&ctx, glue, 2);
     sha1_update             (&ctx, k, site_key_len);
 
@@ -293,8 +339,18 @@ KERNEL_FQ KERNEL_FA void m19500_sxx (KERN_ATTR_ESALT (devise_hash_t))
 
       sha1_update (&ctx, s, salt_len);
       sha1_update (&ctx, glue, 2);
-      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
-      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+      {
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      }
+      else
+      {
+        sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+        sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+      }
+
       sha1_update (&ctx, glue, 2);
       sha1_update (&ctx, k, site_key_len);
 

--- a/OpenCL/m20500_a1-pure.cl
+++ b/OpenCL/m20500_a1-pure.cl
@@ -127,12 +127,15 @@ KERNEL_FQ KERNEL_FA void m20500_sxx (KERN_ATTR_BASIC ())
   u32x key1init = KEY1INIT;
   u32x key2init = KEY2INIT;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
@@ -141,12 +144,33 @@ KERNEL_FQ KERNEL_FA void m20500_sxx (KERN_ATTR_BASIC ())
     u32x key1 = key1init;
     u32x key2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     const u32x r0 = key0;
@@ -203,12 +227,15 @@ KERNEL_FQ KERNEL_FA void m20500_mxx (KERN_ATTR_BASIC ())
   u32x key1init = KEY1INIT;
   u32x key2init = KEY2INIT;
 
-  for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
-    if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+    {
+      if (pws[gid].pw_len >= (i + 1)) update_key012 (key0init, key1init, key2init, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 2)) update_key012 (key0init, key1init, key2init, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 3)) update_key012 (key0init, key1init, key2init, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      if (pws[gid].pw_len >= (i + 4)) update_key012 (key0init, key1init, key2init, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+    }
   }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
@@ -217,12 +244,33 @@ KERNEL_FQ KERNEL_FA void m20500_mxx (KERN_ATTR_BASIC ())
     u32x key1 = key1init;
     u32x key2 = key2init;
 
-    for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
-      if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+    }
+    else
+    {
+      for (u32 i = 0, j = 0; i < combs_buf[il_pos].pw_len; i += 4, j += 1)
+      {
+        if (combs_buf[il_pos].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+        if (combs_buf[il_pos].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (combs_buf[il_pos].i[j]), l_crc32tab);
+      }
+
+      for (u32 i = 0, j = 0; i < pws[gid].pw_len; i += 4, j += 1)
+      {
+        if (pws[gid].pw_len >= (i + 1)) update_key012 (key0, key1, key2, unpack_v8a_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 2)) update_key012 (key0, key1, key2, unpack_v8b_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 3)) update_key012 (key0, key1, key2, unpack_v8c_from_v32_S (pws[gid].i[j]), l_crc32tab);
+        if (pws[gid].pw_len >= (i + 4)) update_key012 (key0, key1, key2, unpack_v8d_from_v32_S (pws[gid].i[j]), l_crc32tab);
+      }
     }
 
     const u32x r0 = key0;

--- a/OpenCL/m20510_a1-pure.cl
+++ b/OpenCL/m20510_a1-pure.cl
@@ -415,18 +415,37 @@ KERNEL_FQ KERNEL_FA void m20510_sxx (KERN_ATTR_BASIC ())
     u32x key1 = prep1;
     u32x key2 = prep2;
 
-    for (int pos = combs_buf[il_pos].pw_len - 1; pos >= 0; pos--)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      const u32 t = hc_bfe_S (combs_buf[il_pos].i[pos / 4], (pos & 3) * 8, 8);
+      for (int pos = combs_buf[il_pos].pw_len - 1; pos >= 0; pos--)
+      {
+        const u32 t = hc_bfe_S (combs_buf[il_pos].i[pos / 4], (pos & 3) * 8, 8);
 
-      inv_update_key012 (key0, key1, key2, t, l_icrc32tab);
+        inv_update_key012 (key0, key1, key2, t, l_icrc32tab);
+      }
+
+      for (int pos = pws_pw_len - 1; pos >= 0; pos--)
+      {
+        const u32 t = hc_bfe_S (w[pos / 4], (pos & 3) * 8, 8);
+
+        inv_update_key012 (key0, key1, key2, t, l_icrc32tab);
+      }
     }
-
-    for (int pos = pws_pw_len - 1; pos >= 0; pos--)
+    else
     {
-      const u32 t = hc_bfe_S (w[pos / 4], (pos & 3) * 8, 8);
+      for (int pos = pws_pw_len - 1; pos >= 0; pos--)
+      {
+        const u32 t = hc_bfe_S (w[pos / 4], (pos & 3) * 8, 8);
 
-      inv_update_key012 (key0, key1, key2, t, l_icrc32tab);
+        inv_update_key012 (key0, key1, key2, t, l_icrc32tab);
+      }
+
+      for (int pos = combs_buf[il_pos].pw_len - 1; pos >= 0; pos--)
+      {
+        const u32 t = hc_bfe_S (combs_buf[il_pos].i[pos / 4], (pos & 3) * 8, 8);
+
+        inv_update_key012 (key0, key1, key2, t, l_icrc32tab);
+      }
     }
 
     u32 password[2];

--- a/OpenCL/m20710_a1-pure.cl
+++ b/OpenCL/m20710_a1-pure.cl
@@ -77,7 +77,10 @@ KERNEL_FQ KERNEL_FA void m20710_mxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -85,9 +88,22 @@ KERNEL_FQ KERNEL_FA void m20710_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 
@@ -199,7 +215,10 @@ KERNEL_FQ KERNEL_FA void m20710_sxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -207,9 +226,22 @@ KERNEL_FQ KERNEL_FA void m20710_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 

--- a/OpenCL/m20712_a1-pure.cl
+++ b/OpenCL/m20712_a1-pure.cl
@@ -77,7 +77,10 @@ KERNEL_FQ KERNEL_FA void m20712_mxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -85,9 +88,22 @@ KERNEL_FQ KERNEL_FA void m20712_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 
@@ -199,7 +215,10 @@ KERNEL_FQ KERNEL_FA void m20712_sxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -207,9 +226,22 @@ KERNEL_FQ KERNEL_FA void m20712_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 

--- a/OpenCL/m20720_a1-pure.cl
+++ b/OpenCL/m20720_a1-pure.cl
@@ -77,7 +77,10 @@ KERNEL_FQ KERNEL_FA void m20720_mxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -85,9 +88,22 @@ KERNEL_FQ KERNEL_FA void m20720_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 
@@ -199,7 +215,10 @@ KERNEL_FQ KERNEL_FA void m20720_sxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -207,9 +226,22 @@ KERNEL_FQ KERNEL_FA void m20720_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 

--- a/OpenCL/m20730_a1-pure.cl
+++ b/OpenCL/m20730_a1-pure.cl
@@ -77,7 +77,10 @@ KERNEL_FQ KERNEL_FA void m20730_mxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -85,9 +88,23 @@ KERNEL_FQ KERNEL_FA void m20730_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
+
     sha256_update (&ctx0, s, salt_len);
 
     sha256_final (&ctx0);
@@ -198,7 +215,10 @@ KERNEL_FQ KERNEL_FA void m20730_sxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -206,9 +226,23 @@ KERNEL_FQ KERNEL_FA void m20730_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
+
     sha256_update (&ctx0, s, salt_len);
 
     sha256_final (&ctx0);

--- a/OpenCL/m20800_a1-pure.cl
+++ b/OpenCL/m20800_a1-pure.cl
@@ -64,7 +64,10 @@ KERNEL_FQ KERNEL_FA void m20800_mxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -72,9 +75,22 @@ KERNEL_FQ KERNEL_FA void m20800_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -175,7 +191,10 @@ KERNEL_FQ KERNEL_FA void m20800_sxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -183,9 +202,22 @@ KERNEL_FQ KERNEL_FA void m20800_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m20900_a1-pure.cl
+++ b/OpenCL/m20900_a1-pure.cl
@@ -64,13 +64,16 @@ KERNEL_FQ KERNEL_FA void m20900_mxx (KERN_ATTR_BASIC ())
 
   sha1_init (&ctx00);
 
-  sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
-
   md5_ctx_t ctx11;
 
   md5_init (&ctx11);
 
-  md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+
+    md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -83,9 +86,22 @@ KERNEL_FQ KERNEL_FA void m20900_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx00;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 
@@ -95,9 +111,22 @@ KERNEL_FQ KERNEL_FA void m20900_mxx (KERN_ATTR_BASIC ())
     const u32 d0 = ctx0.h[3];
     const u32 e0 = ctx0.h[4];
 
-    md5_ctx_t ctx1 = ctx11;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx11;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx11;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -258,13 +287,16 @@ KERNEL_FQ KERNEL_FA void m20900_sxx (KERN_ATTR_BASIC ())
 
   sha1_init (&ctx00);
 
-  sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
-
   md5_ctx_t ctx11;
 
   md5_init (&ctx11);
 
-  md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+
+    md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -277,9 +309,22 @@ KERNEL_FQ KERNEL_FA void m20900_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx00;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 
@@ -289,9 +334,22 @@ KERNEL_FQ KERNEL_FA void m20900_sxx (KERN_ATTR_BASIC ())
     const u32 d0 = ctx0.h[3];
     const u32 e0 = ctx0.h[4];
 
-    md5_ctx_t ctx1 = ctx11;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx11;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx11;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m21000_a1-pure.cl
+++ b/OpenCL/m21000_a1-pure.cl
@@ -33,7 +33,10 @@ KERNEL_FQ KERNEL_FA void m21000_mxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx00);
 
-  sha512_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m21000_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx0 = ctx00;
+    sha512_ctx_t ctx0;
 
-    sha512_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha512_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx00;
+
+      sha512_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx0);
 
@@ -114,7 +130,10 @@ KERNEL_FQ KERNEL_FA void m21000_sxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx00);
 
-  sha512_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -122,9 +141,22 @@ KERNEL_FQ KERNEL_FA void m21000_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx0 = ctx00;
+    sha512_ctx_t ctx0;
 
-    sha512_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha512_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx0 = ctx00;
+
+      sha512_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx0);
 

--- a/OpenCL/m21100_a1-pure.cl
+++ b/OpenCL/m21100_a1-pure.cl
@@ -73,7 +73,10 @@ KERNEL_FQ KERNEL_FA void m21100_mxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -86,9 +89,22 @@ KERNEL_FQ KERNEL_FA void m21100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, s, salt_len);
 
@@ -200,7 +216,10 @@ KERNEL_FQ KERNEL_FA void m21100_sxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -213,9 +232,22 @@ KERNEL_FQ KERNEL_FA void m21100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, s, salt_len);
 

--- a/OpenCL/m21200_a1-pure.cl
+++ b/OpenCL/m21200_a1-pure.cl
@@ -63,7 +63,10 @@ KERNEL_FQ KERNEL_FA void m21200_mxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx11);
 
-  md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * salt
@@ -103,9 +106,22 @@ KERNEL_FQ KERNEL_FA void m21200_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx11;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx11;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -211,7 +227,10 @@ KERNEL_FQ KERNEL_FA void m21200_sxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx11);
 
-  md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx11, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * salt
@@ -251,9 +270,22 @@ KERNEL_FQ KERNEL_FA void m21200_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx11;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx11;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m21300_a1-pure.cl
+++ b/OpenCL/m21300_a1-pure.cl
@@ -66,7 +66,10 @@ KERNEL_FQ KERNEL_FA void m21300_mxx (KERN_ATTR_BASIC ())
 
   sha1_update_global (&ctx00, salt_bufs[SALT_POS_HOST].salt_buf_pc, salt_bufs[SALT_POS_HOST].salt_len_pc);
 
-  sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  }
 
   md5_ctx_t ctx11;
 
@@ -85,9 +88,24 @@ KERNEL_FQ KERNEL_FA void m21300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx00;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx0);
+
+      sha1_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf_pc, salt_bufs[SALT_POS_HOST].salt_len_pc);
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 
@@ -191,7 +209,10 @@ KERNEL_FQ KERNEL_FA void m21300_sxx (KERN_ATTR_BASIC ())
 
   sha1_update_global (&ctx00, salt_bufs[SALT_POS_HOST].salt_buf_pc, salt_bufs[SALT_POS_HOST].salt_len_pc);
 
-  sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  }
 
   md5_ctx_t ctx11;
 
@@ -210,9 +231,24 @@ KERNEL_FQ KERNEL_FA void m21300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx00;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx0);
+
+      sha1_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf_pc, salt_bufs[SALT_POS_HOST].salt_len_pc);
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 

--- a/OpenCL/m21310_a1-pure.cl
+++ b/OpenCL/m21310_a1-pure.cl
@@ -76,7 +76,10 @@ KERNEL_FQ KERNEL_FA void m21310_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   sha1_update_global (&ctx00, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
 
-  sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  }
 
   md5_ctx_t ctx11;
 
@@ -95,9 +98,24 @@ KERNEL_FQ KERNEL_FA void m21310_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx00;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx0);
+
+      sha1_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 
@@ -200,7 +218,10 @@ KERNEL_FQ KERNEL_FA void m21310_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   sha1_update_global (&ctx00, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
 
-  sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx00, pws[gid].i, pws[gid].pw_len);
+  }
 
   md5_ctx_t ctx11;
 
@@ -219,9 +240,24 @@ KERNEL_FQ KERNEL_FA void m21310_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx00;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx00;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx0);
+
+      sha1_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt2_len);
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 

--- a/OpenCL/m21400_a1-pure.cl
+++ b/OpenCL/m21400_a1-pure.cl
@@ -31,9 +31,12 @@ KERNEL_FQ KERNEL_FA void m21400_mxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx1;
 
-  sha256_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -46,9 +49,22 @@ KERNEL_FQ KERNEL_FA void m21400_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx0);
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 
@@ -116,9 +132,12 @@ KERNEL_FQ KERNEL_FA void m21400_sxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx1;
 
-  sha256_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -131,9 +150,22 @@ KERNEL_FQ KERNEL_FA void m21400_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx0);
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 

--- a/OpenCL/m21420_a1-pure.cl
+++ b/OpenCL/m21420_a1-pure.cl
@@ -46,9 +46,12 @@ KERNEL_FQ KERNEL_FA void m21420_mxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx1;
 
-  sha256_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -56,9 +59,22 @@ KERNEL_FQ KERNEL_FA void m21420_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx0);
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 
@@ -151,9 +167,12 @@ KERNEL_FQ KERNEL_FA void m21420_sxx (KERN_ATTR_BASIC ())
 
   sha256_ctx_t ctx1;
 
-  sha256_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_init (&ctx1);
 
-  sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha256_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -161,9 +180,22 @@ KERNEL_FQ KERNEL_FA void m21420_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx0 = ctx1;
+    sha256_ctx_t ctx0;
 
-    sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx0);
+
+      sha256_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx0);
 

--- a/OpenCL/m21900_a1-pure.cl
+++ b/OpenCL/m21900_a1-pure.cl
@@ -89,9 +89,12 @@ KERNEL_FQ KERNEL_FA void m21900_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -99,9 +102,22 @@ KERNEL_FQ KERNEL_FA void m21900_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, salt1_buf, salt1_len);
 
@@ -241,9 +257,12 @@ KERNEL_FQ KERNEL_FA void m21900_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -251,9 +270,22 @@ KERNEL_FQ KERNEL_FA void m21900_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx1, salt1_buf, salt1_len);
 

--- a/OpenCL/m22200_a1-pure.cl
+++ b/OpenCL/m22200_a1-pure.cl
@@ -37,7 +37,10 @@ KERNEL_FQ KERNEL_FA void m22200_mxx (KERN_ATTR_BASIC ())
 
   sha512_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -45,9 +48,22 @@ KERNEL_FQ KERNEL_FA void m22200_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, z, 1);
 
@@ -98,7 +114,10 @@ KERNEL_FQ KERNEL_FA void m22200_sxx (KERN_ATTR_BASIC ())
 
   sha512_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -106,9 +125,22 @@ KERNEL_FQ KERNEL_FA void m22200_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx = ctx0;
+    sha512_ctx_t ctx;
 
-    sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha512_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_update (&ctx, z, 1);
 

--- a/OpenCL/m22300_a1-pure.cl
+++ b/OpenCL/m22300_a1-pure.cl
@@ -44,7 +44,10 @@ KERNEL_FQ KERNEL_FA void m22300_mxx (KERN_ATTR_BASIC ())
 
   sha256_update (&ctx0, s, salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -52,9 +55,22 @@ KERNEL_FQ KERNEL_FA void m22300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update (&ctx, s, salt_len);
 
@@ -111,7 +127,10 @@ KERNEL_FQ KERNEL_FA void m22300_sxx (KERN_ATTR_BASIC ())
 
   sha256_update (&ctx0, s, salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -119,9 +138,22 @@ KERNEL_FQ KERNEL_FA void m22300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_update (&ctx, s, salt_len);
 

--- a/OpenCL/m22500_a1-pure.cl
+++ b/OpenCL/m22500_a1-pure.cl
@@ -112,9 +112,12 @@ KERNEL_FQ KERNEL_FA void m22500_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -126,9 +129,22 @@ KERNEL_FQ KERNEL_FA void m22500_mxx (KERN_ATTR_BASIC ())
      * key1 = md5 ($pass . $salt):
      */
 
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, 8);
     md5_final  (&ctx);
@@ -154,8 +170,16 @@ KERNEL_FQ KERNEL_FA void m22500_mxx (KERN_ATTR_BASIC ())
     md5_init   (&ctx);
     md5_update (&ctx, w, 16);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, 8);
     md5_final  (&ctx);
@@ -177,8 +201,16 @@ KERNEL_FQ KERNEL_FA void m22500_mxx (KERN_ATTR_BASIC ())
     md5_init   (&ctx);
     md5_update (&ctx, w, 16);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, 8);
     md5_final  (&ctx);
@@ -414,9 +446,12 @@ KERNEL_FQ KERNEL_FA void m22500_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -428,9 +463,22 @@ KERNEL_FQ KERNEL_FA void m22500_sxx (KERN_ATTR_BASIC ())
      * key1 = md5 ($pass . $salt):
      */
 
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx);
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, 8);
     md5_final  (&ctx);
@@ -456,8 +504,16 @@ KERNEL_FQ KERNEL_FA void m22500_sxx (KERN_ATTR_BASIC ())
     md5_init   (&ctx);
     md5_update (&ctx, w, 16);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, 8);
     md5_final  (&ctx);
@@ -479,8 +535,16 @@ KERNEL_FQ KERNEL_FA void m22500_sxx (KERN_ATTR_BASIC ())
     md5_init   (&ctx);
     md5_update (&ctx, w, 16);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s, 8);
     md5_final  (&ctx);

--- a/OpenCL/m22800_a1-pure.cl
+++ b/OpenCL/m22800_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m22800_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m22800_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -99,8 +115,16 @@ KERNEL_FQ KERNEL_FA void m22800_mxx (KERN_ATTR_BASIC ())
     md5_update (&ctx, s, salt_len);
 
     // Update with the password combination using global functions
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     // Update with the hexadecimal MD5 result
     u32 w0[4];
@@ -202,9 +226,12 @@ KERNEL_FQ KERNEL_FA void m22800_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -212,9 +239,22 @@ KERNEL_FQ KERNEL_FA void m22800_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -231,8 +271,16 @@ KERNEL_FQ KERNEL_FA void m22800_sxx (KERN_ATTR_BASIC ())
     md5_update (&ctx, s, salt_len);
 
     // Update with the password combination
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     // Update with the hexadecimal MD5 result
     u32 w0[4];

--- a/OpenCL/m22911_a1-pure.cl
+++ b/OpenCL/m22911_a1-pure.cl
@@ -119,9 +119,18 @@ KERNEL_FQ KERNEL_FA void m22911_mxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -162,9 +171,18 @@ KERNEL_FQ KERNEL_FA void m22911_mxx (KERN_ATTR_ESALT (pem_t))
 
     ctx.len = 16;
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, t, 8);
 
@@ -327,9 +345,18 @@ KERNEL_FQ KERNEL_FA void m22911_sxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -370,9 +397,18 @@ KERNEL_FQ KERNEL_FA void m22911_sxx (KERN_ATTR_ESALT (pem_t))
 
     ctx.len = 16;
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, t, 8);
 

--- a/OpenCL/m22921_a1-pure.cl
+++ b/OpenCL/m22921_a1-pure.cl
@@ -119,9 +119,18 @@ KERNEL_FQ KERNEL_FA void m22921_mxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -292,9 +301,18 @@ KERNEL_FQ KERNEL_FA void m22921_sxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 

--- a/OpenCL/m22931_a1-pure.cl
+++ b/OpenCL/m22931_a1-pure.cl
@@ -143,9 +143,18 @@ KERNEL_FQ KERNEL_FA void m22931_mxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -350,9 +359,18 @@ KERNEL_FQ KERNEL_FA void m22931_sxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 

--- a/OpenCL/m22941_a1-pure.cl
+++ b/OpenCL/m22941_a1-pure.cl
@@ -143,9 +143,18 @@ KERNEL_FQ KERNEL_FA void m22941_mxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -186,9 +195,18 @@ KERNEL_FQ KERNEL_FA void m22941_mxx (KERN_ATTR_ESALT (pem_t))
 
     ctx.len = 16;
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, t, 8);
 
@@ -372,9 +390,18 @@ KERNEL_FQ KERNEL_FA void m22941_sxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -415,9 +442,18 @@ KERNEL_FQ KERNEL_FA void m22941_sxx (KERN_ATTR_ESALT (pem_t))
 
     ctx.len = 16;
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, t, 8);
 

--- a/OpenCL/m22951_a1-pure.cl
+++ b/OpenCL/m22951_a1-pure.cl
@@ -143,9 +143,18 @@ KERNEL_FQ KERNEL_FA void m22951_mxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -186,9 +195,18 @@ KERNEL_FQ KERNEL_FA void m22951_mxx (KERN_ATTR_ESALT (pem_t))
 
     ctx.len = 16;
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, t, 8);
 
@@ -376,9 +394,18 @@ KERNEL_FQ KERNEL_FA void m22951_sxx (KERN_ATTR_ESALT (pem_t))
 
     md5_init (&ctx);
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     u32 t[16];
 
@@ -419,9 +446,18 @@ KERNEL_FQ KERNEL_FA void m22951_sxx (KERN_ATTR_ESALT (pem_t))
 
     ctx.len = 16;
 
-    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, t, 8);
 

--- a/OpenCL/m23001_a1-pure.cl
+++ b/OpenCL/m23001_a1-pure.cl
@@ -89,9 +89,12 @@ KERNEL_FQ KERNEL_FA void m23001_mxx (KERN_ATTR_ESALT (securezip_t))
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -99,9 +102,22 @@ KERNEL_FQ KERNEL_FA void m23001_mxx (KERN_ATTR_ESALT (securezip_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -279,9 +295,12 @@ KERNEL_FQ KERNEL_FA void m23001_sxx (KERN_ATTR_ESALT (securezip_t))
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -289,9 +308,22 @@ KERNEL_FQ KERNEL_FA void m23001_sxx (KERN_ATTR_ESALT (securezip_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m23002_a1-pure.cl
+++ b/OpenCL/m23002_a1-pure.cl
@@ -89,9 +89,12 @@ KERNEL_FQ KERNEL_FA void m23002_mxx (KERN_ATTR_ESALT (securezip_t))
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -99,9 +102,22 @@ KERNEL_FQ KERNEL_FA void m23002_mxx (KERN_ATTR_ESALT (securezip_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -332,9 +348,12 @@ KERNEL_FQ KERNEL_FA void m23002_sxx (KERN_ATTR_ESALT (securezip_t))
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -342,9 +361,22 @@ KERNEL_FQ KERNEL_FA void m23002_sxx (KERN_ATTR_ESALT (securezip_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m23003_a1-pure.cl
+++ b/OpenCL/m23003_a1-pure.cl
@@ -89,9 +89,12 @@ KERNEL_FQ KERNEL_FA void m23003_mxx (KERN_ATTR_ESALT (securezip_t))
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -99,9 +102,22 @@ KERNEL_FQ KERNEL_FA void m23003_mxx (KERN_ATTR_ESALT (securezip_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -334,9 +350,12 @@ KERNEL_FQ KERNEL_FA void m23003_sxx (KERN_ATTR_ESALT (securezip_t))
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -344,9 +363,22 @@ KERNEL_FQ KERNEL_FA void m23003_sxx (KERN_ATTR_ESALT (securezip_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m24300_a1-pure.cl
+++ b/OpenCL/m24300_a1-pure.cl
@@ -67,9 +67,12 @@ KERNEL_FQ KERNEL_FA void m24300_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -77,9 +80,22 @@ KERNEL_FQ KERNEL_FA void m24300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update_global_swap (&ctx1, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
@@ -191,9 +207,12 @@ KERNEL_FQ KERNEL_FA void m24300_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1l;
 
-  sha1_init (&ctx1l);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1l);
 
-  sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -201,9 +220,22 @@ KERNEL_FQ KERNEL_FA void m24300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx1);
+
+      sha1_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_update_global_swap (&ctx1, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 

--- a/OpenCL/m24700_a1-pure.cl
+++ b/OpenCL/m24700_a1-pure.cl
@@ -30,9 +30,12 @@ KERNEL_FQ KERNEL_FA void m24700_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -40,9 +43,22 @@ KERNEL_FQ KERNEL_FA void m24700_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -97,9 +113,12 @@ KERNEL_FQ KERNEL_FA void m24700_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -107,9 +126,22 @@ KERNEL_FQ KERNEL_FA void m24700_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m24800_a1-pure.cl
+++ b/OpenCL/m24800_a1-pure.cl
@@ -56,14 +56,39 @@ KERNEL_FQ KERNEL_FA void m24800_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 t[128] = { 0 };
@@ -149,14 +174,39 @@ KERNEL_FQ KERNEL_FA void m24800_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 t[128] = { 0 };

--- a/OpenCL/m26000_a1-pure.cl
+++ b/OpenCL/m26000_a1-pure.cl
@@ -125,14 +125,39 @@ KERNEL_FQ KERNEL_FA void m26000_mxx (KERN_ATTR_ESALT (mozilla_3des_t))
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     // my $hp = sha1 ($global_salt_bin . $word);
@@ -504,14 +529,39 @@ KERNEL_FQ KERNEL_FA void m26000_sxx (KERN_ATTR_ESALT (mozilla_3des_t))
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     // my $hp = sha1 ($global_salt_bin . $word);

--- a/OpenCL/m26300_a1-pure.cl
+++ b/OpenCL/m26300_a1-pure.cl
@@ -35,7 +35,10 @@ KERNEL_FQ KERNEL_FA void m26300_mxx (KERN_ATTR_BASIC ())
 
   sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -43,9 +46,22 @@ KERNEL_FQ KERNEL_FA void m26300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     /**
      * pepper
@@ -119,7 +135,10 @@ KERNEL_FQ KERNEL_FA void m26300_sxx (KERN_ATTR_BASIC ())
 
   sha256_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -127,9 +146,22 @@ KERNEL_FQ KERNEL_FA void m26300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     /**
      * pepper

--- a/OpenCL/m27200_a1-pure.cl
+++ b/OpenCL/m27200_a1-pure.cl
@@ -43,7 +43,10 @@ KERNEL_FQ KERNEL_FA void m27200_mxx (KERN_ATTR_BASIC ())
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
   sha1_update (&ctx0, dash, 2);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -51,9 +54,23 @@ KERNEL_FQ KERNEL_FA void m27200_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
+
     sha1_update (&ctx, dash, 2);
     sha1_final (&ctx);
 
@@ -107,7 +124,10 @@ KERNEL_FQ KERNEL_FA void m27200_sxx (KERN_ATTR_BASIC ())
   sha1_update_global_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
   sha1_update (&ctx0, dash, 2);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -115,9 +135,23 @@ KERNEL_FQ KERNEL_FA void m27200_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
+
     sha1_update (&ctx, dash, 2);
     sha1_final (&ctx);
 

--- a/OpenCL/m27900_a1-pure.cl
+++ b/OpenCL/m27900_a1-pure.cl
@@ -41,7 +41,12 @@ KERNEL_FQ KERNEL_FA void m27900_mxx (KERN_ATTR_BASIC ())
    * base
    */
 
-  u32x a_ref = crc32c_global (pws[gid].i, pws[gid].pw_len, iv);
+  u32x a_ref = 0;
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    a_ref = crc32c_global (pws[gid].i, pws[gid].pw_len, iv);
+  }
 
   /**
    * loop
@@ -49,7 +54,18 @@ KERNEL_FQ KERNEL_FA void m27900_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    u32x a = crc32c_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    u32x a;
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      a = crc32c_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    }
+    else
+    {
+      u32x a_tmp = crc32c_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, iv);
+
+      a = crc32c_global (pws[gid].i, pws[gid].pw_len, a_tmp);
+    }
 
     u32x z = 0;
 
@@ -95,7 +111,12 @@ KERNEL_FQ KERNEL_FA void m27900_sxx (KERN_ATTR_BASIC ())
    * base
    */
 
-  const u32x a_ref = crc32c_global (pws[gid].i, pws[gid].pw_len, iv);
+  u32x a_ref = 0;
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    a_ref = crc32c_global (pws[gid].i, pws[gid].pw_len, iv);
+  }
 
   /**
    * loop
@@ -103,7 +124,18 @@ KERNEL_FQ KERNEL_FA void m27900_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    u32x a = crc32c_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    u32x a;
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      a = crc32c_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref);
+    }
+    else
+    {
+      u32x a_tmp = crc32c_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, iv);
+
+      a = crc32c_global (pws[gid].i, pws[gid].pw_len, a_tmp);
+    }
 
     u32x z = 0;
 

--- a/OpenCL/m28000_a1-pure.cl
+++ b/OpenCL/m28000_a1-pure.cl
@@ -64,7 +64,12 @@ KERNEL_FQ KERNEL_FA void m28000_mxx (KERN_ATTR_ESALT (crc64_t))
    * base
    */
 
-  u64 a_ref = crc64j_global (pws[gid].i, pws[gid].pw_len, iv, s_crc64jonestab);
+  u64 a_ref = 0;
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    a_ref = crc64j_global (pws[gid].i, pws[gid].pw_len, iv, s_crc64jonestab);
+  }
 
   /**
    * loop
@@ -72,7 +77,18 @@ KERNEL_FQ KERNEL_FA void m28000_mxx (KERN_ATTR_ESALT (crc64_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    u64 a = crc64j_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref, s_crc64jonestab);
+    u64 a;
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      a = crc64j_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref, s_crc64jonestab);
+    }
+    else
+    {
+      u64 a_tmp = crc64j_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, iv, s_crc64jonestab);
+
+      a = crc64j_global (pws[gid].i, pws[gid].pw_len, a_tmp, s_crc64jonestab);
+    }
 
     const u32 r0 = l32_from_64 (a);
     const u32 r1 = h32_from_64 (a);
@@ -138,7 +154,12 @@ KERNEL_FQ KERNEL_FA void m28000_sxx (KERN_ATTR_ESALT (crc64_t))
    * base
    */
 
-  u64 a_ref = crc64j_global (pws[gid].i, pws[gid].pw_len, iv, s_crc64jonestab);
+  u64 a_ref = 0;
+
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    a_ref = crc64j_global (pws[gid].i, pws[gid].pw_len, iv, s_crc64jonestab);
+  }
 
   /**
    * loop
@@ -146,7 +167,18 @@ KERNEL_FQ KERNEL_FA void m28000_sxx (KERN_ATTR_ESALT (crc64_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    u64 a = crc64j_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref, s_crc64jonestab);
+    u64 a;
+
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      a = crc64j_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, a_ref, s_crc64jonestab);
+    }
+    else
+    {
+      u64 a_tmp = crc64j_global (combs_buf[il_pos].i, combs_buf[il_pos].pw_len, iv, s_crc64jonestab);
+
+      a = crc64j_global (pws[gid].i, pws[gid].pw_len, a_tmp, s_crc64jonestab);
+    }
 
     const u32 r0 = l32_from_64 (a);
     const u32 r1 = h32_from_64 (a);

--- a/OpenCL/m28300_a1-pure.cl
+++ b/OpenCL/m28300_a1-pure.cl
@@ -82,9 +82,12 @@ KERNEL_FQ KERNEL_FA void m28300_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -92,9 +95,22 @@ KERNEL_FQ KERNEL_FA void m28300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -240,9 +256,12 @@ KERNEL_FQ KERNEL_FA void m28300_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx0;
 
-  sha1_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx0);
 
-  sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -250,9 +269,22 @@ KERNEL_FQ KERNEL_FA void m28300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx);
+
+      sha1_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/OpenCL/m28501_a1-pure.cl
+++ b/OpenCL/m28501_a1-pure.cl
@@ -83,14 +83,39 @@ KERNEL_FQ KERNEL_FA void m28501_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);
@@ -277,14 +302,39 @@ KERNEL_FQ KERNEL_FA void m28501_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);

--- a/OpenCL/m28502_a1-pure.cl
+++ b/OpenCL/m28502_a1-pure.cl
@@ -83,14 +83,39 @@ KERNEL_FQ KERNEL_FA void m28502_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);
@@ -278,14 +303,39 @@ KERNEL_FQ KERNEL_FA void m28502_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);

--- a/OpenCL/m28505_a1-pure.cl
+++ b/OpenCL/m28505_a1-pure.cl
@@ -83,14 +83,39 @@ KERNEL_FQ KERNEL_FA void m28505_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);
@@ -301,14 +326,39 @@ KERNEL_FQ KERNEL_FA void m28505_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);

--- a/OpenCL/m28506_a1-pure.cl
+++ b/OpenCL/m28506_a1-pure.cl
@@ -83,14 +83,39 @@ KERNEL_FQ KERNEL_FA void m28506_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);
@@ -302,14 +327,39 @@ KERNEL_FQ KERNEL_FA void m28506_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 13; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 13; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     const u32 b = hc_swap32_S (c[0]);

--- a/OpenCL/m28700_a1-pure.cl
+++ b/OpenCL/m28700_a1-pure.cl
@@ -115,14 +115,39 @@ KERNEL_FQ KERNEL_FA void m28700_mxx (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 w_t[64];
@@ -376,14 +401,39 @@ KERNEL_FQ KERNEL_FA void m28700_sxx (KERN_ATTR_RULES_ESALT (aws4_sig_v4_t))
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 w_t[64];

--- a/OpenCL/m29000_a1-pure.cl
+++ b/OpenCL/m29000_a1-pure.cl
@@ -64,7 +64,10 @@ KERNEL_FQ KERNEL_FA void m29000_mxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   sha1_update(&ctx1l, colon, 1);
 
-  sha1_update_global_utf16le_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16le_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -72,9 +75,22 @@ KERNEL_FQ KERNEL_FA void m29000_mxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_utf16le_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_utf16le_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_utf16le_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16le_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 
@@ -158,7 +174,10 @@ KERNEL_FQ KERNEL_FA void m29000_sxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   sha1_update(&ctx1l, colon, 1);
 
-  sha1_update_global_utf16le_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16le_swap (&ctx1l, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -166,9 +185,22 @@ KERNEL_FQ KERNEL_FA void m29000_sxx (KERN_ATTR_ESALT (sha1_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx1 = ctx1l;
+    sha1_ctx_t ctx1;
 
-    sha1_update_global_utf16le_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_utf16le_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx1 = ctx1l;
+
+      sha1_update_global_utf16le_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16le_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m29100_a1-pure.cl
+++ b/OpenCL/m29100_a1-pure.cl
@@ -68,14 +68,39 @@ KERNEL_FQ KERNEL_FA void m29100_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx;
@@ -190,14 +215,39 @@ KERNEL_FQ KERNEL_FA void m29100_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     sha1_hmac_ctx_t ctx;

--- a/OpenCL/m29200_a1-pure.cl
+++ b/OpenCL/m29200_a1-pure.cl
@@ -63,7 +63,10 @@ KERNEL_FQ KERNEL_FA void m29200_mxx (KERN_ATTR_ESALT (radmin3_t))
 
   sha1_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].user, esalt_bufs[DIGESTS_OFFSET_HOST].user_len);
 
-  sha1_update_utf16le_swap (&ctx0, w, pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_utf16le_swap (&ctx0, w, pw_len);
+  }
 
 
   // ctx1 with main salt
@@ -139,9 +142,22 @@ KERNEL_FQ KERNEL_FA void m29200_mxx (KERN_ATTR_ESALT (radmin3_t))
   {
     // add password to the user name (and colon and first part of the password, included):
 
-    sha1_ctx_t c0 = ctx0;
+    sha1_ctx_t c0;
 
-    sha1_update_global_utf16le_swap (&c0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      c0 = ctx0;
+
+      sha1_update_global_utf16le_swap (&c0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      c0 = ctx0;
+
+      sha1_update_global_utf16le_swap (&c0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_utf16le_swap (&c0, w, pw_len);
+    }
 
     sha1_final (&c0);
 
@@ -336,7 +352,10 @@ KERNEL_FQ KERNEL_FA void m29200_sxx (KERN_ATTR_ESALT (radmin3_t))
 
   sha1_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].user, esalt_bufs[DIGESTS_OFFSET_HOST].user_len);
 
-  sha1_update_utf16le_swap (&ctx0, w, pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_utf16le_swap (&ctx0, w, pw_len);
+  }
 
 
   // ctx1 with main salt
@@ -412,9 +431,22 @@ KERNEL_FQ KERNEL_FA void m29200_sxx (KERN_ATTR_ESALT (radmin3_t))
   {
     // add password to the user name (and colon and first part of the password, included):
 
-    sha1_ctx_t c0 = ctx0;
+    sha1_ctx_t c0;
 
-    sha1_update_global_utf16le_swap (&c0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      c0 = ctx0;
+
+      sha1_update_global_utf16le_swap (&c0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      c0 = ctx0;
+
+      sha1_update_global_utf16le_swap (&c0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_utf16le_swap (&c0, w, pw_len);
+    }
 
     sha1_final (&c0);
 

--- a/OpenCL/m30420_a1-pure.cl
+++ b/OpenCL/m30420_a1-pure.cl
@@ -33,7 +33,10 @@ KERNEL_FQ KERNEL_FA void m30420_mxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m30420_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -87,7 +103,10 @@ KERNEL_FQ KERNEL_FA void m30420_sxx (KERN_ATTR_BASIC ())
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m30420_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m30500_a1-pure.cl
+++ b/OpenCL/m30500_a1-pure.cl
@@ -72,7 +72,10 @@ KERNEL_FQ KERNEL_FA void m30500_mxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m30500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -238,7 +254,10 @@ KERNEL_FQ KERNEL_FA void m30500_sxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -246,9 +265,22 @@ KERNEL_FQ KERNEL_FA void m30500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m30700_a1-pure.cl
+++ b/OpenCL/m30700_a1-pure.cl
@@ -42,7 +42,10 @@ KERNEL_FQ KERNEL_FA void m30700_mxx (KERN_ATTR_BASIC ())
   ctx0.h[6] = salt_bufs[SALT_POS_HOST].salt_buf_pc[6];
   ctx0.h[7] = salt_bufs[SALT_POS_HOST].salt_buf_pc[7];
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -50,9 +53,22 @@ KERNEL_FQ KERNEL_FA void m30700_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 
@@ -105,7 +121,10 @@ KERNEL_FQ KERNEL_FA void m30700_sxx (KERN_ATTR_BASIC ())
   ctx0.h[6] = salt_bufs[SALT_POS_HOST].salt_buf_pc[6];
   ctx0.h[7] = salt_bufs[SALT_POS_HOST].salt_buf_pc[7];
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -113,9 +132,22 @@ KERNEL_FQ KERNEL_FA void m30700_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha256_final (&ctx);
 

--- a/OpenCL/m30901_a1-pure.cl
+++ b/OpenCL/m30901_a1-pure.cl
@@ -89,14 +89,39 @@ KERNEL_FQ KERNEL_FA void m30901_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;
@@ -248,14 +273,39 @@ KERNEL_FQ KERNEL_FA void m30901_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;

--- a/OpenCL/m30902_a1-pure.cl
+++ b/OpenCL/m30902_a1-pure.cl
@@ -89,14 +89,39 @@ KERNEL_FQ KERNEL_FA void m30902_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;
@@ -254,14 +279,39 @@ KERNEL_FQ KERNEL_FA void m30902_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;

--- a/OpenCL/m30905_a1-pure.cl
+++ b/OpenCL/m30905_a1-pure.cl
@@ -89,14 +89,39 @@ KERNEL_FQ KERNEL_FA void m30905_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;
@@ -271,14 +296,39 @@ KERNEL_FQ KERNEL_FA void m30905_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;

--- a/OpenCL/m30906_a1-pure.cl
+++ b/OpenCL/m30906_a1-pure.cl
@@ -90,14 +90,39 @@ KERNEL_FQ KERNEL_FA void m30906_mxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;
@@ -278,14 +303,39 @@ KERNEL_FQ KERNEL_FA void m30906_sxx (KERN_ATTR_BASIC ())
       c[i] = combs_buf[il_pos].i[i];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (u32 i = 0; i < 16; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 64; i++)
+      {
+        w_tmp[i] = w[i];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (u32 i = 0; i < 16; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 e = 0;

--- a/OpenCL/m31000_a1-pure.cl
+++ b/OpenCL/m31000_a1-pure.cl
@@ -32,7 +32,10 @@ KERNEL_FQ KERNEL_FA void m31000_mxx (KERN_ATTR_BASIC ())
 
   blake2s_init (&ctx0);
 
-  blake2s_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2s_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -40,9 +43,22 @@ KERNEL_FQ KERNEL_FA void m31000_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2s_ctx_t ctx = ctx0;
+    blake2s_ctx_t ctx;
 
-    blake2s_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2s_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2s_init (&ctx);
+
+      blake2s_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2s_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2s_final (&ctx);
 
@@ -85,7 +101,10 @@ KERNEL_FQ KERNEL_FA void m31000_sxx (KERN_ATTR_BASIC ())
 
   blake2s_init (&ctx0);
 
-  blake2s_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2s_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -93,9 +112,22 @@ KERNEL_FQ KERNEL_FA void m31000_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2s_ctx_t ctx = ctx0;
+    blake2s_ctx_t ctx;
 
-    blake2s_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2s_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2s_init (&ctx);
+
+      blake2s_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2s_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2s_final (&ctx);
 

--- a/OpenCL/m31100_a1-pure.cl
+++ b/OpenCL/m31100_a1-pure.cl
@@ -33,7 +33,10 @@ KERNEL_FQ KERNEL_FA void m31100_mxx (KERN_ATTR_BASIC ())
 
   sm3_init (&ctx0);
 
-  sm3_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sm3_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -41,9 +44,22 @@ KERNEL_FQ KERNEL_FA void m31100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sm3_ctx_t ctx = ctx0;
+    sm3_ctx_t ctx;
 
-    sm3_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sm3_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sm3_init (&ctx);
+
+      sm3_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sm3_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sm3_final (&ctx);
 
@@ -87,7 +103,10 @@ KERNEL_FQ KERNEL_FA void m31100_sxx (KERN_ATTR_BASIC ())
 
   sm3_init (&ctx0);
 
-  sm3_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sm3_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m31100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sm3_ctx_t ctx = ctx0;
+    sm3_ctx_t ctx;
 
-    sm3_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sm3_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sm3_init (&ctx);
+
+      sm3_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sm3_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sm3_final (&ctx);
 

--- a/OpenCL/m31300_a1-pure.cl
+++ b/OpenCL/m31300_a1-pure.cl
@@ -55,7 +55,10 @@ KERNEL_FQ KERNEL_FA void m31300_mxx (KERN_ATTR_BASIC ())
 
   md4_init (&ctx0a);
 
-  md4_update_global_utf16le (&ctx0a, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_update_global_utf16le (&ctx0a, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -63,9 +66,22 @@ KERNEL_FQ KERNEL_FA void m31300_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx0 = ctx0a;
+    md4_ctx_t ctx0;
 
-    md4_update_global_utf16le (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx0a;
+
+      md4_update_global_utf16le (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx0);
+
+      md4_update_global_utf16le (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx0);
 
@@ -162,7 +178,10 @@ KERNEL_FQ KERNEL_FA void m31300_sxx (KERN_ATTR_BASIC ())
 
   md4_init (&ctx0a);
 
-  md4_update_global_utf16le (&ctx0a, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md4_update_global_utf16le (&ctx0a, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -170,9 +189,22 @@ KERNEL_FQ KERNEL_FA void m31300_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md4_ctx_t ctx0 = ctx0a;
+    md4_ctx_t ctx0;
 
-    md4_update_global_utf16le (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx0a;
+
+      md4_update_global_utf16le (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md4_init (&ctx0);
+
+      md4_update_global_utf16le (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     md4_final (&ctx0);
 

--- a/OpenCL/m31400_a1-pure.cl
+++ b/OpenCL/m31400_a1-pure.cl
@@ -141,7 +141,10 @@ KERNEL_FQ KERNEL_FA void m31400_mxx (KERN_ATTR_ESALT (scrtv2_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -149,9 +152,22 @@ KERNEL_FQ KERNEL_FA void m31400_mxx (KERN_ATTR_ESALT (scrtv2_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     wt[0] = hc_swap32_S (ctx.w0[0]);
     wt[1] = hc_swap32_S (ctx.w0[1]);
@@ -243,7 +259,10 @@ KERNEL_FQ KERNEL_FA void m31400_sxx (KERN_ATTR_ESALT (scrtv2_t))
 
   sha256_init (&ctx0);
 
-  sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha256_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -251,9 +270,22 @@ KERNEL_FQ KERNEL_FA void m31400_sxx (KERN_ATTR_ESALT (scrtv2_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha256_ctx_t ctx = ctx0;
+    sha256_ctx_t ctx;
 
-    sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha256_init (&ctx);
+
+      sha256_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha256_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     wt[0] = hc_swap32_S (ctx.w0[0]);
     wt[1] = hc_swap32_S (ctx.w0[1]);

--- a/OpenCL/m31700_a1-pure.cl
+++ b/OpenCL/m31700_a1-pure.cl
@@ -91,7 +91,10 @@ KERNEL_FQ KERNEL_FA void m31700_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -99,9 +102,22 @@ KERNEL_FQ KERNEL_FA void m31700_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -243,7 +259,10 @@ KERNEL_FQ KERNEL_FA void m31700_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -251,9 +270,22 @@ KERNEL_FQ KERNEL_FA void m31700_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m32300_a1-pure.cl
+++ b/OpenCL/m32300_a1-pure.cl
@@ -103,7 +103,10 @@ KERNEL_FQ KERNEL_FA void m32300_mxx (KERN_ATTR_ESALT (md5_triple_salt_t))
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -111,9 +114,22 @@ KERNEL_FQ KERNEL_FA void m32300_mxx (KERN_ATTR_ESALT (md5_triple_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -280,7 +296,10 @@ KERNEL_FQ KERNEL_FA void m32300_sxx (KERN_ATTR_ESALT (md5_triple_salt_t))
 
   md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -288,9 +307,22 @@ KERNEL_FQ KERNEL_FA void m32300_sxx (KERN_ATTR_ESALT (md5_triple_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m32410_a1-pure.cl
+++ b/OpenCL/m32410_a1-pure.cl
@@ -81,7 +81,10 @@ KERNEL_FQ KERNEL_FA void m32410_mxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -89,9 +92,22 @@ KERNEL_FQ KERNEL_FA void m32410_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx1 = ctx0;
+    sha512_ctx_t ctx1;
 
-    sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx1);
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx1);
 
@@ -255,7 +271,10 @@ KERNEL_FQ KERNEL_FA void m32410_sxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -263,9 +282,22 @@ KERNEL_FQ KERNEL_FA void m32410_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx1 = ctx0;
+    sha512_ctx_t ctx1;
 
-    sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx1);
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx1);
 

--- a/OpenCL/m32420_a1-pure.cl
+++ b/OpenCL/m32420_a1-pure.cl
@@ -52,7 +52,10 @@ KERNEL_FQ KERNEL_FA void m32420_mxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -60,9 +63,22 @@ KERNEL_FQ KERNEL_FA void m32420_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx1 = ctx0;
+    sha512_ctx_t ctx1;
 
-    sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx1);
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx1);
 
@@ -168,7 +184,10 @@ KERNEL_FQ KERNEL_FA void m32420_sxx (KERN_ATTR_BASIC ())
 
   sha512_init (&ctx0);
 
-  sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha512_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -176,9 +195,22 @@ KERNEL_FQ KERNEL_FA void m32420_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha512_ctx_t ctx1 = ctx0;
+    sha512_ctx_t ctx1;
 
-    sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha512_init (&ctx1);
+
+      sha512_update_global_swap (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha512_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha512_final (&ctx1);
 

--- a/OpenCL/m32600_a1-pure.cl
+++ b/OpenCL/m32600_a1-pure.cl
@@ -87,7 +87,10 @@ KERNEL_FQ KERNEL_FA void m32600_mxx (KERN_ATTR_BASIC ())
 
   whirlpool_update (&ctx0, s, salt_len);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -95,9 +98,22 @@ KERNEL_FQ KERNEL_FA void m32600_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_update (&ctx, s, salt_len);
 
@@ -197,7 +213,10 @@ KERNEL_FQ KERNEL_FA void m32600_sxx (KERN_ATTR_BASIC ())
 
   whirlpool_update (&ctx0, s, salt_len);
 
-  whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    whirlpool_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -205,9 +224,22 @@ KERNEL_FQ KERNEL_FA void m32600_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    whirlpool_ctx_t ctx = ctx0;
+    whirlpool_ctx_t ctx;
 
-    whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      whirlpool_update_global_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      whirlpool_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     whirlpool_update (&ctx, s, salt_len);
 

--- a/OpenCL/m32800_a1-pure.cl
+++ b/OpenCL/m32800_a1-pure.cl
@@ -72,7 +72,10 @@ KERNEL_FQ KERNEL_FA void m32800_mxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx);
 
-  md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m32800_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-md5_ctx_t ctx0 = ctx;
+md5_ctx_t ctx0;
 
-    md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx;
+
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx0);
+
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx0);
 
@@ -212,7 +228,10 @@ KERNEL_FQ KERNEL_FA void m32800_sxx (KERN_ATTR_BASIC ())
 
   md5_init (&ctx);
 
-  md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -220,9 +239,22 @@ KERNEL_FQ KERNEL_FA void m32800_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx0 = ctx;
+    md5_ctx_t ctx0;
 
-    md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx;
+
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx0);
+
+      md5_update_global (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx0);
 

--- a/OpenCL/m33000_a1-pure.cl
+++ b/OpenCL/m33000_a1-pure.cl
@@ -54,7 +54,10 @@ KERNEL_FQ KERNEL_FA void m33000_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -62,9 +65,22 @@ KERNEL_FQ KERNEL_FA void m33000_mxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s2, salt2_len);
 
@@ -121,7 +137,10 @@ KERNEL_FQ KERNEL_FA void m33000_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt1_len);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -129,9 +148,22 @@ KERNEL_FQ KERNEL_FA void m33000_sxx (KERN_ATTR_ESALT (md5_double_salt_t))
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx = ctx0;
+    md5_ctx_t ctx;
 
-    md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      md5_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_update (&ctx, s2, salt2_len);
 

--- a/OpenCL/m33100_a1-pure.cl
+++ b/OpenCL/m33100_a1-pure.cl
@@ -70,9 +70,12 @@ KERNEL_FQ KERNEL_FA void m33100_mxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -80,9 +83,22 @@ KERNEL_FQ KERNEL_FA void m33100_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 
@@ -198,9 +214,12 @@ KERNEL_FQ KERNEL_FA void m33100_sxx (KERN_ATTR_BASIC ())
 
   md5_ctx_t ctx0;
 
-  md5_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    md5_init (&ctx0);
 
-  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -208,9 +227,22 @@ KERNEL_FQ KERNEL_FA void m33100_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    md5_ctx_t ctx1 = ctx0;
+    md5_ctx_t ctx1;
 
-    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx1 = ctx0;
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      md5_init (&ctx1);
+
+      md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      md5_update_global (&ctx1, pws[gid].i, pws[gid].pw_len);
+    }
 
     md5_final (&ctx1);
 

--- a/OpenCL/m33300_a1-pure.cl
+++ b/OpenCL/m33300_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m33300_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     blake2s_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m33300_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     blake2s_hmac_ctx_t ctx;

--- a/OpenCL/m33600_a1-pure.cl
+++ b/OpenCL/m33600_a1-pure.cl
@@ -32,9 +32,12 @@ KERNEL_FQ KERNEL_FA void m33600_mxx (KERN_ATTR_BASIC ())
 
   ripemd320_ctx_t ctx0;
 
-  ripemd320_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    ripemd320_init (&ctx0);
 
-  ripemd320_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    ripemd320_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -42,9 +45,22 @@ KERNEL_FQ KERNEL_FA void m33600_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd320_ctx_t ctx = ctx0;
+    ripemd320_ctx_t ctx;
 
-    ripemd320_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      ripemd320_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ripemd320_init (&ctx);
+
+      ripemd320_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd320_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     ripemd320_final (&ctx);
 
@@ -86,9 +102,12 @@ KERNEL_FQ KERNEL_FA void m33600_sxx (KERN_ATTR_BASIC ())
 
   ripemd320_ctx_t ctx0;
 
-  ripemd320_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    ripemd320_init (&ctx0);
 
-  ripemd320_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    ripemd320_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -96,9 +115,22 @@ KERNEL_FQ KERNEL_FA void m33600_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    ripemd320_ctx_t ctx = ctx0;
+    ripemd320_ctx_t ctx;
 
-    ripemd320_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      ripemd320_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ripemd320_init (&ctx);
+
+      ripemd320_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      ripemd320_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     ripemd320_final (&ctx);
 

--- a/OpenCL/m33650_a1-pure.cl
+++ b/OpenCL/m33650_a1-pure.cl
@@ -65,14 +65,39 @@ KERNEL_FQ KERNEL_FA void m33650_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     ripemd320_hmac_ctx_t ctx;
@@ -155,14 +180,39 @@ KERNEL_FQ KERNEL_FA void m33650_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     ripemd320_hmac_ctx_t ctx;

--- a/OpenCL/m33660_a1-pure.cl
+++ b/OpenCL/m33660_a1-pure.cl
@@ -69,14 +69,39 @@ KERNEL_FQ KERNEL_FA void m33660_mxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     ripemd320_hmac_ctx_t ctx = ctx0;
@@ -161,14 +186,39 @@ KERNEL_FQ KERNEL_FA void m33660_sxx (KERN_ATTR_BASIC ())
       c[idx] = combs_buf[il_pos].i[idx];
     }
 
-    switch_buffer_by_offset_1x64_le_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_le_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_le_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     ripemd320_hmac_ctx_t ctx = ctx0;

--- a/OpenCL/m34200_a1-pure.cl
+++ b/OpenCL/m34200_a1-pure.cl
@@ -83,12 +83,15 @@ KERNEL_FQ KERNEL_FA void m34200_mxx (KERN_ATTR_BASIC ())
   PRIVATE_AS u8 combined_buf[256] = {0};
   PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
-  // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
-  // probably bad for performance
-  for (u32 i = 0; i < pws[gid].pw_len; i++)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    combined_buf[i] = left[i];
+    // copy left buffer
+    GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+    // probably bad for performance
+    for (u32 i = 0; i < pws[gid].pw_len; i++)
+    {
+      combined_buf[i] = left[i];
+    }
   }
 
   /**
@@ -106,11 +109,30 @@ KERNEL_FQ KERNEL_FA void m34200_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
-    for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      combined_buf[i + pws[gid].pw_len] = right[i];
+      // copy right buffer (combs after pws)
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i + pws[gid].pw_len] = right[i];
+      }
+    }
+    else
+    {
+      // copy combs first
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i] = right[i];
+      }
+
+      // copy pws after combs
+      GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+      for (u32 i = 0; i < pws[gid].pw_len; i++)
+      {
+        combined_buf[i + combs_buf[il_pos].pw_len] = left[i];
+      }
     }
 
     u64x hash = MurmurHash64A (seed, comb_ptr, pws[gid].pw_len + combs_buf[il_pos].pw_len);
@@ -141,12 +163,15 @@ KERNEL_FQ KERNEL_FA void m34200_sxx (KERN_ATTR_BASIC ())
   PRIVATE_AS u8 combined_buf[256] = {0};
   PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
-  // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
-  // probably bad for performance
-  for (u32 i = 0; i < pws[gid].pw_len; i++)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    combined_buf[i] = left[i];
+    // copy left buffer
+    GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+    // probably bad for performance
+    for (u32 i = 0; i < pws[gid].pw_len; i++)
+    {
+      combined_buf[i] = left[i];
+    }
   }
 
   /**
@@ -176,11 +201,30 @@ KERNEL_FQ KERNEL_FA void m34200_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
-    for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      combined_buf[i + pws[gid].pw_len] = right[i];
+      // copy right buffer (combs after pws)
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i + pws[gid].pw_len] = right[i];
+      }
+    }
+    else
+    {
+      // copy combs first
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i] = right[i];
+      }
+
+      // copy pws after combs
+      GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+      for (u32 i = 0; i < pws[gid].pw_len; i++)
+      {
+        combined_buf[i + combs_buf[il_pos].pw_len] = left[i];
+      }
     }
 
     u64 hash = MurmurHash64A (seed, comb_ptr, pws[gid].pw_len + combs_buf[il_pos].pw_len);

--- a/OpenCL/m34201_a1-pure.cl
+++ b/OpenCL/m34201_a1-pure.cl
@@ -83,12 +83,15 @@ KERNEL_FQ KERNEL_FA void m34201_mxx (KERN_ATTR_BASIC ())
   PRIVATE_AS u8 combined_buf[256] = {0};
   PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
-  // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
-  // probably bad for performance
-  for (u32 i = 0; i < pws[gid].pw_len; i++)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    combined_buf[i] = left[i];
+    // copy left buffer
+    GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+    // probably bad for performance
+    for (u32 i = 0; i < pws[gid].pw_len; i++)
+    {
+      combined_buf[i] = left[i];
+    }
   }
 
   /**
@@ -97,11 +100,30 @@ KERNEL_FQ KERNEL_FA void m34201_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
-    for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      combined_buf[i + pws[gid].pw_len] = right[i];
+      // copy right buffer (combs after pws)
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i + pws[gid].pw_len] = right[i];
+      }
+    }
+    else
+    {
+      // copy combs first
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i] = right[i];
+      }
+
+      // copy pws after combs
+      GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+      for (u32 i = 0; i < pws[gid].pw_len; i++)
+      {
+        combined_buf[i + combs_buf[il_pos].pw_len] = left[i];
+      }
     }
 
     u64x hash = MurmurHash64A (comb_ptr, pws[gid].pw_len + combs_buf[il_pos].pw_len);
@@ -132,12 +154,15 @@ KERNEL_FQ KERNEL_FA void m34201_sxx (KERN_ATTR_BASIC ())
   PRIVATE_AS u8 combined_buf[256] = {0};
   PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
-  // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
-  // probably bad for performance
-  for (u32 i = 0; i < pws[gid].pw_len; i++)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    combined_buf[i] = left[i];
+    // copy left buffer
+    GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+    // probably bad for performance
+    for (u32 i = 0; i < pws[gid].pw_len; i++)
+    {
+      combined_buf[i] = left[i];
+    }
   }
 
   /**
@@ -158,11 +183,30 @@ KERNEL_FQ KERNEL_FA void m34201_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
-    for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      combined_buf[i + pws[gid].pw_len] = right[i];
+      // copy right buffer (combs after pws)
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i + pws[gid].pw_len] = right[i];
+      }
+    }
+    else
+    {
+      // copy combs first
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i] = right[i];
+      }
+
+      // copy pws after combs
+      GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+      for (u32 i = 0; i < pws[gid].pw_len; i++)
+      {
+        combined_buf[i + combs_buf[il_pos].pw_len] = left[i];
+      }
     }
 
     u64 hash = MurmurHash64A (comb_ptr, pws[gid].pw_len + combs_buf[il_pos].pw_len);

--- a/OpenCL/m34211_a1-pure.cl
+++ b/OpenCL/m34211_a1-pure.cl
@@ -84,12 +84,15 @@ KERNEL_FQ KERNEL_FA void m34211_mxx (KERN_ATTR_BASIC ())
   PRIVATE_AS u8 combined_buf[256] = {0};
   PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
-  // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
-  // probably bad for performance
-  for (u32 i = 0; i < pws[gid].pw_len; i++)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    combined_buf[i] = left[i];
+    // copy left buffer
+    GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+    // probably bad for performance
+    for (u32 i = 0; i < pws[gid].pw_len; i++)
+    {
+      combined_buf[i] = left[i];
+    }
   }
 
   /**
@@ -98,11 +101,30 @@ KERNEL_FQ KERNEL_FA void m34211_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
-    for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      combined_buf[i + pws[gid].pw_len] = right[i];
+      // copy right buffer (combs after pws)
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i + pws[gid].pw_len] = right[i];
+      }
+    }
+    else
+    {
+      // copy combs first
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i] = right[i];
+      }
+
+      // copy pws after combs
+      GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+      for (u32 i = 0; i < pws[gid].pw_len; i++)
+      {
+        combined_buf[i + combs_buf[il_pos].pw_len] = left[i];
+      }
     }
 
     u32 hash = MurmurHash64A_truncated (comb_ptr, pws[gid].pw_len + combs_buf[il_pos].pw_len);
@@ -131,12 +153,15 @@ KERNEL_FQ KERNEL_FA void m34211_sxx (KERN_ATTR_BASIC ())
   PRIVATE_AS u8 combined_buf[256] = {0};
   PRIVATE_AS const u32 *comb_ptr = (PRIVATE_AS const u32 *) combined_buf;
 
-  // copy left buffer
-  GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
-  // probably bad for performance
-  for (u32 i = 0; i < pws[gid].pw_len; i++)
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
   {
-    combined_buf[i] = left[i];
+    // copy left buffer
+    GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+    // probably bad for performance
+    for (u32 i = 0; i < pws[gid].pw_len; i++)
+    {
+      combined_buf[i] = left[i];
+    }
   }
 
   /**
@@ -157,11 +182,30 @@ KERNEL_FQ KERNEL_FA void m34211_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    // copy right buffer
-    GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
-    for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      combined_buf[i + pws[gid].pw_len] = right[i];
+      // copy right buffer (combs after pws)
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i + pws[gid].pw_len] = right[i];
+      }
+    }
+    else
+    {
+      // copy combs first
+      GLOBAL_AS const u8 *right = (GLOBAL_AS const u8 *) combs_buf[il_pos].i;
+      for (u32 i = 0; i < combs_buf[il_pos].pw_len; i++)
+      {
+        combined_buf[i] = right[i];
+      }
+
+      // copy pws after combs
+      GLOBAL_AS const u8 *left = (GLOBAL_AS const u8 *) pws[gid].i;
+      for (u32 i = 0; i < pws[gid].pw_len; i++)
+      {
+        combined_buf[i + combs_buf[il_pos].pw_len] = left[i];
+      }
     }
 
     u32 hash = MurmurHash64A_truncated (comb_ptr, pws[gid].pw_len + combs_buf[il_pos].pw_len);

--- a/OpenCL/m34400_a1-pure.cl
+++ b/OpenCL/m34400_a1-pure.cl
@@ -66,9 +66,12 @@ KERNEL_FQ KERNEL_FA void m34400_mxx (KERN_ATTR_BASIC ())
 
   sha224_ctx_t ctx1;
 
-  sha224_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_init (&ctx1);
 
-  sha224_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha224_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -76,9 +79,22 @@ KERNEL_FQ KERNEL_FA void m34400_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha224_ctx_t ctx0 = ctx1;
+    sha224_ctx_t ctx0;
 
-    sha224_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha224_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha224_init (&ctx0);
+
+      sha224_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_final (&ctx0);
 
@@ -177,9 +193,12 @@ KERNEL_FQ KERNEL_FA void m34400_sxx (KERN_ATTR_BASIC ())
 
   sha224_ctx_t ctx1;
 
-  sha224_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha224_init (&ctx1);
 
-  sha224_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha224_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -187,9 +206,22 @@ KERNEL_FQ KERNEL_FA void m34400_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha224_ctx_t ctx0 = ctx1;
+    sha224_ctx_t ctx0;
 
-    sha224_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha224_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha224_init (&ctx0);
+
+      sha224_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha224_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha224_final (&ctx0);
 

--- a/OpenCL/m34500_a1-pure.cl
+++ b/OpenCL/m34500_a1-pure.cl
@@ -67,9 +67,12 @@ KERNEL_FQ KERNEL_FA void m34500_mxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1;
 
-  sha1_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1);
 
-  sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -77,9 +80,22 @@ KERNEL_FQ KERNEL_FA void m34500_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx1;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx0);
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 
@@ -175,9 +191,12 @@ KERNEL_FQ KERNEL_FA void m34500_sxx (KERN_ATTR_BASIC ())
 
   sha1_ctx_t ctx1;
 
-  sha1_init (&ctx1);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_init (&ctx1);
 
-  sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+    sha1_update_global_swap (&ctx1, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -185,9 +204,22 @@ KERNEL_FQ KERNEL_FA void m34500_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx0 = ctx1;
+    sha1_ctx_t ctx0;
 
-    sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx0 = ctx1;
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      sha1_init (&ctx0);
+
+      sha1_update_global_swap (&ctx0, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx0);
 

--- a/OpenCL/m34700_a1-pure.cl
+++ b/OpenCL/m34700_a1-pure.cl
@@ -105,14 +105,39 @@ KERNEL_FQ KERNEL_FA void m34700_mxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 ukey[8];
@@ -353,14 +378,39 @@ KERNEL_FQ KERNEL_FA void m34700_sxx (KERN_ATTR_BASIC ())
       c[idx] = hc_swap32_S (combs_buf[il_pos].i[idx]);
     }
 
-    switch_buffer_by_offset_1x64_be_S (c, pw_len);
-
-    #ifdef _unroll
-    #pragma unroll
-    #endif
-    for (int i = 0; i < 64; i++)
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
     {
-      c[i] |= w[i];
+      switch_buffer_by_offset_1x64_be_S (c, pw_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w[i];
+      }
+    }
+    else
+    {
+      u32 w_tmp[64];
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int idx = 0; idx < 64; idx++)
+      {
+        w_tmp[idx] = w[idx];
+      }
+
+      switch_buffer_by_offset_1x64_be_S (w_tmp, comb_len);
+
+      #ifdef _unroll
+      #pragma unroll
+      #endif
+      for (int i = 0; i < 64; i++)
+      {
+        c[i] |= w_tmp[i];
+      }
     }
 
     u32 ukey[8];

--- a/OpenCL/m34800_a1-pure.cl
+++ b/OpenCL/m34800_a1-pure.cl
@@ -30,9 +30,12 @@ KERNEL_FQ KERNEL_FA void m34800_mxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_256_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -40,9 +43,22 @@ KERNEL_FQ KERNEL_FA void m34800_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_256_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 
@@ -83,9 +99,12 @@ KERNEL_FQ KERNEL_FA void m34800_sxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_256_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -93,9 +112,22 @@ KERNEL_FQ KERNEL_FA void m34800_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_256_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 

--- a/OpenCL/m34810_a1-pure.cl
+++ b/OpenCL/m34810_a1-pure.cl
@@ -39,9 +39,12 @@ KERNEL_FQ KERNEL_FA void m34810_mxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_256_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -49,9 +52,22 @@ KERNEL_FQ KERNEL_FA void m34810_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_256_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_update (&ctx, s, salt_len);
 
@@ -102,9 +118,12 @@ KERNEL_FQ KERNEL_FA void m34810_sxx (KERN_ATTR_BASIC ())
 
   blake2b_ctx_t ctx0;
 
-  blake2b_256_init (&ctx0);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_256_init (&ctx0);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -112,9 +131,22 @@ KERNEL_FQ KERNEL_FA void m34810_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      blake2b_256_init (&ctx);
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_update (&ctx, s, salt_len);
 

--- a/OpenCL/m34820_a1-pure.cl
+++ b/OpenCL/m34820_a1-pure.cl
@@ -34,7 +34,10 @@ KERNEL_FQ KERNEL_FA void m34820_mxx (KERN_ATTR_BASIC ())
 
   blake2b_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -42,9 +45,22 @@ KERNEL_FQ KERNEL_FA void m34820_mxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 
@@ -89,7 +105,10 @@ KERNEL_FQ KERNEL_FA void m34820_sxx (KERN_ATTR_BASIC ())
 
   blake2b_update_global (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
 
-  blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    blake2b_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   /**
    * loop
@@ -97,9 +116,22 @@ KERNEL_FQ KERNEL_FA void m34820_sxx (KERN_ATTR_BASIC ())
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    blake2b_ctx_t ctx = ctx0;
+    blake2b_ctx_t ctx;
 
-    blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      blake2b_update_global (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      blake2b_update_global (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     blake2b_final (&ctx);
 

--- a/OpenCL/m35200_a1-pure.cl
+++ b/OpenCL/m35200_a1-pure.cl
@@ -29,13 +29,29 @@ KERNEL_FQ KERNEL_FA void m35200_mxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_utf16be_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf_pc, salt_bufs[SALT_POS_HOST].salt_len_pc);
 
-  sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16be_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 
@@ -69,13 +85,29 @@ KERNEL_FQ KERNEL_FA void m35200_sxx (KERN_ATTR_BASIC ())
 
   sha1_update_global_utf16be_swap (&ctx0, salt_bufs[SALT_POS_HOST].salt_buf_pc, salt_bufs[SALT_POS_HOST].salt_len_pc);
 
-  sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+  {
+    sha1_update_global_utf16be_swap (&ctx0, pws[gid].i, pws[gid].pw_len);
+  }
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
-    sha1_ctx_t ctx = ctx0;
+    sha1_ctx_t ctx;
 
-    sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    if (COMBS_MODE == COMBINATOR_MODE_BASE_LEFT)
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+    }
+    else
+    {
+      ctx = ctx0;
+
+      sha1_update_global_utf16be_swap (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+      sha1_update_global_utf16be_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+    }
 
     sha1_final (&ctx);
 

--- a/include/types.h
+++ b/include/types.h
@@ -2728,6 +2728,8 @@ typedef struct combinator_ctx
   u32 combs_mode;
   u64 combs_cnt;
 
+  bool hybrid2_wordlist_base;
+
 } combinator_ctx_t;
 
 typedef struct mask_ctx

--- a/src/backend.c
+++ b/src/backend.c
@@ -3819,7 +3819,102 @@ int run_copy (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const
     }
     else if (user_options_extra->attack_kern == ATTACK_KERN_COMBI)
     {
-      if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+      if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
+      {
+        if (combinator_ctx->hybrid2_wordlist_base == true)
+        {
+
+          if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+          {
+            if (combinator_ctx->combs_mode == COMBINATOR_MODE_BASE_RIGHT)
+            {
+              if (hashconfig->opts_type & OPTS_TYPE_PT_ADD01)
+              {
+                rebuild_pws_compressed_append (device_param, pws_cnt, 0x01);
+              }
+              else if (hashconfig->opts_type & OPTS_TYPE_PT_ADD06)
+              {
+                rebuild_pws_compressed_append (device_param, pws_cnt, 0x06);
+              }
+              else if (hashconfig->opts_type & OPTS_TYPE_PT_ADD80)
+              {
+                rebuild_pws_compressed_append (device_param, pws_cnt, 0x80);
+              }
+            }
+          }
+
+          if (device_param->is_cuda == true)
+          {
+            if (hc_cuMemcpyHtoD (hashcat_ctx, device_param->cuda_d_pws_idx, device_param->pws_idx, pws_cnt * sizeof (pw_idx_t)) == -1) return -1;
+
+            const pw_idx_t *pw_idx = device_param->pws_idx + pws_cnt;
+
+            const u32 off = pw_idx->off;
+
+            if (off)
+            {
+              if (hc_cuMemcpyHtoD (hashcat_ctx, device_param->cuda_d_pws_comp_buf, device_param->pws_comp, off * sizeof (u32)) == -1) return -1;
+            }
+          }
+
+          if (device_param->is_hip == true)
+          {
+            if (hc_hipMemcpyHtoD (hashcat_ctx, device_param->hip_d_pws_idx, device_param->pws_idx, pws_cnt * sizeof (pw_idx_t)) == -1) return -1;
+
+            const pw_idx_t *pw_idx = device_param->pws_idx + pws_cnt;
+
+            const u32 off = pw_idx->off;
+
+            if (off)
+            {
+              if (hc_hipMemcpyHtoD (hashcat_ctx, device_param->hip_d_pws_comp_buf, device_param->pws_comp, off * sizeof (u32)) == -1) return -1;
+            }
+          }
+
+          #if defined (__APPLE__)
+          if (device_param->is_metal == true)
+          {
+            if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_device, device_param->metal_command_queue, device_param->metal_d_pws_idx, 0, device_param->pws_idx, pws_cnt * sizeof (pw_idx_t)) == -1) return -1;
+
+            const pw_idx_t *pw_idx = device_param->pws_idx + pws_cnt;
+
+            const u32 off = pw_idx->off;
+
+            if (off)
+            {
+              if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_device, device_param->metal_command_queue, device_param->metal_d_pws_comp_buf, 0, device_param->pws_comp, off * sizeof (u32)) == -1) return -1;
+            }
+          }
+          #endif
+
+          if (device_param->is_opencl == true)
+          {
+            if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_pws_idx, CL_TRUE, 0, pws_cnt * sizeof (pw_idx_t), device_param->pws_idx, 0, NULL, NULL) == -1) return -1;
+
+            const pw_idx_t *pw_idx = device_param->pws_idx + pws_cnt;
+
+            const u32 off = pw_idx->off;
+
+            if (off)
+            {
+              if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_pws_comp_buf, CL_TRUE, 0, off * sizeof (u32), device_param->pws_comp, 0, NULL, NULL) == -1) return -1;
+            }
+          }
+
+          if (run_kernel_decompress (hashcat_ctx, device_param, pws_cnt) == -1) return -1;
+        }
+        else
+        {
+          // mask as base: generate mask candidates on GPU
+
+          const u64 off = device_param->words_off;
+
+          device_param->kernel_params_mp_buf64[3] = off;
+
+          if (run_kernel_mp (hashcat_ctx, device_param, KERN_RUN_MP, pws_cnt) == -1) return -1;
+        }
+      }
+      else if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
       {
         if (user_options->attack_mode == ATTACK_MODE_COMBI)
         {
@@ -3837,21 +3932,6 @@ int run_copy (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const
             {
               rebuild_pws_compressed_append (device_param, pws_cnt, 0x80);
             }
-          }
-        }
-        else if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
-        {
-          if (hashconfig->opts_type & OPTS_TYPE_PT_ADD01)
-          {
-            rebuild_pws_compressed_append (device_param, pws_cnt, 0x01);
-          }
-          else if (hashconfig->opts_type & OPTS_TYPE_PT_ADD06)
-          {
-            rebuild_pws_compressed_append (device_param, pws_cnt, 0x06);
-          }
-          else if (hashconfig->opts_type & OPTS_TYPE_PT_ADD80)
-          {
-            rebuild_pws_compressed_append (device_param, pws_cnt, 0x80);
           }
         }
 
@@ -4041,14 +4121,6 @@ int run_copy (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const
 
           if (run_kernel_decompress (hashcat_ctx, device_param, pws_cnt) == -1) return -1;
         }
-        else if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
-        {
-          const u64 off = device_param->words_off;
-
-          device_param->kernel_params_mp_buf64[3] = off;
-
-          if (run_kernel_mp (hashcat_ctx, device_param, KERN_RUN_MP, pws_cnt) == -1) return -1;
-        }
       }
     }
     else if (user_options_extra->attack_kern == ATTACK_KERN_BF)
@@ -4179,7 +4251,7 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
     }
     else
     {
-      if ((user_options->attack_mode == ATTACK_MODE_COMBI) || (((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0) && (user_options->attack_mode == ATTACK_MODE_HYBRID2)))
+      if ((user_options->attack_mode == ATTACK_MODE_COMBI) || ((combinator_ctx->hybrid2_wordlist_base == false) && (user_options->attack_mode == ATTACK_MODE_HYBRID2)))
       {
         hc_rewind (combs_fp);
       }
@@ -4293,7 +4365,7 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
         {
           if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
           {
-            if (user_options->attack_mode == ATTACK_MODE_COMBI)
+            if ((user_options->attack_mode == ATTACK_MODE_COMBI) || ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && (combinator_ctx->hybrid2_wordlist_base == false)))
             {
               char *line_buf = device_param->scratch_buf;
 
@@ -4451,7 +4523,7 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
                 if (hc_clEnqueueCopyBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_combs, device_param->opencl_d_combs_c, 0, 0, innerloop_left * sizeof (pw_t), 0, NULL, NULL) == -1) return -1;
               }
             }
-            else if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
+            else if ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && (combinator_ctx->hybrid2_wordlist_base == true))
             {
               u64 off = innerloop_pos;
 
@@ -4484,7 +4556,7 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
           }
           else
           {
-            if ((user_options->attack_mode == ATTACK_MODE_COMBI) || (user_options->attack_mode == ATTACK_MODE_HYBRID2))
+            if ((user_options->attack_mode == ATTACK_MODE_COMBI) || ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && (combinator_ctx->hybrid2_wordlist_base == false)))
             {
               char *line_buf = device_param->scratch_buf;
 
@@ -4615,6 +4687,36 @@ int run_cracker (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, co
               }
             }
             else if (user_options->attack_mode == ATTACK_MODE_HYBRID1)
+            {
+              u64 off = innerloop_pos;
+
+              device_param->kernel_params_mp_buf64[3] = off;
+
+              if (run_kernel_mp (hashcat_ctx, device_param, KERN_RUN_MP, innerloop_left) == -1) return -1;
+
+              if (device_param->is_cuda == true)
+              {
+                if (hc_cuMemcpyDtoD (hashcat_ctx, device_param->cuda_d_combs_c, device_param->cuda_d_combs, innerloop_left * sizeof (pw_t)) == -1) return -1;
+              }
+
+              if (device_param->is_hip == true)
+              {
+                if (hc_hipMemcpyDtoD (hashcat_ctx, device_param->hip_d_combs_c, device_param->hip_d_combs, innerloop_left * sizeof (pw_t)) == -1) return -1;
+              }
+
+              #if defined (__APPLE__)
+              if (device_param->is_metal == true)
+              {
+                if (hc_mtlMemcpyDtoD (hashcat_ctx, device_param->metal_command_queue, device_param->metal_d_combs_c, 0, device_param->metal_d_combs, 0, innerloop_left * sizeof (pw_t)) == -1) return -1;
+              }
+              #endif
+
+              if (device_param->is_opencl == true)
+              {
+                if (hc_clEnqueueCopyBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_combs, device_param->opencl_d_combs_c, 0, 0, innerloop_left * sizeof (pw_t), 0, NULL, NULL) == -1) return -1;
+              }
+            }
+            else if ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && (combinator_ctx->hybrid2_wordlist_base == true))
             {
               u64 off = innerloop_pos;
 
@@ -17406,6 +17508,76 @@ int backend_session_update_combinator (hashcat_ctx_t *hashcat_ctx)
           const int rc_clSetKernelArg = hc_clSetKernelArg (hashcat_ctx, device_param->opencl_kernel_amp, 5, sizeof (cl_uint), device_param->kernel_params_amp[5]);
 
           if (rc_clSetKernelArg == -1) return -1;
+        }
+      }
+
+      // kernel_params_mp[0] for HYBRID2 dynamic base selection
+
+      if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
+      {
+        if (combinator_ctx->hybrid2_wordlist_base == true)
+        {
+          // Mask is the modifier: MP kernel generates into d_combs
+
+          if (device_param->is_cuda == true)
+          {
+            device_param->kernel_params_mp[0] = &device_param->cuda_d_combs;
+          }
+
+          if (device_param->is_hip == true)
+          {
+            device_param->kernel_params_mp[0] = &device_param->hip_d_combs;
+          }
+
+          #if defined (__APPLE__)
+          if (device_param->is_metal == true)
+          {
+            device_param->kernel_params_mp[0] = device_param->metal_d_combs.buf_ptr;
+          }
+          #endif
+
+          if (device_param->is_opencl == true)
+          {
+            device_param->kernel_params_mp[0] = &device_param->opencl_d_combs;
+
+            if (hc_clSetKernelArg (hashcat_ctx, device_param->opencl_kernel_mp, 0, sizeof (cl_mem), device_param->kernel_params_mp[0]) == -1) return -1;
+          }
+        }
+        else
+        {
+          // Mask is the base: MP kernel generates into d_pws_buf (or d_pws_amp_buf)
+
+          if (device_param->is_cuda == true)
+          {
+            device_param->kernel_params_mp[0] = (hashconfig->attack_exec == ATTACK_EXEC_INSIDE_KERNEL)
+                                              ? &device_param->cuda_d_pws_buf
+                                              : &device_param->cuda_d_pws_amp_buf;
+          }
+
+          if (device_param->is_hip == true)
+          {
+            device_param->kernel_params_mp[0] = (hashconfig->attack_exec == ATTACK_EXEC_INSIDE_KERNEL)
+                                              ? &device_param->hip_d_pws_buf
+                                              : &device_param->hip_d_pws_amp_buf;
+          }
+
+          #if defined (__APPLE__)
+          if (device_param->is_metal == true)
+          {
+            device_param->kernel_params_mp[0] = (hashconfig->attack_exec == ATTACK_EXEC_INSIDE_KERNEL)
+                                              ? device_param->metal_d_pws_buf.buf_ptr
+                                              : device_param->metal_d_pws_amp_buf.buf_ptr;
+          }
+          #endif
+
+          if (device_param->is_opencl == true)
+          {
+            device_param->kernel_params_mp[0] = (hashconfig->attack_exec == ATTACK_EXEC_INSIDE_KERNEL)
+                                              ? &device_param->opencl_d_pws_buf
+                                              : &device_param->opencl_d_pws_amp_buf;
+
+            if (hc_clSetKernelArg (hashcat_ctx, device_param->opencl_kernel_mp, 0, sizeof (cl_mem), device_param->kernel_params_mp[0]) == -1) return -1;
+          }
         }
       }
     }

--- a/src/combinator.c
+++ b/src/combinator.c
@@ -298,13 +298,56 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
       }
       else if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
       {
-        combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_RIGHT;
+        mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+
+        char *dictfile = user_options_extra->hc_workv[1];
+
+        // at this point we know the file actually exist
+
+        if (hc_path_is_file (dictfile) == false)
+        {
+          event_log_error (hashcat_ctx, "%s: Not a regular file.", dictfile);
+
+          return -1;
+        }
+
+        HCFILE fp;
+
+        if (hc_fopen (&fp, dictfile, "rb") == false)
+        {
+          event_log_error (hashcat_ctx, "%s: %s", dictfile, strerror (errno));
+
+          return -1;
+        }
+
+        mask_ctx->bfs_cnt = 1;
+
+        u64 words_cnt = 0;
+
+        const int rc = count_words (hashcat_ctx, &fp, dictfile, &words_cnt);
+
+        hc_fclose (&fp);
+
+        if (rc == -1)
+        {
+          event_log_error (hashcat_ctx, "Integer overflow detected in keyspace of wordlist: %s", dictfile);
+
+          return -1;
+        }
+
+        if (rc == -2)
+        {
+          event_log_error (hashcat_ctx, "Error reading wordlist: %s", dictfile);
+
+          return -1;
+        }
+
+        combinator_ctx->combs_cnt  = words_cnt;
+        combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_LEFT;
       }
     }
     else
     {
-      // this is always need to be COMBINATOR_MODE_BASE_LEFT
-
       if (user_options->attack_mode == ATTACK_MODE_COMBI)
       {
         // display
@@ -417,8 +460,28 @@ int combinator_ctx_init (hashcat_ctx_t *hashcat_ctx)
         combinator_ctx->dict1 = dictfile1;
         combinator_ctx->dict2 = dictfile2;
 
-        combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_LEFT;
-        combinator_ctx->combs_cnt  = words2_cnt;
+        if (words1_cnt >= words2_cnt)
+        {
+          combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_LEFT;
+          combinator_ctx->combs_cnt  = words2_cnt;
+        }
+        else
+        {
+          combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_RIGHT;
+          combinator_ctx->combs_cnt  = words1_cnt;
+
+          // we also have to switch wordlist related rules!
+
+          const char *tmpc = user_options->rule_buf_l;
+
+          user_options->rule_buf_l = user_options->rule_buf_r;
+          user_options->rule_buf_r = tmpc;
+
+          u32 tmpi = user_options_extra->rule_len_l;
+
+          user_options_extra->rule_len_l = user_options_extra->rule_len_r;
+          user_options_extra->rule_len_r = tmpi;
+        }
       }
       else if (user_options->attack_mode == ATTACK_MODE_HYBRID1)
       {

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -1306,9 +1306,9 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
   }
   else
   {
-    if ((attack_mode == ATTACK_MODE_BF) || (((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0) && (attack_mode == ATTACK_MODE_HYBRID2)))
+    if ((attack_mode == ATTACK_MODE_BF) || ((combinator_ctx->hybrid2_wordlist_base == false) && (attack_mode == ATTACK_MODE_HYBRID2)))
     {
-      if (((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0) && (attack_mode == ATTACK_MODE_HYBRID2))
+      if ((combinator_ctx->hybrid2_wordlist_base == false) && (attack_mode == ATTACK_MODE_HYBRID2))
       {
         char *dictfile = straight_ctx->dict;
 

--- a/src/hashcat.c
+++ b/src/hashcat.c
@@ -60,9 +60,11 @@
 
 static int inner2_loop (hashcat_ctx_t *hashcat_ctx)
 {
+  combinator_ctx_t     *combinator_ctx      = hashcat_ctx->combinator_ctx;
   hashes_t             *hashes              = hashcat_ctx->hashes;
   induct_ctx_t         *induct_ctx          = hashcat_ctx->induct_ctx;
   logfile_ctx_t        *logfile_ctx         = hashcat_ctx->logfile_ctx;
+  mask_ctx_t           *mask_ctx            = hashcat_ctx->mask_ctx;
   backend_ctx_t        *backend_ctx         = hashcat_ctx->backend_ctx;
   restore_ctx_t        *restore_ctx         = hashcat_ctx->restore_ctx;
   status_ctx_t         *status_ctx          = hashcat_ctx->status_ctx;
@@ -125,6 +127,29 @@ static int inner2_loop (hashcat_ctx_t *hashcat_ctx)
    */
 
   if (straight_ctx_update_loop (hashcat_ctx) == -1) return 0;
+
+  // dynamic base/mod selection for hybrid2
+
+  if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
+  {
+    const u64 mask_ks  = mask_ctx->bfs_cnt;
+    const u64 dict_cnt = combinator_ctx->combs_cnt;
+    const u64 hw_power = backend_ctx->hardware_power_all;
+
+    if (mask_ks < hw_power)
+    {
+      combinator_ctx->hybrid2_wordlist_base = true;
+      combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_RIGHT;
+      combinator_ctx->combs_cnt  = mask_ks;
+    }
+    else
+    {
+      combinator_ctx->hybrid2_wordlist_base = false;
+      combinator_ctx->combs_mode = COMBINATOR_MODE_BASE_LEFT;
+    }
+
+    if (backend_session_update_combinator (hashcat_ctx) == -1) return -1;
+  }
 
   // words base
 

--- a/src/mpsp.c
+++ b/src/mpsp.c
@@ -1345,7 +1345,7 @@ int mask_ctx_update_loop (hashcat_ctx_t *hashcat_ctx)
     }
     else if ((user_options->attack_mode == ATTACK_MODE_HYBRID1) || (user_options->attack_mode == ATTACK_MODE_HYBRID2))
     {
-      if (((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0) && (user_options->attack_mode == ATTACK_MODE_HYBRID2))
+      if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
       {
         mask_ctx->mask = mask_ctx->masks[mask_ctx->masks_pos];
 

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -258,7 +258,7 @@ int build_plain (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pl
     }
     else if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
     {
-      if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+      if (combinator_ctx->hybrid2_wordlist_base == true)
       {
         pw_t pw;
 

--- a/src/status.c
+++ b/src/status.c
@@ -490,7 +490,6 @@ int status_get_guess_mode (const hashcat_ctx_t *hashcat_ctx)
 
 char *status_get_guess_base (const hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t         *hashconfig         = hashcat_ctx->hashconfig;
   const user_options_t       *user_options       = hashcat_ctx->user_options;
   const user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
 
@@ -531,16 +530,18 @@ char *status_get_guess_base (const hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
   {
-    if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-    {
-      const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+    const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      return strdup (mask_ctx->mask);
+    if (combinator_ctx->hybrid2_wordlist_base == true)
+    {
+      const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+
+      return strdup (straight_ctx->dict);
     }
 
-    const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+    const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
 
-    return strdup (straight_ctx->dict);
+    return strdup (mask_ctx->mask);
   }
 
   if (user_options->attack_mode == ATTACK_MODE_GENERIC)
@@ -553,7 +554,6 @@ char *status_get_guess_base (const hashcat_ctx_t *hashcat_ctx)
 
 int status_get_guess_base_offset (const hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const user_options_t *user_options = hashcat_ctx->user_options;
 
   if ((user_options->attack_mode == ATTACK_MODE_STRAIGHT) || (user_options->attack_mode == ATTACK_MODE_ASSOCIATION))
@@ -584,16 +584,18 @@ int status_get_guess_base_offset (const hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
   {
-    if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-    {
-      const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+    const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      return mask_ctx->masks_pos + 1;
+    if (combinator_ctx->hybrid2_wordlist_base == true)
+    {
+      const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+
+      return straight_ctx->dicts_pos + 1;
     }
 
-    const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+    const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
 
-    return straight_ctx->dicts_pos + 1;
+    return mask_ctx->masks_pos + 1;
   }
 
   if (user_options->attack_mode == ATTACK_MODE_GENERIC)
@@ -606,7 +608,6 @@ int status_get_guess_base_offset (const hashcat_ctx_t *hashcat_ctx)
 
 int status_get_guess_base_count (const hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const user_options_t *user_options = hashcat_ctx->user_options;
 
   if ((user_options->attack_mode == ATTACK_MODE_STRAIGHT) || (user_options->attack_mode == ATTACK_MODE_ASSOCIATION))
@@ -637,16 +638,18 @@ int status_get_guess_base_count (const hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
   {
-    if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-    {
-      const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+    const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      return mask_ctx->masks_cnt;
+    if (combinator_ctx->hybrid2_wordlist_base == true)
+    {
+      const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+
+      return straight_ctx->dicts_cnt;
     }
 
-    const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+    const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
 
-    return straight_ctx->dicts_cnt;
+    return mask_ctx->masks_cnt;
   }
 
   if (user_options->attack_mode == ATTACK_MODE_GENERIC)
@@ -669,7 +672,6 @@ double status_get_guess_base_percent (const hashcat_ctx_t *hashcat_ctx)
 
 char *status_get_guess_mod (const hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const user_options_t *user_options = hashcat_ctx->user_options;
 
   if ((user_options->attack_mode == ATTACK_MODE_STRAIGHT) || (user_options->attack_mode == ATTACK_MODE_GENERIC) || (user_options->attack_mode == ATTACK_MODE_ASSOCIATION))
@@ -702,16 +704,18 @@ char *status_get_guess_mod (const hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
   {
-    if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-    {
-      const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+    const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      return strdup (straight_ctx->dict);
+    if (combinator_ctx->hybrid2_wordlist_base == true)
+    {
+      const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+
+      return strdup (mask_ctx->mask);
     }
 
-    const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+    const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
 
-    return strdup (mask_ctx->mask);
+    return strdup (straight_ctx->dict);
   }
 
   return NULL;
@@ -719,7 +723,6 @@ char *status_get_guess_mod (const hashcat_ctx_t *hashcat_ctx)
 
 int status_get_guess_mod_offset (const hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const user_options_t *user_options = hashcat_ctx->user_options;
 
   if ((user_options->attack_mode == ATTACK_MODE_STRAIGHT) || (user_options->attack_mode == ATTACK_MODE_GENERIC) || (user_options->attack_mode == ATTACK_MODE_ASSOCIATION))
@@ -746,16 +749,18 @@ int status_get_guess_mod_offset (const hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
   {
-    if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-    {
-      const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+    const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      return straight_ctx->dicts_pos + 1;
+    if (combinator_ctx->hybrid2_wordlist_base == true)
+    {
+      const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+
+      return mask_ctx->masks_pos + 1;
     }
 
-    const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+    const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
 
-    return mask_ctx->masks_pos + 1;
+    return straight_ctx->dicts_pos + 1;
   }
 
   return 0;
@@ -763,7 +768,6 @@ int status_get_guess_mod_offset (const hashcat_ctx_t *hashcat_ctx)
 
 int status_get_guess_mod_count (const hashcat_ctx_t *hashcat_ctx)
 {
-  const hashconfig_t   *hashconfig   = hashcat_ctx->hashconfig;
   const user_options_t *user_options = hashcat_ctx->user_options;
 
   if ((user_options->attack_mode == ATTACK_MODE_STRAIGHT) || (user_options->attack_mode == ATTACK_MODE_GENERIC) || (user_options->attack_mode == ATTACK_MODE_ASSOCIATION))
@@ -790,16 +794,18 @@ int status_get_guess_mod_count (const hashcat_ctx_t *hashcat_ctx)
 
   if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
   {
-    if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-    {
-      const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
+    const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      return straight_ctx->dicts_cnt;
+    if (combinator_ctx->hybrid2_wordlist_base == true)
+    {
+      const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+
+      return mask_ctx->masks_cnt;
     }
 
-    const mask_ctx_t *mask_ctx = hashcat_ctx->mask_ctx;
+    const straight_ctx_t *straight_ctx = hashcat_ctx->straight_ctx;
 
-    return mask_ctx->masks_cnt;
+    return straight_ctx->dicts_cnt;
   }
 
   return 0;

--- a/src/stdout.c
+++ b/src/stdout.c
@@ -141,7 +141,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
       }
     }
   }
-  else if ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && ((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0))
+  else if ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && (combinator_ctx->hybrid2_wordlist_base == false))
   {
     for (u64 gidvid = 0; gidvid < pws_cnt; gidvid++)
     {
@@ -307,7 +307,7 @@ int process_stdout (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param,
           pw_idx++;
         }
       }
-      else if ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL))
+      else if ((user_options->attack_mode == ATTACK_MODE_HYBRID2) && (combinator_ctx->hybrid2_wordlist_base == true))
       {
         while (pw_idx <= pw_idx_last)
         {

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3313,19 +3313,10 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
       break;
 
     case GUESS_MODE_HYBRID2:
+    {
+      const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-      {
-        event_log_info (hashcat_ctx,
-          "Guess.Base.......: Mask (%s) [%u], Left Side",
-          hashcat_status->guess_base,
-          hashcat_status->guess_mask_length);
-
-        event_log_info (hashcat_ctx,
-          "Guess.Mod........: File (%s), Right Side",
-          hashcat_status->guess_mod);
-      }
-      else
+      if (combinator_ctx->hybrid2_wordlist_base == true)
       {
         event_log_info (hashcat_ctx,
           "Guess.Base.......: File (%s), Right Side",
@@ -3336,27 +3327,26 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
           hashcat_status->guess_mod,
           hashcat_status->guess_mask_length);
       }
+      else
+      {
+        event_log_info (hashcat_ctx,
+          "Guess.Base.......: Mask (%s) [%u], Left Side",
+          hashcat_status->guess_base,
+          hashcat_status->guess_mask_length);
+
+        event_log_info (hashcat_ctx,
+          "Guess.Mod........: File (%s), Right Side",
+          hashcat_status->guess_mod);
+      }
 
       break;
+    }
 
     case GUESS_MODE_HYBRID2_CS:
+    {
+      const combinator_ctx_t *combinator_ctx = hashcat_ctx->combinator_ctx;
 
-      if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
-      {
-        event_log_info (hashcat_ctx,
-          "Guess.Base.......: Mask (%s) [%u], Left Side",
-          hashcat_status->guess_base,
-          hashcat_status->guess_mask_length);
-
-        event_log_info (hashcat_ctx,
-          "Guess.Mod........: File (%s), Right Side",
-          hashcat_status->guess_mod);
-
-        event_log_info (hashcat_ctx,
-          "Guess.Charset....: %s",
-          hashcat_status->guess_charset);
-      }
-      else
+      if (combinator_ctx->hybrid2_wordlist_base == true)
       {
         event_log_info (hashcat_ctx,
           "Guess.Base.......: File (%s), Right Side",
@@ -3371,8 +3361,24 @@ void status_display (hashcat_ctx_t *hashcat_ctx)
           "Guess.Charset....: %s",
           hashcat_status->guess_charset);
       }
+      else
+      {
+        event_log_info (hashcat_ctx,
+          "Guess.Base.......: Mask (%s) [%u], Left Side",
+          hashcat_status->guess_base,
+          hashcat_status->guess_mask_length);
+
+        event_log_info (hashcat_ctx,
+          "Guess.Mod........: File (%s), Right Side",
+          hashcat_status->guess_mod);
+
+        event_log_info (hashcat_ctx,
+          "Guess.Charset....: %s",
+          hashcat_status->guess_charset);
+      }
 
       break;
+    }
 
     case GUESS_MODE_GENERIC:
 

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -469,7 +469,6 @@ void pw_add (hc_device_param_t *device_param, const u8 *pw_buf, const int pw_len
 int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u64 *result)
 {
   combinator_ctx_t     *combinator_ctx     = hashcat_ctx->combinator_ctx;
-  hashconfig_t         *hashconfig         = hashcat_ctx->hashconfig;
   straight_ctx_t       *straight_ctx       = hashcat_ctx->straight_ctx;
   mask_ctx_t           *mask_ctx           = hashcat_ctx->mask_ctx;
   user_options_extra_t *user_options_extra = hashcat_ctx->user_options_extra;
@@ -560,7 +559,7 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
       }
       else if (user_options_extra->attack_kern == ATTACK_KERN_COMBI)
       {
-        if (((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0) && (user_options->attack_mode == ATTACK_MODE_HYBRID2))
+        if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
         {
           if (overflow_check_u64_mul (keyspace, mask_ctx->bfs_cnt) == true) return -1;
 
@@ -670,7 +669,7 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
       }
       else if (user_options_extra->attack_kern == ATTACK_KERN_COMBI)
       {
-        if (((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0) && (user_options->attack_mode == ATTACK_MODE_HYBRID2))
+        if (user_options->attack_mode == ATTACK_MODE_HYBRID2)
         {
           if (overflow_check_u64_add (cnt, mask_ctx->bfs_cnt) == true) return -1;
 


### PR DESCRIPTION
This is a relatively large change, though most of it is systematic/mechanical wrapping of identical code blocks. This PR has been tested but needs **additional testing** and coverage due to how many kernels have been changed. The necessarily documentation changes are not yet in this PR pending additional testing.

This PR changes the work distribution and dispatch order for _a1 kernels to allow both -a 7 and -a 1 to dynamically select base/mod from the available attack elements (dict/dict or mask/dict) based on which one will provide better workload distribution to the GPU. This could also be applied to -a 6 however the likelihood of poor workload for -a 6 is significantly lower so I didn't alter it. The kernel code changes wrap the buffer side swap in an if/else branch that is optimized out at kernel compile time by the JIT compiler based on the state of COMBS_MODE.

The difference to performance in cases where the existing -a 7 and -a 1 distribution fails is significant, with no penalty to normal distribution order.

```
./hashcat -a 7 example0.hash --potfile-disable ?d rockyou.txt

Master:

Session..........: hashcat
Status...........: Exhausted
Hash.Mode........: 0 (MD5)
Hash.Target......: example0.hash
Time.Started.....: Fri Feb 27 12:04:19 2026 (20 secs)
Time.Estimated...: Fri Feb 27 12:04:39 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 0-256 bytes)
Guess.Base.......: File (rockyou.txt), Right Side
Guess.Mod........: Mask (?d) [1], Left Side
Guess.Queue.Base.: 1/1 (100.00%)
Guess.Queue.Mod..: 1/1 (100.00%)
Speed.#01........:  7458.6 kH/s (0.81ms) @ Accel:5 Loops:1024 Thr:1024 Vec:1
Recovered........: 25/6494 (0.38%) Digests (total), 25/6494 (0.38%) Digests (new)
Remaining........: 6469 (99.62%) Digests
Recovered/Time...: CUR:N/A,N/A,N/A AVG:N/A,N/A,N/A (Min,Hour,Day)
Progress.........: 143443840/143443840 (100.00%)
Rejected.........: 0/143443840 (0.00%)
Restore.Point....: 10/10 (100.00%)
Restore.Sub.#01..: Salt:0 Amplifier:14344192-14344384 Iteration:0-1024
Candidate.Engine.: Device Generator
Candidates.#01...: 1 km81088 -> $HEX[36042a0337c2a156616d6f732103]
Hardware.Mon.#01.: Temp: 32c Fan: 90% Util: 60% Core:2805MHz Mem:10251MHz Bus:16

Modified:

Session..........: hashcat
Status...........: Exhausted
Hash.Mode........: 0 (MD5)
Hash.Target......: example0.hash
Time.Started.....: Fri Feb 27 12:04:48 2026 (2 secs)
Time.Estimated...: Fri Feb 27 12:04:50 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 0-256 bytes)
Guess.Base.......: File (rockyou.txt), Right Side
Guess.Mod........: Mask (?d) [1], Left Side
Guess.Queue.Base.: 1/1 (100.00%)
Guess.Queue.Mod..: 1/1 (100.00%)
Speed.#01........:   177.5 MH/s (1.42ms) @ Accel:352 Loops:8 Thr:480 Vec:1
Recovered........: 25/6494 (0.38%) Digests (total), 25/6494 (0.38%) Digests (new)
Remaining........: 6469 (99.62%) Digests
Recovered/Time...: CUR:N/A,N/A,N/A AVG:N/A,N/A,N/A (Min,Hour,Day)
Progress.........: 143443840/143443840 (100.00%)
Rejected.........: 0/143443840 (0.00%)
Restore.Point....: 14344384/14344384 (100.00%)
Restore.Sub.#01..: Salt:0 Amplifier:8-10 Iteration:0-8
Candidate.Engine.: Device Generator
Candidates.#01...: 709194896527 -> $HEX[36042a0337c2a156616d6f732103]
Hardware.Mon.#01.: Temp: 31c Fan: 90% Util:  0% Core:2805MHz Mem:10251MHz Bus:16
```
~20x speed up

```
./hashcat -a 1 -m 3200 '$2a$05$MBCzKhG1KhezLh.0LRa0Kuw12nLJtpHy6DIaU.JAnqJUDYspHC.Ou' comb rockyou.txt

## comb file contains only the string 'test'

Master:

Session..........: hashcat
Status...........: Quit
Hash.Mode........: 3200 (bcrypt $2*$, Blowfish (Unix))
Hash.Target......: $2a$05$MBCzKhG1KhezLh.0LRa0Kuw12nLJtpHy6DIaU.JAnqJU...pHC.Ou
Time.Started.....: Fri Feb 27 12:25:39 2026 (12 secs)
Time.Estimated...: Sun Mar  1 12:54:40 2026 (2 days, 0 hours)
Kernel.Feature...: Pure Kernel (password length 0-72 bytes)
Guess.Base.......: File (comb), Left Side
Guess.Mod........: File (rockyou.txt), Right Side
Speed.#01........:       82 H/s (11.39ms) @ Accel:1 Loops:32 Thr:24 Vec:1
Recovered........: 0/1 (0.00%) Digests (total), 0/1 (0.00%) Digests (new)
Progress.........: 963/14344384 (0.01%)
Rejected.........: 0/963 (0.00%)
Restore.Point....: 0/1 (0.00%)
Restore.Sub.#01..: Salt:0 Amplifier:963-964 Iteration:0-32
Candidate.Engine.: Device Generator
Candidates.#01...: testchicago -> testchicago
Hardware.Mon.#01.: Temp: 31c Fan: 90% Util: 96% Core:2805MHz Mem:10251MHz Bus:16

Modified:

Session..........: hashcat
Status...........: Running
Hash.Mode........: 3200 (bcrypt $2*$, Blowfish (Unix))
Hash.Target......: $2a$05$MBCzKhG1KhezLh.0LRa0Kuw12nLJtpHy6DIaU.JAnqJU...pHC.Ou
Time.Started.....: Fri Feb 27 12:26:02 2026 (12 secs)
Time.Estimated...: Fri Feb 27 12:31:20 2026 (5 mins, 6 secs)
Kernel.Feature...: Pure Kernel (password length 0-72 bytes)
Guess.Base.......: File (rockyou.txt), Right Side
Guess.Mod........: File (comb), Left Side
Speed.#01........:    45169 H/s (12.86ms) @ Accel:1 Loops:32 Thr:24 Vec:1
Recovered........: 0/1 (0.00%) Digests (total), 0/1 (0.00%) Digests (new)
Progress.........: 503712/14344384 (3.51%)
Rejected.........: 0/503712 (0.00%)
Restore.Point....: 503712/14344384 (3.51%)
Restore.Sub.#01..: Salt:0 Amplifier:0-1 Iteration:0-32
Candidate.Engine.: Device Generator
Candidates.#01...: testintino -> testieshia1
Hardware.Mon.#01.: Temp: 31c Fan: 90% Util: 39% Core:2610MHz Mem:10251MHz Bus:16
```
~550x speed up