### PR TITLE
Fix speed-only inaccuracy with multiple hashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -14,6 +14,7 @@ Docker: Add hashcat-toolchain
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build
 - Disable setShouldMaximizeConcurrentCompilation on ext_metal.m, due to segfault on macos Tahoe
+- Fixed --speed-only inaccuracy when loading multiple hashes
 
 * changes v7.1.1 -> v7.1.2
 

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -2503,8 +2503,11 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     user_options->show                = false;
     user_options->status              = false;
     user_options->status_timer        = 0;
-    user_options->bitmap_min          = 1;
-    user_options->bitmap_max          = 1;
+    if (user_options->speed_only == false)
+    {
+      user_options->bitmap_min          = 1;
+      user_options->bitmap_max          = 1;
+    }
     #ifdef WITH_BRAIN
     user_options->brain_client        = false;
     #endif

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -2147,8 +2147,11 @@ void user_options_preprocess (hashcat_ctx_t *hashcat_ctx)
     user_options->show                = false;
     user_options->status              = false;
     user_options->status_timer        = 0;
-    user_options->bitmap_min          = 1;
-    user_options->bitmap_max          = 1;
+    if (user_options->speed_only == false)
+    {
+      user_options->bitmap_min          = 1;
+      user_options->bitmap_max          = 1;
+    }
     #ifdef WITH_BRAIN
     user_options->brain_client        = false;
     #endif


### PR DESCRIPTION
When --speed-only is set, bitmap-max and min were being force set to 1. This is fine for attacks with a single hash but if you load an attack with multiple hashes, the lack of bitmap creation destroys kernel performance due to the misses making it impossible to correctly estimate performance of a real attack on a real set of multiple hashes. This forced bitmap-min/max behavior is present for --benchmark as well, however --benchmark only ever tests with a single has so the problem is effectively avoided there and doesn't require it to be changed. This PR fixes this issue for --speed-only and makes the speed-only estimates significantly more accurate.

Current code:
```
./hashcat -a 3 -m 0 example0.hash --potfile-disable ?a?a?a?a?a?a?a -O --speed-only

Speed.#01........: 23348.8 MH/s (23.43ms)

./hashcat -a 3 -m 0 example0.hash --potfile-disable ?a?a?a?a?a?a?a -O

Speed.#01........: 51088.6 MH/s (11.84ms) @ Accel:9 Loops:1024 Thr:1024 Vec:8
```

Modified:
```
./hashcat -a 3 -m 0 example0.hash --potfile-disable ?a?a?a?a?a?a?a -O --speed-only

Speed.#01........: 51034.5 MH/s (11.91ms)

./hashcat -a 3 -m 0 example0.hash --potfile-disable ?a?a?a?a?a?a?a -O

Speed.#01........: 51167.1 MH/s (11.90ms) @ Accel:9 Loops:1024 Thr:1024 Vec:8
```