### PR TITLE
Docker build: Add clang dependency

### DIFF
--- a/docker/BinaryPackage.ubuntu20
+++ b/docker/BinaryPackage.ubuntu20
@@ -31,7 +31,8 @@ RUN apt-get update && \
     unzip \
     zstd \
     curl \
-    tar
+    tar \
+    clang
 
 WORKDIR /root
 


### PR DESCRIPTION
This PR just adds the clang dependency in the Dockerfile for building with the Ubuntu 20 container.

This dependency is needed for the rust bindings, otherwise the `make` step fails with errors stating that `libclang.so` is missing.

Also related: #4603 