### PR TITLE
Fixed AV false positives on Rust bridge DLLs

### DIFF
--- a/Rust/bridges/dynamic_hash/Cargo.toml
+++ b/Rust/bridges/dynamic_hash/Cargo.toml
@@ -21,6 +21,9 @@ sha3 = "0.10.8"
 thread_local = "1.1.9"
 hashcat-sys = { path = "../../hashcat-sys" }
 
+[build-dependencies]
+winresource = "0.1"
+
 [profile.release]
 opt-level = 3
 codegen-units = 1

--- a/Rust/bridges/dynamic_hash/build.rs
+++ b/Rust/bridges/dynamic_hash/build.rs
@@ -1,0 +1,41 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
+        let version = read_hashcat_version();
+        let mut res = winresource::WindowsResource::new();
+        if let Some(path) = find_windres() {
+            res.set_windres_path(&path);
+        }
+        res.set("FileDescription", "hashcat dynamic hash bridge")
+           .set("ProductName", "hashcat")
+           .set("CompanyName", "hashcat")
+           .set("LegalCopyright", "MIT License")
+           .set("FileVersion", &version)
+           .set("ProductVersion", &version);
+        if let Err(e) = res.compile() {
+            println!("cargo:warning=Failed to embed VERSIONINFO: {e}");
+        }
+    }
+}
+
+fn find_windres() -> Option<String> {
+    let target = std::env::var("TARGET").ok()?;
+    let prefix = target.strip_suffix("-windows-gnu")?;
+    let name = format!("{}-w64-mingw32-windres", prefix.replace("pc-", ""));
+    std::process::Command::new("which").arg(&name).output().ok()
+        .and_then(|o| if o.status.success() {
+            Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+        } else { None })
+}
+
+fn read_hashcat_version() -> String {
+    let makefile = std::fs::read_to_string("../../../src/Makefile")
+        .expect("Cannot read src/Makefile");
+    for line in makefile.lines() {
+        if line.starts_with("PRODUCTION_VERSION") {
+            if let Some(v) = line.split(":=").nth(1) {
+                return v.trim().trim_start_matches('v').to_string();
+            }
+        }
+    }
+    "0.0.0".to_string()
+}

--- a/Rust/bridges/dynamic_hash/build.rs
+++ b/Rust/bridges/dynamic_hash/build.rs
@@ -6,11 +6,11 @@ fn main() {
             res.set_windres_path(&path);
         }
         res.set("FileDescription", "hashcat dynamic hash bridge")
-           .set("ProductName", "hashcat")
-           .set("CompanyName", "hashcat")
-           .set("LegalCopyright", "MIT License")
-           .set("FileVersion", &version)
-           .set("ProductVersion", &version);
+            .set("ProductName", "hashcat")
+            .set("CompanyName", "hashcat")
+            .set("LegalCopyright", "MIT License")
+            .set("FileVersion", &version)
+            .set("ProductVersion", &version);
         if let Err(e) = res.compile() {
             println!("cargo:warning=Failed to embed VERSIONINFO: {e}");
         }
@@ -21,15 +21,22 @@ fn find_windres() -> Option<String> {
     let target = std::env::var("TARGET").ok()?;
     let prefix = target.strip_suffix("-windows-gnu")?;
     let name = format!("{}-w64-mingw32-windres", prefix.replace("pc-", ""));
-    std::process::Command::new("which").arg(&name).output().ok()
-        .and_then(|o| if o.status.success() {
-            Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-        } else { None })
+    std::process::Command::new("which")
+        .arg(&name)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
 }
 
 fn read_hashcat_version() -> String {
-    let makefile = std::fs::read_to_string("../../../src/Makefile")
-        .expect("Cannot read src/Makefile");
+    let makefile =
+        std::fs::read_to_string("../../../src/Makefile").expect("Cannot read src/Makefile");
     for line in makefile.lines() {
         if line.starts_with("PRODUCTION_VERSION") {
             if let Some(v) = line.split(":=").nth(1) {

--- a/Rust/bridges/generic_hash/Cargo.toml
+++ b/Rust/bridges/generic_hash/Cargo.toml
@@ -11,6 +11,9 @@ hex = "0.4.3"
 sha2 = "0.10.9"
 hashcat-sys = { path = "../../hashcat-sys" }
 
+[build-dependencies]
+winresource = "0.1"
+
 [profile.release]
 opt-level = 3
 codegen-units = 1

--- a/Rust/bridges/generic_hash/build.rs
+++ b/Rust/bridges/generic_hash/build.rs
@@ -6,11 +6,11 @@ fn main() {
             res.set_windres_path(&path);
         }
         res.set("FileDescription", "hashcat generic hash bridge")
-           .set("ProductName", "hashcat")
-           .set("CompanyName", "hashcat")
-           .set("LegalCopyright", "MIT License")
-           .set("FileVersion", &version)
-           .set("ProductVersion", &version);
+            .set("ProductName", "hashcat")
+            .set("CompanyName", "hashcat")
+            .set("LegalCopyright", "MIT License")
+            .set("FileVersion", &version)
+            .set("ProductVersion", &version);
         if let Err(e) = res.compile() {
             println!("cargo:warning=Failed to embed VERSIONINFO: {e}");
         }
@@ -21,15 +21,22 @@ fn find_windres() -> Option<String> {
     let target = std::env::var("TARGET").ok()?;
     let prefix = target.strip_suffix("-windows-gnu")?;
     let name = format!("{}-w64-mingw32-windres", prefix.replace("pc-", ""));
-    std::process::Command::new("which").arg(&name).output().ok()
-        .and_then(|o| if o.status.success() {
-            Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-        } else { None })
+    std::process::Command::new("which")
+        .arg(&name)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
 }
 
 fn read_hashcat_version() -> String {
-    let makefile = std::fs::read_to_string("../../../src/Makefile")
-        .expect("Cannot read src/Makefile");
+    let makefile =
+        std::fs::read_to_string("../../../src/Makefile").expect("Cannot read src/Makefile");
     for line in makefile.lines() {
         if line.starts_with("PRODUCTION_VERSION") {
             if let Some(v) = line.split(":=").nth(1) {

--- a/Rust/bridges/generic_hash/build.rs
+++ b/Rust/bridges/generic_hash/build.rs
@@ -1,0 +1,41 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
+        let version = read_hashcat_version();
+        let mut res = winresource::WindowsResource::new();
+        if let Some(path) = find_windres() {
+            res.set_windres_path(&path);
+        }
+        res.set("FileDescription", "hashcat generic hash bridge")
+           .set("ProductName", "hashcat")
+           .set("CompanyName", "hashcat")
+           .set("LegalCopyright", "MIT License")
+           .set("FileVersion", &version)
+           .set("ProductVersion", &version);
+        if let Err(e) = res.compile() {
+            println!("cargo:warning=Failed to embed VERSIONINFO: {e}");
+        }
+    }
+}
+
+fn find_windres() -> Option<String> {
+    let target = std::env::var("TARGET").ok()?;
+    let prefix = target.strip_suffix("-windows-gnu")?;
+    let name = format!("{}-w64-mingw32-windres", prefix.replace("pc-", ""));
+    std::process::Command::new("which").arg(&name).output().ok()
+        .and_then(|o| if o.status.success() {
+            Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+        } else { None })
+}
+
+fn read_hashcat_version() -> String {
+    let makefile = std::fs::read_to_string("../../../src/Makefile")
+        .expect("Cannot read src/Makefile");
+    for line in makefile.lines() {
+        if line.starts_with("PRODUCTION_VERSION") {
+            if let Some(v) = line.split(":=").nth(1) {
+                return v.trim().trim_start_matches('v').to_string();
+            }
+        }
+    }
+    "0.0.0".to_string()
+}


### PR DESCRIPTION
I think further testing is needed, but it seems that with this patch, VirusTotal no longer reports any detections

https://www.virustotal.com/gui/file/cf7416a310a733a0fb4387b97c3a7e02a8c950e026f78fe83392ed50c148be27
https://www.virustotal.com/gui/file/5a9247eba76f55904c0991f2a09bf0d04ce32e91923a18fd861072bf9b8bbd0a