### PR TITLE
Add --rules-concat to use the -r files as one list

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -927,6 +927,7 @@ typedef enum user_options_map
   IDX_RP_GEN_FUNC_SEL           = 0xff41,
   IDX_RP_GEN                    = 'g',
   IDX_RP_GEN_SEED               = 0xff42,
+  IDX_RP_FILE_CONCAT            = 0xff88,
   IDX_RULE_BUF_L                = 'j',
   IDX_RULE_BUF_R                = 'k',
   IDX_RUNTIME                   = 0xff43,
@@ -2527,6 +2528,7 @@ typedef struct user_options
   bool         veracrypt_pim_stop_chgd;
   bool         version;
   bool         wordlist_autohex;
+  bool         rp_files_concat;
   #ifdef WITH_BRAIN
   char        *brain_host;
   char        *brain_password;

--- a/include/types.h
+++ b/include/types.h
@@ -1036,6 +1036,7 @@ typedef enum user_options_map
   IDX_RESTORE_FILE_PATH         = 0xff3e,
   IDX_RESTORE_POSITION          = 0xff87,
   IDX_RP_FILE                   = 'r',
+  IDX_RP_FILE_CONCAT            = 0xff8c,
   IDX_RP_GEN_FUNC_MAX           = 0xff3f,
   IDX_RP_GEN_FUNC_MIN           = 0xff40,
   IDX_RP_GEN_FUNC_SEL           = 0xff41,
@@ -2898,6 +2899,7 @@ typedef struct user_options
   bool         restore;
   bool         restore_enable;
   bool         restore_position;
+  bool         rp_files_concat;
   bool         self_test;
   bool         show;
   bool         slow_candidates;

--- a/src/rp.c
+++ b/src/rp.c
@@ -1022,98 +1022,147 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
   hcfree (rule_buf);
 
   /**
-   * merge rules
+   * merge or concat rules
    */
 
-  u32 kernel_rules_cnt = 1;
+  u32 kernel_rules_cnt = 0;
 
-  u32 *repeats = (u32 *) hccalloc (user_options->rp_files_cnt + 1, sizeof (u32));
+  kernel_rule_t *kernel_rules_buf = NULL;
 
-  repeats[0] = kernel_rules_cnt;
-
-  for (u32 i = 0; i < user_options->rp_files_cnt; i++)
+  if (user_options->rp_files_concat == true)
   {
-    const u32 kernel_rules_cnt_old = kernel_rules_cnt;
+    /**
+     * flat concatenation
+     */
 
-    kernel_rules_cnt *= all_kernel_rules_cnt[i];
-
-    if (kernel_rules_cnt < kernel_rules_cnt_old) // u32 overflow ?
+    for (u32 i = 0; i < user_options->rp_files_cnt; i++)
     {
-      if (all_kernel_rules_cnt[i] > 0) // at least one "valid" rule
+      const u32 kernel_rules_cnt_old = kernel_rules_cnt;
+
+      kernel_rules_cnt += all_kernel_rules_cnt[i];
+
+      if (kernel_rules_cnt < kernel_rules_cnt_old)
       {
-        event_log_error (hashcat_ctx, "Unsupported number of rules used in rule chaining.");
+        event_log_error (hashcat_ctx, "Unsupported number of rules used in rule concatenation.");
 
         hcfree (all_kernel_rules_cnt);
         hcfree (all_kernel_rules_buf);
-
-        hcfree (rule_buf);
-        hcfree (repeats);
 
         return -1;
       }
     }
 
-    repeats[i + 1] = kernel_rules_cnt;
+    kernel_rules_buf = (kernel_rule_t *) hccalloc (kernel_rules_cnt, sizeof (kernel_rule_t));
+
+    u32 offset = 0;
+
+    for (u32 i = 0; i < user_options->rp_files_cnt; i++)
+    {
+      if (all_kernel_rules_cnt[i] > 0)
+      {
+        memcpy (&kernel_rules_buf[offset], all_kernel_rules_buf[i], all_kernel_rules_cnt[i] * sizeof (kernel_rule_t));
+
+        offset += all_kernel_rules_cnt[i];
+      }
+
+      hcfree (all_kernel_rules_buf[i]);
+    }
   }
-
-  kernel_rule_t *kernel_rules_buf = (kernel_rule_t *) hccalloc (kernel_rules_cnt, sizeof (kernel_rule_t));
-
-  if (kernel_rules_buf == NULL)
+  else
   {
-    event_log_error (hashcat_ctx, "Not enough allocatable memory (RAM) for this ruleset.");
+    /**
+     * cross-product (merge)
+     */
 
-    hcfree (all_kernel_rules_cnt);
-    hcfree (all_kernel_rules_buf);
+    kernel_rules_cnt = 1;
+
+    u32 *repeats = (u32 *) hccalloc (user_options->rp_files_cnt + 1, sizeof (u32));
+
+    repeats[0] = kernel_rules_cnt;
+
+    for (u32 i = 0; i < user_options->rp_files_cnt; i++)
+    {
+      const u32 kernel_rules_cnt_old = kernel_rules_cnt;
+
+      kernel_rules_cnt *= all_kernel_rules_cnt[i];
+
+      if (kernel_rules_cnt < kernel_rules_cnt_old) // u32 overflow ?
+      {
+        if (all_kernel_rules_cnt[i] > 0) // at least one "valid" rule
+        {
+          event_log_error (hashcat_ctx, "Unsupported number of rules used in rule chaining.");
+
+          hcfree (all_kernel_rules_cnt);
+          hcfree (all_kernel_rules_buf);
+
+          hcfree (repeats);
+
+          return -1;
+        }
+      }
+
+      repeats[i + 1] = kernel_rules_cnt;
+    }
+
+    kernel_rules_buf = (kernel_rule_t *) hccalloc (kernel_rules_cnt, sizeof (kernel_rule_t));
+
+    if (kernel_rules_buf == NULL)
+    {
+      event_log_error (hashcat_ctx, "Not enough allocatable memory (RAM) for this ruleset.");
+
+      hcfree (all_kernel_rules_cnt);
+      hcfree (all_kernel_rules_buf);
+
+      hcfree (repeats);
+
+      return -1;
+    }
+
+    u32 invalid_cnt = 0;
+    u32 valid_cnt = 0;
+
+    for (u32 i = 0; i < kernel_rules_cnt; i++)
+    {
+      u32 out_pos = 0;
+
+      kernel_rule_t *out = &kernel_rules_buf[i - invalid_cnt];
+
+      for (u32 j = 0; j < user_options->rp_files_cnt; j++)
+      {
+        u32 in_off = (i / repeats[j]) % all_kernel_rules_cnt[j];
+        u32 in_pos;
+
+        kernel_rule_t *in = &all_kernel_rules_buf[j][in_off];
+
+        for (in_pos = 0; in->cmds[in_pos]; in_pos++, out_pos++)
+        {
+          if (out_pos == RULES_MAX - 1)
+          {
+            invalid_cnt++;
+
+            break;
+          }
+          else
+          {
+            valid_cnt++;
+          }
+
+          out->cmds[out_pos] = in->cmds[in_pos];
+        }
+      }
+    }
+
+    if (invalid_cnt > 0)
+    {
+      event_log_warning (hashcat_ctx, "Maximum functions per rule exceeded during chaining of rules.");
+      event_log_warning (hashcat_ctx, "Skipped %u rule chains, %u valid chains remain.", invalid_cnt, valid_cnt);
+      event_log_warning (hashcat_ctx, NULL);
+    }
 
     hcfree (repeats);
 
-    return -1;
+    kernel_rules_cnt -= invalid_cnt;
   }
-
-  u32 invalid_cnt = 0;
-  u32 valid_cnt = 0;
-
-  for (u32 i = 0; i < kernel_rules_cnt; i++)
-  {
-    u32 out_pos = 0;
-
-    kernel_rule_t *out = &kernel_rules_buf[i - invalid_cnt];
-
-    for (u32 j = 0; j < user_options->rp_files_cnt; j++)
-    {
-      u32 in_off = (i / repeats[j]) % all_kernel_rules_cnt[j];
-      u32 in_pos;
-
-      kernel_rule_t *in = &all_kernel_rules_buf[j][in_off];
-
-      for (in_pos = 0; in->cmds[in_pos]; in_pos++, out_pos++)
-      {
-        if (out_pos == RULES_MAX - 1)
-        {
-          invalid_cnt++;
-
-          break;
-        }
-        else
-        {
-          valid_cnt++;
-        }
-
-        out->cmds[out_pos] = in->cmds[in_pos];
-      }
-    }
-  }
-
-  if (invalid_cnt > 0)
-  {
-    event_log_warning (hashcat_ctx, "Maximum functions per rule exceeded during chaining of rules.");
-    event_log_warning (hashcat_ctx, "Skipped %u rule chains, %u valid chains remain.", invalid_cnt, valid_cnt);
-    event_log_warning (hashcat_ctx, NULL);
-  }
-
-  hcfree (repeats);
-
-  kernel_rules_cnt -= invalid_cnt;
 
   hcfree (all_kernel_rules_cnt);
   hcfree (all_kernel_rules_buf);

--- a/src/rp.c
+++ b/src/rp.c
@@ -1244,6 +1244,74 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
     return 0;
   }
 
+  // --rules-concat asks for one list rather than a chain: the rules of every file after each other, so
+  // the count is the sum and not the product. It leaves early for the same reason the single file case
+  // above does, because there is nothing to combine and a second pass would only copy the array.
+
+  if (user_options->rp_files_concat == true)
+  {
+    u32 kernel_rules_cnt = 0;
+
+    for (u32 i = 0; i < user_options->rp_files_cnt; i++)
+    {
+      if (overflow_check_u32_add (kernel_rules_cnt, all_kernel_rules_cnt[i]) == true)
+      {
+        event_log_error (hashcat_ctx, "Unsupported number of rules used in rule concatenation.");
+
+        for (u32 j = 0; j < user_options->rp_files_cnt; j++)
+        {
+          hcfree (all_kernel_rules_buf[j]);
+        }
+
+        hcfree (all_kernel_rules_cnt);
+        hcfree (all_kernel_rules_buf);
+
+        return -1;
+      }
+
+      kernel_rules_cnt += all_kernel_rules_cnt[i];
+    }
+
+    if (kernel_rules_cnt == 0)
+    {
+      event_log_error (hashcat_ctx, "No valid rules left.");
+
+      for (u32 j = 0; j < user_options->rp_files_cnt; j++)
+      {
+        hcfree (all_kernel_rules_buf[j]);
+      }
+
+      hcfree (all_kernel_rules_cnt);
+      hcfree (all_kernel_rules_buf);
+
+      return -1;
+    }
+
+    kernel_rule_t *kernel_rules_buf = (kernel_rule_t *) hccalloc (kernel_rules_cnt, sizeof (kernel_rule_t));
+
+    u32 offset = 0;
+
+    for (u32 i = 0; i < user_options->rp_files_cnt; i++)
+    {
+      if (all_kernel_rules_cnt[i] > 0)
+      {
+        memcpy (&kernel_rules_buf[offset], all_kernel_rules_buf[i], all_kernel_rules_cnt[i] * sizeof (kernel_rule_t));
+
+        offset += all_kernel_rules_cnt[i];
+      }
+
+      hcfree (all_kernel_rules_buf[i]);
+    }
+
+    hcfree (all_kernel_rules_cnt);
+    hcfree (all_kernel_rules_buf);
+
+    *out_cnt = kernel_rules_cnt;
+    *out_buf = kernel_rules_buf;
+
+    return 0;
+  }
+
   /**
    * merge rules
    */

--- a/src/usage.c
+++ b/src/usage.c
@@ -130,6 +130,7 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   " -j, --rule-left                | Rule | Single rule applied to each word from left wordlist  | -j 'c'",
   " -k, --rule-right               | Rule | Single rule applied to each word from right wordlist | -k '^-'",
   " -r, --rules-file               | File | Multiple rules applied to each word from wordlists   | -r rules/best66.rule",
+  "     --rules-concat             |      | Concatenate rules from multiple -r files              |",
   " -g, --generate-rules           | Num  | Generate X random rules                              | -g 10000",
   "     --generate-rules-func-min  | Num  | Force min X functions per rule                       |",
   "     --generate-rules-func-max  | Num  | Force max X functions per rule                       |",

--- a/src/usage.c
+++ b/src/usage.c
@@ -133,6 +133,7 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   " -j, --rule-left                | Rule | Single rule applied to each word from left wordlist  | -j 'c'",
   " -k, --rule-right               | Rule | Single rule applied to each word from right wordlist | -k '^-'",
   " -r, --rules-file               | File | Multiple rules applied to each word from wordlists   | -r rules/best66.rule",
+  "     --rules-concat             |      | Use the -r files as one list instead of chaining them |",
   " -g, --generate-rules           | Num  | Generate X random rules                              | -g 10000",
   "     --generate-rules-func-min  | Num  | Force min X functions per rule                       |",
   "     --generate-rules-func-max  | Num  | Force max X functions per rule                       |",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -137,6 +137,7 @@ static const struct option long_options[] =
   {"rule-left",                 required_argument, NULL, IDX_RULE_BUF_L},
   {"rule-right",                required_argument, NULL, IDX_RULE_BUF_R},
   {"rules-file",                required_argument, NULL, IDX_RP_FILE},
+  {"rules-concat",              no_argument,       NULL, IDX_RP_FILE_CONCAT},
   {"runtime",                   required_argument, NULL, IDX_RUNTIME},
   {"scrypt-tmto",               required_argument, NULL, IDX_SCRYPT_TMTO},
   {"segment-size",              required_argument, NULL, IDX_SEGMENT_SIZE},
@@ -328,6 +329,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->version                   = VERSION;
   user_options->wordlist_autohex          = WORDLIST_AUTOHEX;
   user_options->workload_profile          = WORKLOAD_PROFILE;
+  user_options->rp_files_concat           = false;
   user_options->rp_files_cnt              = 0;
   user_options->rp_files                  = (char **) hccalloc (256, sizeof (char *));
   user_options->hc_bin                    = PROGNAME;
@@ -499,6 +501,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_ATTACK_MODE:               user_options->attack_mode               = hc_strtoul (optarg, NULL, 10);
                                           user_options->attack_mode_chgd          = true;                            break;
       case IDX_RP_FILE:                   user_options->rp_files[user_options->rp_files_cnt++] = optarg;             break;
+      case IDX_RP_FILE_CONCAT:            user_options->rp_files_concat           = true;                            break;
       case IDX_RP_GEN:                    user_options->rp_gen                    = hc_strtoul (optarg, NULL, 10);   break;
       case IDX_RP_GEN_FUNC_MIN:           user_options->rp_gen_func_min           = hc_strtoul (optarg, NULL, 10);   break;
       case IDX_RP_GEN_FUNC_MAX:           user_options->rp_gen_func_max           = hc_strtoul (optarg, NULL, 10);   break;
@@ -1021,6 +1024,20 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
   if ((user_options->rp_files_cnt > 0) && (user_options->rp_gen > 0))
   {
     event_log_error (hashcat_ctx, "Combining -r/--rules-file and -g/--rules-generate is not supported.");
+
+    return -1;
+  }
+
+  if ((user_options->rp_files_concat == true) && (user_options->rp_files_cnt == 0))
+  {
+    event_log_error (hashcat_ctx, "Parameter --rules-concat requires -r/--rules-file.");
+
+    return -1;
+  }
+
+  if ((user_options->rp_files_concat == true) && (user_options->rp_gen > 0))
+  {
+    event_log_error (hashcat_ctx, "Combining --rules-concat with -g/--generate-rules is not supported.");
 
     return -1;
   }
@@ -3760,6 +3777,7 @@ void user_options_logger (hashcat_ctx_t *hashcat_ctx)
   logfile_top_uint   (user_options->veracrypt_pim_start);
   logfile_top_uint   (user_options->veracrypt_pim_stop);
   logfile_top_uint   (user_options->version);
+  logfile_top_uint   (user_options->rp_files_concat);
   logfile_top_uint   (user_options->workload_profile);
   #ifdef WITH_BRAIN
   logfile_top_uint   (user_options->brain_client);

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -144,6 +144,7 @@ static const struct option long_options[] =
   {"rule-left",                 required_argument, NULL, IDX_RULE_BUF_L},
   {"rule-right",                required_argument, NULL, IDX_RULE_BUF_R},
   {"rules-file",                required_argument, NULL, IDX_RP_FILE},
+  {"rules-concat",              no_argument,       NULL, IDX_RP_FILE_CONCAT},
   {"runtime",                   required_argument, NULL, IDX_RUNTIME},
   {"scrypt-tmto",               required_argument, NULL, IDX_SCRYPT_TMTO},
   {"self-test-disable",         no_argument,       NULL, IDX_SELF_TEST_DISABLE},
@@ -311,6 +312,7 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->restore_file_path         = NULL;
   user_options->restore                   = RESTORE;
   user_options->restore_position          = RESTORE_POSITION;
+  user_options->rp_files_concat           = false;
   user_options->restore_timer             = RESTORE_TIMER;
   user_options->rp_gen_func_max           = RP_GEN_FUNC_MAX;
   user_options->rp_gen_func_min           = RP_GEN_FUNC_MIN;
@@ -537,6 +539,7 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_ATTACK_MODE:               user_options->attack_mode               = hc_strtoul (optarg, NULL, 10);
                                           user_options->attack_mode_chgd          = true;                            break;
       case IDX_RP_FILE:                   user_options->rp_files[user_options->rp_files_cnt++] = optarg;             break;
+      case IDX_RP_FILE_CONCAT:            user_options->rp_files_concat           = true;                            break;
       case IDX_RP_GEN:                    user_options->rp_gen                    = hc_strtoul (optarg, NULL, 10);   break;
       case IDX_RP_GEN_FUNC_MIN:           user_options->rp_gen_func_min           = hc_strtoul (optarg, NULL, 10);   break;
       case IDX_RP_GEN_FUNC_MAX:           user_options->rp_gen_func_max           = hc_strtoul (optarg, NULL, 10);   break;
@@ -1195,6 +1198,13 @@ int user_options_sanity (hashcat_ctx_t *hashcat_ctx)
   if ((user_options->rp_files_cnt > 0) && (user_options->rp_gen > 0))
   {
     event_log_error (hashcat_ctx, "Combining -r/--rules-file and -g/--rules-generate is not supported.");
+
+    return -1;
+  }
+
+  if ((user_options->rp_files_concat == true) && (user_options->rp_files_cnt == 0))
+  {
+    event_log_error (hashcat_ctx, "Parameter --rules-concat requires -r/--rules-file.");
 
     return -1;
   }
@@ -4820,6 +4830,7 @@ void user_options_logger (hashcat_ctx_t *hashcat_ctx)
   logfile_top_uint   (user_options->rp_gen_func_max);
   logfile_top_uint   (user_options->rp_gen_func_min);
   logfile_top_uint   (user_options->rp_gen_seed);
+  logfile_top_uint   (user_options->rp_files_concat);
   logfile_top_uint   (user_options->runtime);
   logfile_top_uint   (user_options->scrypt_tmto);
   logfile_top_uint   (user_options->self_test);


### PR DESCRIPTION
Several `-r` files are chained: the rules of one file are applied to the output of the next, so two files of 3 and 2 rules give 6 candidates per word. There is no way to ask for the rules of every file one after another.

## Reproduction

```
$ printf ':\nu\nl\n' > a.rule
$ printf '$1\n$2\n'  > b.rule
$ echo Pass > w.dict

$ ./hashcat --stdout -a 0 -r a.rule -r b.rule w.dict
Pass1
PASS1
pass1
Pass2
PASS2
pass2
        6 candidates, which is 3 * 2

$ ./hashcat --stdout -a 0 --rules-concat -r a.rule -r b.rule w.dict

before: hashcat: unrecognized option `--rules-concat'
        Invalid argument specified.
        rc=255
after:  Pass
        PASS
        pass
        Pass1
        Pass2
        5 candidates, which is 3 + 2
        rc=0
```

## How it works

`kernel_rules_load ()` reads every file into `all_kernel_rules_buf` and then combines them. The count of a chain is the product of the counts, and the count of a list is their sum, so the concatenating case is one allocation and one `memcpy` per file:

```c
if (user_options->rp_files_concat == true)
{
  u32 kernel_rules_cnt = 0;

  for (u32 i = 0; i < user_options->rp_files_cnt; i++)
  {
    if (overflow_check_u32_add (kernel_rules_cnt, all_kernel_rules_cnt[i]) == true)
    ...
```

It leaves early, which is what the single file case immediately above it already does, and for the same reason given in the comment there: there is nothing to combine, and going on would copy the array a second time.

`overflow_check_u32_add ()` is the same guard the chaining path uses in its multiplying form.

## What is refused

`--rules-concat` without `-r` has nothing to concatenate, so it is refused. There is no separate check against `-g`, because `-r` with `-g` is already refused and without `-r` the first check fires:

```
$ ./hashcat --stdout -a 0 --rules-concat w.dict
Parameter --rules-concat requires -r/--rules-file.
rc=255

$ ./hashcat --stdout -a 0 --rules-concat -r a.rule -g 10 w.dict
Combining -r/--rules-file and -g/--rules-generate is not supported.
rc=255
```

## tools/test_edge.sh

No hash mode is touched. The change is in rule loading, which every mode that takes `-r` shares, and the runs above exercise both paths of it.