### PR TITLE
Add PKCS#12 (.pfx, .p12) cracking support (modes 24430, 24440)

### DIFF
--- a/OpenCL/m24430-pure.cl
+++ b/OpenCL/m24430-pure.cl
@@ -1,0 +1,263 @@
+/**
+ * Author......: kozmer
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct pkcs12_tmp
+{
+  u32  dgst[5];
+  u32  out[5];
+
+} pkcs12_tmp_t;
+
+typedef struct pkcs12
+{
+  u32 data_buf[16384];
+  int data_len;
+
+  u32 mac_digest[5];
+
+} pkcs12_t;
+
+KERNEL_FQ KERNEL_FA void m24430_init (KERN_ATTR_TMPS_ESALT (pkcs12_tmp_t, pkcs12_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // PKCS#12 KDF (RFC 7292 Appendix B), id=3 for MAC key derivation
+  // Compute SHA-1(D || S || P) where:
+  //   D = 64 bytes of 0x03
+  //   S = salt repeated to 64 bytes
+  //   P = UTF-16BE password (with null terminator) repeated to ceil(len/64)*64
+
+  const int pw_len = pws[gid].pw_len;
+  const int salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+  const int utf16_len = (pw_len + 1) * 2;
+  const int v2 = ((utf16_len + 63) / 64) * 64;
+
+  sha1_ctx_t ctx;
+
+  sha1_init (&ctx);
+
+  // diversifier
+
+  {
+    u32 w0[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+    u32 w1[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+    u32 w2[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+    u32 w3[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+
+    sha1_update_64 (&ctx, w0, w1, w2, w3, 64);
+  }
+
+  // salt block
+
+  {
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    #define SALT_BYTE(k) ((salt_bufs[SALT_POS_HOST].salt_buf[((k) % salt_len) / 4] >> ((((k) % salt_len) & 3) * 8)) & 0xff)
+    #define SALT_BE(base) (u32)((SALT_BYTE(base) << 24) | (SALT_BYTE((base)+1) << 16) | (SALT_BYTE((base)+2) << 8) | SALT_BYTE((base)+3))
+
+    w0[0] = SALT_BE ( 0);
+    w0[1] = SALT_BE ( 4);
+    w0[2] = SALT_BE ( 8);
+    w0[3] = SALT_BE (12);
+    w1[0] = SALT_BE (16);
+    w1[1] = SALT_BE (20);
+    w1[2] = SALT_BE (24);
+    w1[3] = SALT_BE (28);
+    w2[0] = SALT_BE (32);
+    w2[1] = SALT_BE (36);
+    w2[2] = SALT_BE (40);
+    w2[3] = SALT_BE (44);
+    w3[0] = SALT_BE (48);
+    w3[1] = SALT_BE (52);
+    w3[2] = SALT_BE (56);
+    w3[3] = SALT_BE (60);
+
+    #undef SALT_BYTE
+    #undef SALT_BE
+
+    sha1_update_64 (&ctx, w0, w1, w2, w3, 64);
+  }
+
+  // password block
+
+  {
+    #define PWD_BYTE_RAW(k) (((k) & 1) == 0 ? (u32)0 : ((k) / 2 < pw_len ? ((pws[gid].i[((k) / 2) / 4] >> ((((k) / 2) & 3) * 8)) & 0xff) : (u32)0))
+    #define PWD_BYTE(k) PWD_BYTE_RAW((k) % utf16_len)
+    #define PWD_BE(base) (u32)((PWD_BYTE(base) << 24) | (PWD_BYTE((base)+1) << 16) | (PWD_BYTE((base)+2) << 8) | PWD_BYTE((base)+3))
+
+    for (int off = 0; off < v2; off += 64)
+    {
+      u32 w0[4];
+      u32 w1[4];
+      u32 w2[4];
+      u32 w3[4];
+
+      w0[0] = PWD_BE (off +  0);
+      w0[1] = PWD_BE (off +  4);
+      w0[2] = PWD_BE (off +  8);
+      w0[3] = PWD_BE (off + 12);
+      w1[0] = PWD_BE (off + 16);
+      w1[1] = PWD_BE (off + 20);
+      w1[2] = PWD_BE (off + 24);
+      w1[3] = PWD_BE (off + 28);
+      w2[0] = PWD_BE (off + 32);
+      w2[1] = PWD_BE (off + 36);
+      w2[2] = PWD_BE (off + 40);
+      w2[3] = PWD_BE (off + 44);
+      w3[0] = PWD_BE (off + 48);
+      w3[1] = PWD_BE (off + 52);
+      w3[2] = PWD_BE (off + 56);
+      w3[3] = PWD_BE (off + 60);
+
+      sha1_update_64 (&ctx, w0, w1, w2, w3, 64);
+    }
+
+    #undef PWD_BYTE_RAW
+    #undef PWD_BYTE
+    #undef PWD_BE
+  }
+
+  sha1_final (&ctx);
+
+  tmps[gid].dgst[0] = ctx.h[0];
+  tmps[gid].dgst[1] = ctx.h[1];
+  tmps[gid].dgst[2] = ctx.h[2];
+  tmps[gid].dgst[3] = ctx.h[3];
+  tmps[gid].dgst[4] = ctx.h[4];
+
+  tmps[gid].out[0] = ctx.h[0];
+  tmps[gid].out[1] = ctx.h[1];
+  tmps[gid].out[2] = ctx.h[2];
+  tmps[gid].out[3] = ctx.h[3];
+  tmps[gid].out[4] = ctx.h[4];
+}
+
+KERNEL_FQ KERNEL_FA void m24430_loop (KERN_ATTR_TMPS_ESALT (pkcs12_tmp_t, pkcs12_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 dgst[5];
+
+  dgst[0] = tmps[gid].dgst[0];
+  dgst[1] = tmps[gid].dgst[1];
+  dgst[2] = tmps[gid].dgst[2];
+  dgst[3] = tmps[gid].dgst[3];
+  dgst[4] = tmps[gid].dgst[4];
+
+  for (u32 j = 0; j < LOOP_CNT; j++)
+  {
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = dgst[0];
+    w0[1] = dgst[1];
+    w0[2] = dgst[2];
+    w0[3] = dgst[3];
+    w1[0] = dgst[4];
+    w1[1] = 0x80000000;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 20 * 8;
+
+    dgst[0] = SHA1M_A;
+    dgst[1] = SHA1M_B;
+    dgst[2] = SHA1M_C;
+    dgst[3] = SHA1M_D;
+    dgst[4] = SHA1M_E;
+
+    sha1_transform (w0, w1, w2, w3, dgst);
+  }
+
+  tmps[gid].dgst[0] = dgst[0];
+  tmps[gid].dgst[1] = dgst[1];
+  tmps[gid].dgst[2] = dgst[2];
+  tmps[gid].dgst[3] = dgst[3];
+  tmps[gid].dgst[4] = dgst[4];
+
+  tmps[gid].out[0] = dgst[0];
+  tmps[gid].out[1] = dgst[1];
+  tmps[gid].out[2] = dgst[2];
+  tmps[gid].out[3] = dgst[3];
+  tmps[gid].out[4] = dgst[4];
+}
+
+KERNEL_FQ KERNEL_FA void m24430_comp (KERN_ATTR_TMPS_ESALT (pkcs12_tmp_t, pkcs12_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // MAC key from KDF
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  w0[0] = tmps[gid].out[0];
+  w0[1] = tmps[gid].out[1];
+  w0[2] = tmps[gid].out[2];
+  w0[3] = tmps[gid].out[3];
+  w1[0] = tmps[gid].out[4];
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  // HMAC-SHA1 over authSafe content
+
+  sha1_hmac_ctx_t hmac_ctx;
+
+  sha1_hmac_init_64 (&hmac_ctx, w0, w1, w2, w3);
+
+  sha1_hmac_update_global_swap (&hmac_ctx, esalt_bufs[DIGESTS_OFFSET_HOST].data_buf, esalt_bufs[DIGESTS_OFFSET_HOST].data_len);
+
+  sha1_hmac_final (&hmac_ctx);
+
+  const u32 r0 = hmac_ctx.opad.h[DGST_R0];
+  const u32 r1 = hmac_ctx.opad.h[DGST_R1];
+  const u32 r2 = hmac_ctx.opad.h[DGST_R2];
+  const u32 r3 = hmac_ctx.opad.h[DGST_R3];
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/OpenCL/m24440-pure.cl
+++ b/OpenCL/m24440-pure.cl
@@ -1,0 +1,281 @@
+/**
+ * Author......: kozmer
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct pkcs12_tmp
+{
+  u32  dgst[8];
+  u32  out[8];
+
+} pkcs12_tmp_t;
+
+typedef struct pkcs12
+{
+  u32 data_buf[16384];
+  int data_len;
+
+  u32 mac_digest[8];
+
+} pkcs12_t;
+
+KERNEL_FQ KERNEL_FA void m24440_init (KERN_ATTR_TMPS_ESALT (pkcs12_tmp_t, pkcs12_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // PKCS#12 KDF (RFC 7292 Appendix B), id=3 for MAC key derivation
+  // Compute SHA-256(D || S || P) where:
+  //   D = 64 bytes of 0x03
+  //   S = salt repeated to 64 bytes
+  //   P = UTF-16BE password (with null terminator) repeated to ceil(len/64)*64
+
+  const int pw_len = pws[gid].pw_len;
+  const int salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+  const int utf16_len = (pw_len + 1) * 2;
+  const int v2 = ((utf16_len + 63) / 64) * 64;
+
+  sha256_ctx_t ctx;
+
+  sha256_init (&ctx);
+
+  // diversifier
+
+  {
+    u32 w0[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+    u32 w1[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+    u32 w2[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+    u32 w3[4] = { 0x03030303, 0x03030303, 0x03030303, 0x03030303 };
+
+    sha256_update_64 (&ctx, w0, w1, w2, w3, 64);
+  }
+
+  // salt block
+
+  {
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    #define SALT_BYTE(k) ((salt_bufs[SALT_POS_HOST].salt_buf[((k) % salt_len) / 4] >> ((((k) % salt_len) & 3) * 8)) & 0xff)
+    #define SALT_BE(base) (u32)((SALT_BYTE(base) << 24) | (SALT_BYTE((base)+1) << 16) | (SALT_BYTE((base)+2) << 8) | SALT_BYTE((base)+3))
+
+    w0[0] = SALT_BE ( 0);
+    w0[1] = SALT_BE ( 4);
+    w0[2] = SALT_BE ( 8);
+    w0[3] = SALT_BE (12);
+    w1[0] = SALT_BE (16);
+    w1[1] = SALT_BE (20);
+    w1[2] = SALT_BE (24);
+    w1[3] = SALT_BE (28);
+    w2[0] = SALT_BE (32);
+    w2[1] = SALT_BE (36);
+    w2[2] = SALT_BE (40);
+    w2[3] = SALT_BE (44);
+    w3[0] = SALT_BE (48);
+    w3[1] = SALT_BE (52);
+    w3[2] = SALT_BE (56);
+    w3[3] = SALT_BE (60);
+
+    #undef SALT_BYTE
+    #undef SALT_BE
+
+    sha256_update_64 (&ctx, w0, w1, w2, w3, 64);
+  }
+
+  // password block
+
+  {
+    #define PWD_BYTE_RAW(k) (((k) & 1) == 0 ? (u32)0 : ((k) / 2 < pw_len ? ((pws[gid].i[((k) / 2) / 4] >> ((((k) / 2) & 3) * 8)) & 0xff) : (u32)0))
+    #define PWD_BYTE(k) PWD_BYTE_RAW((k) % utf16_len)
+    #define PWD_BE(base) (u32)((PWD_BYTE(base) << 24) | (PWD_BYTE((base)+1) << 16) | (PWD_BYTE((base)+2) << 8) | PWD_BYTE((base)+3))
+
+    for (int off = 0; off < v2; off += 64)
+    {
+      u32 w0[4];
+      u32 w1[4];
+      u32 w2[4];
+      u32 w3[4];
+
+      w0[0] = PWD_BE (off +  0);
+      w0[1] = PWD_BE (off +  4);
+      w0[2] = PWD_BE (off +  8);
+      w0[3] = PWD_BE (off + 12);
+      w1[0] = PWD_BE (off + 16);
+      w1[1] = PWD_BE (off + 20);
+      w1[2] = PWD_BE (off + 24);
+      w1[3] = PWD_BE (off + 28);
+      w2[0] = PWD_BE (off + 32);
+      w2[1] = PWD_BE (off + 36);
+      w2[2] = PWD_BE (off + 40);
+      w2[3] = PWD_BE (off + 44);
+      w3[0] = PWD_BE (off + 48);
+      w3[1] = PWD_BE (off + 52);
+      w3[2] = PWD_BE (off + 56);
+      w3[3] = PWD_BE (off + 60);
+
+      sha256_update_64 (&ctx, w0, w1, w2, w3, 64);
+    }
+
+    #undef PWD_BYTE_RAW
+    #undef PWD_BYTE
+    #undef PWD_BE
+  }
+
+  sha256_final (&ctx);
+
+  tmps[gid].dgst[0] = ctx.h[0];
+  tmps[gid].dgst[1] = ctx.h[1];
+  tmps[gid].dgst[2] = ctx.h[2];
+  tmps[gid].dgst[3] = ctx.h[3];
+  tmps[gid].dgst[4] = ctx.h[4];
+  tmps[gid].dgst[5] = ctx.h[5];
+  tmps[gid].dgst[6] = ctx.h[6];
+  tmps[gid].dgst[7] = ctx.h[7];
+
+  tmps[gid].out[0] = ctx.h[0];
+  tmps[gid].out[1] = ctx.h[1];
+  tmps[gid].out[2] = ctx.h[2];
+  tmps[gid].out[3] = ctx.h[3];
+  tmps[gid].out[4] = ctx.h[4];
+  tmps[gid].out[5] = ctx.h[5];
+  tmps[gid].out[6] = ctx.h[6];
+  tmps[gid].out[7] = ctx.h[7];
+}
+
+KERNEL_FQ KERNEL_FA void m24440_loop (KERN_ATTR_TMPS_ESALT (pkcs12_tmp_t, pkcs12_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  u32 dgst[8];
+
+  dgst[0] = tmps[gid].dgst[0];
+  dgst[1] = tmps[gid].dgst[1];
+  dgst[2] = tmps[gid].dgst[2];
+  dgst[3] = tmps[gid].dgst[3];
+  dgst[4] = tmps[gid].dgst[4];
+  dgst[5] = tmps[gid].dgst[5];
+  dgst[6] = tmps[gid].dgst[6];
+  dgst[7] = tmps[gid].dgst[7];
+
+  for (u32 j = 0; j < LOOP_CNT; j++)
+  {
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = dgst[0];
+    w0[1] = dgst[1];
+    w0[2] = dgst[2];
+    w0[3] = dgst[3];
+    w1[0] = dgst[4];
+    w1[1] = dgst[5];
+    w1[2] = dgst[6];
+    w1[3] = dgst[7];
+    w2[0] = 0x80000000;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 32 * 8;
+
+    dgst[0] = SHA256M_A;
+    dgst[1] = SHA256M_B;
+    dgst[2] = SHA256M_C;
+    dgst[3] = SHA256M_D;
+    dgst[4] = SHA256M_E;
+    dgst[5] = SHA256M_F;
+    dgst[6] = SHA256M_G;
+    dgst[7] = SHA256M_H;
+
+    sha256_transform (w0, w1, w2, w3, dgst);
+  }
+
+  tmps[gid].dgst[0] = dgst[0];
+  tmps[gid].dgst[1] = dgst[1];
+  tmps[gid].dgst[2] = dgst[2];
+  tmps[gid].dgst[3] = dgst[3];
+  tmps[gid].dgst[4] = dgst[4];
+  tmps[gid].dgst[5] = dgst[5];
+  tmps[gid].dgst[6] = dgst[6];
+  tmps[gid].dgst[7] = dgst[7];
+
+  tmps[gid].out[0] = dgst[0];
+  tmps[gid].out[1] = dgst[1];
+  tmps[gid].out[2] = dgst[2];
+  tmps[gid].out[3] = dgst[3];
+  tmps[gid].out[4] = dgst[4];
+  tmps[gid].out[5] = dgst[5];
+  tmps[gid].out[6] = dgst[6];
+  tmps[gid].out[7] = dgst[7];
+}
+
+KERNEL_FQ KERNEL_FA void m24440_comp (KERN_ATTR_TMPS_ESALT (pkcs12_tmp_t, pkcs12_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // MAC key from KDF
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  w0[0] = tmps[gid].out[0];
+  w0[1] = tmps[gid].out[1];
+  w0[2] = tmps[gid].out[2];
+  w0[3] = tmps[gid].out[3];
+  w1[0] = tmps[gid].out[4];
+  w1[1] = tmps[gid].out[5];
+  w1[2] = tmps[gid].out[6];
+  w1[3] = tmps[gid].out[7];
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  // HMAC-SHA256 over authSafe content
+
+  sha256_hmac_ctx_t hmac_ctx;
+
+  sha256_hmac_init_64 (&hmac_ctx, w0, w1, w2, w3);
+
+  sha256_hmac_update_global_swap (&hmac_ctx, esalt_bufs[DIGESTS_OFFSET_HOST].data_buf, esalt_bufs[DIGESTS_OFFSET_HOST].data_len);
+
+  sha256_hmac_final (&hmac_ctx);
+
+  const u32 r0 = hmac_ctx.opad.h[DGST_R0];
+  const u32 r1 = hmac_ctx.opad.h[DGST_R1];
+  const u32 r2 = hmac_ctx.opad.h[DGST_R2];
+  const u32 r3 = hmac_ctx.opad.h[DGST_R3];
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/src/modules/module_24430.c
+++ b/src/modules/module_24430.c
@@ -1,0 +1,342 @@
+/**
+ * Author......: kozmer
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PRIVATE_KEY;
+static const char *HASH_NAME      = "PKCS#12 (.pfx, .p12) (SHA1 + HMAC-SHA1)";
+static const u64   KERN_TYPE      = 24430;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$pkcs12$1$2048$16$0123456789abcdef0123456789abcdef$100$308200003082000006092a864886f70d0100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa$ae3c0125849b1d877327a42c0aa768be0b1509c6";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+#define PKCS12_MIN_SALT_LEN     ( 8)
+#define PKCS12_MAX_SALT_LEN     (40)
+#define PKCS12_MIN_SALT_HEX_LEN (PKCS12_MIN_SALT_LEN * 2)
+#define PKCS12_MAX_SALT_HEX_LEN (PKCS12_MAX_SALT_LEN * 2)
+
+typedef struct pkcs12_tmp
+{
+  u32  dgst[5];
+  u32  out[5];
+
+} pkcs12_tmp_t;
+
+typedef struct pkcs12
+{
+  u32 data_buf[16384];
+  int data_len;
+
+  u32 mac_digest[5];
+
+} pkcs12_t;
+
+static const char *SIGNATURE_PKCS12 = "$pkcs12$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (pkcs12_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (pkcs12_tmp_t);
+
+  return tmp_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  pkcs12_t *pkcs12 = (pkcs12_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 8;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_PKCS12;
+
+  // $pkcs12$
+  token.len[0]     = 8;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // mac_algo
+  token.sep[1]     = '$';
+  token.len[1]     = 1;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // iterations
+  token.sep[2]     = '$';
+  token.len_min[2] = 1;
+  token.len_max[2] = 8;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // salt_len
+  token.sep[3]     = '$';
+  token.len_min[3] = 1;
+  token.len_max[3] = 3;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // salt buffer
+  token.sep[4]     = '$';
+  token.len_min[4] = PKCS12_MIN_SALT_HEX_LEN;
+  token.len_max[4] = PKCS12_MAX_SALT_HEX_LEN;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // data_len
+  token.sep[5]     = '$';
+  token.len_min[5] = 1;
+  token.len_max[5] = 8;
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // data
+  token.sep[6]     = '$';
+  token.len_min[6] = 64;
+  token.len_max[6] = 131072;
+  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // mac
+  token.sep[7]     = '$';
+  token.len[7]     = 40;
+  token.attr[7]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // mac_algo
+
+  const u8 *mac_algo_pos = token.buf[1];
+
+  if (mac_algo_pos[0] != '1') return (PARSER_SIGNATURE_UNMATCHED);
+
+  // iterations
+
+  const u8 *iter_pos = token.buf[2];
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  salt->salt_iter = iter - 1;
+
+  // salt_len
+
+  const u8 *salt_len_pos = token.buf[3];
+
+  const int salt_len_check = hc_strtoul ((const char *) salt_len_pos, NULL, 10);
+
+  // salt buffer
+
+  const u8 *salt_pos = token.buf[4];
+
+  salt->salt_len = hex_decode (salt_pos, token.len[4], (u8 *) salt->salt_buf);
+
+  if (salt_len_check != (int) salt->salt_len) return (PARSER_SALT_LENGTH);
+
+  // data_len
+
+  const u8 *data_len_pos = token.buf[5];
+
+  const int data_len_check = hc_strtoul ((const char *) data_len_pos, NULL, 10);
+
+  // data
+
+  const u8 *data_pos = token.buf[6];
+  const int data_hex_len = token.len[6];
+
+  pkcs12->data_len = hex_decode (data_pos, data_hex_len, (u8 *) pkcs12->data_buf);
+
+  if (data_len_check != pkcs12->data_len) return (PARSER_HASH_LENGTH);
+
+  // mac_hex
+
+  const u8 *mac_pos = token.buf[7];
+
+  u8 mac_buf[20];
+
+  hex_decode (mac_pos, 40, mac_buf);
+
+  pkcs12->mac_digest[0] = byte_swap_32 (((u32 *) mac_buf)[0]);
+  pkcs12->mac_digest[1] = byte_swap_32 (((u32 *) mac_buf)[1]);
+  pkcs12->mac_digest[2] = byte_swap_32 (((u32 *) mac_buf)[2]);
+  pkcs12->mac_digest[3] = byte_swap_32 (((u32 *) mac_buf)[3]);
+  pkcs12->mac_digest[4] = byte_swap_32 (((u32 *) mac_buf)[4]);
+
+  // hash
+
+  digest[0] = pkcs12->mac_digest[0];
+  digest[1] = pkcs12->mac_digest[1];
+  digest[2] = pkcs12->mac_digest[2];
+  digest[3] = pkcs12->mac_digest[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const pkcs12_t *pkcs12 = (const pkcs12_t *) esalt_buf;
+
+  // salt
+
+  char salt_hex[PKCS12_MAX_SALT_HEX_LEN + 1] = { 0 };
+
+  hex_encode ((const u8 *) salt->salt_buf, salt->salt_len, (u8 *) salt_hex);
+
+  // mac
+
+  u32 mac_buf[5];
+
+  mac_buf[0] = byte_swap_32 (pkcs12->mac_digest[0]);
+  mac_buf[1] = byte_swap_32 (pkcs12->mac_digest[1]);
+  mac_buf[2] = byte_swap_32 (pkcs12->mac_digest[2]);
+  mac_buf[3] = byte_swap_32 (pkcs12->mac_digest[3]);
+  mac_buf[4] = byte_swap_32 (pkcs12->mac_digest[4]);
+
+  char mac_hex[41] = { 0 };
+
+  hex_encode ((const u8 *) mac_buf, 20, (u8 *) mac_hex);
+
+  // output
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  int out_len = snprintf ((char *) out_buf, line_size, "%s1$%d$%d$%s$%d$",
+    SIGNATURE_PKCS12,
+    (int) salt->salt_iter + 1,
+    (int) salt->salt_len,
+    salt_hex,
+    pkcs12->data_len);
+
+  out_len += hex_encode ((const u8 *) pkcs12->data_buf, pkcs12->data_len, out_buf + out_len);
+
+  out_len += snprintf ((char *) out_buf + out_len, line_size - out_len, "$%s", mac_hex);
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_24440.c
+++ b/src/modules/module_24440.c
@@ -1,0 +1,352 @@
+/**
+ * Author......: kozmer
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PRIVATE_KEY;
+static const char *HASH_NAME      = "PKCS#12 (.pfx, .p12) (SHA256 + HMAC-SHA256)";
+static const u64   KERN_TYPE      = 24440;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$pkcs12$256$2048$16$0123456789abcdef0123456789abcdef$100$308200003082000006092a864886f70d0100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa$5b3715d7e4ee5fab89f56e803447637e69b8965cdcc6e2ef27e0c97448203671";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+#define PKCS12_MIN_SALT_LEN     ( 8)
+#define PKCS12_MAX_SALT_LEN     (40)
+#define PKCS12_MIN_SALT_HEX_LEN (PKCS12_MIN_SALT_LEN * 2)
+#define PKCS12_MAX_SALT_HEX_LEN (PKCS12_MAX_SALT_LEN * 2)
+
+typedef struct pkcs12_tmp
+{
+  u32  dgst[8];
+  u32  out[8];
+
+} pkcs12_tmp_t;
+
+typedef struct pkcs12
+{
+  u32 data_buf[16384];
+  int data_len;
+
+  u32 mac_digest[8];
+
+} pkcs12_t;
+
+static const char *SIGNATURE_PKCS12 = "$pkcs12$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (pkcs12_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (pkcs12_tmp_t);
+
+  return tmp_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  pkcs12_t *pkcs12 = (pkcs12_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 8;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_PKCS12;
+
+  // $pkcs12$
+  token.len[0]     = 8;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // mac_algo
+  token.sep[1]     = '$';
+  token.len_min[1] = 1;
+  token.len_max[1] = 3;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // iterations
+  token.sep[2]     = '$';
+  token.len_min[2] = 1;
+  token.len_max[2] = 8;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // salt_len
+  token.sep[3]     = '$';
+  token.len_min[3] = 1;
+  token.len_max[3] = 3;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // salt buffer
+  token.sep[4]     = '$';
+  token.len_min[4] = PKCS12_MIN_SALT_HEX_LEN;
+  token.len_max[4] = PKCS12_MAX_SALT_HEX_LEN;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // data_len
+  token.sep[5]     = '$';
+  token.len_min[5] = 1;
+  token.len_max[5] = 8;
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // data
+  token.sep[6]     = '$';
+  token.len_min[6] = 64;
+  token.len_max[6] = 131072;
+  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // mac
+  token.sep[7]     = '$';
+  token.len[7]     = 64;
+  token.attr[7]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // mac_algo
+
+  const u8 *mac_algo_pos = token.buf[1];
+
+  if (token.len[1] != 3) return (PARSER_SIGNATURE_UNMATCHED);
+  if (mac_algo_pos[0] != '2') return (PARSER_SIGNATURE_UNMATCHED);
+  if (mac_algo_pos[1] != '5') return (PARSER_SIGNATURE_UNMATCHED);
+  if (mac_algo_pos[2] != '6') return (PARSER_SIGNATURE_UNMATCHED);
+
+  // iterations
+
+  const u8 *iter_pos = token.buf[2];
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  salt->salt_iter = iter - 1;
+
+  // salt_len
+
+  const u8 *salt_len_pos = token.buf[3];
+
+  const int salt_len_check = hc_strtoul ((const char *) salt_len_pos, NULL, 10);
+
+  // salt buffer
+
+  const u8 *salt_pos = token.buf[4];
+
+  salt->salt_len = hex_decode (salt_pos, token.len[4], (u8 *) salt->salt_buf);
+
+  if (salt_len_check != (int) salt->salt_len) return (PARSER_SALT_LENGTH);
+
+  // data_len
+
+  const u8 *data_len_pos = token.buf[5];
+
+  const int data_len_check = hc_strtoul ((const char *) data_len_pos, NULL, 10);
+
+  // data
+
+  const u8 *data_pos = token.buf[6];
+  const int data_hex_len = token.len[6];
+
+  pkcs12->data_len = hex_decode (data_pos, data_hex_len, (u8 *) pkcs12->data_buf);
+
+  if (data_len_check != pkcs12->data_len) return (PARSER_HASH_LENGTH);
+
+  // mac_hex
+
+  const u8 *mac_pos = token.buf[7];
+
+  u8 mac_buf[32];
+
+  hex_decode (mac_pos, 64, mac_buf);
+
+  pkcs12->mac_digest[0] = byte_swap_32 (((u32 *) mac_buf)[0]);
+  pkcs12->mac_digest[1] = byte_swap_32 (((u32 *) mac_buf)[1]);
+  pkcs12->mac_digest[2] = byte_swap_32 (((u32 *) mac_buf)[2]);
+  pkcs12->mac_digest[3] = byte_swap_32 (((u32 *) mac_buf)[3]);
+  pkcs12->mac_digest[4] = byte_swap_32 (((u32 *) mac_buf)[4]);
+  pkcs12->mac_digest[5] = byte_swap_32 (((u32 *) mac_buf)[5]);
+  pkcs12->mac_digest[6] = byte_swap_32 (((u32 *) mac_buf)[6]);
+  pkcs12->mac_digest[7] = byte_swap_32 (((u32 *) mac_buf)[7]);
+
+  // hash
+
+  digest[0] = pkcs12->mac_digest[0];
+  digest[1] = pkcs12->mac_digest[1];
+  digest[2] = pkcs12->mac_digest[2];
+  digest[3] = pkcs12->mac_digest[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const pkcs12_t *pkcs12 = (const pkcs12_t *) esalt_buf;
+
+  // salt
+
+  char salt_hex[PKCS12_MAX_SALT_HEX_LEN + 1] = { 0 };
+
+  hex_encode ((const u8 *) salt->salt_buf, salt->salt_len, (u8 *) salt_hex);
+
+  // mac
+
+  u32 mac_buf[8];
+
+  mac_buf[0] = byte_swap_32 (pkcs12->mac_digest[0]);
+  mac_buf[1] = byte_swap_32 (pkcs12->mac_digest[1]);
+  mac_buf[2] = byte_swap_32 (pkcs12->mac_digest[2]);
+  mac_buf[3] = byte_swap_32 (pkcs12->mac_digest[3]);
+  mac_buf[4] = byte_swap_32 (pkcs12->mac_digest[4]);
+  mac_buf[5] = byte_swap_32 (pkcs12->mac_digest[5]);
+  mac_buf[6] = byte_swap_32 (pkcs12->mac_digest[6]);
+  mac_buf[7] = byte_swap_32 (pkcs12->mac_digest[7]);
+
+  char mac_hex[65] = { 0 };
+
+  hex_encode ((const u8 *) mac_buf, 32, (u8 *) mac_hex);
+
+  // output
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  int out_len = snprintf ((char *) out_buf, line_size, "%s256$%d$%d$%s$%d$",
+    SIGNATURE_PKCS12,
+    (int) salt->salt_iter + 1,
+    (int) salt->salt_len,
+    salt_hex,
+    pkcs12->data_len);
+
+  out_len += hex_encode ((const u8 *) pkcs12->data_buf, pkcs12->data_len, out_buf + out_len);
+
+  out_len += snprintf ((char *) out_buf + out_len, line_size - out_len, "$%s", mac_hex);
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/pkcs12_to_hashcat.py
+++ b/tools/pkcs12_to_hashcat.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import binascii
+import sys
+
+try:
+    from asn1crypto import pkcs12
+except ImportError:
+    sys.stderr.write("asn1crypto is missing, run 'pip install asn1crypto' to install it\n")
+    sys.exit(1)
+
+
+def parse_pkcs12(filename):
+    data = open(filename, "rb").read()
+    pfx = pkcs12.Pfx.load(data)
+
+    auth_safe = pfx['auth_safe']
+    if auth_safe['content_type'].native != 'data':
+        sys.stderr.write("%s: only password-protected PKCS12 files are supported\n" % filename)
+        return
+
+    mac_data = pfx['mac_data']
+    if not mac_data:
+        sys.stderr.write("%s: no MAC data found in PKCS12 file\n" % filename)
+        return
+
+    mac_algo = mac_data['mac']['digest_algorithm']['algorithm'].native
+
+    mac_algo_numeric = {
+        'sha1': 1,
+        'sha256': 256,
+        'sha512': 512,
+    }.get(mac_algo)
+
+    if mac_algo_numeric is None:
+        sys.stderr.write("%s: unsupported MAC algorithm '%s'\n" % (filename, mac_algo))
+        return
+
+    salt = mac_data['mac_salt'].native
+    iterations = mac_data['iterations'].native
+    stored_hmac = mac_data['mac']['digest'].native
+    content_data = auth_safe['content'].contents
+
+    hash_line = "$pkcs12$%s$%s$%s$%s$%s$%s$%s" % (
+        mac_algo_numeric,
+        iterations,
+        len(salt),
+        binascii.hexlify(salt).decode(),
+        len(content_data),
+        binascii.hexlify(content_data).decode(),
+        binascii.hexlify(stored_hmac).decode(),
+    )
+
+    sys.stdout.write("%s\n" % hash_line)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.stderr.write("Usage: %s <.pfx/.p12 file(s)>\n" % sys.argv[0])
+        sys.exit(1)
+
+    for i in range(1, len(sys.argv)):
+        parse_pkcs12(sys.argv[i])

--- a/tools/test_modules/m24430.pm
+++ b/tools/test_modules/m24430.pm
@@ -1,0 +1,113 @@
+#!/usr/bin/env perl
+
+##
+## Author......: kozmer
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha1 hmac_sha1);
+use Encode;
+
+sub module_constraints { [[0, 48], [16, 40], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $iter = shift // 2048;
+  my $data = shift;
+
+  my $salt_bin = pack ("H*", $salt);
+
+  if (defined ($data) == 0)
+  {
+    $data = unpack ("H*", random_bytes (100));
+  }
+
+  my $data_bin = pack ("H*", $data);
+
+  # PKCS#12 KDF (RFC 7292 Appendix B), id=3 (MAC key)
+
+  my $pwd_utf16 = encode ("UTF-16BE", $word) . "\x00\x00";
+  my $p = length ($pwd_utf16);
+
+  my $D = "\x03" x 64;
+
+  my $v = 64;
+  my $S = "";
+
+  if (length ($salt_bin) > 0)
+  {
+    my $s_repeats = int ($v / length ($salt_bin)) + 1;
+    $S = substr ($salt_bin x $s_repeats, 0, $v);
+  }
+
+  my $v2 = int (($p + $v - 1) / $v) * $v;
+  my $P = "";
+
+  if ($p > 0)
+  {
+    my $p_repeats = int ($v2 / $p) + 1;
+    $P = substr ($pwd_utf16 x $p_repeats, 0, $v2);
+  }
+
+  my $h = sha1 ($D . $S . $P);
+
+  for (my $i = 1; $i < $iter; $i++)
+  {
+    $h = sha1 ($h);
+  }
+
+  my $mac_key = substr ($h, 0, 20);
+
+  my $computed_mac = hmac_sha1 ($data_bin, $mac_key);
+
+  my $hash = sprintf ('$pkcs12$1$%d$%d$%s$%d$%s$%s',
+    $iter,
+    length ($salt_bin),
+    unpack ("H*", $salt_bin),
+    length ($data_bin),
+    $data,
+    unpack ("H*", $computed_mac));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless substr ($hash, 0, 9) eq '$pkcs12$1';
+
+  my (undef, $signature, $mac_algo, $iter, $salt_len, $salt, $data_len, $data, $mac) = split '\$', $hash;
+
+  return unless defined $signature;
+  return unless defined $mac_algo;
+  return unless defined $iter;
+  return unless defined $salt_len;
+  return unless defined $salt;
+  return unless defined $data_len;
+  return unless defined $data;
+  return unless defined $mac;
+
+  return unless ($signature eq 'pkcs12');
+  return unless ($mac_algo eq '1');
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $iter, $data);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m24440.pm
+++ b/tools/test_modules/m24440.pm
@@ -1,0 +1,113 @@
+#!/usr/bin/env perl
+
+##
+## Author......: kozmer
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha256 hmac_sha256);
+use Encode;
+
+sub module_constraints { [[0, 48], [16, 40], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $iter = shift // 2048;
+  my $data = shift;
+
+  my $salt_bin = pack ("H*", $salt);
+
+  if (defined ($data) == 0)
+  {
+    $data = unpack ("H*", random_bytes (100));
+  }
+
+  my $data_bin = pack ("H*", $data);
+
+  # PKCS#12 KDF (RFC 7292 Appendix B), id=3 (MAC key)
+
+  my $pwd_utf16 = encode ("UTF-16BE", $word) . "\x00\x00";
+  my $p = length ($pwd_utf16);
+
+  my $D = "\x03" x 64;
+
+  my $v = 64;
+  my $S = "";
+
+  if (length ($salt_bin) > 0)
+  {
+    my $s_repeats = int ($v / length ($salt_bin)) + 1;
+    $S = substr ($salt_bin x $s_repeats, 0, $v);
+  }
+
+  my $v2 = int (($p + $v - 1) / $v) * $v;
+  my $P = "";
+
+  if ($p > 0)
+  {
+    my $p_repeats = int ($v2 / $p) + 1;
+    $P = substr ($pwd_utf16 x $p_repeats, 0, $v2);
+  }
+
+  my $h = sha256 ($D . $S . $P);
+
+  for (my $i = 1; $i < $iter; $i++)
+  {
+    $h = sha256 ($h);
+  }
+
+  my $mac_key = substr ($h, 0, 32);
+
+  my $computed_mac = hmac_sha256 ($data_bin, $mac_key);
+
+  my $hash = sprintf ('$pkcs12$256$%d$%d$%s$%d$%s$%s',
+    $iter,
+    length ($salt_bin),
+    unpack ("H*", $salt_bin),
+    length ($data_bin),
+    $data,
+    unpack ("H*", $computed_mac));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless substr ($hash, 0, 10) eq '$pkcs12$2';
+
+  my (undef, $signature, $mac_algo, $iter, $salt_len, $salt, $data_len, $data, $mac) = split '\$', $hash;
+
+  return unless defined $signature;
+  return unless defined $mac_algo;
+  return unless defined $iter;
+  return unless defined $salt_len;
+  return unless defined $salt;
+  return unless defined $data_len;
+  return unless defined $data;
+  return unless defined $mac;
+
+  return unless ($signature eq 'pkcs12');
+  return unless ($mac_algo eq '256');
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $iter, $data);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This resolves #351 which has been open since 2016. It adds PKCS#12 (.pfx, .p12) password cracking by going after the integrity MAC instead of the encrypted contents. Uses the PKCS#12 KDF from RFC 7292 Appendix B with id=3, which means only one key derivation is needed and no decryption at all.

- 24430: SHA-1 KDF + HMAC-SHA1
- 24440: SHA-256 KDF + HMAC-SHA256

Also includes extraction tool (`tools/pkcs12_to_hashcat.py`) and test modules for both modes.

```
$ ./tools/test.sh -m 24430 -a all -t all -P
[ test_1773946355 ] > Init test for hash type 24430.
[ test_1773946355 ] [ Type 24430, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1773946355 ] [ Type 24430, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1773946355 ] [ Type 24430, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1773946355 ] [ Type 24430, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
```

```
$ ./tools/test.sh -m 24440 -a all -t all -P
[ test_1773946384 ] > Init test for hash type 24440.
[ test_1773946384 ] [ Type 24440, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1773946384 ] [ Type 24440, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1773946384 ] [ Type 24440, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1773946384 ] [ Type 24440, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
```