### PR TITLE
Fix Windows/WSL PATH issue

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -9521,9 +9521,15 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
         nvrtc_options[nvrtc_options_idx++] = "--minimal";
       }
 
-      // untested on windows, but it should work
-      #if defined (__CYGWIN__) || defined (__MSYS__)
-      // when built with cygwin or msys, cpath_real is a POSIX-style path that GPU runtimes cannot use
+      #if defined (_WIN)
+      // cpath_real on _WIN uses forward slashes, but UNC paths (\\server\share)
+      // become //server/share after conversion. The leading // is interpreted as a
+      // C++ line comment when embedded in a -D preprocessor value, leaving
+      // INCLUDE_PATH empty. Instead pass shared_dir as an explicit -I search path
+      // and keep INCLUDE_PATH as the relative subdirectory name.
+      hc_asprintf (&nvrtc_options[nvrtc_options_idx++], "-I%s", folder_config->shared_dir);
+      hc_asprintf (&nvrtc_options[nvrtc_options_idx++], "-D INCLUDE_PATH=%s", "OpenCL");
+      #elif defined (__CYGWIN__) || defined (__MSYS__)
       hc_asprintf (&nvrtc_options[nvrtc_options_idx++], "-D INCLUDE_PATH=%s", "OpenCL");
       #else
       hc_asprintf (&nvrtc_options[nvrtc_options_idx++], "-D INCLUDE_PATH=%s", folder_config->cpath_real);
@@ -9769,13 +9775,16 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
         hc_asprintf (&hiprtc_options[hiprtc_options_idx++], "--gpu-max-threads-per-block=%d", (user_options->kernel_threads_chgd == true) ? user_options->kernel_threads : device_param->kernel_threads_max);
       }
 
-      // untested but it should work
-      #if defined (__CYGWIN__) || defined (__MSYS__)
-      // when built with cygwin or msys, cpath_real is a POSIX-style path that GPU runtimes cannot use
+      #if defined (_WIN)
+      // See NVRTC comment above: avoid embedding cpath_real in -D INCLUDE_PATH
+      // because UNC paths become // after forward-slash conversion and are then
+      // treated as C++ comments by the compiler preprocessor.
+      hc_asprintf (&hiprtc_options[hiprtc_options_idx++], "-I%s", folder_config->shared_dir);
+      hc_asprintf (&hiprtc_options[hiprtc_options_idx++], "-D INCLUDE_PATH=%s", "OpenCL");
+      #elif defined (__CYGWIN__) || defined (__MSYS__)
       hc_asprintf (&hiprtc_options[hiprtc_options_idx++], "-D INCLUDE_PATH=%s/OpenCL/", folder_config->cwd);
       // ugly, but required since HIPRTC is changing the current working folder to the temporary compile folder
       #else
-      // cpath_real is an absolute path (short/8.3 on Windows) so it is immune to cwd changes by HIPRTC
       hc_asprintf (&hiprtc_options[hiprtc_options_idx++], "-D INCLUDE_PATH=%s", folder_config->cpath_real);
       #endif
 
@@ -14332,25 +14341,24 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
     }
     else
     {
-      #if defined (__CYGWIN__) || defined (__MSYS__)
+      #if defined (_WIN)
+      // See NVRTC comment above: cpath_real cannot be used as -D INCLUDE_PATH on
+      // _WIN because UNC paths produce a leading // that is treated as a C++ comment.
+      // Pass shared_dir as an explicit -I search path instead.
+      const char *win_opencl_include_fmt = (strchr (folder_config->shared_dir, ' ') != NULL) ? "-I \"%s\" " : "-I %s ";
+
+      build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, win_opencl_include_fmt, folder_config->shared_dir);
+      build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-D INCLUDE_PATH=%s ", "OpenCL");
+      #elif defined (__CYGWIN__) || defined (__MSYS__)
       // workaround for AMD
       if (device_param->opencl_platform_vendor_id == VENDOR_ID_AMD && device_param->opencl_device_vendor_id == VENDOR_ID_AMD)
       {
         build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-I . ");
       }
 
-      // when built with cygwin or msys, cpath_real is a POSIX-style path that GPU runtimes cannot use
+      // when built with cygwin or msys, cpath_real doesn't work
       build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-D INCLUDE_PATH=%s ", "OpenCL");
       #else
-      #if defined (_WIN)
-      // workaround for AMD on Windows: keep -I . so AMD's runtime can fall back to cwd-relative includes
-      if (device_param->opencl_platform_vendor_id == VENDOR_ID_AMD && device_param->opencl_device_vendor_id == VENDOR_ID_AMD)
-      {
-        build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-I . ");
-      }
-      #endif
-
-      // cpath_real is an absolute (and 8.3/short on Windows) path, safe for all compilers
       const char *build_options_include_fmt = (strchr (folder_config->cpath_real, ' ') != NULL) ? "-D INCLUDE_PATH=\"%s\" " : "-D INCLUDE_PATH=%s ";
 
       build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, build_options_include_fmt, folder_config->cpath_real);

--- a/src/backend.c
+++ b/src/backend.c
@@ -9522,7 +9522,8 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
       }
 
       // untested on windows, but it should work
-      #if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
+      #if defined (__CYGWIN__) || defined (__MSYS__)
+      // when built with cygwin or msys, cpath_real is a POSIX-style path that GPU runtimes cannot use
       hc_asprintf (&nvrtc_options[nvrtc_options_idx++], "-D INCLUDE_PATH=%s", "OpenCL");
       #else
       hc_asprintf (&nvrtc_options[nvrtc_options_idx++], "-D INCLUDE_PATH=%s", folder_config->cpath_real);
@@ -9769,10 +9770,12 @@ static bool load_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
       }
 
       // untested but it should work
-      #if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
+      #if defined (__CYGWIN__) || defined (__MSYS__)
+      // when built with cygwin or msys, cpath_real is a POSIX-style path that GPU runtimes cannot use
       hc_asprintf (&hiprtc_options[hiprtc_options_idx++], "-D INCLUDE_PATH=%s/OpenCL/", folder_config->cwd);
       // ugly, but required since HIPRTC is changing the current working folder to the temporary compile folder
       #else
+      // cpath_real is an absolute path (short/8.3 on Windows) so it is immune to cwd changes by HIPRTC
       hc_asprintf (&hiprtc_options[hiprtc_options_idx++], "-D INCLUDE_PATH=%s", folder_config->cpath_real);
       #endif
 
@@ -14329,16 +14332,25 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
     }
     else
     {
-      #if defined (_WIN) || defined (__CYGWIN__) || defined (__MSYS__)
+      #if defined (__CYGWIN__) || defined (__MSYS__)
       // workaround for AMD
       if (device_param->opencl_platform_vendor_id == VENDOR_ID_AMD && device_param->opencl_device_vendor_id == VENDOR_ID_AMD)
       {
         build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-I . ");
       }
 
-      // when built with cygwin or msys, cpath_real doesn't work
+      // when built with cygwin or msys, cpath_real is a POSIX-style path that GPU runtimes cannot use
       build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-D INCLUDE_PATH=%s ", "OpenCL");
       #else
+      #if defined (_WIN)
+      // workaround for AMD on Windows: keep -I . so AMD's runtime can fall back to cwd-relative includes
+      if (device_param->opencl_platform_vendor_id == VENDOR_ID_AMD && device_param->opencl_device_vendor_id == VENDOR_ID_AMD)
+      {
+        build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-I . ");
+      }
+      #endif
+
+      // cpath_real is an absolute (and 8.3/short on Windows) path, safe for all compilers
       const char *build_options_include_fmt = (strchr (folder_config->cpath_real, ' ') != NULL) ? "-D INCLUDE_PATH=\"%s\" " : "-D INCLUDE_PATH=%s ";
 
       build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, build_options_include_fmt, folder_config->cpath_real);

--- a/src/folder.c
+++ b/src/folder.c
@@ -40,7 +40,7 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   wchar_t *wexec_path = (wchar_t *) hcmalloc (exec_path_sz * sizeof (wchar_t));
 
-  const DWORD wlen = GetModuleFileNameW (NULL, wexec_path, (DWORD) exec_path_sz);
+  const DWORD wlen = GetModuleFileNameW (NULL, wexec_path, (DWORD) (exec_path_sz - 1));
 
   if (wlen == 0)
   {
@@ -49,13 +49,13 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
     return -1;
   }
 
-  const int conv_len = WideCharToMultiByte (CP_UTF8, 0, wexec_path, -1, exec_path, (int) exec_path_sz, NULL, NULL);
+  // Convert UTF-16 path to UTF-8. Pass wlen (not -1) so the returned byte
+  // count excludes the null terminator, matching what exec_path[len] = 0 expects.
+  const int len = WideCharToMultiByte (CP_UTF8, 0, wexec_path, (int) wlen, exec_path, (int) (exec_path_sz - 1), NULL, NULL);
 
   hcfree (wexec_path);
 
-  if (conv_len == 0) return -1;
-
-  const size_t len = (size_t) conv_len - 1;
+  if (len == 0) return -1;
 
   #elif defined (__APPLE__)
 
@@ -513,53 +513,7 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   char *cpath_real = NULL;
 
-  {
-    char *cpath_tmp = NULL;
-
-    hc_asprintf (&cpath_tmp, "%s\\OpenCL\\", shared_dir);
-
-    // Try to obtain the 8.3 short path so that NVRTC/OpenCL compilers receive an
-    // ASCII-only include path even when the user's home directory contains
-    // non-ASCII characters (e.g. Chinese/Japanese user names).
-    wchar_t *wpath_long  = (wchar_t *) hcmalloc (HCBUFSIZ_TINY * sizeof (wchar_t));
-    wchar_t *wpath_short = (wchar_t *) hcmalloc (HCBUFSIZ_TINY * sizeof (wchar_t));
-
-    if (MultiByteToWideChar (CP_UTF8, 0, cpath_tmp, -1, wpath_long, HCBUFSIZ_TINY) > 0)
-    {
-      const DWORD short_len = GetShortPathNameW (wpath_long, wpath_short, (DWORD) HCBUFSIZ_TINY);
-
-      if (short_len > 0 && short_len < (DWORD) HCBUFSIZ_TINY)
-      {
-        char *cpath_short = (char *) hcmalloc (HCBUFSIZ_TINY);
-
-        if (WideCharToMultiByte (CP_UTF8, 0, wpath_short, -1, cpath_short, HCBUFSIZ_TINY, NULL, NULL) > 0)
-        {
-          cpath_real = cpath_short;
-        }
-        else
-        {
-          hcfree (cpath_short);
-
-          cpath_real = cpath_tmp;
-          cpath_tmp  = NULL;
-        }
-      }
-      else
-      {
-        cpath_real = cpath_tmp;
-        cpath_tmp  = NULL;
-      }
-    }
-    else
-    {
-      cpath_real = cpath_tmp;
-      cpath_tmp  = NULL;
-    }
-
-    hcfree (wpath_long);
-    hcfree (wpath_short);
-    hcfree (cpath_tmp);
-  }
+  hc_asprintf (&cpath_real, "%s\\OpenCL\\", shared_dir);
 
   #else
 

--- a/src/folder.c
+++ b/src/folder.c
@@ -38,9 +38,24 @@ static int get_exec_path (char *exec_path, const size_t exec_path_sz)
 
   #elif defined (_WIN)
 
-  memset (exec_path, 0, exec_path_sz);
+  wchar_t *wexec_path = (wchar_t *) hcmalloc (exec_path_sz * sizeof (wchar_t));
 
-  const int len = 0;
+  const DWORD wlen = GetModuleFileNameW (NULL, wexec_path, (DWORD) exec_path_sz);
+
+  if (wlen == 0)
+  {
+    hcfree (wexec_path);
+
+    return -1;
+  }
+
+  const int conv_len = WideCharToMultiByte (CP_UTF8, 0, wexec_path, -1, exec_path, (int) exec_path_sz, NULL, NULL);
+
+  hcfree (wexec_path);
+
+  if (conv_len == 0) return -1;
+
+  const size_t len = (size_t) conv_len - 1;
 
   #elif defined (__APPLE__)
 
@@ -498,7 +513,53 @@ int folder_config_init (hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED const char *ins
 
   char *cpath_real = NULL;
 
-  hc_asprintf (&cpath_real, "%s\\OpenCL\\", shared_dir);
+  {
+    char *cpath_tmp = NULL;
+
+    hc_asprintf (&cpath_tmp, "%s\\OpenCL\\", shared_dir);
+
+    // Try to obtain the 8.3 short path so that NVRTC/OpenCL compilers receive an
+    // ASCII-only include path even when the user's home directory contains
+    // non-ASCII characters (e.g. Chinese/Japanese user names).
+    wchar_t *wpath_long  = (wchar_t *) hcmalloc (HCBUFSIZ_TINY * sizeof (wchar_t));
+    wchar_t *wpath_short = (wchar_t *) hcmalloc (HCBUFSIZ_TINY * sizeof (wchar_t));
+
+    if (MultiByteToWideChar (CP_UTF8, 0, cpath_tmp, -1, wpath_long, HCBUFSIZ_TINY) > 0)
+    {
+      const DWORD short_len = GetShortPathNameW (wpath_long, wpath_short, (DWORD) HCBUFSIZ_TINY);
+
+      if (short_len > 0 && short_len < (DWORD) HCBUFSIZ_TINY)
+      {
+        char *cpath_short = (char *) hcmalloc (HCBUFSIZ_TINY);
+
+        if (WideCharToMultiByte (CP_UTF8, 0, wpath_short, -1, cpath_short, HCBUFSIZ_TINY, NULL, NULL) > 0)
+        {
+          cpath_real = cpath_short;
+        }
+        else
+        {
+          hcfree (cpath_short);
+
+          cpath_real = cpath_tmp;
+          cpath_tmp  = NULL;
+        }
+      }
+      else
+      {
+        cpath_real = cpath_tmp;
+        cpath_tmp  = NULL;
+      }
+    }
+    else
+    {
+      cpath_real = cpath_tmp;
+      cpath_tmp  = NULL;
+    }
+
+    hcfree (wpath_long);
+    hcfree (wpath_short);
+    hcfree (cpath_tmp);
+  }
 
   #else
 


### PR DESCRIPTION
This PR fixes what is probably the most annoying bug on Windows/WSL. Fixes #3365, #1539, and addresses the UTF-16 username issue from #4180.

**Executable path not resolved on Windows (src/folder.c)**                                                                                                                                             

get_exec_path() had a stub Windows implementation that always returned an empty string, so the install directory always defaulted to . (current working directory).

**Fix:** Replaced with GetModuleFileNameW() which returns the actual path of the running executable regardless of where it was launched from. The wide-char result is converted to UTF-8 via WideCharToMultiByte(CP_UTF8, ...) so that paths containing non-ASCII characters (e.g. a username with Chinese/Unicode characters) are handled correctly. GetModuleFileNameA would silently corrupt or drop such characters on non-matching system code pages.

**GPU kernel include path hardcoded to relative "OpenCL" (src/backend.c)**                                                                                                            

Even with the correct executable path, all three GPU compiler backends (NVRTC/CUDA, HIPRTC/HIP, OpenCL) had a #if defined(_WIN) || ... branch that discarded cpath_real and hardcoded INCLUDE_PATH=OpenCL, relying on the CWD to resolve the include.

**Fix:** Removed _WIN from those conditions so it falls through to the cpath_real code path, matching the behaviour on Linux/macOS.                                                                                                                                                                         
                  
**UNC paths breaking the preprocessor (src/backend.c)**                                                                                                                    

When running from the WSL home directory, GetModuleFileNameW returns a UNC path like \\wsl.localhost\Ubuntu\home\user\hashcat\hashcat.exe. After the existing naive_replace('\\', '/') in folder.c, cpath_real becomes //wsl.localhost/.... Passing this as -D INCLUDE_PATH=//wsl.localhost/... to a GPU compiler is equivalent to writing #define INCLUDE_PATH //wsl.localhost/... in C source — the // is a line comment, so INCLUDE_PATH expands to nothing and #include M2S(INCLUDE_PATH/inc_vendor.h) becomes #include "/inc_vendor.h".           

**Fix:** For _WIN builds, pass shared_dir as an explicit -I compiler include search path (a filesystem-level flag, never parsed as C tokens) and keep INCLUDE_PATH=OpenCL as a plain subdirectory name. The compiler resolves #include "OpenCL/inc_vendor.h" by searching the -I path, finding the headers in shared_dir/OpenCL/ regardless of CWD.
