### PR TITLE
Replace salt separator in multi salt hashes for compatibility with Hashtopolis

### DIFF
--- a/src/modules/module_03730.c
+++ b/src/modules/module_03730.c
@@ -75,17 +75,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 32;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -182,13 +182,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) md5_double_salt->salt1_buf, md5_double_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_18100.c
+++ b/src/modules/module_18100.c
@@ -72,13 +72,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     for (int i = 0; i < count; i += 2)
     {
-      token.sep[i + 0]     = hashconfig->separator;
+      token.sep[i + 0]     = ':';
       token.len[i + 0]     = 6;
       token.attr[i + 0]    = TOKEN_ATTR_FIXED_LENGTH
                            | TOKEN_ATTR_VERIFY_DIGIT;
 
       // 0 to 18446744073709551616
-      token.sep[i + 1]     = hashconfig->separator;
+      token.sep[i + 1]     = ':';
       token.len_min[i + 1] = 1;
       token.len_max[i + 1] = 20;
       token.attr[i + 1]    = TOKEN_ATTR_VERIFY_LENGTH
@@ -163,7 +163,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   for (; i < count - 1; i += 1)
   {
     const u64 tmp_salt_buf = (((u64) (salt->salt_buf[4 * i + 2])) << 32) | ((u64) (salt->salt_buf[4 * i + 3]));
-    const int ret = snprintf (line_buf + line_len, line_size - line_len, "%06d%c%" PRIu64 "%c", digest[i], hashconfig->separator, tmp_salt_buf, hashconfig->separator);
+    const int ret = snprintf (line_buf + line_len, line_size - line_len, "%06d%c%" PRIu64 "%c", digest[i], ':', tmp_salt_buf, ':');
     line_len += ret;
 
     // error
@@ -175,7 +175,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // the last TOTP code
   const u64 tmp_salt_buf = (((u64) (salt->salt_buf[4 * i + 2])) << 32) | ((u64) (salt->salt_buf[4 * i + 3]));
-  const int ret = snprintf (line_buf + line_len, line_size - line_len, "%06d%c%" PRIu64, digest[i], hashconfig->separator, tmp_salt_buf);
+  const int ret = snprintf (line_buf + line_len, line_size - line_len, "%06d%c%" PRIu64, digest[i], ':', tmp_salt_buf);
   line_len += ret;
 
   // error

--- a/src/modules/module_19300.c
+++ b/src/modules/module_19300.c
@@ -72,17 +72,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 40;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -178,13 +178,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[4], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) sha1_double_salt->salt1_buf, sha1_double_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_19500.c
+++ b/src/modules/module_19500.c
@@ -89,17 +89,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 40;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -195,13 +195,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[4], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) devise_double_salt->salt_buf, devise_double_salt->salt_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_21310.c
+++ b/src/modules/module_21310.c
@@ -77,17 +77,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 32;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -193,13 +193,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) md5_double_salt->salt1_buf, md5_double_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_21900.c
+++ b/src/modules/module_21900.c
@@ -73,17 +73,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 32;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -180,13 +180,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) md5_double_salt->salt1_buf, md5_double_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_29000.c
+++ b/src/modules/module_29000.c
@@ -95,18 +95,18 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 40;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
@@ -208,13 +208,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[4], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) sha1_double_salt->salt1_buf, sha1_double_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_30700.c
+++ b/src/modules/module_30700.c
@@ -185,7 +185,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[6], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[7], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_31700.c
+++ b/src/modules/module_31700.c
@@ -73,17 +73,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 32;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -180,13 +180,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) md5_double_salt->salt1_buf, md5_double_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_32300.c
+++ b/src/modules/module_32300.c
@@ -97,17 +97,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 32;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -226,13 +226,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) md5_triple_salt->salt1_buf, md5_triple_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 

--- a/src/modules/module_33000.c
+++ b/src/modules/module_33000.c
@@ -98,17 +98,17 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.token_cnt  = 3;
 
-  token.sep[0]     = hashconfig->separator;
+  token.sep[0]     = ':';
   token.len[0]     = 32;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[1]     = hashconfig->separator;
+  token.sep[1]     = ':';
   token.len_min[1] = SALT_MIN;
   token.len_max[1] = SALT_MAX;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.sep[2]     = hashconfig->separator;
+  token.sep[2]     = ':';
   token.len_min[2] = SALT_MIN;
   token.len_max[2] = SALT_MAX;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
@@ -205,13 +205,13 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   u32_to_hex (tmp[2], out_buf + out_len); out_len += 8;
   u32_to_hex (tmp[3], out_buf + out_len); out_len += 8;
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 
   out_len += generic_salt_encode (hashconfig, (const u8 *) md5_double_salt->salt1_buf, md5_double_salt->salt1_len, out_buf + out_len);
 
-  out_buf[out_len] = hashconfig->separator;
+  out_buf[out_len] = ':';
 
   out_len += 1;
 


### PR DESCRIPTION


Fixed #4445 using the same implementation as https://github.com/hashcat/hashcat/pull/1727

This pull request standardizes the separator character used in hash encoding and decoding across multiple hash module files. Previously, the separator was configurable via `hashconfig->separator`, but now it is hardcoded to `':'` (colon) for consistency. This affects both the parsing (decode) and formatting (encode) logic in each affected module.

**Modules Affected:**
* The change applies to the following modules: `module_03730.c`, `module_18100.c`, `module_19300.c`, `module_19500.c`, `module_21310.c`, `module_21900.c`, `module_29000.c`, `module_30700.c`, `module_31700.c`, `module_32300.c`, and `module_33000.c`. Each module's encode/decode logic is updated to use the colon separator. 

Implementing this is required to make them work with Hashtopolis.

I used the following script to find affected modules:

```
#!/usr/bin/env bash

SEARCH_DIR="${1:-.}"

find "$SEARCH_DIR" -type f -print0 |
while IFS= read -r -d '' file; do

    # File must contain separator
    grep -q "hashconfig->separator" "$file" || continue

    # Process ST_HASH lines safely
    while read -r line; do

        # Remove // comments
        line="${line%%//*}"

        # Extract quoted string
        hash=$(sed -n 's/.*ST_HASH[^"]*"\([^"]*\)".*/\1/p' <<< "$line")

        [[ -z "$hash" ]] && continue

        # Count colons only inside quoted hash
        colon_count=$(tr -cd ':' <<< "$hash" | wc -c)

        if (( colon_count > 1 )); then
            echo "Updating: $file"
            sed -i "s/hashconfig->separator/':'/g" "$file"
            break
        fi

    done < <(grep 'ST_HASH' "$file")

done
```