### PR TITLE
Add hash-mode: Mozilla key4.db SHA384 (m26150)

### DIFF
--- a/OpenCL/m26150-pure.cl
+++ b/OpenCL/m26150-pure.cl
@@ -1,0 +1,447 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha384.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct mozilla_aes_tmp
+{
+  u32  ipad[8];
+  u32  opad[8];
+
+  u32  dgst[8];
+  u32  out[8];
+
+} mozilla_aes_tmp_t;
+
+typedef struct mozilla_aes
+{
+  u32 iv_buf[4];
+  u32 ct_buf[4];
+
+} mozilla_aes_t;
+
+DECLSPEC void hmac_sha256_run_V (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad, PRIVATE_AS u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+  digest[5] = ipad[5];
+  digest[6] = ipad[6];
+  digest[7] = ipad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = digest[5];
+  w1[2] = digest[6];
+  w1[3] = digest[7];
+  w2[0] = 0x80000000;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 32) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+  digest[5] = opad[5];
+  digest[6] = opad[6];
+  digest[7] = opad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+}
+
+KERNEL_FQ KERNEL_FA void m26150_init (KERN_ATTR_TMPS_ESALT (mozilla_aes_tmp_t, mozilla_aes_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // SHA384(global_salt + password) -- Firefox 146+ uses SHA384 instead of SHA1
+  // global_salt is 48 bytes (12 x u32) stored in salt_buf[0..11]
+
+  sha384_ctx_t ctx;
+
+  sha384_init (&ctx);
+
+  u32 gs[32] = { 0 };
+
+  gs[ 0] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 0];
+  gs[ 1] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 1];
+  gs[ 2] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 2];
+  gs[ 3] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 3];
+  gs[ 4] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 4];
+  gs[ 5] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 5];
+  gs[ 6] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 6];
+  gs[ 7] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 7];
+  gs[ 8] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 8];
+  gs[ 9] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[ 9];
+  gs[10] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[10];
+  gs[11] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[11];
+
+  sha384_update_swap (&ctx, gs, 48);
+  sha384_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+
+  sha384_final (&ctx);
+
+  // Full 48-byte SHA384 output used as PBKDF2 password
+  // SHA384 ctx.h[] are u64 (big-endian), extract to u32
+
+  u32 ek[16] = { 0 };
+
+  ek[ 0] = h32_from_64_S (ctx.h[0]);
+  ek[ 1] = l32_from_64_S (ctx.h[0]);
+  ek[ 2] = h32_from_64_S (ctx.h[1]);
+  ek[ 3] = l32_from_64_S (ctx.h[1]);
+  ek[ 4] = h32_from_64_S (ctx.h[2]);
+  ek[ 5] = l32_from_64_S (ctx.h[2]);
+  ek[ 6] = h32_from_64_S (ctx.h[3]);
+  ek[ 7] = l32_from_64_S (ctx.h[3]);
+  ek[ 8] = h32_from_64_S (ctx.h[4]);
+  ek[ 9] = l32_from_64_S (ctx.h[4]);
+  ek[10] = h32_from_64_S (ctx.h[5]);
+  ek[11] = l32_from_64_S (ctx.h[5]);
+
+  // PBKDF2-HMAC-SHA256 with full 48-byte SHA384 as password
+
+  sha256_hmac_ctx_t sha256_hmac_ctx;
+
+  sha256_hmac_init (&sha256_hmac_ctx, ek, 48);
+
+  tmps[gid].ipad[0] = sha256_hmac_ctx.ipad.h[0];
+  tmps[gid].ipad[1] = sha256_hmac_ctx.ipad.h[1];
+  tmps[gid].ipad[2] = sha256_hmac_ctx.ipad.h[2];
+  tmps[gid].ipad[3] = sha256_hmac_ctx.ipad.h[3];
+  tmps[gid].ipad[4] = sha256_hmac_ctx.ipad.h[4];
+  tmps[gid].ipad[5] = sha256_hmac_ctx.ipad.h[5];
+  tmps[gid].ipad[6] = sha256_hmac_ctx.ipad.h[6];
+  tmps[gid].ipad[7] = sha256_hmac_ctx.ipad.h[7];
+
+  tmps[gid].opad[0] = sha256_hmac_ctx.opad.h[0];
+  tmps[gid].opad[1] = sha256_hmac_ctx.opad.h[1];
+  tmps[gid].opad[2] = sha256_hmac_ctx.opad.h[2];
+  tmps[gid].opad[3] = sha256_hmac_ctx.opad.h[3];
+  tmps[gid].opad[4] = sha256_hmac_ctx.opad.h[4];
+  tmps[gid].opad[5] = sha256_hmac_ctx.opad.h[5];
+  tmps[gid].opad[6] = sha256_hmac_ctx.opad.h[6];
+  tmps[gid].opad[7] = sha256_hmac_ctx.opad.h[7];
+
+  // entry_salt starts at salt_buf[12] (after 48 bytes of global_salt)
+
+  u32 es[16] = { 0 };
+
+  es[0] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[12];
+  es[1] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[13];
+  es[2] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[14];
+  es[3] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[15];
+  es[4] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[16];
+  es[5] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[17];
+  es[6] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[18];
+  es[7] = salt_bufs[DIGESTS_OFFSET_HOST].salt_buf[19];
+
+  sha256_hmac_update_swap (&sha256_hmac_ctx, es, 32);
+
+  for (u32 i = 0, j = 1; i < 8; i += 8, j += 1)
+  {
+    sha256_hmac_ctx_t sha256_hmac_ctx2 = sha256_hmac_ctx;
+
+    u32 w0[4];
+    u32 w1[4];
+    u32 w2[4];
+    u32 w3[4];
+
+    w0[0] = j;
+    w0[1] = 0;
+    w0[2] = 0;
+    w0[3] = 0;
+    w1[0] = 0;
+    w1[1] = 0;
+    w1[2] = 0;
+    w1[3] = 0;
+    w2[0] = 0;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = 0;
+
+    sha256_hmac_update_64 (&sha256_hmac_ctx2, w0, w1, w2, w3, 4);
+
+    sha256_hmac_final (&sha256_hmac_ctx2);
+
+    tmps[gid].dgst[i + 0] = sha256_hmac_ctx2.opad.h[0];
+    tmps[gid].dgst[i + 1] = sha256_hmac_ctx2.opad.h[1];
+    tmps[gid].dgst[i + 2] = sha256_hmac_ctx2.opad.h[2];
+    tmps[gid].dgst[i + 3] = sha256_hmac_ctx2.opad.h[3];
+    tmps[gid].dgst[i + 4] = sha256_hmac_ctx2.opad.h[4];
+    tmps[gid].dgst[i + 5] = sha256_hmac_ctx2.opad.h[5];
+    tmps[gid].dgst[i + 6] = sha256_hmac_ctx2.opad.h[6];
+    tmps[gid].dgst[i + 7] = sha256_hmac_ctx2.opad.h[7];
+
+    tmps[gid].out[i + 0] = tmps[gid].dgst[i + 0];
+    tmps[gid].out[i + 1] = tmps[gid].dgst[i + 1];
+    tmps[gid].out[i + 2] = tmps[gid].dgst[i + 2];
+    tmps[gid].out[i + 3] = tmps[gid].dgst[i + 3];
+    tmps[gid].out[i + 4] = tmps[gid].dgst[i + 4];
+    tmps[gid].out[i + 5] = tmps[gid].dgst[i + 5];
+    tmps[gid].out[i + 6] = tmps[gid].dgst[i + 6];
+    tmps[gid].out[i + 7] = tmps[gid].dgst[i + 7];
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m26150_loop (KERN_ATTR_TMPS_ESALT (mozilla_aes_tmp_t, mozilla_aes_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= GID_CNT) return;
+
+  u32x ipad[8];
+  u32x opad[8];
+
+  ipad[0] = packv (tmps, ipad, gid, 0);
+  ipad[1] = packv (tmps, ipad, gid, 1);
+  ipad[2] = packv (tmps, ipad, gid, 2);
+  ipad[3] = packv (tmps, ipad, gid, 3);
+  ipad[4] = packv (tmps, ipad, gid, 4);
+  ipad[5] = packv (tmps, ipad, gid, 5);
+  ipad[6] = packv (tmps, ipad, gid, 6);
+  ipad[7] = packv (tmps, ipad, gid, 7);
+
+  opad[0] = packv (tmps, opad, gid, 0);
+  opad[1] = packv (tmps, opad, gid, 1);
+  opad[2] = packv (tmps, opad, gid, 2);
+  opad[3] = packv (tmps, opad, gid, 3);
+  opad[4] = packv (tmps, opad, gid, 4);
+  opad[5] = packv (tmps, opad, gid, 5);
+  opad[6] = packv (tmps, opad, gid, 6);
+  opad[7] = packv (tmps, opad, gid, 7);
+
+  for (u32 i = 0; i < 8; i += 8)
+  {
+    u32x dgst[8];
+    u32x out[8];
+
+    dgst[0] = packv (tmps, dgst, gid, i + 0);
+    dgst[1] = packv (tmps, dgst, gid, i + 1);
+    dgst[2] = packv (tmps, dgst, gid, i + 2);
+    dgst[3] = packv (tmps, dgst, gid, i + 3);
+    dgst[4] = packv (tmps, dgst, gid, i + 4);
+    dgst[5] = packv (tmps, dgst, gid, i + 5);
+    dgst[6] = packv (tmps, dgst, gid, i + 6);
+    dgst[7] = packv (tmps, dgst, gid, i + 7);
+
+    out[0] = packv (tmps, out, gid, i + 0);
+    out[1] = packv (tmps, out, gid, i + 1);
+    out[2] = packv (tmps, out, gid, i + 2);
+    out[3] = packv (tmps, out, gid, i + 3);
+    out[4] = packv (tmps, out, gid, i + 4);
+    out[5] = packv (tmps, out, gid, i + 5);
+    out[6] = packv (tmps, out, gid, i + 6);
+    out[7] = packv (tmps, out, gid, i + 7);
+
+    for (u32 j = 0; j < LOOP_CNT; j++)
+    {
+      u32x w0[4];
+      u32x w1[4];
+      u32x w2[4];
+      u32x w3[4];
+
+      w0[0] = dgst[0];
+      w0[1] = dgst[1];
+      w0[2] = dgst[2];
+      w0[3] = dgst[3];
+      w1[0] = dgst[4];
+      w1[1] = dgst[5];
+      w1[2] = dgst[6];
+      w1[3] = dgst[7];
+      w2[0] = 0x80000000;
+      w2[1] = 0;
+      w2[2] = 0;
+      w2[3] = 0;
+      w3[0] = 0;
+      w3[1] = 0;
+      w3[2] = 0;
+      w3[3] = (64 + 32) * 8;
+
+      hmac_sha256_run_V (w0, w1, w2, w3, ipad, opad, dgst);
+
+      out[0] ^= dgst[0];
+      out[1] ^= dgst[1];
+      out[2] ^= dgst[2];
+      out[3] ^= dgst[3];
+      out[4] ^= dgst[4];
+      out[5] ^= dgst[5];
+      out[6] ^= dgst[6];
+      out[7] ^= dgst[7];
+    }
+
+    unpackv (tmps, dgst, gid, i + 0, dgst[0]);
+    unpackv (tmps, dgst, gid, i + 1, dgst[1]);
+    unpackv (tmps, dgst, gid, i + 2, dgst[2]);
+    unpackv (tmps, dgst, gid, i + 3, dgst[3]);
+    unpackv (tmps, dgst, gid, i + 4, dgst[4]);
+    unpackv (tmps, dgst, gid, i + 5, dgst[5]);
+    unpackv (tmps, dgst, gid, i + 6, dgst[6]);
+    unpackv (tmps, dgst, gid, i + 7, dgst[7]);
+
+    unpackv (tmps, out, gid, i + 0, out[0]);
+    unpackv (tmps, out, gid, i + 1, out[1]);
+    unpackv (tmps, out, gid, i + 2, out[2]);
+    unpackv (tmps, out, gid, i + 3, out[3]);
+    unpackv (tmps, out, gid, i + 4, out[4]);
+    unpackv (tmps, out, gid, i + 5, out[5]);
+    unpackv (tmps, out, gid, i + 6, out[6]);
+    unpackv (tmps, out, gid, i + 7, out[7]);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m26150_comp (KERN_ATTR_TMPS_ESALT (mozilla_aes_tmp_t, mozilla_aes_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  u32 ukey[8];
+
+  ukey[0] = tmps[gid].out[0];
+  ukey[1] = tmps[gid].out[1];
+  ukey[2] = tmps[gid].out[2];
+  ukey[3] = tmps[gid].out[3];
+  ukey[4] = tmps[gid].out[4];
+  ukey[5] = tmps[gid].out[5];
+  ukey[6] = tmps[gid].out[6];
+  ukey[7] = tmps[gid].out[7];
+
+  u32 ks[60];
+
+  AES256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+  // first check the padding
+
+  u32 iv_buf[4];
+
+  iv_buf[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[0];
+  iv_buf[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[1];
+  iv_buf[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[2];
+  iv_buf[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv_buf[3];
+
+  u32 ct_buf[4];
+
+  ct_buf[0] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf[0];
+  ct_buf[1] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf[1];
+  ct_buf[2] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf[2];
+  ct_buf[3] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf[3];
+
+  u32 pt_buf[4];
+
+  aes256_decrypt (ks, ct_buf, pt_buf, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+  pt_buf[0] ^= iv_buf[0];
+  pt_buf[1] ^= iv_buf[1];
+  pt_buf[2] ^= iv_buf[2];
+  pt_buf[3] ^= iv_buf[3];
+
+  // password-check\x02\x02
+
+  if (pt_buf[0] != 0x73736170) return;
+  if (pt_buf[1] != 0x64726f77) return;
+  if (pt_buf[2] != 0x6568632d) return;
+  if (pt_buf[3] != 0x02026b63) return;
+
+  const u32 r0 = ct_buf[0];
+  const u32 r1 = ct_buf[1];
+  const u32 r2 = ct_buf[2];
+  const u32 r3 = ct_buf[3];
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,6 +1,12 @@
 * changes v7.1.2 -> v7.1.x
 
 ##
+## New Algorithms
+##
+
+- Added hash-mode: Mozilla key4.db SHA384
+
+##
 ## Improvements
 ##
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -262,6 +262,7 @@ For a tree full of modules, this does it:
 - Added hash-mode: scryptcrypt, scrypt (Unix)
 - Added hash-mode: KDE KWallet 4.13+ (PBKDF2-HMAC-SHA512, Blowfish)
 - Added hash-mode: KDE KWallet < 4.13 (SHA-1, Blowfish)
+- Added hash-mode: Mozilla key4.db SHA384
 
 ##
 ## New Attack modes and changed Attack modes

--- a/src/modules/module_26150.c
+++ b/src/modules/module_26150.c
@@ -1,0 +1,327 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PASSWORD_MANAGER;
+static const char *HASH_NAME      = "Mozilla key4.db SHA384";
+static const u64   KERN_TYPE      = 26150;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_REGISTER_LIMIT
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$mozilla$*AES*95f6acda22fbfb543226eca01b2e65099730d20cb3114c47536bc33a96b9137ea4a1dcebbcb8d924d20f5784be1fb1f3*b3edd4ec861f2e7a16c72771302a55f11b1504ac1792a4c408c44aa82023ef7f*10000*040eaff904bd66d4f3ba86cbb13ced52*a0b908a87ba816a5cb4d9632f015a972";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct mozilla_aes_tmp
+{
+  u32  ipad[8];
+  u32  opad[8];
+
+  u32  dgst[8];
+  u32  out[8];
+
+} mozilla_aes_tmp_t;
+
+typedef struct mozilla_aes
+{
+  u32 iv_buf[4];
+  u32 ct_buf[4];
+
+} mozilla_aes_t;
+
+static const char *SIGNATURE_MOZILLA     = "$mozilla$";
+static const char *SIGNATURE_MOZILLA_AES = "AES";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (mozilla_aes_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (mozilla_aes_tmp_t);
+
+  return tmp_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  mozilla_aes_t *mozilla_aes = (mozilla_aes_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 7;
+
+  token.signatures_cnt    = 2;
+  token.signatures_buf[0] = SIGNATURE_MOZILLA;
+  token.signatures_buf[1] = SIGNATURE_MOZILLA_AES;
+
+  token.sep[0]     = '*';
+  token.len[0]     = 9;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '*';
+  token.len[1]     = 3;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[2]     = '*';
+  token.len[2]     = 96;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[3]     = '*';
+  token.len[3]     = 64;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[4]     = '*';
+  token.len_min[4] = 1;
+  token.len_max[4] = 6;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[5]     = '*';
+  token.len[5]     = 32;
+  token.attr[5]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[6]     = '*';
+  token.len[6]     = 32;
+  token.attr[6]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // global salt buffer + entry salt buffer combined
+  // we do this because both buffer are accessed before the _loop kernel
+  // this also requires us to copy to local variables in _init kernel
+
+  const u8 *global_salt_pos = token.buf[2];
+  const u8 *entry_salt_pos  = token.buf[3];
+
+  // global_salt: 48 bytes (12 x u32) -- SHA384 variant has longer global salt
+  salt->salt_buf[ 0] = hex_to_u32 (global_salt_pos +  0);
+  salt->salt_buf[ 1] = hex_to_u32 (global_salt_pos +  8);
+  salt->salt_buf[ 2] = hex_to_u32 (global_salt_pos + 16);
+  salt->salt_buf[ 3] = hex_to_u32 (global_salt_pos + 24);
+  salt->salt_buf[ 4] = hex_to_u32 (global_salt_pos + 32);
+  salt->salt_buf[ 5] = hex_to_u32 (global_salt_pos + 40);
+  salt->salt_buf[ 6] = hex_to_u32 (global_salt_pos + 48);
+  salt->salt_buf[ 7] = hex_to_u32 (global_salt_pos + 56);
+  salt->salt_buf[ 8] = hex_to_u32 (global_salt_pos + 64);
+  salt->salt_buf[ 9] = hex_to_u32 (global_salt_pos + 72);
+  salt->salt_buf[10] = hex_to_u32 (global_salt_pos + 80);
+  salt->salt_buf[11] = hex_to_u32 (global_salt_pos + 88);
+
+  // entry_salt: 32 bytes (8 x u32) -- starts at offset 12
+  salt->salt_buf[12] = hex_to_u32 (entry_salt_pos +  0);
+  salt->salt_buf[13] = hex_to_u32 (entry_salt_pos +  8);
+  salt->salt_buf[14] = hex_to_u32 (entry_salt_pos + 16);
+  salt->salt_buf[15] = hex_to_u32 (entry_salt_pos + 24);
+  salt->salt_buf[16] = hex_to_u32 (entry_salt_pos + 32);
+  salt->salt_buf[17] = hex_to_u32 (entry_salt_pos + 40);
+  salt->salt_buf[18] = hex_to_u32 (entry_salt_pos + 48);
+  salt->salt_buf[19] = hex_to_u32 (entry_salt_pos + 56);
+
+  salt->salt_len = 80;
+
+  // iter
+
+  const u8 *iter_pos = token.buf[4];
+
+  int iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  salt->salt_iter = iter - 1;
+
+  // IV buffer
+
+  const u8 *iv_pos = token.buf[5];
+
+  mozilla_aes->iv_buf[0] = hex_to_u32 (iv_pos +  0);
+  mozilla_aes->iv_buf[1] = hex_to_u32 (iv_pos +  8);
+  mozilla_aes->iv_buf[2] = hex_to_u32 (iv_pos + 16);
+  mozilla_aes->iv_buf[3] = hex_to_u32 (iv_pos + 24);
+
+  // CT buffer
+
+  const u8 *ct_pos = token.buf[6];
+
+  mozilla_aes->ct_buf[0] = hex_to_u32 (ct_pos +  0);
+  mozilla_aes->ct_buf[1] = hex_to_u32 (ct_pos +  8);
+  mozilla_aes->ct_buf[2] = hex_to_u32 (ct_pos + 16);
+  mozilla_aes->ct_buf[3] = hex_to_u32 (ct_pos + 24);
+
+  // hash
+
+  digest[0] = mozilla_aes->ct_buf[0];
+  digest[1] = mozilla_aes->ct_buf[1];
+  digest[2] = mozilla_aes->ct_buf[2];
+  digest[3] = mozilla_aes->ct_buf[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const mozilla_aes_t *mozilla_aes = (const mozilla_aes_t *) esalt_buf;
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  const int out_len = snprintf ((char *) out_buf, line_size, "%s*%s*%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x*%08x%08x%08x%08x",
+    SIGNATURE_MOZILLA,
+    SIGNATURE_MOZILLA_AES,
+    byte_swap_32 (salt->salt_buf[ 0]),
+    byte_swap_32 (salt->salt_buf[ 1]),
+    byte_swap_32 (salt->salt_buf[ 2]),
+    byte_swap_32 (salt->salt_buf[ 3]),
+    byte_swap_32 (salt->salt_buf[ 4]),
+    byte_swap_32 (salt->salt_buf[ 5]),
+    byte_swap_32 (salt->salt_buf[ 6]),
+    byte_swap_32 (salt->salt_buf[ 7]),
+    byte_swap_32 (salt->salt_buf[ 8]),
+    byte_swap_32 (salt->salt_buf[ 9]),
+    byte_swap_32 (salt->salt_buf[10]),
+    byte_swap_32 (salt->salt_buf[11]),
+    byte_swap_32 (salt->salt_buf[12]),
+    byte_swap_32 (salt->salt_buf[13]),
+    byte_swap_32 (salt->salt_buf[14]),
+    byte_swap_32 (salt->salt_buf[15]),
+    byte_swap_32 (salt->salt_buf[16]),
+    byte_swap_32 (salt->salt_buf[17]),
+    byte_swap_32 (salt->salt_buf[18]),
+    byte_swap_32 (salt->salt_buf[19]),
+    salt->salt_iter + 1,
+    byte_swap_32 (mozilla_aes->iv_buf[0]),
+    byte_swap_32 (mozilla_aes->iv_buf[1]),
+    byte_swap_32 (mozilla_aes->iv_buf[2]),
+    byte_swap_32 (mozilla_aes->iv_buf[3]),
+    byte_swap_32 (mozilla_aes->ct_buf[0]),
+    byte_swap_32 (mozilla_aes->ct_buf[1]),
+    byte_swap_32 (mozilla_aes->ct_buf[2]),
+    byte_swap_32 (mozilla_aes->ct_buf[3]));
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_26150.c
+++ b/src/modules/module_26150.c
@@ -1,0 +1,330 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "parser.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PASSWORD_MANAGER;
+static const char *HASH_NAME      = "Mozilla key4.db SHA384";
+static const u64   KERN_TYPE      = 26150;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_REGISTER_LIMIT
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$mozilla$*AES*95f6acda22fbfb543226eca01b2e65099730d20cb3114c47536bc33a96b9137ea4a1dcebbcb8d924d20f5784be1fb1f3*b3edd4ec861f2e7a16c72771302a55f11b1504ac1792a4c408c44aa82023ef7f*10000*040eaff904bd66d4f3ba86cbb13ced52*a0b908a87ba816a5cb4d9632f015a972";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct mozilla_aes_tmp
+{
+  u32  ipad[8];
+  u32  opad[8];
+
+  u32  dgst[8];
+  u32  out[8];
+
+} mozilla_aes_tmp_t;
+
+typedef struct mozilla_aes
+{
+  u32 iv_buf[4];
+  u32 ct_buf[4];
+
+} mozilla_aes_t;
+
+static const char *SIGNATURE_MOZILLA     = "$mozilla$";
+static const char *SIGNATURE_MOZILLA_AES = "AES";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (mozilla_aes_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (mozilla_aes_tmp_t);
+
+  return tmp_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  mozilla_aes_t *mozilla_aes = (mozilla_aes_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 7;
+
+  token.signatures_cnt    = 2;
+  token.signatures_buf[0] = SIGNATURE_MOZILLA;
+  token.signatures_buf[1] = SIGNATURE_MOZILLA_AES;
+
+  token.sep[0]     = '*';
+  token.len[0]     = 9;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '*';
+  token.len[1]     = 3;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[2]     = '*';
+  token.len[2]     = 96;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[3]     = '*';
+  token.len[3]     = 64;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[4]     = '*';
+  token.len_min[4] = 1;
+  token.len_max[4] = 6;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[5]     = '*';
+  token.len[5]     = 32;
+  token.attr[5]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[6]     = '*';
+  token.len[6]     = 32;
+  token.attr[6]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // global salt buffer + entry salt buffer combined
+  // we do this because both buffer are accessed before the _loop kernel
+  // this also requires us to copy to local variables in _init kernel
+
+  const u8 *global_salt_pos = token.buf[2];
+  const u8 *entry_salt_pos  = token.buf[3];
+
+  // global_salt: 48 bytes (12 x u32) -- SHA384 variant has longer global salt
+  salt->salt_buf[ 0] = hex_to_u32 (global_salt_pos +  0);
+  salt->salt_buf[ 1] = hex_to_u32 (global_salt_pos +  8);
+  salt->salt_buf[ 2] = hex_to_u32 (global_salt_pos + 16);
+  salt->salt_buf[ 3] = hex_to_u32 (global_salt_pos + 24);
+  salt->salt_buf[ 4] = hex_to_u32 (global_salt_pos + 32);
+  salt->salt_buf[ 5] = hex_to_u32 (global_salt_pos + 40);
+  salt->salt_buf[ 6] = hex_to_u32 (global_salt_pos + 48);
+  salt->salt_buf[ 7] = hex_to_u32 (global_salt_pos + 56);
+  salt->salt_buf[ 8] = hex_to_u32 (global_salt_pos + 64);
+  salt->salt_buf[ 9] = hex_to_u32 (global_salt_pos + 72);
+  salt->salt_buf[10] = hex_to_u32 (global_salt_pos + 80);
+  salt->salt_buf[11] = hex_to_u32 (global_salt_pos + 88);
+
+  // entry_salt: 32 bytes (8 x u32) -- starts at offset 12
+  salt->salt_buf[12] = hex_to_u32 (entry_salt_pos +  0);
+  salt->salt_buf[13] = hex_to_u32 (entry_salt_pos +  8);
+  salt->salt_buf[14] = hex_to_u32 (entry_salt_pos + 16);
+  salt->salt_buf[15] = hex_to_u32 (entry_salt_pos + 24);
+  salt->salt_buf[16] = hex_to_u32 (entry_salt_pos + 32);
+  salt->salt_buf[17] = hex_to_u32 (entry_salt_pos + 40);
+  salt->salt_buf[18] = hex_to_u32 (entry_salt_pos + 48);
+  salt->salt_buf[19] = hex_to_u32 (entry_salt_pos + 56);
+
+  salt->salt_len = 80;
+
+  // iter
+
+  const u8 *iter_pos = token.buf[4];
+
+  int iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  salt->salt_iter = iter - 1;
+
+  // IV buffer
+
+  const u8 *iv_pos = token.buf[5];
+
+  mozilla_aes->iv_buf[0] = hex_to_u32 (iv_pos +  0);
+  mozilla_aes->iv_buf[1] = hex_to_u32 (iv_pos +  8);
+  mozilla_aes->iv_buf[2] = hex_to_u32 (iv_pos + 16);
+  mozilla_aes->iv_buf[3] = hex_to_u32 (iv_pos + 24);
+
+  // CT buffer
+
+  const u8 *ct_pos = token.buf[6];
+
+  mozilla_aes->ct_buf[0] = hex_to_u32 (ct_pos +  0);
+  mozilla_aes->ct_buf[1] = hex_to_u32 (ct_pos +  8);
+  mozilla_aes->ct_buf[2] = hex_to_u32 (ct_pos + 16);
+  mozilla_aes->ct_buf[3] = hex_to_u32 (ct_pos + 24);
+
+  // hash
+
+  digest[0] = mozilla_aes->ct_buf[0];
+  digest[1] = mozilla_aes->ct_buf[1];
+  digest[2] = mozilla_aes->ct_buf[2];
+  digest[3] = mozilla_aes->ct_buf[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const mozilla_aes_t *mozilla_aes = (const mozilla_aes_t *) esalt_buf;
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  const int out_len = snprintf ((char *) out_buf, line_size, "%s*%s*%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x*%08x%08x%08x%08x%08x%08x%08x%08x*%d*%08x%08x%08x%08x*%08x%08x%08x%08x",
+    SIGNATURE_MOZILLA,
+    SIGNATURE_MOZILLA_AES,
+    byte_swap_32 (salt->salt_buf[ 0]),
+    byte_swap_32 (salt->salt_buf[ 1]),
+    byte_swap_32 (salt->salt_buf[ 2]),
+    byte_swap_32 (salt->salt_buf[ 3]),
+    byte_swap_32 (salt->salt_buf[ 4]),
+    byte_swap_32 (salt->salt_buf[ 5]),
+    byte_swap_32 (salt->salt_buf[ 6]),
+    byte_swap_32 (salt->salt_buf[ 7]),
+    byte_swap_32 (salt->salt_buf[ 8]),
+    byte_swap_32 (salt->salt_buf[ 9]),
+    byte_swap_32 (salt->salt_buf[10]),
+    byte_swap_32 (salt->salt_buf[11]),
+    byte_swap_32 (salt->salt_buf[12]),
+    byte_swap_32 (salt->salt_buf[13]),
+    byte_swap_32 (salt->salt_buf[14]),
+    byte_swap_32 (salt->salt_buf[15]),
+    byte_swap_32 (salt->salt_buf[16]),
+    byte_swap_32 (salt->salt_buf[17]),
+    byte_swap_32 (salt->salt_buf[18]),
+    byte_swap_32 (salt->salt_buf[19]),
+    salt->salt_iter + 1,
+    byte_swap_32 (mozilla_aes->iv_buf[0]),
+    byte_swap_32 (mozilla_aes->iv_buf[1]),
+    byte_swap_32 (mozilla_aes->iv_buf[2]),
+    byte_swap_32 (mozilla_aes->iv_buf[3]),
+    byte_swap_32 (mozilla_aes->ct_buf[0]),
+    byte_swap_32 (mozilla_aes->ct_buf[1]),
+    byte_swap_32 (mozilla_aes->ct_buf[2]),
+    byte_swap_32 (mozilla_aes->ct_buf[3]));
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_advice_notice            = MODULE_DEFAULT;
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_hints               = MODULE_DEFAULT;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_usage_notice             = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/mozilla2hashcat.py
+++ b/tools/mozilla2hashcat.py
@@ -2,6 +2,13 @@
 #
 # Script to extract the "hash" from a password protected key3.db or key4.db file.
 #
+# The hash mode is detected automatically and reported on stderr:
+#   key3.db / 3DES                     -> m26000 (Mozilla key3.db)
+#   key4.db / AES, 20-byte global salt -> m26100 (Mozilla key4.db)
+#   key4.db / AES, 48-byte global salt -> m26150 (Mozilla key4.db SHA384)
+# Firefox 146 (NSS SHA384 change) produces the 48-byte-salt variant; the salt
+# length is what separates m26100 from m26150.
+#
 # This code is based on the tool "firepwd" (https://github.com/lclevy/firepwd (GPL-license)
 # Although the code has been changed a bit, all credit goes to @lclevy for his initial work.
 #
@@ -29,7 +36,8 @@ from pyasn1.codec.der import decoder
 
 
 class MasterPasswordInfos:
-    def __init__(self, mode, global_salt, entry_salt, cipher_text, no_master_password, iteration=None, iv=None):
+    def __init__(self, mode, global_salt, entry_salt, cipher_text, no_master_password, iteration=None, iv=None,
+                 hashcat_mode=None):
         if mode not in ['aes', '3des']:
             raise ValueError('Bad mode')
 
@@ -40,6 +48,7 @@ class MasterPasswordInfos:
         self.no_master_password = no_master_password
         self.iteration = iteration
         self.iv = iv
+        self.hashcat_mode = hashcat_mode
 
 
 def read_bsd_db(db_filepath: str) -> {}:
@@ -130,11 +139,12 @@ def is_decrypting_mozilla_3des_without_master_password(global_salt, entry_salt, 
     return DES3.new(key, DES3.MODE_CBC, iv).decrypt(cipher_text) == b'password-check\x02\x02'
 
 
-def is_decrypting_pbe_aes_without_password(global_salt, entry_salt, iteration, iv, cipher_text):
+def is_decrypting_pbe_aes_without_password(prf, global_salt, entry_salt, iteration, iv, cipher_text):
     """
     Indicate if the cipher_text can be decrypted to password-check\x02\x02' without a master password
     in the the AES mode.
 
+    :param prf: the hash used for the KDF prelude, 'sha1' (m26100) or 'sha384' (m26150)
     :param global_salt: the global salt
     :param entry_salt: the entry salt
     :param iteration: the number of iteration
@@ -142,7 +152,7 @@ def is_decrypting_pbe_aes_without_password(global_salt, entry_salt, iteration, i
     :param cipher_text: the encrypted text
     :return: the decrypted text
     """
-    k = hashlib.sha1(global_salt).digest()
+    k = hashlib.new(prf, global_salt).digest()
     key = hashlib.pbkdf2_hmac('sha256', k, entry_salt, iteration, dklen=32)
 
     return AES.new(key, AES.MODE_CBC, iv).decrypt(cipher_text) == b'password-check\x02\x02'
@@ -173,7 +183,8 @@ def extract_master_password_infos(db_filepath: str, db_version: int) -> MasterPa
 
         no_master_password = is_decrypting_mozilla_3des_without_master_password(global_salt, entry_salt, cipher_text)
 
-        return MasterPasswordInfos('3des', global_salt, entry_salt, cipher_text, no_master_password)
+        return MasterPasswordInfos('3des', global_salt, entry_salt, cipher_text, no_master_password,
+                                   hashcat_mode=26000)
     else:
         db = sqlite3.connect(db_filepath)
         c = db.cursor()
@@ -188,7 +199,8 @@ def extract_master_password_infos(db_filepath: str, db_version: int) -> MasterPa
 
             no_master_password = is_decrypting_mozilla_3des_without_master_password(global_salt, entry_salt,
                                                                                     cipher_text)
-            return MasterPasswordInfos('3des', global_salt, entry_salt, cipher_text, no_master_password)
+            return MasterPasswordInfos('3des', global_salt, entry_salt, cipher_text, no_master_password,
+                                       hashcat_mode=26000)
         elif pbe_algo == '1.2.840.113549.1.5.13':  # pkcs5 pbes2
             assert str(decoded_item2[0][0][1][0][0]) == '1.2.840.113549.1.5.12'
             assert str(decoded_item2[0][0][1][0][1][3][0]) == '1.2.840.113549.2.9'
@@ -200,9 +212,25 @@ def extract_master_password_infos(db_filepath: str, db_version: int) -> MasterPa
             iv = b'\x04\x0e' + decoded_item2[0][0][1][1][1].asOctets()
             cipher_text = decoded_item2[0][1].asOctets()
 
-            no_master_password = is_decrypting_pbe_aes_without_password(global_salt, entry_salt, iteration, iv,
+            # Firefox 146 (NSS SHA384 change) keeps the same PBES2/PBKDF2-HMAC-SHA256
+            # structure but grows the global salt from 20 to 48 bytes and derives the
+            # PBKDF2 password with SHA384 instead of SHA1. The salt length is what
+            # separates the two hash modes:
+            #   20 bytes -> SHA1   -> m26100 (Mozilla key4.db)
+            #   48 bytes -> SHA384 -> m26150 (Mozilla key4.db SHA384, Firefox 146+)
+            gs_len = len(global_salt)
+            if gs_len == 20:
+                prf, hashcat_mode = 'sha1', 26100
+            elif gs_len == 48:
+                prf, hashcat_mode = 'sha384', 26150
+            else:
+                raise ValueError(f'unexpected global_salt length {gs_len}; '
+                                 'expected 20 (SHA1/m26100) or 48 (SHA384/m26150)')
+
+            no_master_password = is_decrypting_pbe_aes_without_password(prf, global_salt, entry_salt, iteration, iv,
                                                                           cipher_text)
-            return MasterPasswordInfos('aes', global_salt, entry_salt, cipher_text, no_master_password, iteration, iv)
+            return MasterPasswordInfos('aes', global_salt, entry_salt, cipher_text, no_master_password, iteration, iv,
+                                       hashcat_mode=hashcat_mode)
 
 def hex(b) -> str:
     """
@@ -272,3 +300,6 @@ if __name__ == '__main__':
 
     infos = extract_master_password_infos(db_filepath, db_type)
     print(get_hashcat_string(infos))
+
+    if infos.hashcat_mode is not None and not infos.no_master_password:
+        sys.stderr.write(f'Detected hash-mode {infos.hashcat_mode}; crack with: hashcat -m {infos.hashcat_mode}\n')

--- a/tools/mozilla2hashcat_sha384.py
+++ b/tools/mozilla2hashcat_sha384.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Extract a Firefox 146+ (SHA384 variant) master-password hash from a key4.db
+in hashcat m26150 format.
+
+Firefox 146 changed the KDF prelude from
+    sha1  = SHA1(global_salt)            # 20-byte global salt
+to
+    sha384 = SHA384(global_salt || pwd)  # 48-byte global salt, full 48-byte digest
+
+Detection: if metaData.item1 (global_salt) is 48 bytes the profile is the
+SHA384 variant (m26150). 20 bytes means the legacy SHA1 variant (m26000) and
+hashcat's existing tools/mozilla2hashcat.py should be used instead.
+
+Output format (m26150, same shape as m26000):
+    $mozilla$*AES*<global_salt>*<entry_salt>*<iter>*<iv>*<ct>
+
+Usage:
+    python3 mozilla2hashcat_sha384.py <profile_dir_or_key4.db>
+
+Example profile paths (close Firefox first, the SQLite file is locked while
+Firefox is running):
+    Linux   : ~/.mozilla/firefox/<random>.default-release/
+              e.g. ~/.mozilla/firefox/xxxxxxxx.default-release/
+    macOS   : ~/Library/Application Support/Firefox/Profiles/<random>.default-release/
+    Windows : %APPDATA%\\Mozilla\\Firefox\\Profiles\\<random>.default-release\\
+
+You can also pass key4.db directly:
+    python3 mozilla2hashcat_sha384.py ~/.mozilla/firefox/xxxxxxxx.default-release/key4.db
+
+Find your active profile via ~/.mozilla/firefox/profiles.ini (look for the
+[Install*] section's Default= entry, or the [Profile*] with Default=1).
+
+Dependencies: Python stdlib only (sqlite3). A minimal DER parser is included
+so no pyasn1/PyCryptodome install is required.
+"""
+
+import argparse
+import binascii
+import os
+import sqlite3
+import sys
+
+
+def _der_read_len(buf, off):
+    first = buf[off]
+    off += 1
+    if first & 0x80 == 0:
+        return first, off
+    n = first & 0x7F
+    length = int.from_bytes(buf[off:off + n], "big")
+    return length, off + n
+
+
+def _der_parse(buf, off=0):
+    """Parse one TLV. Returns (tag, value_bytes, next_off)."""
+    tag = buf[off]
+    length, off = _der_read_len(buf, off + 1)
+    return tag, buf[off:off + length], off + length
+
+
+def _der_children(seq_bytes):
+    out = []
+    off = 0
+    while off < len(seq_bytes):
+        tag, val, off = _der_parse(seq_bytes, off)
+        out.append((tag, val))
+    return out
+
+
+def _oid_decode(val):
+    if not val:
+        return ""
+    first = val[0]
+    parts = [str(first // 40), str(first % 40)]
+    i = 1
+    while i < len(val):
+        v = 0
+        while True:
+            b = val[i]
+            i += 1
+            v = (v << 7) | (b & 0x7F)
+            if b & 0x80 == 0:
+                break
+        parts.append(str(v))
+    return ".".join(parts)
+
+
+def _int_decode(val):
+    return int.from_bytes(val, "big", signed=False)
+
+
+OID_PBES2 = "1.2.840.113549.1.5.13"
+OID_PBKDF2 = "1.2.840.113549.1.5.12"
+OID_HMAC_SHA256 = "1.2.840.113549.2.9"
+OID_AES256_CBC = "2.16.840.1.101.3.4.1.42"
+
+
+def parse_item2(item2):
+    """
+    Parse the PBES2 ASN.1 blob from metaData.item2.
+
+    Expected structure:
+      SEQUENCE {
+        SEQUENCE {                           -- AlgorithmIdentifier (PBES2)
+          OID pbes2
+          SEQUENCE {                         -- PBES2-params
+            SEQUENCE {                       -- KDF
+              OID pbkdf2
+              SEQUENCE {
+                OCTET STRING entry_salt
+                INTEGER iterations
+                INTEGER keyLength (32)
+                SEQUENCE { OID hmac-sha256; NULL }
+              }
+            }
+            SEQUENCE {                       -- encryption scheme
+              OID aes-256-cbc
+              OCTET STRING iv (14 bytes raw)
+            }
+          }
+        }
+        OCTET STRING ciphertext
+      }
+    """
+    tag, outer, _ = _der_parse(item2)
+    assert tag == 0x30, "top-level is not SEQUENCE"
+    outer_children = _der_children(outer)
+    assert len(outer_children) == 2
+
+    alg_tag, alg_val = outer_children[0]
+    ct_tag, ct_val = outer_children[1]
+    assert alg_tag == 0x30 and ct_tag == 0x04
+
+    alg_children = _der_children(alg_val)
+    pbes2_oid_tag, pbes2_oid_val = alg_children[0]
+    pbes2_params_tag, pbes2_params_val = alg_children[1]
+    assert pbes2_oid_tag == 0x06
+    assert _oid_decode(pbes2_oid_val) == OID_PBES2, "not a PBES2 blob"
+    assert pbes2_params_tag == 0x30
+
+    params_children = _der_children(pbes2_params_val)
+    kdf_tag, kdf_val = params_children[0]
+    enc_tag, enc_val = params_children[1]
+    assert kdf_tag == 0x30 and enc_tag == 0x30
+
+    # KDF: pbkdf2 OID + pbkdf2-params SEQUENCE
+    kdf_children = _der_children(kdf_val)
+    assert _oid_decode(kdf_children[0][1]) == OID_PBKDF2
+    pbkdf2_params_children = _der_children(kdf_children[1][1])
+
+    salt_tag, entry_salt = pbkdf2_params_children[0]
+    iter_tag, iter_val = pbkdf2_params_children[1]
+    keylen_tag, keylen_val = pbkdf2_params_children[2]
+    prf_tag, prf_val = pbkdf2_params_children[3]
+    assert salt_tag == 0x04
+    assert iter_tag == 0x02
+    assert keylen_tag == 0x02
+    assert _int_decode(keylen_val) == 32
+    prf_children = _der_children(prf_val)
+    assert _oid_decode(prf_children[0][1]) == OID_HMAC_SHA256
+    iterations = _int_decode(iter_val)
+
+    # Encryption: aes256-cbc OID + OCTET STRING(iv_raw)
+    enc_children = _der_children(enc_val)
+    assert _oid_decode(enc_children[0][1]) == OID_AES256_CBC
+    iv_raw_tag, iv_raw = enc_children[1]
+    assert iv_raw_tag == 0x04
+
+    # hashcat's mozilla2hashcat.py prepends the original DER OCTET STRING header
+    # bytes b'\x04\x0e' to the IV. We reproduce that so the hash string is
+    # byte-identical to what hashcat's format expects.
+    iv = b"\x04\x0e" + iv_raw
+
+    return entry_salt, iterations, iv, ct_val
+
+
+def extract(db_path):
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    cur = con.cursor()
+    cur.execute("SELECT item1, item2 FROM metaData WHERE id = ?", ("password",))
+    row = cur.fetchone()
+    con.close()
+    if row is None:
+        raise SystemExit("metaData row id='password' not found — profile has no master password?")
+    global_salt, item2 = row
+    return global_salt, item2
+
+
+def hexs(b):
+    return binascii.hexlify(b).decode()
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Extract Firefox 146+ (SHA384 variant) master password hash in hashcat m26150 format.",
+        epilog=(
+            "Example profile paths (close Firefox before running):\n"
+            "  Linux  : ~/.mozilla/firefox/<random>.default-release/\n"
+            "           e.g. ~/.mozilla/firefox/xxxxxxxx.default-release/\n"
+            "  macOS  : ~/Library/Application Support/Firefox/Profiles/<random>.default-release/\n"
+            "  Windows: %APPDATA%\\Mozilla\\Firefox\\Profiles\\<random>.default-release\\\n\n"
+            "Look up the active profile in ~/.mozilla/firefox/profiles.ini."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "path",
+        help="profile directory or key4.db file (e.g. ~/.mozilla/firefox/xxxxx.default-release/)",
+    )
+    args = ap.parse_args()
+
+    p = args.path
+    if os.path.isdir(p):
+        p = os.path.join(p, "key4.db")
+    if not os.path.isfile(p):
+        sys.exit(f"key4.db not found at {p}")
+
+    global_salt, item2 = extract(p)
+
+    gs_len = len(global_salt)
+    if gs_len == 20:
+        sys.exit(
+            "global_salt is 20 bytes — this is the legacy SHA1 variant (m26000).\n"
+            "Use hashcat's tools/mozilla2hashcat.py for this profile."
+        )
+    if gs_len != 48:
+        sys.exit(f"unexpected global_salt length {gs_len}; expected 48 (SHA384) or 20 (SHA1)")
+
+    entry_salt, iterations, iv, ct = parse_item2(item2)
+
+    print(
+        f"$mozilla$*AES*{hexs(global_salt)}*{hexs(entry_salt)}*{iterations}*{hexs(iv)}*{hexs(ct)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_modules/m26150.pm
+++ b/tools/test_modules/m26150.pm
@@ -1,0 +1,120 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Crypt::PBKDF2;
+use Crypt::CBC;
+use Digest::SHA qw (sha384);
+
+sub module_constraints { [[0, 256], [96, 96], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word        = shift;
+  my $global_salt = shift;
+  my $entry_salt  = shift // random_hex_string (64);
+  my $iter        = shift // 10000;
+  my $iv          = shift // random_hex_string (32);
+  my $ct          = shift;
+
+  my $kdf = Crypt::PBKDF2->new
+  (
+    hasher     => Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256),
+    iterations => $iter,
+    output_len => 32
+  );
+
+  my $global_salt_bin = pack ("H*", $global_salt);
+
+  my $global_key = sha384 ($global_salt_bin . $word);
+
+  my $entry_salt_bin = pack ("H*", $entry_salt);
+
+  my $entry_key = $kdf->PBKDF2 ($entry_salt_bin, $global_key);
+
+  my $iv_bin = pack ("H*", $iv);
+
+  my $pt;
+
+  if (defined $ct)
+  {
+    my $aes_cbc = Crypt::CBC->new ({
+      cipher      => "Crypt::Rijndael",
+      iv          => $iv_bin,
+      key         => $entry_key,
+      keysize     => 32,
+      literal_key => 1,
+      header      => "none",
+      padding     => "none"
+    });
+
+    my $ct_bin = pack ("H*", $ct);
+
+    $pt = $aes_cbc->decrypt ($ct_bin);
+
+    if ($pt ne "password-check\x02\x02")
+    {
+      $pt = "\xff" x 16;
+    }
+  }
+  else
+  {
+    $pt = "password-check\x02\x02";
+  }
+
+  my $aes_cbc = Crypt::CBC->new ({
+    cipher      => "Crypt::Rijndael",
+    iv          => $iv_bin,
+    key         => $entry_key,
+    keysize     => 32,
+    literal_key => 1,
+    header      => "none",
+    padding     => "none"
+  });
+
+  my $ct_bin = $aes_cbc->encrypt ($pt);
+
+  my $hash = sprintf ('$mozilla$*AES*%s*%s*%d*%s*%s', unpack ("H*", $global_salt_bin), unpack ("H*", $entry_salt_bin), $iter, unpack ("H*", $iv_bin), unpack ("H*", $ct_bin));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless substr ($hash, 0, 9) eq '$mozilla$';
+
+  my ($signature, $type, $global_salt, $entry_salt, $iter, $iv, $ct) = split '\*', $hash;
+
+  return unless defined $signature;
+  return unless defined $type;
+  return unless defined $global_salt;
+  return unless defined $entry_salt;
+  return unless defined $iter;
+  return unless defined $iv;
+  return unless defined $ct;
+
+  return unless $type eq 'AES';
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $global_salt, $entry_salt, $iter, $iv, $ct);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
# Add hash-mode: Mozilla key4.db SHA384 (m26150)

## Summary

Adds hash-mode `26150` for cracking the password of Mozilla `key4.db` files
as written by Firefox 146 and later. Starting with Firefox 146 (released March
2025), Mozilla replaced the SHA1-based key derivation from the legacy NSS
`SDR` container with a SHA384-based variant. The existing `26100` plugin no
longer works against these new profiles.

Tracks issue #4585.

## Algorithm

```
sha384_hash = SHA384(global_salt || password)                         # full 48 bytes
master_key  = PBKDF2-HMAC-SHA256(sha384_hash, entry_salt, iter, 32)
plaintext   = AES-256-CBC-Decrypt(master_key, iv, ct)
verify      : plaintext == b"password-check\x02\x02"
```

Differences vs. m26100:

- Inner hash is SHA384 instead of SHA1.
- `global_salt` is 48 bytes (was 20 bytes for SHA1-based profiles).
- The *full* 48-byte SHA384 output is used as the PBKDF2 password. The
  original issue description suggested truncating to 20 bytes - this is
  incorrect; verified against a real Firefox 146 key4.db and independently
  with Python before any kernel work.

The rest of the pipeline (PBKDF2-HMAC-SHA256, AES-256-CBC decrypt, PKCS#7
padding check against `"password-check\x02\x02"`) is identical to m26100.

## Hash Format

```
$mozilla$*AES*<global_salt_96hex>*<entry_salt_64hex>*<iterations>*<iv_32hex>*<ct_32hex>
```

- `global_salt`: 48 bytes, 96 hex chars
- `entry_salt` : 32 bytes, 64 hex chars
- `iterations` : decimal, typically 10000
- `iv`         : 16 bytes, 32 hex chars
- `ct`         : 16 bytes, 32 hex chars (encrypted `password-check` string)

Example (self-test vector, password `hashcat`):

```
$mozilla$*AES*95f6acda22fbfb543226eca01b2e65099730d20cb3114c47536bc33a96b9137ea4a1dcebbcb8d924d20f5784be1fb1f3*b3edd4ec861f2e7a16c72771302a55f11b1504ac1792a4c408c44aa82023ef7f*10000*040eaff904bd66d4f3ba86cbb13ced52*a0b908a87ba816a5cb4d9632f015a972
```

## Files

- `src/modules/module_26150.c` - host module (based on m26100)
- `OpenCL/m26150-pure.cl` - GPU kernel (SHA384 init, SIMD PBKDF2-HMAC-SHA256 loop, AES-256-CBC comp)
- `tools/test_modules/m26150.pm` - Perl unit test module
- `tools/mozilla2hashcat_sha384.py` - extractor for Firefox 146+ `key4.db`
- `docs/changes.txt` - changelog entry

## Extracting from a real profile

`tools/mozilla2hashcat.py` only produces SHA1-variant (`m26000`) hashes. The
new `tools/mozilla2hashcat_sha384.py` handles the SHA384 variant. It is
stdlib-only (sqlite3 + a tiny hand-rolled DER parser, no pyasn1/PyCryptodome
dependency), opens `key4.db` read-only, and auto-detects the variant by the
`metaData.item1` length (48 bytes = SHA384 / m26150, 20 bytes = SHA1 /
m26000). Legacy profiles are rejected with a pointer to the existing tool so
the two scripts stay cleanly separated.

Verified end-to-end against a local Firefox 146 profile with master password
`hashcat`: the extracted hash decrypts to `password-check\x02\x02` in the
Python reference and cracks with the m26150 kernel on an RTX 3080.

## Test Results

### test.sh (single)

```
$ ./tools/test.sh -m 26150 -a 0 -t single
[ test_1775802750 ] > Init test for hash type 26150.
[ test_1775802750 ] [ Type 26150, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

### Benchmark (self-test inside hashcat)

```
$ ./hashcat -m 26150 -b -d 1
-------------------------------------------------------------
* Hash-Mode 26150 (Mozilla key4.db SHA384) [Iterations: 9999]
-------------------------------------------------------------

Speed.#01........:   332.1 kH/s (93.84ms) @ Accel:6 Loops:1000 Thr:768 Vec:1
```

GPU: NVIDIA RTX 3080. Performance is in the same ballpark as m26100 since
SHA384 only runs once per candidate in the init kernel; the hot path is the
PBKDF2-HMAC-SHA256 loop which is identical to m26100.

### Mask attack self-test

```
$ ./hashcat -m 26150 -a 3 '$mozilla$*AES*95f6acda...' 'hashc?a?a'
$mozilla$*AES*95f6acda...:hashcat
```

## Real-world Use Case

Firefox 146 was released on 4 March 2025. Any Firefox profile created or
password-migrated on Firefox 146 or later uses the new SHA384-based key
derivation for `key4.db`. `m26100` does not work against Firefox 146+ profiles.

The algorithm is also used by Thunderbird once it picks up the same NSS
change.

## Notes

- Based on m26100; kernel structure is a drop-in replacement with SHA384
  instead of SHA1 in the init kernel and a longer global salt in the host
  decoder. The PBKDF2 loop and AES-CBC comp kernels are unchanged.
- `module_hashes_count_max` behavior matches m26100 (multi-hash with
  distinct salts works; multi-hash with the same salt follows the same
  constraint as m26100 via the esalt path).
- `OPTS_TYPE_PT_GENERATE_LE` matches m26100.
- A Python reference implementation (`verify_m26150.py`) was used to verify
  the test vector before any kernel code was written, per the lesson learned
  in issue #4585 where the spec description was incorrect about truncation.

Closes #4585.
