### PR TITLE
tunings: add Apple Silicon Vec:2 tuning for 7 hash modes

### DIFF
--- a/tunings/Alias.hctune
+++ b/tunings/Alias.hctune
@@ -459,3 +459,24 @@ Intel(R)_Arc(TM)_Pro_B50_Graphics               ALIAS_INTEL
 Intel(R)_Arc(TM)_Pro_B60_Graphics               ALIAS_INTEL
 
 Intel(R)_Data_Center_GPU_Max_1100               ALIAS_INTEL
+
+##
+## Apple Silicon
+##
+
+Apple_M1                                        ALIAS_Apple_M
+Apple_M1_Pro                                    ALIAS_Apple_M
+Apple_M1_Max                                    ALIAS_Apple_M
+Apple_M1_Ultra                                  ALIAS_Apple_M
+Apple_M2                                        ALIAS_Apple_M
+Apple_M2_Pro                                    ALIAS_Apple_M
+Apple_M2_Max                                    ALIAS_Apple_M
+Apple_M2_Ultra                                  ALIAS_Apple_M
+Apple_M3                                        ALIAS_Apple_M
+Apple_M3_Pro                                    ALIAS_Apple_M
+Apple_M3_Max                                    ALIAS_Apple_M
+Apple_M3_Ultra                                  ALIAS_Apple_M
+Apple_M4                                        ALIAS_Apple_M
+Apple_M4_Pro                                    ALIAS_Apple_M
+Apple_M4_Max                                    ALIAS_Apple_M
+Apple_M4_Ultra                                  ALIAS_Apple_M

--- a/tunings/Modules_default.hctune
+++ b/tunings/Modules_default.hctune
@@ -190,6 +190,8 @@ ALIAS_INTEL                                     3       23700   2       A       
 ALIAS_INTEL                                     3       24700   2       A       A
 ALIAS_INTEL                                     3       99999   4       A       A
 
+ALIAS_Apple_M                                   *       1000    2       A       A
+
 ##
 ## CryptoAPI
 ##

--- a/tunings/Modules_default.hctune
+++ b/tunings/Modules_default.hctune
@@ -190,7 +190,13 @@ ALIAS_INTEL                                     3       23700   2       A       
 ALIAS_INTEL                                     3       24700   2       A       A
 ALIAS_INTEL                                     3       99999   4       A       A
 
+ALIAS_Apple_M                                   *       0       2       A       A
+ALIAS_Apple_M                                   *       11      2       A       A
+ALIAS_Apple_M                                   *       22      2       A       A
+ALIAS_Apple_M                                   *       900     2       A       A
 ALIAS_Apple_M                                   *       1000    2       A       A
+ALIAS_Apple_M                                   *       1100    2       A       A
+ALIAS_Apple_M                                   *       2600    2       A       A
 
 ##
 ## CryptoAPI

--- a/tunings/Modules_default.hctune
+++ b/tunings/Modules_default.hctune
@@ -190,13 +190,22 @@ ALIAS_INTEL                                     3       23700   2       A       
 ALIAS_INTEL                                     3       24700   2       A       A
 ALIAS_INTEL                                     3       99999   4       A       A
 
-ALIAS_Apple_M                                   *       0       2       A       A
-ALIAS_Apple_M                                   *       11      2       A       A
-ALIAS_Apple_M                                   *       22      2       A       A
-ALIAS_Apple_M                                   *       900     2       A       A
-ALIAS_Apple_M                                   *       1000    2       A       A
-ALIAS_Apple_M                                   *       1100    2       A       A
-ALIAS_Apple_M                                   *       2600    2       A       A
+ALIAS_Apple_M                                   3       0       2       A       A
+ALIAS_Apple_M                                   3       10      2       A       A
+ALIAS_Apple_M                                   3       11      2       A       A
+ALIAS_Apple_M                                   3       20      2       A       A
+ALIAS_Apple_M                                   3       22      2       A       A
+ALIAS_Apple_M                                   3       30      2       A       A
+ALIAS_Apple_M                                   3       40      2       A       A
+ALIAS_Apple_M                                   3       200     4       A       A
+ALIAS_Apple_M                                   3       900     2       A       A
+ALIAS_Apple_M                                   3       1000    2       A       A
+ALIAS_Apple_M                                   3       1100    2       A       A
+ALIAS_Apple_M                                   3       2400    2       A       A
+ALIAS_Apple_M                                   3       2410    2       A       A
+ALIAS_Apple_M                                   3       3800    2       A       A
+ALIAS_Apple_M                                   3       4800    2       A       A
+ALIAS_Apple_M                                   3       18700   2       A       A
 
 ##
 ## CryptoAPI

--- a/tunings/Modules_default.hctune
+++ b/tunings/Modules_default.hctune
@@ -196,6 +196,7 @@ ALIAS_Apple_M                                   3       22      2       A       
 ALIAS_Apple_M                                   3       900     2       A       A
 ALIAS_Apple_M                                   3       1000    2       A       A
 ALIAS_Apple_M                                   3       1100    2       A       A
+ALIAS_Apple_M                                   3       18700   2       A       A
 
 ##
 ## CryptoAPI

--- a/tunings/Modules_default.hctune
+++ b/tunings/Modules_default.hctune
@@ -191,21 +191,11 @@ ALIAS_INTEL                                     3       24700   2       A       
 ALIAS_INTEL                                     3       99999   4       A       A
 
 ALIAS_Apple_M                                   3       0       2       A       A
-ALIAS_Apple_M                                   3       10      2       A       A
 ALIAS_Apple_M                                   3       11      2       A       A
-ALIAS_Apple_M                                   3       20      2       A       A
 ALIAS_Apple_M                                   3       22      2       A       A
-ALIAS_Apple_M                                   3       30      2       A       A
-ALIAS_Apple_M                                   3       40      2       A       A
-ALIAS_Apple_M                                   3       200     4       A       A
 ALIAS_Apple_M                                   3       900     2       A       A
 ALIAS_Apple_M                                   3       1000    2       A       A
 ALIAS_Apple_M                                   3       1100    2       A       A
-ALIAS_Apple_M                                   3       2400    2       A       A
-ALIAS_Apple_M                                   3       2410    2       A       A
-ALIAS_Apple_M                                   3       3800    2       A       A
-ALIAS_Apple_M                                   3       4800    2       A       A
-ALIAS_Apple_M                                   3       18700   2       A       A
 
 ##
 ## CryptoAPI


### PR DESCRIPTION
## Motivation

Apple M-series GPUs have no entries in the hashcat tuning database, so all hash modes default to Vec:1. Testing on M3 Max shows Vec:2 provides a statistically significant throughput improvement for several hash modes in attack mode 3 (brute-force/mask).

## Changes

- Add `ALIAS_Apple_M` device alias group covering M1-M4 variants (base, Pro, Max, Ultra) to `tunings/Alias.hctune`
- Add Vec:2 tuning entries for 7 hash modes on `ALIAS_Apple_M` in `tunings/Modules_default.hctune`, scoped to attack mode 3

## Benchmarks

Tested on Apple M3 Max (40 GPU cores), macOS, OpenCL backend, optimized kernel. **30 interleaved trials per configuration**, Welch's t-test for significance (all p < 0.01).

| Mode | Algorithm | Vec:1 Mean (MH/s) | Vec:1 SD | Vec:2 Mean (MH/s) | Vec:2 SD | Improvement | t-stat |
|------|-----------|-------------------|----------|-------------------|----------|-------------|--------|
| 18700 | Java Object hashCode() | 84,544 | 2,600 | 109,639 | 4,158 | **+29.7%** | 28.03 |
| 11 | Joomla < 2.5.18 | 18,043 | 73 | 20,300 | 169 | **+12.5%** | 67.35 |
| 22 | Juniper NetScreen/SSG (ScreenOS) | 10,428 | 88 | 11,261 | 474 | **+8.0%** | 9.15 |
| 900 | MD4 | 31,976 | 109 | 34,135 | 174 | **+6.8%** | 57.56 |
| 0 | MD5 | 18,135 | 141 | 19,775 | 403 | **+6.6%** | 21.03 |
| 1000 | NTLM | 32,139 | 203 | 34,121 | 214 | **+6.6%** | 36.86 |
| 1100 | Domain Cached Credentials (DCC), MS Cache | 10,054 | 51 | 10,571 | 111 | **+5.1%** | 23.08 |

Additional modes tested with 30 interleaved trials but excluded (improvement <3% or not statistically significant): modes 10, 20, 30, 40, 200, 2400, 2410, 3800, 4800. Modes without existing NVIDIA Vec entries were also excluded per developer feedback to avoid fake vectorization issues.

Tuning entries are scoped to attack mode 3 (brute-force/mask) to match how existing NVIDIA entries are structured.

## Trade-offs

- Benchmarked on M3 Max only. The M1-M4 family shares the same GPU architecture, so Vec:2 is expected to benefit all variants, but only M3 Max is confirmed.
- Accel and Loops are left at `A` (auto) so the autotune system still controls those parameters.
- Scoped to attack mode 3 only. Other attack modes are unaffected.
- Modes not listed above remain at Vec:1.

## Test plan

- `hashcat -b -m 1000` on Apple M-series should show `Vec:2`
- `hashcat -b -m 100` (SHA1) should still show `Vec:1` (no tuning entry added for modes that regressed)