### PR TITLE
Added hash-mode: Meshtastic LoRa frame (AES-128-CTR PSK)

### DIFF
--- a/OpenCL/m99001_a0-pure.cl
+++ b/OpenCL/m99001_a0-pure.cl
@@ -16,19 +16,28 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-#define MESHTASTIC_NAME_MAX 64
-#define MESHTASTIC_CT_MAX   256
+#define MESHTASTIC_NAME_MAX   64
+#define MESHTASTIC_CT_MAX     256
+#define MESHTASTIC_FRAMES_MAX 16
+
+typedef struct meshtastic_frame
+{
+  u32 packet_id;
+  u32 from_node;
+  u32 ct_len;
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_frame_t;
 
 typedef struct meshtastic
 {
   u32 chash;
   u32 name_xor;
-  u32 packet_id;
-  u32 from_node;
   u32 name_len;
-  u32 ct_len;
+  u32 nframes;
   u32 name_buf[MESHTASTIC_NAME_MAX / 4];
-  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+  meshtastic_frame_t frames[MESHTASTIC_FRAMES_MAX];
 
 } meshtastic_t;
 
@@ -60,17 +69,14 @@ DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, cons
       || target == 0x6f;  /* admin      */
 }
 
-DECLSPEC int meshtastic_verify
+/* Structural check on one decrypted Meshtastic Data envelope. Called once per
+ * frame in the verifier; ALL frames must return 1 for a candidate to be reported
+ * as a crack (single-frame false positives at scale are why v2 exists). */
+DECLSPEC int meshtastic_verify_frame
 (
-  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
-  const u32 key_words,            // 4 = AES-128, 8 = AES-256
-  const u32 chash,
-  const u32 name_xor,
-  const u32 name_len,
-  const u32 packet_id,
-  const u32 from_node,
-  const u32 ct_len,
-  GLOBAL_AS const u32 *ct,
+  PRIVATE_AS const u32 *ks,
+  const u32 key_words,
+  GLOBAL_AS const meshtastic_frame_t *fr,
   SHM_TYPE u32 *s_te0,
   SHM_TYPE u32 *s_te1,
   SHM_TYPE u32 *s_te2,
@@ -78,47 +84,30 @@ DECLSPEC int meshtastic_verify
   SHM_TYPE u32 *s_te4
 )
 {
-  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
-  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
-
-  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
-
-  const u32 xh = (xw >> 16) ^ xw;
-  const u32 xq = (xh >>  8) ^ xh;
-
-  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
-
-  // The AES helpers swap32 their inputs internally; pass key/nonce in hashcat-native LE-byte u32 form.
-
   u32 nonce[4];
 
-  nonce[0] = packet_id;
+  nonce[0] = fr->packet_id;
   nonce[1] = 0;
-  nonce[2] = from_node;
+  nonce[2] = fr->from_node;
   nonce[3] = 0;
 
   u32 ks_block[4];
 
   if (key_words == 8)
   {
-    u32 ks[60]; // AES-256: 4 * (14 + 1)
-
-    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
     aes256_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
   }
   else
   {
-    u32 ks[44]; // AES-128: 4 * (10 + 1)
-
-    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
     aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
   }
 
-  // Decrypt the full first 16 bytes of plaintext for structural checks.
-  const u32 pt0 = ks_block[0] ^ ct[0];
-  const u32 pt1 = ks_block[1] ^ ct[1];
-  const u32 pt2 = ks_block[2] ^ ct[2];
-  const u32 pt3 = ks_block[3] ^ ct[3];
+  const u32 ct_len = fr->ct_len;
+
+  const u32 pt0 = ks_block[0] ^ fr->ct_buf[0];
+  const u32 pt1 = ks_block[1] ^ fr->ct_buf[1];
+  const u32 pt2 = ks_block[2] ^ fr->ct_buf[2];
+  const u32 pt3 = ks_block[3] ^ fr->ct_buf[3];
 
   // Meshtastic Data envelope header:
   //   pt[0] == 0x08  (field 1 / varint)       -- portnum tag
@@ -139,8 +128,8 @@ DECLSPEC int meshtastic_verify
 
   // If a byte exists right after the payload AND it falls within the
   // first AES block, require it to be 0x00 (padding) or one of the known
-  // Meshtastic Data optional-field tags (fields 3..9, varint or length-
-  // delim wire types). This drops the false-positive rate by ~5 bits.
+  // Meshtastic Data optional-field tags (fields 3..10, varint or length-
+  // delim wire types). Drops the per-frame FP rate by ~5 bits.
   const u32 trail_pos = 4 + pb_b3;
 
   if (trail_pos < 16 && trail_pos < ct_len)
@@ -161,6 +150,60 @@ DECLSPEC int meshtastic_verify
         trail_byte != 0x48 &&  /* field 9, varint        */
         trail_byte != 0x50 &&  /* field 10, varint       */
         trail_byte != 0x52)    /* field 10, length-delim */
+    {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+DECLSPEC int meshtastic_verify
+(
+  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
+  const u32 key_words,            // 4 = AES-128, 8 = AES-256
+  const u32 chash,
+  const u32 name_xor,
+  const u32 name_len,
+  GLOBAL_AS const meshtastic_t *esalt,
+  SHM_TYPE u32 *s_te0,
+  SHM_TYPE u32 *s_te1,
+  SHM_TYPE u32 *s_te2,
+  SHM_TYPE u32 *s_te3,
+  SHM_TYPE u32 *s_te4
+)
+{
+  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
+  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+
+  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
+
+  const u32 xh = (xw >> 16) ^ xw;
+  const u32 xq = (xh >>  8) ^ xh;
+
+  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
+
+  // Build the AES key schedule ONCE per candidate. Reused for every frame
+  // in the v2 multi-frame case. Sized for AES-256; AES-128 uses entries 0..43.
+  u32 ks[60];
+
+  if (key_words == 8)
+  {
+    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  }
+  else
+  {
+    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  }
+
+  // ALL-must-pass cross-frame validation. v1 lines run this loop exactly
+  // once (nframes == 1) so v1 throughput is unchanged.
+  const u32 nframes = esalt->nframes;
+
+  for (u32 f = 0; f < nframes; f++)
+  {
+    if (meshtastic_verify_frame (ks, key_words, &esalt->frames[f],
+                                 s_te0, s_te1, s_te2, s_te3, s_te4) == 0)
     {
       return 0;
     }
@@ -220,11 +263,9 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
 
   COPY_PW (pws[gid]);
 
-  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
-  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
-  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
-  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
-  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+  const u32 chash    = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
 
   /**
    * loop
@@ -268,9 +309,8 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
       key_words = 4;
     }
 
-    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len,
+                           &esalt_bufs[DIGESTS_OFFSET_HOST],
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
     {
       if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
@@ -332,11 +372,9 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
 
   COPY_PW (pws[gid]);
 
-  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
-  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
-  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
-  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
-  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+  const u32 chash    = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
 
   /**
    * loop
@@ -377,9 +415,8 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
       key_words = 4;
     }
 
-    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len,
+                           &esalt_bufs[DIGESTS_OFFSET_HOST],
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
     {
       if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)

--- a/OpenCL/m99001_a0-pure.cl
+++ b/OpenCL/m99001_a0-pure.cl
@@ -62,7 +62,8 @@ DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, cons
 
 DECLSPEC int meshtastic_verify
 (
-  PRIVATE_AS const u32 *key_le,
+  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
+  const u32 key_words,            // 4 = AES-128, 8 = AES-256
   const u32 chash,
   const u32 name_xor,
   const u32 name_len,
@@ -77,25 +78,17 @@ DECLSPEC int meshtastic_verify
   SHM_TYPE u32 *s_te4
 )
 {
-  // 1-byte channel-hash prefilter: xor of all 16 PSK bytes XOR xor of name bytes == chash.
-  // Eliminates ~99.6% of candidates before any AES work in the known-name case;
-  // the unknown-name path widens the accept set to ~13/256 (one per common name).
+  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
+  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
 
-  const u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
+
   const u32 xh = (xw >> 16) ^ xw;
   const u32 xq = (xh >>  8) ^ xh;
 
   if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
 
-  // The AES helpers swap32 their inputs internally; pass key/nonce in
-  // hashcat-native LE-byte u32 form. Output comes back LE-byte too, so the
-  // ct buffer on the host stays LE and XORs directly.
-
-  #define MESHTASTIC_KEYLEN 44
-
-  u32 ks[MESHTASTIC_KEYLEN];
-
-  aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  // The AES helpers swap32 their inputs internally; pass key/nonce in hashcat-native LE-byte u32 form.
 
   u32 nonce[4];
 
@@ -106,7 +99,20 @@ DECLSPEC int meshtastic_verify
 
   u32 ks_block[4];
 
-  aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  if (key_words == 8)
+  {
+    u32 ks[60]; // AES-256: 4 * (14 + 1)
+
+    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+    aes256_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  }
+  else
+  {
+    u32 ks[44]; // AES-128: 4 * (10 + 1)
+
+    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+    aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  }
 
   // Decrypt the full first 16 bytes of plaintext for structural checks.
   const u32 pt0 = ks_block[0] ^ ct[0];
@@ -230,20 +236,39 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
 
     tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
 
-    // first 16 bytes of candidate, zero-padded, used as the AES-128 key.
+    // First 16 or 32 bytes of candidate become the AES key, zero-padded.
+    // Length <=16 selects AES-128, 17..32 selects AES-256.
 
-    u32 key_le[4];
+    u32 key_le[8] = { 0 };
 
     key_le[0] = tmp.i[0];
     key_le[1] = tmp.i[1];
     key_le[2] = tmp.i[2];
     key_le[3] = tmp.i[3];
 
-    const u32 plen = (tmp.pw_len < 16) ? tmp.pw_len : 16;
+    u32 key_words;
 
-    truncate_block_4x4_le_S (key_le, plen);
+    if (tmp.pw_len > 16) // 17..32 bytes -> AES-256
+    {
+      key_le[4] = tmp.i[4];
+      key_le[5] = tmp.i[5];
+      key_le[6] = tmp.i[6];
+      key_le[7] = tmp.i[7];
 
-    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+      const u32 plen = (tmp.pw_len < 32) ? tmp.pw_len : 32;
+
+      truncate_block_4x4_le_S (&key_le[4], plen - 16); // low 16 are full; trim high block
+
+      key_words = 8;
+    }
+    else
+    {
+      truncate_block_4x4_le_S (key_le, tmp.pw_len);
+
+      key_words = 4;
+    }
+
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
@@ -323,18 +348,36 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
 
     tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
 
-    u32 key_le[4];
+    u32 key_le[8] = { 0 };
 
     key_le[0] = tmp.i[0];
     key_le[1] = tmp.i[1];
     key_le[2] = tmp.i[2];
     key_le[3] = tmp.i[3];
 
-    const u32 plen = (tmp.pw_len < 16) ? tmp.pw_len : 16;
+    u32 key_words;
 
-    truncate_block_4x4_le_S (key_le, plen);
+    if (tmp.pw_len > 16) // 17..32 bytes -> AES-256
+    {
+      key_le[4] = tmp.i[4];
+      key_le[5] = tmp.i[5];
+      key_le[6] = tmp.i[6];
+      key_le[7] = tmp.i[7];
 
-    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+      const u32 plen = (tmp.pw_len < 32) ? tmp.pw_len : 32;
+
+      truncate_block_4x4_le_S (&key_le[4], plen - 16); // low 16 are full; trim high block
+
+      key_words = 8;
+    }
+    else
+    {
+      truncate_block_4x4_le_S (key_le, tmp.pw_len);
+
+      key_words = 4;
+    }
+
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)

--- a/OpenCL/m99001_a0-pure.cl
+++ b/OpenCL/m99001_a0-pure.cl
@@ -1,0 +1,348 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+#define MESHTASTIC_NAME_MAX 64
+#define MESHTASTIC_CT_MAX   256
+
+typedef struct meshtastic
+{
+  u32 chash;
+  u32 name_xor;
+  u32 packet_id;
+  u32 from_node;
+  u32 name_len;
+  u32 ct_len;
+  u32 name_buf[MESHTASTIC_NAME_MAX / 4];
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_t;
+
+// xor-byte of every UTF-8 channel name commonly encountered on the air.
+// Used when the hash file has an empty name field -- the kernel iterates
+// these to find any name that yields a chash match for the candidate PSK.
+// Source list lives in meshtastic-recover (companion CPU tool); keep in sync.
+DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, const u32 chash, const u32 name_known)
+{
+  if (name_known)
+  {
+    return ((psk_xor ^ name_xor) & 0xff) == (chash & 0xff);
+  }
+
+  const u32 target = (psk_xor ^ chash) & 0xff;
+
+  return target == 0x0a   /* LongFast   */
+      || target == 0x0d   /* LongSlow   */
+      || target == 0x6c   /* LongMod    */
+      || target == 0x74   /* LongTurbo  */
+      || target == 0x1d   /* MediumFast */
+      || target == 0x1a   /* MediumSlow */
+      || target == 0x72   /* ShortFast  */
+      || target == 0x75   /* ShortSlow  */
+      || target == 0x0c   /* ShortTurbo */
+      || target == 0x4b   /* Default    */
+      || target == 0x4c   /* Primary    */
+      || target == 0x21   /* Public     */
+      || target == 0x6f;  /* admin      */
+}
+
+DECLSPEC int meshtastic_verify
+(
+  PRIVATE_AS const u32 *key_le,
+  const u32 chash,
+  const u32 name_xor,
+  const u32 name_len,
+  const u32 packet_id,
+  const u32 from_node,
+  const u32 ct_len,
+  GLOBAL_AS const u32 *ct,
+  SHM_TYPE u32 *s_te0,
+  SHM_TYPE u32 *s_te1,
+  SHM_TYPE u32 *s_te2,
+  SHM_TYPE u32 *s_te3,
+  SHM_TYPE u32 *s_te4
+)
+{
+  // 1-byte channel-hash prefilter: xor of all 16 PSK bytes XOR xor of name bytes == chash.
+  // Eliminates ~99.6% of candidates before any AES work in the known-name case;
+  // the unknown-name path widens the accept set to ~13/256 (one per common name).
+
+  const u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+  const u32 xh = (xw >> 16) ^ xw;
+  const u32 xq = (xh >>  8) ^ xh;
+
+  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
+
+  // The AES helpers swap32 their inputs internally; pass key/nonce in
+  // hashcat-native LE-byte u32 form. Output comes back LE-byte too, so the
+  // ct buffer on the host stays LE and XORs directly.
+
+  #define MESHTASTIC_KEYLEN 44
+
+  u32 ks[MESHTASTIC_KEYLEN];
+
+  aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+
+  u32 nonce[4];
+
+  nonce[0] = packet_id;
+  nonce[1] = 0;
+  nonce[2] = from_node;
+  nonce[3] = 0;
+
+  u32 ks_block[4];
+
+  aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  // Decrypt the full first 16 bytes of plaintext for structural checks.
+  const u32 pt0 = ks_block[0] ^ ct[0];
+  const u32 pt1 = ks_block[1] ^ ct[1];
+  const u32 pt2 = ks_block[2] ^ ct[2];
+  const u32 pt3 = ks_block[3] ^ ct[3];
+
+  // Meshtastic Data envelope header:
+  //   pt[0] == 0x08  (field 1 / varint)       -- portnum tag
+  //   pt[1] in 1..127                         -- single-byte varint portnum
+  //   pt[2] == 0x12  (field 2 / length-delim) -- payload tag
+  //   pt[3]  > 0   AND pt[3] + 4 <= ct_len    -- payload fits
+
+  const u32 pb_b0 =  pt0        & 0xff;
+  const u32 pb_b1 = (pt0 >>  8) & 0xff;
+  const u32 pb_b2 = (pt0 >> 16) & 0xff;
+  const u32 pb_b3 = (pt0 >> 24) & 0xff;
+
+  if (pb_b0 != 0x08)               return 0;
+  if (pb_b1 == 0 || pb_b1 >= 0x80) return 0;
+  if (pb_b2 != 0x12)               return 0;
+  if (pb_b3 == 0)                  return 0;
+  if (pb_b3 + 4 > ct_len)          return 0;
+
+  // If a byte exists right after the payload AND it falls within the
+  // first AES block, require it to be 0x00 (padding) or one of the known
+  // Meshtastic Data optional-field tags (fields 3..9, varint or length-
+  // delim wire types). This drops the false-positive rate by ~5 bits.
+  const u32 trail_pos = 4 + pb_b3;
+
+  if (trail_pos < 16 && trail_pos < ct_len)
+  {
+    const u32 trail_word = (trail_pos < 4)  ? pt0 :
+                           (trail_pos < 8)  ? pt1 :
+                           (trail_pos < 12) ? pt2 : pt3;
+
+    const u32 trail_byte = (trail_word >> ((trail_pos & 3) * 8)) & 0xff;
+
+    if (trail_byte != 0x00 &&
+        trail_byte != 0x18 &&  /* field 3, varint        */
+        trail_byte != 0x20 &&  /* field 4, varint        */
+        trail_byte != 0x28 &&  /* field 5, varint        */
+        trail_byte != 0x30 &&  /* field 6, varint        */
+        trail_byte != 0x38 &&  /* field 7, varint        */
+        trail_byte != 0x40 &&  /* field 8, varint        */
+        trail_byte != 0x48 &&  /* field 9, varint        */
+        trail_byte != 0x50 &&  /* field 10, varint       */
+        trail_byte != 0x52)    /* field 10, length-delim */
+    {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
+  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
+  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    // first 16 bytes of candidate, zero-padded, used as the AES-128 key.
+
+    u32 key_le[4];
+
+    key_le[0] = tmp.i[0];
+    key_le[1] = tmp.i[1];
+    key_le[2] = tmp.i[2];
+    key_le[3] = tmp.i[3];
+
+    const u32 plen = (tmp.pw_len < 16) ? tmp.pw_len : 16;
+
+    truncate_block_4x4_le_S (key_le, plen);
+
+    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+                           s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_RULES_ESALT (meshtastic_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
+  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
+  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    u32 key_le[4];
+
+    key_le[0] = tmp.i[0];
+    key_le[1] = tmp.i[1];
+    key_le[2] = tmp.i[2];
+    key_le[3] = tmp.i[3];
+
+    const u32 plen = (tmp.pw_len < 16) ? tmp.pw_len : 16;
+
+    truncate_block_4x4_le_S (key_le, plen);
+
+    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+                           s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m99001_a1-pure.cl
+++ b/OpenCL/m99001_a1-pure.cl
@@ -14,19 +14,28 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-#define MESHTASTIC_NAME_MAX 64
-#define MESHTASTIC_CT_MAX   256
+#define MESHTASTIC_NAME_MAX   64
+#define MESHTASTIC_CT_MAX     256
+#define MESHTASTIC_FRAMES_MAX 16
+
+typedef struct meshtastic_frame
+{
+  u32 packet_id;
+  u32 from_node;
+  u32 ct_len;
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_frame_t;
 
 typedef struct meshtastic
 {
   u32 chash;
   u32 name_xor;
-  u32 packet_id;
-  u32 from_node;
   u32 name_len;
-  u32 ct_len;
+  u32 nframes;
   u32 name_buf[MESHTASTIC_NAME_MAX / 4];
-  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+  meshtastic_frame_t frames[MESHTASTIC_FRAMES_MAX];
 
 } meshtastic_t;
 
@@ -54,17 +63,14 @@ DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, cons
       || target == 0x6f;  /* admin      */
 }
 
-DECLSPEC int meshtastic_verify
+/* Structural check on one decrypted Meshtastic Data envelope. Called once per
+ * frame in the verifier; ALL frames must return 1 for a candidate to be reported
+ * as a crack. */
+DECLSPEC int meshtastic_verify_frame
 (
-  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
-  const u32 key_words,            // 4 = AES-128, 8 = AES-256
-  const u32 chash,
-  const u32 name_xor,
-  const u32 name_len,
-  const u32 packet_id,
-  const u32 from_node,
-  const u32 ct_len,
-  GLOBAL_AS const u32 *ct,
+  PRIVATE_AS const u32 *ks,
+  const u32 key_words,
+  GLOBAL_AS const meshtastic_frame_t *fr,
   SHM_TYPE u32 *s_te0,
   SHM_TYPE u32 *s_te1,
   SHM_TYPE u32 *s_te2,
@@ -72,47 +78,30 @@ DECLSPEC int meshtastic_verify
   SHM_TYPE u32 *s_te4
 )
 {
-  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
-  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
-
-  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
-
-  const u32 xh = (xw >> 16) ^ xw;
-  const u32 xq = (xh >>  8) ^ xh;
-
-  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
-
-  // The AES helpers swap32 their inputs internally; pass key/nonce in hashcat-native LE-byte u32 form.
-
   u32 nonce[4];
 
-  nonce[0] = packet_id;
+  nonce[0] = fr->packet_id;
   nonce[1] = 0;
-  nonce[2] = from_node;
+  nonce[2] = fr->from_node;
   nonce[3] = 0;
 
   u32 ks_block[4];
 
   if (key_words == 8)
   {
-    u32 ks[60]; // AES-256: 4 * (14 + 1)
-
-    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
     aes256_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
   }
   else
   {
-    u32 ks[44]; // AES-128: 4 * (10 + 1)
-
-    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
     aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
   }
 
-  // Decrypt the full first 16 bytes of plaintext for structural checks.
-  const u32 pt0 = ks_block[0] ^ ct[0];
-  const u32 pt1 = ks_block[1] ^ ct[1];
-  const u32 pt2 = ks_block[2] ^ ct[2];
-  const u32 pt3 = ks_block[3] ^ ct[3];
+  const u32 ct_len = fr->ct_len;
+
+  const u32 pt0 = ks_block[0] ^ fr->ct_buf[0];
+  const u32 pt1 = ks_block[1] ^ fr->ct_buf[1];
+  const u32 pt2 = ks_block[2] ^ fr->ct_buf[2];
+  const u32 pt3 = ks_block[3] ^ fr->ct_buf[3];
 
   const u32 pb_b0 =  pt0        & 0xff;
   const u32 pb_b1 = (pt0 >>  8) & 0xff;
@@ -145,6 +134,59 @@ DECLSPEC int meshtastic_verify
         trail_byte != 0x48 &&
         trail_byte != 0x50 &&
         trail_byte != 0x52)
+    {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+DECLSPEC int meshtastic_verify
+(
+  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
+  const u32 key_words,            // 4 = AES-128, 8 = AES-256
+  const u32 chash,
+  const u32 name_xor,
+  const u32 name_len,
+  GLOBAL_AS const meshtastic_t *esalt,
+  SHM_TYPE u32 *s_te0,
+  SHM_TYPE u32 *s_te1,
+  SHM_TYPE u32 *s_te2,
+  SHM_TYPE u32 *s_te3,
+  SHM_TYPE u32 *s_te4
+)
+{
+  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
+  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+
+  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
+
+  const u32 xh = (xw >> 16) ^ xw;
+  const u32 xq = (xh >>  8) ^ xh;
+
+  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
+
+  // Build the AES key schedule ONCE per candidate, reused across all frames.
+  u32 ks[60];
+
+  if (key_words == 8)
+  {
+    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  }
+  else
+  {
+    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  }
+
+  // ALL frames must pass for a cross-frame crack to be reported.
+  // v1 lines run this loop once (nframes == 1).
+  const u32 nframes = esalt->nframes;
+
+  for (u32 f = 0; f < nframes; f++)
+  {
+    if (meshtastic_verify_frame (ks, key_words, &esalt->frames[f],
+                                 s_te0, s_te1, s_te2, s_te3, s_te4) == 0)
     {
       return 0;
     }
@@ -216,11 +258,9 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_ESALT (meshtastic_t))
   base[6] = pws[gid].i[6];
   base[7] = pws[gid].i[7];
 
-  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
-  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
-  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
-  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
-  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+  const u32 chash    = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
 
   /**
    * loop
@@ -302,9 +342,8 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_ESALT (meshtastic_t))
       key_words = 4;
     }
 
-    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len,
+                           &esalt_bufs[DIGESTS_OFFSET_HOST],
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
     {
       if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
@@ -378,11 +417,9 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_ESALT (meshtastic_t))
   base[6] = pws[gid].i[6];
   base[7] = pws[gid].i[7];
 
-  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
-  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
-  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
-  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
-  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+  const u32 chash    = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
 
   /**
    * loop
@@ -464,9 +501,8 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_ESALT (meshtastic_t))
       key_words = 4;
     }
 
-    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len,
+                           &esalt_bufs[DIGESTS_OFFSET_HOST],
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
     {
       if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)

--- a/OpenCL/m99001_a1-pure.cl
+++ b/OpenCL/m99001_a1-pure.cl
@@ -1,0 +1,377 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+#define MESHTASTIC_NAME_MAX 64
+#define MESHTASTIC_CT_MAX   256
+
+typedef struct meshtastic
+{
+  u32 chash;
+  u32 name_xor;
+  u32 packet_id;
+  u32 from_node;
+  u32 name_len;
+  u32 ct_len;
+  u32 name_buf[MESHTASTIC_NAME_MAX / 4];
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_t;
+
+DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, const u32 chash, const u32 name_known)
+{
+  if (name_known)
+  {
+    return ((psk_xor ^ name_xor) & 0xff) == (chash & 0xff);
+  }
+
+  const u32 target = (psk_xor ^ chash) & 0xff;
+
+  return target == 0x0a   /* LongFast   */
+      || target == 0x0d   /* LongSlow   */
+      || target == 0x6c   /* LongMod    */
+      || target == 0x74   /* LongTurbo  */
+      || target == 0x1d   /* MediumFast */
+      || target == 0x1a   /* MediumSlow */
+      || target == 0x72   /* ShortFast  */
+      || target == 0x75   /* ShortSlow  */
+      || target == 0x0c   /* ShortTurbo */
+      || target == 0x4b   /* Default    */
+      || target == 0x4c   /* Primary    */
+      || target == 0x21   /* Public     */
+      || target == 0x6f;  /* admin      */
+}
+
+DECLSPEC int meshtastic_verify
+(
+  PRIVATE_AS const u32 *key_le,
+  const u32 chash,
+  const u32 name_xor,
+  const u32 name_len,
+  const u32 packet_id,
+  const u32 from_node,
+  const u32 ct_len,
+  GLOBAL_AS const u32 *ct,
+  SHM_TYPE u32 *s_te0,
+  SHM_TYPE u32 *s_te1,
+  SHM_TYPE u32 *s_te2,
+  SHM_TYPE u32 *s_te3,
+  SHM_TYPE u32 *s_te4
+)
+{
+  const u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+  const u32 xh = (xw >> 16) ^ xw;
+  const u32 xq = (xh >>  8) ^ xh;
+
+  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
+
+  #define MESHTASTIC_KEYLEN 44
+
+  u32 ks[MESHTASTIC_KEYLEN];
+
+  aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+
+  u32 nonce[4];
+
+  nonce[0] = packet_id;
+  nonce[1] = 0;
+  nonce[2] = from_node;
+  nonce[3] = 0;
+
+  u32 ks_block[4];
+
+  aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  const u32 pt0 = ks_block[0] ^ ct[0];
+  const u32 pt1 = ks_block[1] ^ ct[1];
+  const u32 pt2 = ks_block[2] ^ ct[2];
+  const u32 pt3 = ks_block[3] ^ ct[3];
+
+  const u32 pb_b0 =  pt0        & 0xff;
+  const u32 pb_b1 = (pt0 >>  8) & 0xff;
+  const u32 pb_b2 = (pt0 >> 16) & 0xff;
+  const u32 pb_b3 = (pt0 >> 24) & 0xff;
+
+  if (pb_b0 != 0x08)               return 0;
+  if (pb_b1 == 0 || pb_b1 >= 0x80) return 0;
+  if (pb_b2 != 0x12)               return 0;
+  if (pb_b3 == 0)                  return 0;
+  if (pb_b3 + 4 > ct_len)          return 0;
+
+  const u32 trail_pos = 4 + pb_b3;
+
+  if (trail_pos < 16 && trail_pos < ct_len)
+  {
+    const u32 trail_word = (trail_pos < 4)  ? pt0 :
+                           (trail_pos < 8)  ? pt1 :
+                           (trail_pos < 12) ? pt2 : pt3;
+
+    const u32 trail_byte = (trail_word >> ((trail_pos & 3) * 8)) & 0xff;
+
+    if (trail_byte != 0x00 &&
+        trail_byte != 0x18 &&
+        trail_byte != 0x20 &&
+        trail_byte != 0x28 &&
+        trail_byte != 0x30 &&
+        trail_byte != 0x38 &&
+        trail_byte != 0x40 &&
+        trail_byte != 0x48 &&
+        trail_byte != 0x50 &&
+        trail_byte != 0x52)
+    {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_ESALT (meshtastic_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 base_len = pws[gid].pw_len;
+
+  u32 base[4];
+
+  base[0] = pws[gid].i[0];
+  base[1] = pws[gid].i[1];
+  base[2] = pws[gid].i[2];
+  base[3] = pws[gid].i[3];
+
+  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
+  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
+  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+    const u32 total    = base_len + comb_len;
+    const u32 plen     = (total < 16) ? total : 16;
+
+    u32 key_le[4];
+
+    key_le[0] = base[0];
+    key_le[1] = base[1];
+    key_le[2] = base[2];
+    key_le[3] = base[3];
+
+    if (base_len < 16)
+    {
+      // clear bytes >= base_len so we can OR the comb in cleanly
+      truncate_block_4x4_le_S (key_le, base_len);
+
+      // shift the first 16 bytes of comb right by base_len in the byte stream
+      u32 c0[4] = { 0 };
+      u32 c1[4] = { 0 };
+      u32 c2[4] = { 0 };
+      u32 c3[4] = { 0 };
+
+      c0[0] = combs_buf[il_pos].i[0];
+      c0[1] = combs_buf[il_pos].i[1];
+      c0[2] = combs_buf[il_pos].i[2];
+      c0[3] = combs_buf[il_pos].i[3];
+
+      switch_buffer_by_offset_le_S (c0, c1, c2, c3, base_len);
+
+      key_le[0] |= c0[0];
+      key_le[1] |= c0[1];
+      key_le[2] |= c0[2];
+      key_le[3] |= c0[3];
+    }
+
+    truncate_block_4x4_le_S (key_le, plen);
+
+    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+                           s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_ESALT (meshtastic_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 base_len = pws[gid].pw_len;
+
+  u32 base[4];
+
+  base[0] = pws[gid].i[0];
+  base[1] = pws[gid].i[1];
+  base[2] = pws[gid].i[2];
+  base[3] = pws[gid].i[3];
+
+  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
+  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
+  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    const u32 comb_len = combs_buf[il_pos].pw_len;
+    const u32 total    = base_len + comb_len;
+    const u32 plen     = (total < 16) ? total : 16;
+
+    u32 key_le[4];
+
+    key_le[0] = base[0];
+    key_le[1] = base[1];
+    key_le[2] = base[2];
+    key_le[3] = base[3];
+
+    if (base_len < 16)
+    {
+      truncate_block_4x4_le_S (key_le, base_len);
+
+      u32 c0[4] = { 0 };
+      u32 c1[4] = { 0 };
+      u32 c2[4] = { 0 };
+      u32 c3[4] = { 0 };
+
+      c0[0] = combs_buf[il_pos].i[0];
+      c0[1] = combs_buf[il_pos].i[1];
+      c0[2] = combs_buf[il_pos].i[2];
+      c0[3] = combs_buf[il_pos].i[3];
+
+      switch_buffer_by_offset_le_S (c0, c1, c2, c3, base_len);
+
+      key_le[0] |= c0[0];
+      key_le[1] |= c0[1];
+      key_le[2] |= c0[2];
+      key_le[3] |= c0[3];
+    }
+
+    truncate_block_4x4_le_S (key_le, plen);
+
+    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+                           s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/OpenCL/m99001_a1-pure.cl
+++ b/OpenCL/m99001_a1-pure.cl
@@ -56,7 +56,8 @@ DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, cons
 
 DECLSPEC int meshtastic_verify
 (
-  PRIVATE_AS const u32 *key_le,
+  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
+  const u32 key_words,            // 4 = AES-128, 8 = AES-256
   const u32 chash,
   const u32 name_xor,
   const u32 name_len,
@@ -71,17 +72,17 @@ DECLSPEC int meshtastic_verify
   SHM_TYPE u32 *s_te4
 )
 {
-  const u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
+  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+
+  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
+
   const u32 xh = (xw >> 16) ^ xw;
   const u32 xq = (xh >>  8) ^ xh;
 
   if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
 
-  #define MESHTASTIC_KEYLEN 44
-
-  u32 ks[MESHTASTIC_KEYLEN];
-
-  aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  // The AES helpers swap32 their inputs internally; pass key/nonce in hashcat-native LE-byte u32 form.
 
   u32 nonce[4];
 
@@ -92,8 +93,22 @@ DECLSPEC int meshtastic_verify
 
   u32 ks_block[4];
 
-  aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  if (key_words == 8)
+  {
+    u32 ks[60]; // AES-256: 4 * (14 + 1)
 
+    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+    aes256_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  }
+  else
+  {
+    u32 ks[44]; // AES-128: 4 * (10 + 1)
+
+    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+    aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  }
+
+  // Decrypt the full first 16 bytes of plaintext for structural checks.
   const u32 pt0 = ks_block[0] ^ ct[0];
   const u32 pt1 = ks_block[1] ^ ct[1];
   const u32 pt2 = ks_block[2] ^ ct[2];
@@ -189,12 +204,17 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_ESALT (meshtastic_t))
 
   const u32 base_len = pws[gid].pw_len;
 
-  u32 base[4];
+  // Load up to 32 bytes of base. Bytes past pw_len are zero by hashcat convention.
+  u32 base[8];
 
   base[0] = pws[gid].i[0];
   base[1] = pws[gid].i[1];
   base[2] = pws[gid].i[2];
   base[3] = pws[gid].i[3];
+  base[4] = pws[gid].i[4];
+  base[5] = pws[gid].i[5];
+  base[6] = pws[gid].i[6];
+  base[7] = pws[gid].i[7];
 
   const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
   const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
@@ -210,21 +230,37 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_ESALT (meshtastic_t))
   {
     const u32 comb_len = combs_buf[il_pos].pw_len;
     const u32 total    = base_len + comb_len;
-    const u32 plen     = (total < 16) ? total : 16;
+    const u32 plen     = (total < 32) ? total : 32;
 
-    u32 key_le[4];
+    // First 32 bytes of (base || comb), assembled into 8 u32 LE-byte words.
+    u32 key_le[8];
 
     key_le[0] = base[0];
     key_le[1] = base[1];
     key_le[2] = base[2];
     key_le[3] = base[3];
+    key_le[4] = base[4];
+    key_le[5] = base[5];
+    key_le[6] = base[6];
+    key_le[7] = base[7];
 
-    if (base_len < 16)
+    if (base_len < 32)
     {
-      // clear bytes >= base_len so we can OR the comb in cleanly
-      truncate_block_4x4_le_S (key_le, base_len);
+      // Clear bytes >= base_len so we can OR the shifted comb in cleanly.
+      if (base_len <= 16)
+      {
+        truncate_block_4x4_le_S (key_le, base_len);
+        key_le[4] = 0;
+        key_le[5] = 0;
+        key_le[6] = 0;
+        key_le[7] = 0;
+      }
+      else
+      {
+        truncate_block_4x4_le_S (&key_le[4], base_len - 16);
+      }
 
-      // shift the first 16 bytes of comb right by base_len in the byte stream
+      // Shift the first 32 bytes of comb right by base_len in the byte stream.
       u32 c0[4] = { 0 };
       u32 c1[4] = { 0 };
       u32 c2[4] = { 0 };
@@ -234,6 +270,10 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_ESALT (meshtastic_t))
       c0[1] = combs_buf[il_pos].i[1];
       c0[2] = combs_buf[il_pos].i[2];
       c0[3] = combs_buf[il_pos].i[3];
+      c1[0] = combs_buf[il_pos].i[4];
+      c1[1] = combs_buf[il_pos].i[5];
+      c1[2] = combs_buf[il_pos].i[6];
+      c1[3] = combs_buf[il_pos].i[7];
 
       switch_buffer_by_offset_le_S (c0, c1, c2, c3, base_len);
 
@@ -241,11 +281,28 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_ESALT (meshtastic_t))
       key_le[1] |= c0[1];
       key_le[2] |= c0[2];
       key_le[3] |= c0[3];
+      key_le[4] |= c1[0];
+      key_le[5] |= c1[1];
+      key_le[6] |= c1[2];
+      key_le[7] |= c1[3];
     }
 
-    truncate_block_4x4_le_S (key_le, plen);
+    // Final truncation at total length, with cipher selection.
+    u32 key_words;
 
-    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+    if (plen > 16) // 17..32 bytes -> AES-256
+    {
+      truncate_block_4x4_le_S (&key_le[4], plen - 16); // low half is full; trim high
+      key_words = 8;
+    }
+    else
+    {
+      truncate_block_4x4_le_S (key_le, plen);
+      // high half stayed zero above
+      key_words = 4;
+    }
+
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
@@ -309,12 +366,17 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_ESALT (meshtastic_t))
 
   const u32 base_len = pws[gid].pw_len;
 
-  u32 base[4];
+  // Load up to 32 bytes of base. Bytes past pw_len are zero by hashcat convention.
+  u32 base[8];
 
   base[0] = pws[gid].i[0];
   base[1] = pws[gid].i[1];
   base[2] = pws[gid].i[2];
   base[3] = pws[gid].i[3];
+  base[4] = pws[gid].i[4];
+  base[5] = pws[gid].i[5];
+  base[6] = pws[gid].i[6];
+  base[7] = pws[gid].i[7];
 
   const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
   const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
@@ -330,19 +392,37 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_ESALT (meshtastic_t))
   {
     const u32 comb_len = combs_buf[il_pos].pw_len;
     const u32 total    = base_len + comb_len;
-    const u32 plen     = (total < 16) ? total : 16;
+    const u32 plen     = (total < 32) ? total : 32;
 
-    u32 key_le[4];
+    // First 32 bytes of (base || comb), assembled into 8 u32 LE-byte words.
+    u32 key_le[8];
 
     key_le[0] = base[0];
     key_le[1] = base[1];
     key_le[2] = base[2];
     key_le[3] = base[3];
+    key_le[4] = base[4];
+    key_le[5] = base[5];
+    key_le[6] = base[6];
+    key_le[7] = base[7];
 
-    if (base_len < 16)
+    if (base_len < 32)
     {
-      truncate_block_4x4_le_S (key_le, base_len);
+      // Clear bytes >= base_len so we can OR the shifted comb in cleanly.
+      if (base_len <= 16)
+      {
+        truncate_block_4x4_le_S (key_le, base_len);
+        key_le[4] = 0;
+        key_le[5] = 0;
+        key_le[6] = 0;
+        key_le[7] = 0;
+      }
+      else
+      {
+        truncate_block_4x4_le_S (&key_le[4], base_len - 16);
+      }
 
+      // Shift the first 32 bytes of comb right by base_len in the byte stream.
       u32 c0[4] = { 0 };
       u32 c1[4] = { 0 };
       u32 c2[4] = { 0 };
@@ -352,6 +432,10 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_ESALT (meshtastic_t))
       c0[1] = combs_buf[il_pos].i[1];
       c0[2] = combs_buf[il_pos].i[2];
       c0[3] = combs_buf[il_pos].i[3];
+      c1[0] = combs_buf[il_pos].i[4];
+      c1[1] = combs_buf[il_pos].i[5];
+      c1[2] = combs_buf[il_pos].i[6];
+      c1[3] = combs_buf[il_pos].i[7];
 
       switch_buffer_by_offset_le_S (c0, c1, c2, c3, base_len);
 
@@ -359,11 +443,28 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_ESALT (meshtastic_t))
       key_le[1] |= c0[1];
       key_le[2] |= c0[2];
       key_le[3] |= c0[3];
+      key_le[4] |= c1[0];
+      key_le[5] |= c1[1];
+      key_le[6] |= c1[2];
+      key_le[7] |= c1[3];
     }
 
-    truncate_block_4x4_le_S (key_le, plen);
+    // Final truncation at total length, with cipher selection.
+    u32 key_words;
 
-    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+    if (plen > 16) // 17..32 bytes -> AES-256
+    {
+      truncate_block_4x4_le_S (&key_le[4], plen - 16); // low half is full; trim high
+      key_words = 8;
+    }
+    else
+    {
+      truncate_block_4x4_le_S (key_le, plen);
+      // high half stayed zero above
+      key_words = 4;
+    }
+
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)

--- a/OpenCL/m99001_a3-pure.cl
+++ b/OpenCL/m99001_a3-pure.cl
@@ -14,19 +14,28 @@
 #include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
 #endif
 
-#define MESHTASTIC_NAME_MAX 64
-#define MESHTASTIC_CT_MAX   256
+#define MESHTASTIC_NAME_MAX   64
+#define MESHTASTIC_CT_MAX     256
+#define MESHTASTIC_FRAMES_MAX 16
+
+typedef struct meshtastic_frame
+{
+  u32 packet_id;
+  u32 from_node;
+  u32 ct_len;
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_frame_t;
 
 typedef struct meshtastic
 {
   u32 chash;
   u32 name_xor;
-  u32 packet_id;
-  u32 from_node;
   u32 name_len;
-  u32 ct_len;
+  u32 nframes;
   u32 name_buf[MESHTASTIC_NAME_MAX / 4];
-  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+  meshtastic_frame_t frames[MESHTASTIC_FRAMES_MAX];
 
 } meshtastic_t;
 
@@ -54,17 +63,14 @@ DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, cons
       || target == 0x6f;  /* admin      */
 }
 
-DECLSPEC int meshtastic_verify
+/* Structural check on one decrypted Meshtastic Data envelope. Called once per
+ * frame in the verifier; ALL frames must return 1 for a candidate to be reported
+ * as a crack. */
+DECLSPEC int meshtastic_verify_frame
 (
-  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
-  const u32 key_words,            // 4 = AES-128, 8 = AES-256
-  const u32 chash,
-  const u32 name_xor,
-  const u32 name_len,
-  const u32 packet_id,
-  const u32 from_node,
-  const u32 ct_len,
-  GLOBAL_AS const u32 *ct,
+  PRIVATE_AS const u32 *ks,
+  const u32 key_words,
+  GLOBAL_AS const meshtastic_frame_t *fr,
   SHM_TYPE u32 *s_te0,
   SHM_TYPE u32 *s_te1,
   SHM_TYPE u32 *s_te2,
@@ -72,47 +78,30 @@ DECLSPEC int meshtastic_verify
   SHM_TYPE u32 *s_te4
 )
 {
-  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
-  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
-
-  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
-
-  const u32 xh = (xw >> 16) ^ xw;
-  const u32 xq = (xh >>  8) ^ xh;
-
-  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
-
-  // The AES helpers swap32 their inputs internally; pass key/nonce in hashcat-native LE-byte u32 form.
-
   u32 nonce[4];
 
-  nonce[0] = packet_id;
+  nonce[0] = fr->packet_id;
   nonce[1] = 0;
-  nonce[2] = from_node;
+  nonce[2] = fr->from_node;
   nonce[3] = 0;
 
   u32 ks_block[4];
 
   if (key_words == 8)
   {
-    u32 ks[60]; // AES-256: 4 * (14 + 1)
-
-    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
     aes256_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
   }
   else
   {
-    u32 ks[44]; // AES-128: 4 * (10 + 1)
-
-    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
     aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
   }
 
-  // Decrypt the full first 16 bytes of plaintext for structural checks.
-  const u32 pt0 = ks_block[0] ^ ct[0];
-  const u32 pt1 = ks_block[1] ^ ct[1];
-  const u32 pt2 = ks_block[2] ^ ct[2];
-  const u32 pt3 = ks_block[3] ^ ct[3];
+  const u32 ct_len = fr->ct_len;
+
+  const u32 pt0 = ks_block[0] ^ fr->ct_buf[0];
+  const u32 pt1 = ks_block[1] ^ fr->ct_buf[1];
+  const u32 pt2 = ks_block[2] ^ fr->ct_buf[2];
+  const u32 pt3 = ks_block[3] ^ fr->ct_buf[3];
 
   const u32 pb_b0 =  pt0        & 0xff;
   const u32 pb_b1 = (pt0 >>  8) & 0xff;
@@ -145,6 +134,59 @@ DECLSPEC int meshtastic_verify
         trail_byte != 0x48 &&
         trail_byte != 0x50 &&
         trail_byte != 0x52)
+    {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+DECLSPEC int meshtastic_verify
+(
+  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
+  const u32 key_words,            // 4 = AES-128, 8 = AES-256
+  const u32 chash,
+  const u32 name_xor,
+  const u32 name_len,
+  GLOBAL_AS const meshtastic_t *esalt,
+  SHM_TYPE u32 *s_te0,
+  SHM_TYPE u32 *s_te1,
+  SHM_TYPE u32 *s_te2,
+  SHM_TYPE u32 *s_te3,
+  SHM_TYPE u32 *s_te4
+)
+{
+  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
+  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+
+  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
+
+  const u32 xh = (xw >> 16) ^ xw;
+  const u32 xq = (xh >>  8) ^ xh;
+
+  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
+
+  // Build the AES key schedule ONCE per candidate, reused across all frames.
+  u32 ks[60];
+
+  if (key_words == 8)
+  {
+    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  }
+  else
+  {
+    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  }
+
+  // ALL frames must pass for a cross-frame crack to be reported.
+  // v1 lines run this loop once (nframes == 1).
+  const u32 nframes = esalt->nframes;
+
+  for (u32 f = 0; f < nframes; f++)
+  {
+    if (meshtastic_verify_frame (ks, key_words, &esalt->frames[f],
+                                 s_te0, s_te1, s_te2, s_te3, s_te4) == 0)
     {
       return 0;
     }
@@ -211,11 +253,9 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
     w[idx] = pws[gid].i[idx];
   }
 
-  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
-  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
-  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
-  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
-  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+  const u32 chash    = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
 
   /**
    * loop
@@ -258,9 +298,8 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
       key_words = 4;
     }
 
-    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len,
+                           &esalt_bufs[DIGESTS_OFFSET_HOST],
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
     {
       if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
@@ -329,11 +368,9 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
     w[idx] = pws[gid].i[idx];
   }
 
-  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
-  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
-  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
-  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
-  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+  const u32 chash    = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
 
   /**
    * loop
@@ -376,9 +413,8 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
       key_words = 4;
     }
 
-    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
-                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len,
+                           &esalt_bufs[DIGESTS_OFFSET_HOST],
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
     {
       if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)

--- a/OpenCL/m99001_a3-pure.cl
+++ b/OpenCL/m99001_a3-pure.cl
@@ -56,7 +56,8 @@ DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, cons
 
 DECLSPEC int meshtastic_verify
 (
-  PRIVATE_AS const u32 *key_le,
+  PRIVATE_AS const u32 *key_le,   // up to 8 u32, zero-padded
+  const u32 key_words,            // 4 = AES-128, 8 = AES-256
   const u32 chash,
   const u32 name_xor,
   const u32 name_len,
@@ -71,17 +72,17 @@ DECLSPEC int meshtastic_verify
   SHM_TYPE u32 *s_te4
 )
 {
-  const u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+  // 1-byte channel-hash prefilter over the FULL key (xorHash covers all 16 or 32 PSK bytes).
+  u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+
+  if (key_words == 8) xw ^= key_le[4] ^ key_le[5] ^ key_le[6] ^ key_le[7];
+
   const u32 xh = (xw >> 16) ^ xw;
   const u32 xq = (xh >>  8) ^ xh;
 
   if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
 
-  #define MESHTASTIC_KEYLEN 44
-
-  u32 ks[MESHTASTIC_KEYLEN];
-
-  aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+  // The AES helpers swap32 their inputs internally; pass key/nonce in hashcat-native LE-byte u32 form.
 
   u32 nonce[4];
 
@@ -92,8 +93,22 @@ DECLSPEC int meshtastic_verify
 
   u32 ks_block[4];
 
-  aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  if (key_words == 8)
+  {
+    u32 ks[60]; // AES-256: 4 * (14 + 1)
 
+    aes256_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+    aes256_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  }
+  else
+  {
+    u32 ks[44]; // AES-128: 4 * (10 + 1)
+
+    aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+    aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+  }
+
+  // Decrypt the full first 16 bytes of plaintext for structural checks.
   const u32 pt0 = ks_block[0] ^ ct[0];
   const u32 pt1 = ks_block[1] ^ ct[1];
   const u32 pt2 = ks_block[2] ^ ct[2];
@@ -214,18 +229,36 @@ KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
 
     const u32x w0 = w0l | w0r;
 
-    u32 key_le[4];
+    u32 key_le[8] = { 0 };
 
     key_le[0] = w0;
     key_le[1] = w[1];
     key_le[2] = w[2];
     key_le[3] = w[3];
 
-    const u32 plen = (pw_len < 16) ? pw_len : 16;
+    u32 key_words;
 
-    truncate_block_4x4_le_S (key_le, plen);
+    if (pw_len > 16) // 17..32 bytes -> AES-256
+    {
+      key_le[4] = w[4];
+      key_le[5] = w[5];
+      key_le[6] = w[6];
+      key_le[7] = w[7];
 
-    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+      const u32 plen = (pw_len < 32) ? pw_len : 32;
+
+      truncate_block_4x4_le_S (&key_le[4], plen - 16); // low 16 are full; trim high block
+
+      key_words = 8;
+    }
+    else
+    {
+      truncate_block_4x4_le_S (key_le, pw_len);
+
+      key_words = 4;
+    }
+
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
@@ -314,18 +347,36 @@ KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
 
     const u32x w0 = w0l | w0r;
 
-    u32 key_le[4];
+    u32 key_le[8] = { 0 };
 
     key_le[0] = w0;
     key_le[1] = w[1];
     key_le[2] = w[2];
     key_le[3] = w[3];
 
-    const u32 plen = (pw_len < 16) ? pw_len : 16;
+    u32 key_words;
 
-    truncate_block_4x4_le_S (key_le, plen);
+    if (pw_len > 16) // 17..32 bytes -> AES-256
+    {
+      key_le[4] = w[4];
+      key_le[5] = w[5];
+      key_le[6] = w[6];
+      key_le[7] = w[7];
 
-    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+      const u32 plen = (pw_len < 32) ? pw_len : 32;
+
+      truncate_block_4x4_le_S (&key_le[4], plen - 16); // low 16 are full; trim high block
+
+      key_words = 8;
+    }
+    else
+    {
+      truncate_block_4x4_le_S (key_le, pw_len);
+
+      key_words = 4;
+    }
+
+    if (meshtastic_verify (key_le, key_words, chash, name_xor, name_len, packet_id, from_node,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
                            esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
                            s_te0, s_te1, s_te2, s_te3, s_te4) == 1)

--- a/OpenCL/m99001_a3-pure.cl
+++ b/OpenCL/m99001_a3-pure.cl
@@ -1,0 +1,339 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+#define MESHTASTIC_NAME_MAX 64
+#define MESHTASTIC_CT_MAX   256
+
+typedef struct meshtastic
+{
+  u32 chash;
+  u32 name_xor;
+  u32 packet_id;
+  u32 from_node;
+  u32 name_len;
+  u32 ct_len;
+  u32 name_buf[MESHTASTIC_NAME_MAX / 4];
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_t;
+
+DECLSPEC int meshtastic_chash_match (const u32 psk_xor, const u32 name_xor, const u32 chash, const u32 name_known)
+{
+  if (name_known)
+  {
+    return ((psk_xor ^ name_xor) & 0xff) == (chash & 0xff);
+  }
+
+  const u32 target = (psk_xor ^ chash) & 0xff;
+
+  return target == 0x0a   /* LongFast   */
+      || target == 0x0d   /* LongSlow   */
+      || target == 0x6c   /* LongMod    */
+      || target == 0x74   /* LongTurbo  */
+      || target == 0x1d   /* MediumFast */
+      || target == 0x1a   /* MediumSlow */
+      || target == 0x72   /* ShortFast  */
+      || target == 0x75   /* ShortSlow  */
+      || target == 0x0c   /* ShortTurbo */
+      || target == 0x4b   /* Default    */
+      || target == 0x4c   /* Primary    */
+      || target == 0x21   /* Public     */
+      || target == 0x6f;  /* admin      */
+}
+
+DECLSPEC int meshtastic_verify
+(
+  PRIVATE_AS const u32 *key_le,
+  const u32 chash,
+  const u32 name_xor,
+  const u32 name_len,
+  const u32 packet_id,
+  const u32 from_node,
+  const u32 ct_len,
+  GLOBAL_AS const u32 *ct,
+  SHM_TYPE u32 *s_te0,
+  SHM_TYPE u32 *s_te1,
+  SHM_TYPE u32 *s_te2,
+  SHM_TYPE u32 *s_te3,
+  SHM_TYPE u32 *s_te4
+)
+{
+  const u32 xw = key_le[0] ^ key_le[1] ^ key_le[2] ^ key_le[3];
+  const u32 xh = (xw >> 16) ^ xw;
+  const u32 xq = (xh >>  8) ^ xh;
+
+  if (meshtastic_chash_match (xq, name_xor, chash, name_len) == 0) return 0;
+
+  #define MESHTASTIC_KEYLEN 44
+
+  u32 ks[MESHTASTIC_KEYLEN];
+
+  aes128_set_encrypt_key (ks, key_le, s_te0, s_te1, s_te2, s_te3);
+
+  u32 nonce[4];
+
+  nonce[0] = packet_id;
+  nonce[1] = 0;
+  nonce[2] = from_node;
+  nonce[3] = 0;
+
+  u32 ks_block[4];
+
+  aes128_encrypt (ks, nonce, ks_block, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+  const u32 pt0 = ks_block[0] ^ ct[0];
+  const u32 pt1 = ks_block[1] ^ ct[1];
+  const u32 pt2 = ks_block[2] ^ ct[2];
+  const u32 pt3 = ks_block[3] ^ ct[3];
+
+  const u32 pb_b0 =  pt0        & 0xff;
+  const u32 pb_b1 = (pt0 >>  8) & 0xff;
+  const u32 pb_b2 = (pt0 >> 16) & 0xff;
+  const u32 pb_b3 = (pt0 >> 24) & 0xff;
+
+  if (pb_b0 != 0x08)               return 0;
+  if (pb_b1 == 0 || pb_b1 >= 0x80) return 0;
+  if (pb_b2 != 0x12)               return 0;
+  if (pb_b3 == 0)                  return 0;
+  if (pb_b3 + 4 > ct_len)          return 0;
+
+  const u32 trail_pos = 4 + pb_b3;
+
+  if (trail_pos < 16 && trail_pos < ct_len)
+  {
+    const u32 trail_word = (trail_pos < 4)  ? pt0 :
+                           (trail_pos < 8)  ? pt1 :
+                           (trail_pos < 12) ? pt2 : pt3;
+
+    const u32 trail_byte = (trail_word >> ((trail_pos & 3) * 8)) & 0xff;
+
+    if (trail_byte != 0x00 &&
+        trail_byte != 0x18 &&
+        trail_byte != 0x20 &&
+        trail_byte != 0x28 &&
+        trail_byte != 0x30 &&
+        trail_byte != 0x38 &&
+        trail_byte != 0x40 &&
+        trail_byte != 0x48 &&
+        trail_byte != 0x50 &&
+        trail_byte != 0x52)
+    {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+KERNEL_FQ KERNEL_FA void m99001_mxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
+  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
+  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    u32 key_le[4];
+
+    key_le[0] = w0;
+    key_le[1] = w[1];
+    key_le[2] = w[2];
+    key_le[3] = w[3];
+
+    const u32 plen = (pw_len < 16) ? pw_len : 16;
+
+    truncate_block_4x4_le_S (key_le, plen);
+
+    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+                           s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m99001_sxx (KERN_ATTR_VECTOR_ESALT (meshtastic_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  #else
+
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 chash     = esalt_bufs[DIGESTS_OFFSET_HOST].chash;
+  const u32 name_xor  = esalt_bufs[DIGESTS_OFFSET_HOST].name_xor;
+  const u32 name_len  = esalt_bufs[DIGESTS_OFFSET_HOST].name_len;
+  const u32 packet_id = esalt_bufs[DIGESTS_OFFSET_HOST].packet_id;
+  const u32 from_node = esalt_bufs[DIGESTS_OFFSET_HOST].from_node;
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    u32 key_le[4];
+
+    key_le[0] = w0;
+    key_le[1] = w[1];
+    key_le[2] = w[2];
+    key_le[3] = w[3];
+
+    const u32 plen = (pw_len < 16) ? pw_len : 16;
+
+    truncate_block_4x4_le_S (key_le, plen);
+
+    if (meshtastic_verify (key_le, chash, name_xor, name_len, packet_id, from_node,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_len,
+                           esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf,
+                           s_te0, s_te1, s_te2, s_te3, s_te4) == 1)
+    {
+      if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+      {
+        mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, il_pos, 0, 0);
+      }
+    }
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,6 +1,12 @@
 * changes v7.1.2 -> v7.1.x
 
 ##
+## New Algorithms
+##
+
+- Added hash-mode: Meshtastic LoRa frame (AES-128-CTR PSK)
+
+##
 ## Improvements
 ##
 

--- a/docs/credits.txt
+++ b/docs/credits.txt
@@ -96,4 +96,7 @@ Costin Enache <costin@detack.de>
 * IBM AS400 DES and SSHA1 modules
 * Cisco-ISE Hashed Password (SHA256) module
 
+Aaron (@alphafox02)
+* Meshtastic LoRa frame (AES-128-CTR PSK) kernel module
+
 !!! All the package maintainers of hashcat !!!

--- a/src/modules/module_99001.c
+++ b/src/modules/module_99001.c
@@ -43,19 +43,30 @@ u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, 
 const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
 const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
 
-#define MESHTASTIC_NAME_MAX 64
-#define MESHTASTIC_CT_MAX   256
+#define MESHTASTIC_NAME_MAX  64
+#define MESHTASTIC_CT_MAX    256
+#define MESHTASTIC_FRAMES_MAX 16   /* matches sniffer-side --hashcat-export-merge cap */
+
+/* Per-frame portion of the hash. v1 lines populate a single entry; v2 lines
+ * populate nframes entries (2..16) sharing the same chash and channel name. */
+typedef struct meshtastic_frame
+{
+  u32 packet_id;
+  u32 from_node;
+  u32 ct_len;
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_frame_t;
 
 typedef struct meshtastic
 {
   u32 chash;
   u32 name_xor;
-  u32 packet_id;
-  u32 from_node;
   u32 name_len;
-  u32 ct_len;
+  u32 nframes;        /* 1 for v1, 2..16 for v2 */
   u32 name_buf[MESHTASTIC_NAME_MAX / 4];
-  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+  meshtastic_frame_t frames[MESHTASTIC_FRAMES_MAX];
 
 } meshtastic_t;
 
@@ -83,89 +94,174 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   memset (meshtastic, 0, sizeof (meshtastic_t));
 
+  // Detect format version by peeking at the digit after the signature.
+  // We need "$meshtastic$" (12 chars) plus one digit, so line_len >= 13.
+  if (line_len < 14) return (PARSER_SALT_LENGTH);
+
+  const char version_char = line_buf[12];
+
+  if (version_char != '1' && version_char != '2') return (PARSER_SALT_VALUE);
+
+  u32 nframes = 1;
+
+  // For v2 we have to know N (the frame count) before configuring the
+  // tokenizer, since the token count grows with N. Walk the line to read
+  // it: skip "$meshtastic$2*", skip chash + '*', skip name + '*', then
+  // read the decimal N up to the next '*'.
+  if (version_char == '2')
+  {
+    int p = 13;                                  // index of '*' after the '2'
+    if (p >= line_len || line_buf[p] != '*') return (PARSER_SALT_VALUE);
+    p++;
+
+    // chash field: exactly 2 hex chars then '*'
+    if (p + 3 > line_len) return (PARSER_SALT_LENGTH);
+    if (line_buf[p + 2] != '*') return (PARSER_SALT_VALUE);
+    p += 3;
+
+    // name field: variable, terminated by '*'
+    while (p < line_len && line_buf[p] != '*') p++;
+    if (p >= line_len) return (PARSER_SALT_VALUE);
+    p++;
+
+    // N field: 1..2 decimal digits, terminated by '*'
+    int n_start = p;
+    while (p < line_len && line_buf[p] != '*')
+    {
+      if (line_buf[p] < '0' || line_buf[p] > '9') return (PARSER_SALT_VALUE);
+      p++;
+    }
+    if (p >= line_len) return (PARSER_SALT_VALUE);
+
+    int n_len = p - n_start;
+    if (n_len < 1 || n_len > 2) return (PARSER_SALT_VALUE);
+
+    nframes = (u32) hc_strtoul ((const char *) (line_buf + n_start), NULL, 10);
+    if (nframes < 2 || nframes > MESHTASTIC_FRAMES_MAX) return (PARSER_SALT_VALUE);
+  }
+
   hc_token_t token;
 
   memset (&token, 0, sizeof (hc_token_t));
 
-  token.token_cnt  = 7;
-
   token.signatures_cnt    = 1;
   token.signatures_buf[0] = SIGNATURE_MESHTASTIC;
 
+  // token 0: signature
   token.len[0]     = 12;
   token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_SIGNATURE;
 
-  // version
-
+  // token 1: version digit
   token.sep[1]     = '*';
   token.len[1]     = 1;
   token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_DIGIT;
 
-  // chash byte (frame[13])
-
+  // token 2: chash byte (frame[13])
   token.sep[2]     = '*';
   token.len[2]     = 2;
   token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
 
-  // packet id (4 LE bytes)
+  u32 name_token_idx;
+  u32 frames_first_token_idx;
 
-  token.sep[3]     = '*';
-  token.len[3]     = 8;
-  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
-                   | TOKEN_ATTR_VERIFY_HEX;
+  if (version_char == '1')
+  {
+    // v1 layout: signature | 1 | chash | pkt | from | name | ct
+    token.token_cnt = 7;
 
-  // from node (4 LE bytes)
+    // token 3: packet_id (4 LE bytes)
+    token.sep[3]     = '*';
+    token.len[3]     = 8;
+    token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[4]     = '*';
-  token.len[4]     = 8;
-  token.attr[4]    = TOKEN_ATTR_FIXED_LENGTH
-                   | TOKEN_ATTR_VERIFY_HEX;
+    // token 4: from_node (4 LE bytes)
+    token.sep[4]     = '*';
+    token.len[4]     = 8;
+    token.attr[4]    = TOKEN_ATTR_FIXED_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
 
-  // channel name (variable hex, may be empty)
+    // token 5: channel name (variable hex, may be empty)
+    token.sep[5]     = '*';
+    token.len_min[5] = 0;
+    token.len_max[5] = MESHTASTIC_NAME_MAX * 2;
+    token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
 
-  token.sep[5]     = '*';
-  token.len_min[5] = 0;
-  token.len_max[5] = MESHTASTIC_NAME_MAX * 2;
-  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_HEX;
+    // token 6: ciphertext (>= 4 bytes so the kernel can check the protobuf header)
+    token.sep[6]     = '*';
+    token.len_min[6] = 8;
+    token.len_max[6] = MESHTASTIC_CT_MAX * 2;
+    token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
 
-  // ciphertext: at minimum the 4-byte protobuf header so the kernel can verify the shape
+    name_token_idx         = 5;
+    frames_first_token_idx = 3;  // pkt at +0, from at +1, ct at +3 (after name)
+  }
+  else
+  {
+    // v2 layout: signature | 2 | chash | name | N | (pkt | from | ct){N}
+    token.token_cnt = 5 + 3 * nframes;
 
-  token.sep[6]     = '*';
-  token.len_min[6] = 8;
-  token.len_max[6] = MESHTASTIC_CT_MAX * 2;
-  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
-                   | TOKEN_ATTR_VERIFY_HEX;
+    // token 3: channel name (variable hex)
+    token.sep[3]     = '*';
+    token.len_min[3] = 0;
+    token.len_max[3] = MESHTASTIC_NAME_MAX * 2;
+    token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_HEX;
+
+    // token 4: N (1..2 decimal digits)
+    token.sep[4]     = '*';
+    token.len_min[4] = 1;
+    token.len_max[4] = 2;
+    token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                     | TOKEN_ATTR_VERIFY_DIGIT;
+
+    // tokens 5..(5 + 3*N - 1): N consecutive (pkt, from, ct) triples
+    for (u32 f = 0; f < nframes; f++)
+    {
+      const u32 base = 5 + 3 * f;
+
+      token.sep[base + 0]     = '*';
+      token.len[base + 0]     = 8;
+      token.attr[base + 0]    = TOKEN_ATTR_FIXED_LENGTH
+                              | TOKEN_ATTR_VERIFY_HEX;
+
+      token.sep[base + 1]     = '*';
+      token.len[base + 1]     = 8;
+      token.attr[base + 1]    = TOKEN_ATTR_FIXED_LENGTH
+                              | TOKEN_ATTR_VERIFY_HEX;
+
+      token.sep[base + 2]     = '*';
+      token.len_min[base + 2] = 8;
+      token.len_max[base + 2] = MESHTASTIC_CT_MAX * 2;
+      token.attr[base + 2]    = TOKEN_ATTR_VERIFY_LENGTH
+                              | TOKEN_ATTR_VERIFY_HEX;
+    }
+
+    name_token_idx         = 3;
+    frames_first_token_idx = 5;  // each frame triple lives at (5 + 3*f, 6 + 3*f, 7 + 3*f)
+  }
 
   const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
 
   if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
 
-  // version
-
+  // version sanity (tokenizer enforces digit, we enforce value)
   const u32 version = hc_strtoul ((const char *) token.buf[1], NULL, 10);
-
-  if (version != 1) return (PARSER_SALT_VALUE);
+  if (version_char == '1' && version != 1) return (PARSER_SALT_VALUE);
+  if (version_char == '2' && version != 2) return (PARSER_SALT_VALUE);
 
   // chash
-
-  const u8 chash = hex_to_u8 (token.buf[2]);
-
-  meshtastic->chash = (u32) chash;
-
-  // packet_id and from_node are 4-byte LE on the wire; hex_to_u32 reads
-  // them into a host integer that already matches the LE byte order.
-
-  meshtastic->packet_id = hex_to_u32 (token.buf[3]);
-  meshtastic->from_node = hex_to_u32 (token.buf[4]);
+  meshtastic->chash   = (u32) hex_to_u8 (token.buf[2]);
+  meshtastic->nframes = nframes;
 
   // channel name -- copied raw (LE-packed in u32) for the encoder, plus
   // a precomputed xor-byte for the kernel-side prefilter.
-
-  const int name_hex_len = token.len[5];
+  const int name_hex_len = token.len[name_token_idx];
 
   if ((name_hex_len & 1) != 0) return (PARSER_SALT_VALUE);
 
@@ -174,12 +270,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   if (name_len > MESHTASTIC_NAME_MAX) return (PARSER_SALT_LENGTH);
 
   u8 *name_ptr = (u8 *) meshtastic->name_buf;
-
   u8 name_xor = 0;
 
   for (u32 i = 0; i < name_len; i++)
   {
-    const u8 b = hex_to_u8 (token.buf[5] + (i * 2));
+    const u8 b = hex_to_u8 (token.buf[name_token_idx] + (i * 2));
 
     name_ptr[i] = b;
     name_xor   ^= b;
@@ -188,45 +283,85 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   meshtastic->name_len = name_len;
   meshtastic->name_xor = (u32) name_xor;
 
-  // ciphertext -- byte-swap to BE so the kernel can XOR directly with AES output.
-
-  const int ct_hex_len = token.len[6];
-
-  if ((ct_hex_len & 1) != 0) return (PARSER_SALT_VALUE);
-
-  const u32 ct_len = (u32) (ct_hex_len / 2);
-
-  if (ct_len > MESHTASTIC_CT_MAX) return (PARSER_SALT_LENGTH);
-
-  // LE-packed: byte i of ct lands in byte (i % 4) of ct_buf[i / 4].
-  // Matches hashcat's hex_to_u32 convention and the AES helper's u32
-  // I/O byte order, so the kernel can XOR ct_buf[0] with the AES output
-  // directly.
-  for (u32 i = 0; i < ct_len; i++)
+  // Per-frame triples. In v1 there's a single triple at tokens [3, 4, 6]
+  // (with name sandwiched at 5); in v2 the triples start at token 5 and
+  // are contiguous (pkt, from, ct repeated).
+  for (u32 f = 0; f < nframes; f++)
   {
-    const u8 b = hex_to_u8 (token.buf[6] + (i * 2));
+    u32 pkt_idx, from_idx, ct_idx;
 
-    meshtastic->ct_buf[i / 4] |= ((u32) b) << ((i & 3) * 8);
+    if (version_char == '1')
+    {
+      pkt_idx  = 3;
+      from_idx = 4;
+      ct_idx   = 6;
+    }
+    else
+    {
+      pkt_idx  = frames_first_token_idx + 3 * f + 0;
+      from_idx = frames_first_token_idx + 3 * f + 1;
+      ct_idx   = frames_first_token_idx + 3 * f + 2;
+    }
+
+    meshtastic_frame_t *fr = &meshtastic->frames[f];
+
+    fr->packet_id = hex_to_u32 (token.buf[pkt_idx]);
+    fr->from_node = hex_to_u32 (token.buf[from_idx]);
+
+    const int ct_hex_len = token.len[ct_idx];
+
+    if ((ct_hex_len & 1) != 0) return (PARSER_SALT_VALUE);
+
+    const u32 ct_len = (u32) (ct_hex_len / 2);
+
+    if (ct_len > MESHTASTIC_CT_MAX) return (PARSER_SALT_LENGTH);
+
+    // LE-packed: byte i of ct lands in byte (i % 4) of ct_buf[i / 4].
+    // Matches hashcat's hex_to_u32 convention and the AES helper's u32
+    // I/O byte order, so the kernel can XOR ct_buf[0] with the AES output
+    // directly.
+    for (u32 i = 0; i < ct_len; i++)
+    {
+      const u8 b = hex_to_u8 (token.buf[ct_idx] + (i * 2));
+
+      fr->ct_buf[i / 4] |= ((u32) b) << ((i & 3) * 8);
+    }
+
+    fr->ct_len = ct_len;
   }
 
-  meshtastic->ct_len = ct_len;
+  // Aggregate identity across every frame so two v2 lines that share their
+  // first frame but differ in later frames do not collide on the same salt
+  // (which would make hashcat dedupe them). Plain XOR is enough: real captures
+  // never reuse identical (packet_id, from_node, ct_buf[0], ct_len) tuples
+  // across frames of a single channel.
+  u32 agg_packet_id = 0;
+  u32 agg_from_node = 0;
+  u32 agg_ct_first  = 0;
+  u32 agg_ct_len    = 0;
 
-  // make the salt unique per frame so multiple frames in the same hash
-  // file each get their own _comp pass.
+  for (u32 f = 0; f < nframes; f++)
+  {
+    agg_packet_id ^= meshtastic->frames[f].packet_id;
+    agg_from_node ^= meshtastic->frames[f].from_node;
+    agg_ct_first  ^= meshtastic->frames[f].ct_buf[0];
+    agg_ct_len    ^= meshtastic->frames[f].ct_len;
+  }
 
-  salt->salt_buf[0] = meshtastic->packet_id;
-  salt->salt_buf[1] = meshtastic->from_node;
-  salt->salt_buf[2] = meshtastic->chash;
-  salt->salt_len    = 12;
+  salt->salt_buf[0] = agg_packet_id;
+  salt->salt_buf[1] = agg_from_node;
+  salt->salt_buf[2] = (meshtastic->chash << 16) | (meshtastic->nframes & 0xffff);
+  salt->salt_buf[3] = agg_ct_first;
+  salt->salt_len    = 16;
 
-  // there is no traditional digest here; the verifier matches by
-  // decrypting and checking a protobuf shape. fill a stable sentinel so
-  // the dispatch keeps each frame distinct.
-
-  digest[0] = meshtastic->packet_id;
-  digest[1] = meshtastic->from_node;
-  digest[2] = meshtastic->ct_buf[0];
-  digest[3] = (meshtastic->chash << 24) | (meshtastic->name_xor << 16) | (meshtastic->ct_len & 0xffff);
+  // Digest sentinel (verifier is structural, not a real hash).
+  digest[0] = agg_packet_id;
+  digest[1] = agg_from_node;
+  digest[2] = agg_ct_first;
+  digest[3] = (meshtastic->chash << 24)
+            | (meshtastic->name_xor << 16)
+            | ((meshtastic->nframes & 0xff) << 8)
+            |  (agg_ct_len & 0xff);
 
   return (PARSER_OK);
 }
@@ -235,31 +370,69 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 {
   const meshtastic_t *meshtastic = (const meshtastic_t *) esalt_buf;
 
-  // packet_id and from_node round-trip through hex_to_u32 which reads
-  // the file hex as little-endian on-wire bytes; print them swapped so
-  // we re-emit those same on-wire bytes.
-  int line_len = snprintf (line_buf, line_size, "%s1*%02x*%08x*%08x*",
-    SIGNATURE_MESHTASTIC,
-    meshtastic->chash & 0xff,
-    byte_swap_32 (meshtastic->packet_id),
-    byte_swap_32 (meshtastic->from_node));
-
   const u8 *name_ptr = (const u8 *) meshtastic->name_buf;
 
-  for (u32 i = 0; i < meshtastic->name_len; i++)
+  int line_len = 0;
+
+  if (meshtastic->nframes <= 1)
   {
-    line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", name_ptr[i]);
+    // v1: signature * chash * pkt * from * name * ct
+    // packet_id and from_node round-trip through hex_to_u32 which reads
+    // the file hex as little-endian on-wire bytes; print them swapped so
+    // we re-emit those same on-wire bytes.
+    line_len = snprintf (line_buf, line_size, "%s1*%02x*%08x*%08x*",
+      SIGNATURE_MESHTASTIC,
+      meshtastic->chash & 0xff,
+      byte_swap_32 (meshtastic->frames[0].packet_id),
+      byte_swap_32 (meshtastic->frames[0].from_node));
+
+    for (u32 i = 0; i < meshtastic->name_len; i++)
+    {
+      line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", name_ptr[i]);
+    }
+
+    line_len += snprintf (line_buf + line_len, line_size - line_len, "*");
+
+    for (u32 i = 0; i < meshtastic->frames[0].ct_len; i++)
+    {
+      const u32 w  = meshtastic->frames[0].ct_buf[i / 4];
+      const u32 sh = (i % 4) * 8; // ct_buf is LE-packed
+      const u8  b  = (u8) (w >> sh);
+
+      line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", b);
+    }
   }
-
-  line_len += snprintf (line_buf + line_len, line_size - line_len, "*");
-
-  for (u32 i = 0; i < meshtastic->ct_len; i++)
+  else
   {
-    const u32 w  = meshtastic->ct_buf[i / 4];
-    const u32 sh = (i % 4) * 8; // ct_buf is LE-packed
-    const u8  b  = (u8) (w >> sh);
+    // v2: signature * chash * name * N * (pkt * from * ct){N}
+    line_len = snprintf (line_buf, line_size, "%s2*%02x*",
+      SIGNATURE_MESHTASTIC,
+      meshtastic->chash & 0xff);
 
-    line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", b);
+    for (u32 i = 0; i < meshtastic->name_len; i++)
+    {
+      line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", name_ptr[i]);
+    }
+
+    line_len += snprintf (line_buf + line_len, line_size - line_len, "*%u", meshtastic->nframes);
+
+    for (u32 f = 0; f < meshtastic->nframes; f++)
+    {
+      const meshtastic_frame_t *fr = &meshtastic->frames[f];
+
+      line_len += snprintf (line_buf + line_len, line_size - line_len, "*%08x*%08x*",
+        byte_swap_32 (fr->packet_id),
+        byte_swap_32 (fr->from_node));
+
+      for (u32 i = 0; i < fr->ct_len; i++)
+      {
+        const u32 w  = fr->ct_buf[i / 4];
+        const u32 sh = (i % 4) * 8;
+        const u8  b  = (u8) (w >> sh);
+
+        line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", b);
+      }
+    }
   }
 
   return line_len;

--- a/src/modules/module_99001.c
+++ b/src/modules/module_99001.c
@@ -17,7 +17,7 @@ static const u32   DGST_POS2      = 2;
 static const u32   DGST_POS3      = 3;
 static const u32   DGST_SIZE      = DGST_SIZE_4_4;
 static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
-static const char *HASH_NAME      = "Meshtastic LoRa frame (AES-128-CTR PSK)";
+static const char *HASH_NAME      = "Meshtastic LoRa frame (AES-128/256-CTR PSK)";
 static const u64   KERN_TYPE      = 99001;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
                                   | OPTI_TYPE_NOT_ITERATED
@@ -25,8 +25,8 @@ static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
-static const char *ST_PASS        = "hashcat";
-static const char *ST_HASH        = "$meshtastic$1*00*efbeadde*efbeadde*68617368636174*56c09c1c6132ed37ce376f95a350b133";
+static const char *ST_PASS        = "0123456789abcdef0123456789abcdef";
+static const char *ST_HASH        = "$meshtastic$1*0a*efbeadde*efbeadde*4c6f6e6746617374*e9886af9b78d2bdd9c52f492cc999e04";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -63,7 +63,8 @@ static const char *SIGNATURE_MESHTASTIC = "$meshtastic$";
 
 u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
-  // Meshtastic PSK is 16 bytes for AES-128, 32 for AES-256. Anything longer is truncated by the kernel.
+  // Meshtastic PSK length selects the cipher: <=16 byte candidate -> AES-128 (zero-padded to 16),
+  // 17..32 byte candidate -> AES-256 (zero-padded to 32). Anything longer is truncated to 32 by the kernel.
   return 32;
 }
 

--- a/src/modules/module_99001.c
+++ b/src/modules/module_99001.c
@@ -1,0 +1,347 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "Meshtastic LoRa frame (AES-128-CTR PSK)";
+static const u64   KERN_TYPE      = 99001;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_EARLY_SKIP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$meshtastic$1*00*efbeadde*efbeadde*68617368636174*56c09c1c6132ed37ce376f95a350b133";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+#define MESHTASTIC_NAME_MAX 64
+#define MESHTASTIC_CT_MAX   256
+
+typedef struct meshtastic
+{
+  u32 chash;
+  u32 name_xor;
+  u32 packet_id;
+  u32 from_node;
+  u32 name_len;
+  u32 ct_len;
+  u32 name_buf[MESHTASTIC_NAME_MAX / 4];
+  u32 ct_buf[MESHTASTIC_CT_MAX / 4];
+
+} meshtastic_t;
+
+static const char *SIGNATURE_MESHTASTIC = "$meshtastic$";
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // Meshtastic PSK is 16 bytes for AES-128, 32 for AES-256. Anything longer is truncated by the kernel.
+  return 32;
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (meshtastic_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  meshtastic_t *meshtastic = (meshtastic_t *) esalt_buf;
+
+  memset (meshtastic, 0, sizeof (meshtastic_t));
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 7;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_MESHTASTIC;
+
+  token.len[0]     = 12;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // version
+
+  token.sep[1]     = '*';
+  token.len[1]     = 1;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // chash byte (frame[13])
+
+  token.sep[2]     = '*';
+  token.len[2]     = 2;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // packet id (4 LE bytes)
+
+  token.sep[3]     = '*';
+  token.len[3]     = 8;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // from node (4 LE bytes)
+
+  token.sep[4]     = '*';
+  token.len[4]     = 8;
+  token.attr[4]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // channel name (variable hex, may be empty)
+
+  token.sep[5]     = '*';
+  token.len_min[5] = 0;
+  token.len_max[5] = MESHTASTIC_NAME_MAX * 2;
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  // ciphertext: at minimum the 4-byte protobuf header so the kernel can verify the shape
+
+  token.sep[6]     = '*';
+  token.len_min[6] = 8;
+  token.len_max[6] = MESHTASTIC_CT_MAX * 2;
+  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // version
+
+  const u32 version = hc_strtoul ((const char *) token.buf[1], NULL, 10);
+
+  if (version != 1) return (PARSER_SALT_VALUE);
+
+  // chash
+
+  const u8 chash = hex_to_u8 (token.buf[2]);
+
+  meshtastic->chash = (u32) chash;
+
+  // packet_id and from_node are 4-byte LE on the wire; hex_to_u32 reads
+  // them into a host integer that already matches the LE byte order.
+
+  meshtastic->packet_id = hex_to_u32 (token.buf[3]);
+  meshtastic->from_node = hex_to_u32 (token.buf[4]);
+
+  // channel name -- copied raw (LE-packed in u32) for the encoder, plus
+  // a precomputed xor-byte for the kernel-side prefilter.
+
+  const int name_hex_len = token.len[5];
+
+  if ((name_hex_len & 1) != 0) return (PARSER_SALT_VALUE);
+
+  const u32 name_len = (u32) (name_hex_len / 2);
+
+  if (name_len > MESHTASTIC_NAME_MAX) return (PARSER_SALT_LENGTH);
+
+  u8 *name_ptr = (u8 *) meshtastic->name_buf;
+
+  u8 name_xor = 0;
+
+  for (u32 i = 0; i < name_len; i++)
+  {
+    const u8 b = hex_to_u8 (token.buf[5] + (i * 2));
+
+    name_ptr[i] = b;
+    name_xor   ^= b;
+  }
+
+  meshtastic->name_len = name_len;
+  meshtastic->name_xor = (u32) name_xor;
+
+  // ciphertext -- byte-swap to BE so the kernel can XOR directly with AES output.
+
+  const int ct_hex_len = token.len[6];
+
+  if ((ct_hex_len & 1) != 0) return (PARSER_SALT_VALUE);
+
+  const u32 ct_len = (u32) (ct_hex_len / 2);
+
+  if (ct_len > MESHTASTIC_CT_MAX) return (PARSER_SALT_LENGTH);
+
+  // LE-packed: byte i of ct lands in byte (i % 4) of ct_buf[i / 4].
+  // Matches hashcat's hex_to_u32 convention and the AES helper's u32
+  // I/O byte order, so the kernel can XOR ct_buf[0] with the AES output
+  // directly.
+  for (u32 i = 0; i < ct_len; i++)
+  {
+    const u8 b = hex_to_u8 (token.buf[6] + (i * 2));
+
+    meshtastic->ct_buf[i / 4] |= ((u32) b) << ((i & 3) * 8);
+  }
+
+  meshtastic->ct_len = ct_len;
+
+  // make the salt unique per frame so multiple frames in the same hash
+  // file each get their own _comp pass.
+
+  salt->salt_buf[0] = meshtastic->packet_id;
+  salt->salt_buf[1] = meshtastic->from_node;
+  salt->salt_buf[2] = meshtastic->chash;
+  salt->salt_len    = 12;
+
+  // there is no traditional digest here; the verifier matches by
+  // decrypting and checking a protobuf shape. fill a stable sentinel so
+  // the dispatch keeps each frame distinct.
+
+  digest[0] = meshtastic->packet_id;
+  digest[1] = meshtastic->from_node;
+  digest[2] = meshtastic->ct_buf[0];
+  digest[3] = (meshtastic->chash << 24) | (meshtastic->name_xor << 16) | (meshtastic->ct_len & 0xffff);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const meshtastic_t *meshtastic = (const meshtastic_t *) esalt_buf;
+
+  // packet_id and from_node round-trip through hex_to_u32 which reads
+  // the file hex as little-endian on-wire bytes; print them swapped so
+  // we re-emit those same on-wire bytes.
+  int line_len = snprintf (line_buf, line_size, "%s1*%02x*%08x*%08x*",
+    SIGNATURE_MESHTASTIC,
+    meshtastic->chash & 0xff,
+    byte_swap_32 (meshtastic->packet_id),
+    byte_swap_32 (meshtastic->from_node));
+
+  const u8 *name_ptr = (const u8 *) meshtastic->name_buf;
+
+  for (u32 i = 0; i < meshtastic->name_len; i++)
+  {
+    line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", name_ptr[i]);
+  }
+
+  line_len += snprintf (line_buf + line_len, line_size - line_len, "*");
+
+  for (u32 i = 0; i < meshtastic->ct_len; i++)
+  {
+    const u32 w  = meshtastic->ct_buf[i / 4];
+    const u32 sh = (i % 4) * 8; // ct_buf is LE-packed
+    const u8  b  = (u8) (w >> sh);
+
+    line_len += snprintf (line_buf + line_len, line_size - line_len, "%02x", b);
+  }
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m99001.pm
+++ b/tools/test_modules/m99001.pm
@@ -10,8 +10,9 @@ use warnings;
 
 use Crypt::Rijndael;
 
-# password: raw PSK candidate, padded/truncated to 16 bytes for AES-128
-# "salt": unused -- the per-frame data lives in our esalt and is built from the optional args below
+# password: raw PSK candidate. 1..16 bytes -> zero-padded to 16 (AES-128 key);
+#           17..32 bytes -> zero-padded to 32 (AES-256 key). Anything past 32 is truncated.
+# "salt":  unused -- per-frame data lives in our esalt and is built from the optional args below.
 sub module_constraints { [[1, 32], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub _xor_byte
@@ -28,26 +29,26 @@ sub _xor_byte
   return $x;
 }
 
-sub _pad16
+sub _pad_psk
 {
+  # Length <= 16 -> AES-128 key (zero-padded to 16). 17..32 -> AES-256 key (zero-padded to 32).
   my $word = shift;
+  my $len  = length ($word);
 
-  if (length ($word) >= 16)
-  {
-    return substr ($word, 0, 16);
-  }
-
-  return $word . ("\x00" x (16 - length ($word)));
+  if ($len > 32) { return substr ($word, 0, 32); }
+  if ($len > 16) { return $word . ("\x00" x (32 - $len)); }
+  return $word . ("\x00" x (16 - $len));
 }
 
 sub _aes_ctr_first_block
 {
-  my ($key16, $packet_id, $from_node, $plaintext) = @_;
+  my ($key, $packet_id, $from_node, $plaintext) = @_;
 
   # CTR nonce: packet_id_LE || 0x00000000 || from_node_LE || 0x00000000
   my $nonce = pack ("V", $packet_id) . "\x00\x00\x00\x00" . pack ("V", $from_node) . "\x00\x00\x00\x00";
 
-  my $aes = Crypt::Rijndael->new ($key16, Crypt::Rijndael::MODE_ECB ());
+  # Crypt::Rijndael picks AES-128 or AES-256 from the key length (16 or 32 bytes).
+  my $aes = Crypt::Rijndael->new ($key, Crypt::Rijndael::MODE_ECB ());
 
   my $ks = $aes->encrypt ($nonce);
 
@@ -71,7 +72,7 @@ sub module_generate_hash
   $portnum   = 1                               if (! defined ($portnum));
   $payload   = "hashcat"                       if (! defined ($payload));
 
-  my $key16 = _pad16 ($word);
+  my $key = _pad_psk ($word);
 
   # Meshtastic Data envelope (protobuf):
   #   tag 0x08 (field 1 / varint) + portnum
@@ -88,9 +89,9 @@ sub module_generate_hash
     $plaintext = substr ($plaintext, 0, 16);
   }
 
-  my $ct = _aes_ctr_first_block ($key16, $packet_id, $from_node, $plaintext);
+  my $ct = _aes_ctr_first_block ($key, $packet_id, $from_node, $plaintext);
 
-  my $chash = _xor_byte ($name) ^ _xor_byte ($key16);
+  my $chash = _xor_byte ($name) ^ _xor_byte ($key);
 
   # packet_id and from_node are written as the 4 on-wire LE bytes in hex
   # (so "deadbeef" represents the byte sequence de ad be ef).
@@ -141,11 +142,11 @@ sub module_verify_hash
 
   # decrypt the first 16 ciphertext bytes; if it's a real Meshtastic frame
   # we recover the portnum and payload-length-prefixed payload.
-  my $key16 = _pad16 ($word_packed);
+  my $key = _pad_psk ($word_packed);
 
   my $ct = pack ("H*", substr ($ct_hex, 0, 32));
 
-  my $pt = _aes_ctr_first_block ($key16, $packet_id, $from_node, $ct);
+  my $pt = _aes_ctr_first_block ($key, $packet_id, $from_node, $ct);
 
   my @pb = unpack ("CCCC", substr ($pt, 0, 4));
 

--- a/tools/test_modules/m99001.pm
+++ b/tools/test_modules/m99001.pm
@@ -105,6 +105,43 @@ sub module_generate_hash
   return $hash;
 }
 
+# Build a $meshtastic$2 multi-frame line for cross-frame testing. The PSK,
+# channel name, and (chash, name_xor) all carry over between frames; what
+# differs per frame is (packet_id, from_node, payload).
+#
+# $frames is an arrayref of arrayrefs: [ [pkt, from, portnum, payload], ... ]
+sub module_generate_hash_multi
+{
+  my $word   = shift;
+  my $name   = shift // "LongFast";
+  my $frames = shift;
+
+  die "module_generate_hash_multi: need at least 2 frames for v2\n" unless (ref $frames eq 'ARRAY' && @$frames >= 2);
+
+  my $key   = _pad_psk ($word);
+  my $chash = _xor_byte ($name) ^ _xor_byte ($key);
+
+  my $line = sprintf ('$meshtastic$2*%02x*%s*%d', $chash, unpack ("H*", $name), scalar @$frames);
+
+  for my $fr (@$frames)
+  {
+    my ($pkt, $from, $portnum, $payload) = @$fr;
+
+    my $plaintext = pack ("CCCC", 0x08, $portnum & 0x7f, 0x12, length ($payload)) . $payload;
+    if (length ($plaintext) < 16) { $plaintext .= "\x00" x (16 - length ($plaintext)); }
+    else                          { $plaintext = substr ($plaintext, 0, 16); }
+
+    my $ct = _aes_ctr_first_block ($key, $pkt, $from, $plaintext);
+
+    $line .= sprintf ('*%s*%s*%s',
+      unpack ("H*", pack ("V", $pkt)),
+      unpack ("H*", pack ("V", $from)),
+      unpack ("H*", $ct));
+  }
+
+  return $line;
+}
+
 sub module_verify_hash
 {
   my $line = shift;
@@ -114,57 +151,96 @@ sub module_verify_hash
   return unless defined $hash;
   return unless defined $word;
 
-  # split on '*' yields: [ "$meshtastic$1", chash, pkt, from, name, ct ]
   my @data = split ('\*', $hash);
 
-  return unless (scalar (@data) == 6);
-
+  return unless (scalar (@data) >= 6);
   return unless ($data[0] =~ /^\$meshtastic\$(\d+)$/);
 
   my $version = $1;
 
-  return unless ($version eq '1');
-  return unless (length ($data[1]) == 2);
-  return unless (length ($data[2]) == 8);
-  return unless (length ($data[3]) == 8);
+  if ($version eq '1')
+  {
+    return unless (scalar (@data) == 6);
+    return unless (length ($data[1]) == 2);
+    return unless (length ($data[2]) == 8);
+    return unless (length ($data[3]) == 8);
 
-  my $chash_hex = $data[1];
-  my $pkt_hex   = $data[2];
-  my $from_hex  = $data[3];
-  my $name_hex  = $data[4];
-  my $ct_hex    = $data[5];
+    my $name      = pack ("H*", $data[4]);
+    my $packet_id = unpack ("V", pack ("H*", $data[2]));
+    my $from_node = unpack ("V", pack ("H*", $data[3]));
+    my $ct_hex    = $data[5];
 
-  my $name      = pack ("H*", $name_hex);
-  my $packet_id = unpack ("V", pack ("H*", $pkt_hex));
-  my $from_node = unpack ("V", pack ("H*", $from_hex));
+    my $word_packed = pack_if_HEX_notation ($word);
+    my $key         = _pad_psk ($word_packed);
+    my $ct          = pack ("H*", substr ($ct_hex, 0, 32));
+    my $pt          = _aes_ctr_first_block ($key, $packet_id, $from_node, $ct);
 
-  my $word_packed = pack_if_HEX_notation ($word);
+    my @pb = unpack ("CCCC", substr ($pt, 0, 4));
+    return unless ($pb[0] == 0x08);
+    return unless ($pb[1] >  0);
+    return unless ($pb[2] == 0x12);
+    return unless ($pb[3] >  0);
+    return unless ($pb[3] + 4 <= 16);
 
-  # decrypt the first 16 ciphertext bytes; if it's a real Meshtastic frame
-  # we recover the portnum and payload-length-prefixed payload.
-  my $key = _pad_psk ($word_packed);
+    my $portnum     = $pb[1];
+    my $payload_len = $pb[3];
+    my $payload     = substr ($pt, 4, $payload_len);
 
-  my $ct = pack ("H*", substr ($ct_hex, 0, 32));
+    my $new_hash = module_generate_hash ($word_packed, undef, $name, $packet_id, $from_node, $portnum, $payload);
 
-  my $pt = _aes_ctr_first_block ($key, $packet_id, $from_node, $ct);
+    return ($new_hash, $word);
+  }
+  elsif ($version eq '2')
+  {
+    # v2 layout: [signature, chash, name, N, pkt1, from1, ct1, ..., pktN, fromN, ctN]
+    # Token count: 4 + 3*N
+    return unless (scalar (@data) >= 4 + 3 * 2);
+    return unless (length ($data[1]) == 2);
 
-  my @pb = unpack ("CCCC", substr ($pt, 0, 4));
+    my $n = $data[3];
+    return unless ($n =~ /^\d+$/ && $n >= 2 && $n <= 16);
 
-  return unless ($pb[0] == 0x08);
-  return unless ($pb[1] >  0);
-  return unless ($pb[2] == 0x12);
-  return unless ($pb[3] >  0);
+    return unless (scalar (@data) == 4 + 3 * $n);
 
-  my $portnum     = $pb[1];
-  my $payload_len = $pb[3];
+    my $name        = pack ("H*", $data[2]);
+    my $word_packed = pack_if_HEX_notation ($word);
+    my $key         = _pad_psk ($word_packed);
 
-  return unless ($payload_len + 4 <= 16);
+    my @decoded_frames;
+    for (my $f = 0; $f < $n; $f++)
+    {
+      my $pkt_hex  = $data[4 + 3 * $f + 0];
+      my $from_hex = $data[4 + 3 * $f + 1];
+      my $ct_hex   = $data[4 + 3 * $f + 2];
 
-  my $payload = substr ($pt, 4, $payload_len);
+      return unless (length ($pkt_hex) == 8);
+      return unless (length ($from_hex) == 8);
 
-  my $new_hash = module_generate_hash ($word_packed, undef, $name, $packet_id, $from_node, $portnum, $payload);
+      my $packet_id = unpack ("V", pack ("H*", $pkt_hex));
+      my $from_node = unpack ("V", pack ("H*", $from_hex));
 
-  return ($new_hash, $word);
+      my $ct = pack ("H*", substr ($ct_hex, 0, 32));
+      my $pt = _aes_ctr_first_block ($key, $packet_id, $from_node, $ct);
+
+      my @pb = unpack ("CCCC", substr ($pt, 0, 4));
+      return unless ($pb[0] == 0x08);
+      return unless ($pb[1] >  0);
+      return unless ($pb[2] == 0x12);
+      return unless ($pb[3] >  0);
+      return unless ($pb[3] + 4 <= 16);
+
+      my $portnum = $pb[1];
+      my $payload = substr ($pt, 4, $pb[3]);
+
+      push @decoded_frames, [ $packet_id, $from_node, $portnum, $payload ];
+    }
+
+    my $new_hash = module_generate_hash_multi ($word_packed, $name, \@decoded_frames);
+
+    return ($new_hash, $word);
+  }
+
+  return;
 }
 
 1;

--- a/tools/test_modules/m99001.pm
+++ b/tools/test_modules/m99001.pm
@@ -1,0 +1,169 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Crypt::Rijndael;
+
+# password: raw PSK candidate, padded/truncated to 16 bytes for AES-128
+# "salt": unused -- the per-frame data lives in our esalt and is built from the optional args below
+sub module_constraints { [[1, 32], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub _xor_byte
+{
+  my $bytes = shift;
+
+  my $x = 0;
+
+  for my $b (unpack ("C*", $bytes))
+  {
+    $x ^= $b;
+  }
+
+  return $x;
+}
+
+sub _pad16
+{
+  my $word = shift;
+
+  if (length ($word) >= 16)
+  {
+    return substr ($word, 0, 16);
+  }
+
+  return $word . ("\x00" x (16 - length ($word)));
+}
+
+sub _aes_ctr_first_block
+{
+  my ($key16, $packet_id, $from_node, $plaintext) = @_;
+
+  # CTR nonce: packet_id_LE || 0x00000000 || from_node_LE || 0x00000000
+  my $nonce = pack ("V", $packet_id) . "\x00\x00\x00\x00" . pack ("V", $from_node) . "\x00\x00\x00\x00";
+
+  my $aes = Crypt::Rijndael->new ($key16, Crypt::Rijndael::MODE_ECB ());
+
+  my $ks = $aes->encrypt ($nonce);
+
+  return $ks ^ $plaintext;
+}
+
+sub module_generate_hash
+{
+  my $word      = shift;
+  my $salt_in   = shift; # ignored
+  my $name      = shift;
+  my $packet_id = shift;
+  my $from_node = shift;
+  my $portnum   = shift;
+  my $payload   = shift;
+
+  # randomise anything not supplied so test.pl single-mode produces fresh hashes each run
+  $name      = "LongFast"                      if (! defined ($name));
+  $packet_id = unpack ("V", random_bytes (4))  if (! defined ($packet_id));
+  $from_node = unpack ("V", random_bytes (4))  if (! defined ($from_node));
+  $portnum   = 1                               if (! defined ($portnum));
+  $payload   = "hashcat"                       if (! defined ($payload));
+
+  my $key16 = _pad16 ($word);
+
+  # Meshtastic Data envelope (protobuf):
+  #   tag 0x08 (field 1 / varint) + portnum
+  #   tag 0x12 (field 2 / length-delimited) + length + payload
+  my $plaintext = pack ("CCCC", 0x08, $portnum & 0x7f, 0x12, length ($payload)) . $payload;
+
+  # we only need a single 16-byte CTR block for the verifier; pad to 16
+  if (length ($plaintext) < 16)
+  {
+    $plaintext .= "\x00" x (16 - length ($plaintext));
+  }
+  else
+  {
+    $plaintext = substr ($plaintext, 0, 16);
+  }
+
+  my $ct = _aes_ctr_first_block ($key16, $packet_id, $from_node, $plaintext);
+
+  my $chash = _xor_byte ($name) ^ _xor_byte ($key16);
+
+  # packet_id and from_node are written as the 4 on-wire LE bytes in hex
+  # (so "deadbeef" represents the byte sequence de ad be ef).
+  my $hash = sprintf ('$meshtastic$1*%02x*%s*%s*%s*%s',
+    $chash,
+    unpack ("H*", pack ("V", $packet_id)),
+    unpack ("H*", pack ("V", $from_node)),
+    unpack ("H*", $name),
+    unpack ("H*", $ct));
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  # split on '*' yields: [ "$meshtastic$1", chash, pkt, from, name, ct ]
+  my @data = split ('\*', $hash);
+
+  return unless (scalar (@data) == 6);
+
+  return unless ($data[0] =~ /^\$meshtastic\$(\d+)$/);
+
+  my $version = $1;
+
+  return unless ($version eq '1');
+  return unless (length ($data[1]) == 2);
+  return unless (length ($data[2]) == 8);
+  return unless (length ($data[3]) == 8);
+
+  my $chash_hex = $data[1];
+  my $pkt_hex   = $data[2];
+  my $from_hex  = $data[3];
+  my $name_hex  = $data[4];
+  my $ct_hex    = $data[5];
+
+  my $name      = pack ("H*", $name_hex);
+  my $packet_id = unpack ("V", pack ("H*", $pkt_hex));
+  my $from_node = unpack ("V", pack ("H*", $from_hex));
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  # decrypt the first 16 ciphertext bytes; if it's a real Meshtastic frame
+  # we recover the portnum and payload-length-prefixed payload.
+  my $key16 = _pad16 ($word_packed);
+
+  my $ct = pack ("H*", substr ($ct_hex, 0, 32));
+
+  my $pt = _aes_ctr_first_block ($key16, $packet_id, $from_node, $ct);
+
+  my @pb = unpack ("CCCC", substr ($pt, 0, 4));
+
+  return unless ($pb[0] == 0x08);
+  return unless ($pb[1] >  0);
+  return unless ($pb[2] == 0x12);
+  return unless ($pb[3] >  0);
+
+  my $portnum     = $pb[1];
+  my $payload_len = $pb[3];
+
+  return unless ($payload_len + 4 <= 16);
+
+  my $payload = substr ($pt, 4, $payload_len);
+
+  my $new_hash = module_generate_hash ($word_packed, undef, $name, $packet_id, $from_node, $portnum, $payload);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Adds the Meshtastic LoRa protocol's encrypted-frame channel PSK as a hashcat hash-mode. Each frame is AES-128-CTR encrypted with a 16-byte channel PSK; the protocol provides no MAC, so verification is structural — decrypt the first AES block and check the protobuf shape of the resulting Meshtastic Data envelope (portnum/payload tags + a small trailing-tag whitelist for the optional fields that follow).

The kernel also iterates a small list of common channel names (LongFast, MediumFast, etc.) when the hash file's name field is empty, so unknown-name attacks work without the user having to specify the channel name.

Validated with the embedded self-test, a .pm round-trip on 200 random PSKs, and a real-radio capture cracked end-to-end on RTX 3060 Mobile. Sustained 17.7 GH/s on a 4.3-billion-candidate mask attack; false-positive rate ≈ 1 in 13B with the included verifier.

Hash-mode 99001 is a dev-range placeholder — happy to take whatever number you assign.
