### PR TITLE
Fix double-free in rule processor 

### DIFF
--- a/src/rp.c
+++ b/src/rp.c
@@ -919,6 +919,11 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
     {
       event_log_error (hashcat_ctx, "%s: %s", rp_file, strerror (errno));
 
+      for (u32 j = 0; j < i; j++)
+      {
+        hcfree (all_kernel_rules_buf[j]);
+      }
+
       hcfree (all_kernel_rules_cnt);
       hcfree (all_kernel_rules_buf);
 
@@ -934,6 +939,15 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
       if (rule_line == (u32) -1)
       {
         event_log_error (hashcat_ctx, "Unsupported number of lines in rule file %s.", rp_file);
+
+        hc_fclose (&fp);
+
+        hcfree (kernel_rules_buf);
+
+        for (u32 j = 0; j < i; j++)
+        {
+          hcfree (all_kernel_rules_buf[j]);
+        }
 
         hcfree (all_kernel_rules_cnt);
         hcfree (all_kernel_rules_buf);
@@ -960,6 +974,15 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
         if (kernel_rules_avail < kernel_rules_avail_old) // u32 overflow
         {
           event_log_error (hashcat_ctx, "Unsupported number of rules in rule file %s.", rp_file);
+
+          hc_fclose (&fp);
+
+          hcfree (kernel_rules_buf);
+
+          for (u32 j = 0; j < i; j++)
+          {
+            hcfree (all_kernel_rules_buf[j]);
+          }
 
           hcfree (all_kernel_rules_cnt);
           hcfree (all_kernel_rules_buf);
@@ -1001,6 +1024,15 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
       if (kernel_rules_cnt == (u32) -1)
       {
         event_log_error (hashcat_ctx, "Unsupported number of rules in rule file %s.", rp_file);
+
+        hc_fclose (&fp);
+
+        hcfree (kernel_rules_buf);
+
+        for (u32 j = 0; j < i; j++)
+        {
+          hcfree (all_kernel_rules_buf[j]);
+        }
 
         hcfree (all_kernel_rules_cnt);
         hcfree (all_kernel_rules_buf);

--- a/src/rp.c
+++ b/src/rp.c
@@ -1043,10 +1043,14 @@ int kernel_rules_load (hashcat_ctx_t *hashcat_ctx, kernel_rule_t **out_buf, u32 
       {
         event_log_error (hashcat_ctx, "Unsupported number of rules used in rule chaining.");
 
+        for (u32 j = 0; j < user_options->rp_files_cnt; j++)
+        {
+          hcfree (all_kernel_rules_buf[j]);
+        }
+
         hcfree (all_kernel_rules_cnt);
         hcfree (all_kernel_rules_buf);
 
-        hcfree (rule_buf);
         hcfree (repeats);
 
         return -1;


### PR DESCRIPTION
When combining rules with multiple usages of -r such as `-r rule1 -r rule2 -r rule3` and so on, if the total number of rules exceeds u32 the rule processor can segfault.