### PR TITLE
New Algorithm: Reimplement Sun MD5 for GPU

### DIFF
--- a/OpenCL/m03300-pure.cl
+++ b/OpenCL/m03300-pure.cl
@@ -1,0 +1,372 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct md5sun_tmp
+{
+  u32 digest_buf[4];
+
+} md5sun_tmp_t;
+
+#define CONSTANT_PHRASE_LEN 1517
+
+CONSTANT_VK u32a constant_phrase[380] =
+{
+  0x62206f54, 0x6f202c65, 0x6f6e2072, 0x6f742074, 0x2c656220, 0x68742d2d, 0x69207461, 0x68742073,
+  0x75712065, 0x69747365, 0x2d3a6e6f, 0x68570a2d, 0x65687465, 0x74272072, 0x6e207369, 0x656c626f,
+  0x6e692072, 0x65687420, 0x6e696d20, 0x6f742064, 0x66757320, 0x0a726566, 0x20656854, 0x6e696c73,
+  0x61207367, 0x6120646e, 0x776f7272, 0x666f2073, 0x74756f20, 0x65676172, 0x2073756f, 0x74726f66,
+  0x0a656e75, 0x7420724f, 0x6174206f, 0x6120656b, 0x20736d72, 0x69616761, 0x2074736e, 0x65732061,
+  0x666f2061, 0x6f727420, 0x656c6275, 0x410a2c73, 0x6220646e, 0x706f2079, 0x69736f70, 0x6520676e,
+  0x7420646e, 0x3f6d6568, 0x6f542d2d, 0x65696420, 0x742d2d2c, 0x6c73206f, 0x2c706565, 0x4e0a2d2d,
+  0x6f6d206f, 0x203b6572, 0x20646e61, 0x61207962, 0x656c7320, 0x74207065, 0x6173206f, 0x65772079,
+  0x646e6520, 0x6568540a, 0x61656820, 0x63617472, 0x202c6568, 0x20646e61, 0x20656874, 0x756f6874,
+  0x646e6173, 0x74616e20, 0x6c617275, 0x6f687320, 0x0a736b63, 0x74616854, 0x656c6620, 0x69206873,
+  0x65682073, 0x74207269, 0x2d2d2c6f, 0x73697427, 0x63206120, 0x75736e6f, 0x74616d6d, 0x0a6e6f69,
+  0x6f766544, 0x796c7475, 0x206f7420, 0x77206562, 0x27687369, 0x54202e64, 0x6964206f, 0x2d2d2c65,
+  0x73206f74, 0x7065656c, 0x0a2d2d3b, 0x73206f54, 0x7065656c, 0x65702021, 0x61686372, 0x2065636e,
+  0x64206f74, 0x6d616572, 0x612d2d3a, 0x74202c79, 0x65726568, 0x74207327, 0x72206568, 0x0a3b6275,
+  0x20726f46, 0x74206e69, 0x20746168, 0x65656c73, 0x666f2070, 0x61656420, 0x77206874, 0x20746168,
+  0x61657264, 0x6d20736d, 0x63207961, 0x2c656d6f, 0x6568570a, 0x6577206e, 0x76616820, 0x68732065,
+  0x6c666675, 0x6f206465, 0x74206666, 0x20736968, 0x74726f6d, 0x63206c61, 0x2c6c696f, 0x73754d0a,
+  0x69672074, 0x75206576, 0x61702073, 0x3a657375, 0x65687420, 0x73276572, 0x65687420, 0x73657220,
+  0x74636570, 0x6168540a, 0x616d2074, 0x2073656b, 0x616c6163, 0x7974696d, 0x20666f20, 0x6c206f73,
+  0x20676e6f, 0x6566696c, 0x6f460a3b, 0x68772072, 0x6f77206f, 0x20646c75, 0x72616562, 0x65687420,
+  0x69687720, 0x61207370, 0x7320646e, 0x6e726f63, 0x666f2073, 0x6d697420, 0x540a2c65, 0x6f206568,
+  0x65727070, 0x726f7373, 0x77207327, 0x676e6f72, 0x6874202c, 0x72702065, 0x2064756f, 0x276e616d,
+  0x6f632073, 0x6d75746e, 0x2c796c65, 0x6568540a, 0x6e617020, 0x6f207367, 0x65642066, 0x73697073,
+  0x6c206427, 0x2c65766f, 0x65687420, 0x77616c20, 0x64207327, 0x79616c65, 0x68540a2c, 0x6e692065,
+  0x656c6f73, 0x2065636e, 0x6f20666f, 0x63696666, 0x61202c65, 0x7420646e, 0x73206568, 0x6e727570,
+  0x68540a73, 0x70207461, 0x65697461, 0x6d20746e, 0x74697265, 0x20666f20, 0x20656874, 0x6f776e75,
+  0x79687472, 0x6b617420, 0x0a2c7365, 0x6e656857, 0x20656820, 0x736d6968, 0x20666c65, 0x6867696d,
+  0x69682074, 0x75712073, 0x75746569, 0x616d2073, 0x570a656b, 0x20687469, 0x61622061, 0x62206572,
+  0x696b646f, 0x77203f6e, 0x77206f68, 0x646c756f, 0x65687420, 0x66206573, 0x65647261, 0x6220736c,
+  0x2c726165, 0x206f540a, 0x6e757267, 0x6e612074, 0x77732064, 0x20746165, 0x65646e75, 0x20612072,
+  0x72616577, 0x696c2079, 0x0a2c6566, 0x20747542, 0x74616874, 0x65687420, 0x65726420, 0x6f206461,
+  0x6f732066, 0x6874656d, 0x20676e69, 0x65746661, 0x65642072, 0x2c687461, 0x540a2d2d, 0x75206568,
+  0x7369646e, 0x65766f63, 0x20642772, 0x6e756f63, 0x2c797274, 0x6f726620, 0x6877206d, 0x2065736f,
+  0x72756f62, 0x6f4e0a6e, 0x61727420, 0x6c6c6576, 0x72207265, 0x72757465, 0x2d2c736e, 0x7a75702d,
+  0x73656c7a, 0x65687420, 0x6c697720, 0x410a2c6c, 0x6d20646e, 0x73656b61, 0x20737520, 0x68746172,
+  0x62207265, 0x20726165, 0x736f6874, 0x6c692065, 0x7720736c, 0x61682065, 0x540a6576, 0x206e6168,
+  0x20796c66, 0x6f206f74, 0x72656874, 0x68742073, 0x77207461, 0x6e6b2065, 0x6e20776f, 0x6f20746f,
+  0x540a3f66, 0x20737568, 0x736e6f63, 0x6e656963, 0x64206563, 0x2073656f, 0x656b616d, 0x776f6320,
+  0x73647261, 0x20666f20, 0x61207375, 0x0a3b6c6c, 0x20646e41, 0x73756874, 0x65687420, 0x74616e20,
+  0x20657669, 0x20657568, 0x7220666f, 0x6c6f7365, 0x6f697475, 0x73490a6e, 0x63697320, 0x65696c6b,
+  0x276f2064, 0x77207265, 0x20687469, 0x20656874, 0x656c6170, 0x73616320, 0x666f2074, 0x6f687420,
+  0x74686775, 0x6e410a3b, 0x6e652064, 0x70726574, 0x65736972, 0x666f2073, 0x65726720, 0x70207461,
+  0x20687469, 0x20646e61, 0x656d6f6d, 0x0a2c746e, 0x68746957, 0x69687420, 0x65722073, 0x64726167,
+  0x6874202c, 0x20726965, 0x72727563, 0x73746e65, 0x72757420, 0x7761206e, 0x0a2c7972, 0x20646e41,
+  0x65736f6c, 0x65687420, 0x6d616e20, 0x666f2065, 0x74636120, 0x2e6e6f69, 0x6f532d2d, 0x79207466,
+  0x6e20756f, 0x0a21776f, 0x20656854, 0x72696166, 0x68704f20, 0x61696c65, 0x4e2d2d21, 0x68706d79,
+  0x6e69202c, 0x79687420, 0x69726f20, 0x736e6f73, 0x2065420a, 0x206c6c61, 0x7320796d, 0x20736e69,
+  0x656d6572, 0x7265626d, 0x0a2e6427, 0x00000000,
+};
+
+DECLSPEC u32 sunmd5_getbyte (PRIVATE_AS const u32 *d, const int idx)
+{
+  return (d[idx >> 2] >> ((idx & 3) << 3)) & 0xff;
+}
+
+DECLSPEC int sunmd5_getbit (PRIVATE_AS const u32 *d, const int n)
+{
+  const int bn = n & 127;
+
+  return (d[bn >> 5] >> (bn & 31)) & 1;
+}
+
+DECLSPEC int sunmd5_coin (PRIVATE_AS const u32 *digest, const int round_num)
+{
+  u32 x = 0;
+  u32 y = 0;
+
+  for (int i = 0; i < 8; i++)
+  {
+    u32 a, b, r, v;
+
+    a = sunmd5_getbyte (digest, (i + 0) % 16);
+    b = sunmd5_getbyte (digest, (i + 3) % 16);
+    r = a >> (b % 5);
+    v = sunmd5_getbyte (digest, r % 16);
+
+    if (b & (1u << (a % 8)))
+    {
+      v >>= 1;
+    }
+
+    x |= ((u32) sunmd5_getbit (digest, v)) << i;
+
+    a = sunmd5_getbyte (digest, (i + 8) % 16);
+    b = sunmd5_getbyte (digest, (i + 11) % 16);
+    r = a >> (b % 5);
+    v = sunmd5_getbyte (digest, r % 16);
+
+    if (b & (1u << (a % 8)))
+    {
+      v >>= 1;
+    }
+
+    y |= ((u32) sunmd5_getbit (digest, v)) << i;
+  }
+
+  if (sunmd5_getbit (digest, round_num))
+  {
+    x >>= 1;
+  }
+
+  if (sunmd5_getbit (digest, round_num + 64))
+  {
+    y >>= 1;
+  }
+
+  return sunmd5_getbit (digest, x & 0x7f) ^ sunmd5_getbit (digest, y & 0x7f);
+}
+
+DECLSPEC void sunmd5_update_constant_phrase (PRIVATE_AS md5_ctx_t *ctx)
+{
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  for (int i = 0; i < 23; i++)
+  {
+    const int off = i * 16;
+
+    w0[0] = constant_phrase[off +  0];
+    w0[1] = constant_phrase[off +  1];
+    w0[2] = constant_phrase[off +  2];
+    w0[3] = constant_phrase[off +  3];
+    w1[0] = constant_phrase[off +  4];
+    w1[1] = constant_phrase[off +  5];
+    w1[2] = constant_phrase[off +  6];
+    w1[3] = constant_phrase[off +  7];
+    w2[0] = constant_phrase[off +  8];
+    w2[1] = constant_phrase[off +  9];
+    w2[2] = constant_phrase[off + 10];
+    w2[3] = constant_phrase[off + 11];
+    w3[0] = constant_phrase[off + 12];
+    w3[1] = constant_phrase[off + 13];
+    w3[2] = constant_phrase[off + 14];
+    w3[3] = constant_phrase[off + 15];
+
+    md5_update_64 (ctx, w0, w1, w2, w3, 64);
+  }
+
+  const int off = 23 * 16;
+
+  w0[0] = constant_phrase[off +  0];
+  w0[1] = constant_phrase[off +  1];
+  w0[2] = constant_phrase[off +  2];
+  w0[3] = constant_phrase[off +  3];
+  w1[0] = constant_phrase[off +  4];
+  w1[1] = constant_phrase[off +  5];
+  w1[2] = constant_phrase[off +  6];
+  w1[3] = constant_phrase[off +  7];
+  w2[0] = constant_phrase[off +  8];
+  w2[1] = constant_phrase[off +  9];
+  w2[2] = constant_phrase[off + 10];
+  w2[3] = constant_phrase[off + 11];
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  md5_update_64 (ctx, w0, w1, w2, w3, 45);
+}
+
+DECLSPEC int sunmd5_itoa (const u32 num, PRIVATE_AS u32 *buf)
+{
+  buf[0] = 0;
+  buf[1] = 0;
+
+  int num_digits = 0;
+  u32 tmp = num;
+
+  do
+  {
+    num_digits++;
+    tmp /= 10;
+  } while (tmp > 0);
+
+  u32 divisor = 1;
+
+  for (int i = 1; i < num_digits; i++)
+  {
+    divisor *= 10;
+  }
+
+  tmp = num;
+
+  for (int k = 0; k < num_digits; k++)
+  {
+    const u32 d = tmp / divisor;
+
+    tmp %= divisor;
+    divisor /= 10;
+
+    buf[k >> 2] |= (d + 0x30) << ((k & 3) << 3);
+  }
+
+  return num_digits;
+}
+
+KERNEL_FQ KERNEL_FA void m03300_init (KERN_ATTR_TMPS (md5sun_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * init
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  /**
+   * digest = MD5 (password || puresalt)
+   */
+
+  md5_ctx_t md5_ctx;
+
+  md5_init (&md5_ctx);
+
+  md5_update (&md5_ctx, w, pw_len);
+
+  md5_update (&md5_ctx, s, salt_len);
+
+  md5_final (&md5_ctx);
+
+  tmps[gid].digest_buf[0] = md5_ctx.h[0];
+  tmps[gid].digest_buf[1] = md5_ctx.h[1];
+  tmps[gid].digest_buf[2] = md5_ctx.h[2];
+  tmps[gid].digest_buf[3] = md5_ctx.h[3];
+}
+
+KERNEL_FQ KERNEL_FA void m03300_loop (KERN_ATTR_TMPS (md5sun_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  u32 digest[4];
+
+  digest[0] = tmps[gid].digest_buf[0];
+  digest[1] = tmps[gid].digest_buf[1];
+  digest[2] = tmps[gid].digest_buf[2];
+  digest[3] = tmps[gid].digest_buf[3];
+
+  /**
+   * loop
+   */
+
+  for (u32 i = 0, j = LOOP_POS; i < LOOP_CNT; i++, j++)
+  {
+    const int coin = sunmd5_coin (digest, j);
+
+    md5_ctx_t md5_ctx;
+
+    md5_init (&md5_ctx);
+
+    u32 d[16] = { 0 };
+
+    d[0] = digest[0];
+    d[1] = digest[1];
+    d[2] = digest[2];
+    d[3] = digest[3];
+
+    md5_update (&md5_ctx, d, 16);
+
+    if (coin == 1)
+    {
+      sunmd5_update_constant_phrase (&md5_ctx);
+    }
+
+    u32 round_buf[4] = { 0 };
+
+    const int round_len = sunmd5_itoa (j, round_buf);
+
+    md5_update (&md5_ctx, round_buf, round_len);
+
+    md5_final (&md5_ctx);
+
+    digest[0] = md5_ctx.h[0];
+    digest[1] = md5_ctx.h[1];
+    digest[2] = md5_ctx.h[2];
+    digest[3] = md5_ctx.h[3];
+  }
+
+  tmps[gid].digest_buf[0] = digest[0];
+  tmps[gid].digest_buf[1] = digest[1];
+  tmps[gid].digest_buf[2] = digest[2];
+  tmps[gid].digest_buf[3] = digest[3];
+}
+
+KERNEL_FQ KERNEL_FA void m03300_comp (KERN_ATTR_TMPS (md5sun_tmp_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  const u64 lid = get_local_id (0);
+
+  /**
+   * digest
+   */
+
+  const u32 r0 = tmps[gid].digest_buf[DGST_R0];
+  const u32 r1 = tmps[gid].digest_buf[DGST_R1];
+  const u32 r2 = tmps[gid].digest_buf[DGST_R2];
+  const u32 r3 = tmps[gid].digest_buf[DGST_R3];
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,6 +1,12 @@
 * changes v7.1.2 -> v7.1.x
 
 ##
+## New Algorithms
+##
+
+- Added hash-mode: MD5(Sun), SunMD5
+
+##
 ## Improvements
 ##
 

--- a/src/modules/module_03300.c
+++ b/src/modules/module_03300.c
@@ -1,0 +1,352 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_OS;
+static const char *HASH_NAME      = "MD5(Sun), SunMD5";
+static const u64   KERN_TYPE      = 3300;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$md5,rounds=904$4ol8A9yh$$DrANxVf9omze48HtDkwHQ0";
+
+typedef struct md5sun_tmp
+{
+  u32 digest_buf[4];
+
+} md5sun_tmp_t;
+
+static const u32   ROUNDS_MD5SUN_MIN = 4096;
+static const char *SIGNATURE_MD5SUN  = "$md5";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+const char *module_usage_notice (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return USAGE_NOTICE_NUM_ROUNDS;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (md5sun_tmp_t);
+
+  return tmp_size;
+}
+
+static void md5sun_decode (u8 digest[16], const u8 buf[22])
+{
+  int l;
+
+  l  = itoa64_to_int (buf[ 0]) <<  0;
+  l |= itoa64_to_int (buf[ 1]) <<  6;
+  l |= itoa64_to_int (buf[ 2]) << 12;
+  l |= itoa64_to_int (buf[ 3]) << 18;
+
+  digest[ 0] = (l >> 16) & 0xff;
+  digest[ 6] = (l >>  8) & 0xff;
+  digest[12] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[ 4]) <<  0;
+  l |= itoa64_to_int (buf[ 5]) <<  6;
+  l |= itoa64_to_int (buf[ 6]) << 12;
+  l |= itoa64_to_int (buf[ 7]) << 18;
+
+  digest[ 1] = (l >> 16) & 0xff;
+  digest[ 7] = (l >>  8) & 0xff;
+  digest[13] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[ 8]) <<  0;
+  l |= itoa64_to_int (buf[ 9]) <<  6;
+  l |= itoa64_to_int (buf[10]) << 12;
+  l |= itoa64_to_int (buf[11]) << 18;
+
+  digest[ 2] = (l >> 16) & 0xff;
+  digest[ 8] = (l >>  8) & 0xff;
+  digest[14] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[12]) <<  0;
+  l |= itoa64_to_int (buf[13]) <<  6;
+  l |= itoa64_to_int (buf[14]) << 12;
+  l |= itoa64_to_int (buf[15]) << 18;
+
+  digest[ 3] = (l >> 16) & 0xff;
+  digest[ 9] = (l >>  8) & 0xff;
+  digest[15] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[16]) <<  0;
+  l |= itoa64_to_int (buf[17]) <<  6;
+  l |= itoa64_to_int (buf[18]) << 12;
+  l |= itoa64_to_int (buf[19]) << 18;
+
+  digest[ 4] = (l >> 16) & 0xff;
+  digest[10] = (l >>  8) & 0xff;
+  digest[ 5] = (l >>  0) & 0xff;
+
+  l  = itoa64_to_int (buf[20]) <<  0;
+  l |= itoa64_to_int (buf[21]) <<  6;
+
+  digest[11] = (l >>  0) & 0xff;
+}
+
+static void md5sun_encode (const u8 digest[16], u8 buf[22])
+{
+  int l;
+
+  l = (digest[ 0] << 16) | (digest[ 6] << 8) | (digest[12] << 0);
+
+  buf[ 0] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 1] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 2] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 3] = int_to_itoa64 (l & 0x3f);
+
+  l = (digest[ 1] << 16) | (digest[ 7] << 8) | (digest[13] << 0);
+
+  buf[ 4] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 5] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 6] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 7] = int_to_itoa64 (l & 0x3f);
+
+  l = (digest[ 2] << 16) | (digest[ 8] << 8) | (digest[14] << 0);
+
+  buf[ 8] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[ 9] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[10] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[11] = int_to_itoa64 (l & 0x3f);
+
+  l = (digest[ 3] << 16) | (digest[ 9] << 8) | (digest[15] << 0);
+
+  buf[12] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[13] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[14] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[15] = int_to_itoa64 (l & 0x3f);
+
+  l = (digest[ 4] << 16) | (digest[10] << 8) | (digest[ 5] << 0);
+
+  buf[16] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[17] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[18] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[19] = int_to_itoa64 (l & 0x3f);
+
+  l = (digest[11] << 0);
+
+  buf[20] = int_to_itoa64 (l & 0x3f); l >>= 6;
+  buf[21] = int_to_itoa64 (l & 0x3f);
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 pw_max = PW_MAX;
+
+  return pw_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  if (line_len < 4) return (PARSER_HASH_LENGTH);
+
+  if (memcmp (line_buf, SIGNATURE_MD5SUN, 4) != 0) return (PARSER_SIGNATURE_UNMATCHED);
+
+  int pos = 4;
+  u32 extra_rounds = 0;
+
+  if (line_buf[pos] == ',' || line_buf[pos] == '$')
+  {
+    pos++;
+  }
+  else
+  {
+    return (PARSER_SIGNATURE_UNMATCHED);
+  }
+
+  if (pos + 7 <= line_len && memcmp (line_buf + pos, "rounds=", 7) == 0)
+  {
+    pos += 7;
+
+    const int rounds_start = pos;
+
+    while (pos < line_len && line_buf[pos] >= '0' && line_buf[pos] <= '9')
+    {
+      pos++;
+    }
+
+    if (pos == rounds_start) return (PARSER_SALT_VALUE);
+
+    if (pos >= line_len || line_buf[pos] != '$') return (PARSER_SEPARATOR_UNMATCHED);
+
+    char rounds_str[8] = { 0 };
+
+    const int rounds_len = pos - rounds_start;
+
+    if (rounds_len > 7) return (PARSER_SALT_VALUE);
+
+    memcpy (rounds_str, line_buf + rounds_start, rounds_len);
+
+    extra_rounds = (u32) hc_strtoul (rounds_str, NULL, 10);
+
+    pos++;
+  }
+
+  const int salt_start = pos;
+
+  int last_sep = -1;
+
+  for (int i = line_len - 1; i >= salt_start; i--)
+  {
+    if (line_buf[i] == '$')
+    {
+      last_sep = i;
+      break;
+    }
+  }
+
+  if (last_sep < 0) return (PARSER_SEPARATOR_UNMATCHED);
+
+  const char *hash_pos = line_buf + last_sep + 1;
+  const int hash_len = line_len - last_sep - 1;
+
+  if (hash_len != 22) return (PARSER_HASH_LENGTH);
+
+  const int puresalt_len = last_sep;
+
+  if (puresalt_len < 6) return (PARSER_SALT_LENGTH);
+
+  if (puresalt_len > 255) return (PARSER_SALT_LENGTH);
+
+  memset (salt->salt_buf, 0, sizeof (salt->salt_buf));
+  memcpy ((char *) salt->salt_buf, line_buf, puresalt_len);
+
+  salt->salt_len = puresalt_len;
+
+  salt->salt_iter = ROUNDS_MD5SUN_MIN + extra_rounds;
+
+  md5sun_decode ((u8 *) digest, (const u8 *) hash_pos);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  u8 tmp[100] = { 0 };
+
+  md5sun_encode (digest_buf, tmp);
+
+  tmp[22] = 0;
+
+  int line_len = snprintf (line_buf, line_size, "%s$%s", (const char *) salt->salt_buf, tmp);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_usage_notice             = module_usage_notice;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = module_pw_max;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m03300.pm
+++ b/tools/test_modules/m03300.pm
@@ -1,0 +1,250 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::MD5 qw (md5);
+
+sub module_constraints { [[0, 256], [1, 8], [-1, -1], [-1, -1], [-1, -1]] }
+
+my $constant_phrase =
+  "To be, or not to be,--that is the question:--\n" .
+  "Whether 'tis nobler in the mind to suffer\n" .
+  "The slings and arrows of outrageous fortune\n" .
+  "Or to take arms against a sea of troubles,\n" .
+  "And by opposing end them?--To die,--to sleep,--\n" .
+  "No more; and by a sleep to say we end\n" .
+  "The heartache, and the thousand natural shocks\n" .
+  "That flesh is heir to,--'tis a consummation\n" .
+  "Devoutly to be wish'd. To die,--to sleep;--\n" .
+  "To sleep! perchance to dream:--ay, there's the rub;\n" .
+  "For in that sleep of death what dreams may come,\n" .
+  "When we have shuffled off this mortal coil,\n" .
+  "Must give us pause: there's the respect\n" .
+  "That makes calamity of so long life;\n" .
+  "For who would bear the whips and scorns of time,\n" .
+  "The oppressor's wrong, the proud man's contumely,\n" .
+  "The pangs of despis'd love, the law's delay,\n" .
+  "The insolence of office, and the spurns\n" .
+  "That patient merit of the unworthy takes,\n" .
+  "When he himself might his quietus make\n" .
+  "With a bare bodkin? who would these fardels bear,\n" .
+  "To grunt and sweat under a weary life,\n" .
+  "But that the dread of something after death,--\n" .
+  "The undiscover'd country, from whose bourn\n" .
+  "No traveller returns,--puzzles the will,\n" .
+  "And makes us rather bear those ills we have\n" .
+  "Than fly to others that we know not of?\n" .
+  "Thus conscience does make cowards of us all;\n" .
+  "And thus the native hue of resolution\n" .
+  "Is sicklied o'er with the pale cast of thought;\n" .
+  "And enterprises of great pith and moment,\n" .
+  "With this regard, their currents turn awry,\n" .
+  "And lose the name of action.--Soft you now!\n" .
+  "The fair Ophelia!--Nymph, in thy orisons\n" .
+  "Be all my sins remember'd.\n";
+
+my $constant_phrase_with_nul = $constant_phrase . "\x00";
+
+sub md5bit
+{
+  my ($digest, $n) = @_;
+
+  $n %= 128;
+
+  my $byte_off = int ($n / 8);
+  my $bit_off  = $n % 8;
+
+  my $byte = ord (substr ($digest, $byte_off, 1));
+
+  return ($byte >> $bit_off) & 1;
+}
+
+sub sunmd5_coin
+{
+  my ($digest, $round) = @_;
+
+  my @db;
+
+  for (my $i = 0; $i < 16; $i++)
+  {
+    $db[$i] = ord (substr ($digest, $i, 1));
+  }
+
+  my $x = 0;
+  my $y = 0;
+
+  for (my $i = 0; $i < 8; $i++)
+  {
+    my ($a, $b, $r, $v);
+
+    $a = $db[($i + 0) % 16];
+    $b = $db[($i + 3) % 16];
+    $r = $a >> ($b % 5);
+    $v = $db[$r % 16];
+
+    if ($b & (1 << ($a % 8)))
+    {
+      $v >>= 1;
+    }
+
+    $x |= md5bit ($digest, $v) << $i;
+
+    $a = $db[($i + 8) % 16];
+    $b = $db[($i + 11) % 16];
+    $r = $a >> ($b % 5);
+    $v = $db[$r % 16];
+
+    if ($b & (1 << ($a % 8)))
+    {
+      $v >>= 1;
+    }
+
+    $y |= md5bit ($digest, $v) << $i;
+  }
+
+  if (md5bit ($digest, $round))
+  {
+    $x >>= 1;
+  }
+
+  if (md5bit ($digest, $round + 64))
+  {
+    $y >>= 1;
+  }
+
+  return md5bit ($digest, $x & 0x7f) ^ md5bit ($digest, $y & 0x7f);
+}
+
+sub to64
+{
+  my $v = shift;
+  my $n = shift;
+
+  my $itoa64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+  my $ret = "";
+
+  while (($n - 1) >= 0)
+  {
+    $n = $n - 1;
+
+    $ret .= substr ($itoa64, $v & 0x3f, 1);
+
+    $v = $v >> 6;
+  }
+
+  return $ret;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $iter = shift;
+
+  my $extra_rounds = 0;
+
+  if (defined ($iter))
+  {
+    $extra_rounds = int ($iter);
+  }
+
+  my $total_rounds = 4096 + $extra_rounds;
+
+  my $puresalt;
+
+  if ($extra_rounds > 0)
+  {
+    $puresalt = sprintf ("\$md5,rounds=%d\$%s\$", $extra_rounds, $salt);
+  }
+  else
+  {
+    $puresalt = sprintf ("\$md5\$%s\$", $salt);
+  }
+
+  my $digest = md5 ($word . $puresalt);
+
+  for (my $round = 0; $round < $total_rounds; $round++)
+  {
+    my $coin = sunmd5_coin ($digest, $round);
+
+    my $buf = $digest;
+
+    if ($coin == 1)
+    {
+      $buf .= $constant_phrase_with_nul;
+    }
+
+    $buf .= sprintf ("%d", $round);
+
+    $digest = md5 ($buf);
+  }
+
+  my $hash = "";
+
+  $hash .= to64 ((ord (substr ($digest,  0, 1)) << 16) | (ord (substr ($digest,  6, 1)) << 8) | (ord (substr ($digest, 12, 1))), 4);
+  $hash .= to64 ((ord (substr ($digest,  1, 1)) << 16) | (ord (substr ($digest,  7, 1)) << 8) | (ord (substr ($digest, 13, 1))), 4);
+  $hash .= to64 ((ord (substr ($digest,  2, 1)) << 16) | (ord (substr ($digest,  8, 1)) << 8) | (ord (substr ($digest, 14, 1))), 4);
+  $hash .= to64 ((ord (substr ($digest,  3, 1)) << 16) | (ord (substr ($digest,  9, 1)) << 8) | (ord (substr ($digest, 15, 1))), 4);
+  $hash .= to64 ((ord (substr ($digest,  4, 1)) << 16) | (ord (substr ($digest, 10, 1)) << 8) | (ord (substr ($digest,  5, 1))), 4);
+  $hash .= to64 (ord (substr ($digest, 11, 1)), 2);
+
+  return sprintf ("%s\$%s", $puresalt, $hash);
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  return unless (substr ($hash, 0, 4) eq '$md5');
+
+  my $extra_rounds = 0;
+  my $salt;
+  my $pos = 4;
+
+  my $c = substr ($hash, $pos, 1);
+
+  return unless ($c eq ',' || $c eq '$');
+
+  $pos++;
+
+  if (substr ($hash, $pos, 7) eq 'rounds=')
+  {
+    $pos += 7;
+
+    my $rounds_end = index ($hash, '$', $pos);
+
+    return if ($rounds_end < 0);
+
+    $extra_rounds = int (substr ($hash, $pos, $rounds_end - $pos));
+
+    $pos = $rounds_end + 1;
+  }
+
+  my $last_sep = rindex ($hash, '$');
+
+  return if ($last_sep < $pos);
+
+  $salt = substr ($hash, $pos, $last_sep - $pos);
+
+  $salt =~ s/\$$//;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $extra_rounds);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Reimplemented Sun MD5 from hashcat-legacy on GPU for compatibility.

Maintain original Sun MD5 mode of 3300

```
------------------------------------------------------
* Hash-Mode 3300 (MD5(Sun), SunMD5) [Iterations: 5000]
------------------------------------------------------

Speed.#01........:   309.5 kH/s (87.04ms) @ Accel:8 Loops:250 Thr:1024 Vec:1
```

```
$md5$rounds=904$iPPKEBnEkp3JV8uX$0L6m7rOFTVFn.SGqo2M9W1:hashcat

Session..........: hashcat
Status...........: Cracked
Hash.Mode........: 3300 (MD5(Sun), SunMD5)
Hash.Target......: $md5$rounds=904$iPPKEBnEkp3JV8uX$0L6m7rOFTVFn.SGqo2M9W1
Time.Started.....: Wed May 13 01:29:11 2026 (0 secs)
Time.Estimated...: Wed May 13 01:29:11 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 0-256 bytes)
Guess.Base.......: File (test.dict)
Guess.Queue......: 1/775 (0.13%)
Speed.#01........:    71737 H/s (5.28ms) @ Accel:2 Loops:124 Thr:1024 Vec:1
Recovered........: 1/1 (100.00%) Digests (total), 1/1 (100.00%) Digests (new)
Progress.........: 15951/15951 (100.00%)
Rejected.........: 0/15951 (0.00%)
Restore.Point....: 0/15951 (0.00%)
Restore.Sub.#01..: Salt:0 Amplifier:0-1 Iteration:4960-5000
Candidate.Engine.: Device Generator
Candidates.#01...: testpass -> football123
Hardware.Mon.#01.: Temp: 38c Fan: 90% Util:  0% Core:2790MHz Mem:10251MHz Bus:16
```