### PR TITLE
Fix salt iter parsing undefined behavior, false positives/false negatives

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed undefined behavior in 16 modules when hash cost/iteration field >= 32 caused silent wrong results via shift wrap
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/modules/module_00400.c
+++ b/src/modules/module_00400.c
@@ -203,11 +203,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *iter_pos = token.buf[1];
 
-  u32 salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  const u32 iter = itoa64_to_int (iter_pos[0]);
 
-  if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
+  if (iter > 31) return (PARSER_SALT_ITERATION);
 
-  salt->salt_iter = salt_iter;
+  salt->salt_iter = 1u << iter;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_00400.c
+++ b/src/modules/module_00400.c
@@ -202,11 +202,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *iter_pos = token.buf[1];
 
-  u32 salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  const u32 iter = itoa64_to_int (iter_pos[0]);
 
-  if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
+  if (iter > 31) return (PARSER_SALT_ITERATION);
 
-  salt->salt_iter = salt_iter;
+  salt->salt_iter = 1u << iter;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_03200.c
+++ b/src/modules/module_03200.c
@@ -146,7 +146,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_03200.c
+++ b/src/modules/module_03200.c
@@ -145,7 +145,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_06400.c
+++ b/src/modules/module_06400.c
@@ -285,9 +285,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 salt_iter[3] = { iter_pos[0], iter_pos[1], 0 };
 
-  salt->salt_sign[0] = hc_strtoul ((const char *) salt_iter, NULL, 10);
+  const u32 iter = hc_strtoul ((const char *) salt_iter, NULL, 10);
 
-  salt->salt_iter = (1u << hc_strtoul ((const char *) salt_iter, NULL, 10)) - 1;
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_sign[0] = iter;
+
+  salt->salt_iter = (1u << iter) - 1;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_06400.c
+++ b/src/modules/module_06400.c
@@ -284,9 +284,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 salt_iter[3] = { iter_pos[0], iter_pos[1], 0 };
 
-  salt->salt_sign[0] = hc_strtoul ((const char *) salt_iter, NULL, 10);
+  const u32 iter = hc_strtoul ((const char *) salt_iter, NULL, 10);
 
-  salt->salt_iter = (1u << hc_strtoul ((const char *) salt_iter, NULL, 10)) - 1;
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_sign[0] = iter;
+
+  salt->salt_iter = (1u << iter) - 1;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_06500.c
+++ b/src/modules/module_06500.c
@@ -457,9 +457,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 salt_iter[3] = { iter_pos[0], iter_pos[1], 0 };
 
-  salt->salt_sign[0] = hc_strtoul ((const char *) salt_iter, NULL, 10);
+  const u32 iter = hc_strtoul ((const char *) salt_iter, NULL, 10);
 
-  salt->salt_iter = (1u << hc_strtoul ((const char *) salt_iter, NULL, 10)) - 1;
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_sign[0] = iter;
+
+  salt->salt_iter = (1u << iter) - 1;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_06500.c
+++ b/src/modules/module_06500.c
@@ -456,9 +456,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 salt_iter[3] = { iter_pos[0], iter_pos[1], 0 };
 
-  salt->salt_sign[0] = hc_strtoul ((const char *) salt_iter, NULL, 10);
+  const u32 iter = hc_strtoul ((const char *) salt_iter, NULL, 10);
 
-  salt->salt_iter = (1u << hc_strtoul ((const char *) salt_iter, NULL, 10)) - 1;
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_sign[0] = iter;
+
+  salt->salt_iter = (1u << iter) - 1;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_06700.c
+++ b/src/modules/module_06700.c
@@ -219,9 +219,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 salt_iter[3] = { iter_pos[0], iter_pos[1], 0 };
 
-  salt->salt_sign[0] = hc_strtoul ((const char *) salt_iter, NULL, 10);
+  const u32 iter = hc_strtoul ((const char *) salt_iter, NULL, 10);
 
-  salt->salt_iter = (1u << hc_strtoul ((const char *) salt_iter, NULL, 10)) - 1;
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_sign[0] = iter;
+
+  salt->salt_iter = (1u << iter) - 1;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_06700.c
+++ b/src/modules/module_06700.c
@@ -218,9 +218,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 salt_iter[3] = { iter_pos[0], iter_pos[1], 0 };
 
-  salt->salt_sign[0] = hc_strtoul ((const char *) salt_iter, NULL, 10);
+  const u32 iter = hc_strtoul ((const char *) salt_iter, NULL, 10);
 
-  salt->salt_iter = (1u << hc_strtoul ((const char *) salt_iter, NULL, 10)) - 1;
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_sign[0] = iter;
+
+  salt->salt_iter = (1u << iter) - 1;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_07900.c
+++ b/src/modules/module_07900.c
@@ -344,13 +344,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *iter_pos = token.buf[1];
 
-  u32 salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  const u32 iter = itoa64_to_int (iter_pos[0]);
 
-  if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
+  if (iter > 31) return (PARSER_SALT_ITERATION);
 
   memcpy ((u8 *) salt->salt_sign, line_buf, 4);
 
-  salt->salt_iter = salt_iter;
+  salt->salt_iter = 1u << iter;
 
   // salt
 

--- a/src/modules/module_07900.c
+++ b/src/modules/module_07900.c
@@ -343,13 +343,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *iter_pos = token.buf[1];
 
-  u32 salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  const u32 iter = itoa64_to_int (iter_pos[0]);
 
-  if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
+  if (iter > 31) return (PARSER_SALT_ITERATION);
 
   memcpy ((u8 *) salt->salt_sign, line_buf, 4);
 
-  salt->salt_iter = salt_iter;
+  salt->salt_iter = 1u << iter;
 
   // salt
 

--- a/src/modules/module_11600.c
+++ b/src/modules/module_11600.c
@@ -685,6 +685,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   salt->salt_sign[0] = data_type;
 
+  // 7-Zip NumCyclesPower can be 0-63 per spec, but salt_iter is u32
+  // and the kernel dispatch loop is u32-bound, so we cannot support > 31.
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
   salt->salt_iter = 1u << iter;
 
   /**

--- a/src/modules/module_11600.c
+++ b/src/modules/module_11600.c
@@ -705,6 +705,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   salt->salt_sign[0] = data_type;
 
+  // 7-Zip NumCyclesPower can be 0-63 per spec, but salt_iter is u32
+  // and the kernel dispatch loop is u32-bound, so we cannot support > 31.
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
   salt->salt_iter = 1u << iter;
 
   /**

--- a/src/modules/module_13000.c
+++ b/src/modules/module_13000.c
@@ -179,9 +179,14 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u32 iterations = hc_strtoul ((const char *) iter_pos, NULL, 10);
 
-  salt->salt_iter = ((1u << iterations) + 32) - 1;
-
   if (iterations == 0) return (PARSER_SALT_VALUE);
+
+  // RAR5 log2 iteration count has no hard spec cap, but salt_iter is u32
+  // and the kernel dispatch loop is u32-bound, so we cannot support > 31.
+
+  if (iterations > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = ((1u << iterations) + 32) - 1;
 
   salt->salt_sign[0] = iterations;
 

--- a/src/modules/module_13000.c
+++ b/src/modules/module_13000.c
@@ -178,9 +178,14 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u32 iterations = hc_strtoul ((const char *) iter_pos, NULL, 10);
 
-  salt->salt_iter = ((1u << iterations) + 32) - 1;
-
   if (iterations == 0) return (PARSER_SALT_VALUE);
+
+  // RAR5 log2 iteration count has no hard spec cap, but salt_iter is u32
+  // and the kernel dispatch loop is u32-bound, so we cannot support > 31.
+
+  if (iterations > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = ((1u << iterations) + 32) - 1;
 
   salt->salt_sign[0] = iterations;
 

--- a/src/modules/module_25600.c
+++ b/src/modules/module_25600.c
@@ -115,7 +115,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_25600.c
+++ b/src/modules/module_25600.c
@@ -114,7 +114,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_25800.c
+++ b/src/modules/module_25800.c
@@ -115,7 +115,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_25800.c
+++ b/src/modules/module_25800.c
@@ -114,7 +114,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_28400.c
+++ b/src/modules/module_28400.c
@@ -115,7 +115,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_28400.c
+++ b/src/modules/module_28400.c
@@ -114,7 +114,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_30600.c
+++ b/src/modules/module_30600.c
@@ -115,7 +115,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_30600.c
+++ b/src/modules/module_30600.c
@@ -114,7 +114,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 

--- a/src/modules/module_30601.c
+++ b/src/modules/module_30601.c
@@ -141,7 +141,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // Parse salt for bcrypt
   salt->salt_len  = 16;
-  salt->salt_iter = (1u << hc_strtoul ((const char *) iter_pos, NULL, 10));
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   // memcpy ((char *) salt->salt_sign, line_buf, 26);
 

--- a/src/modules/module_30601.c
+++ b/src/modules/module_30601.c
@@ -140,7 +140,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // Parse salt for bcrypt
   salt->salt_len  = 16;
-  salt->salt_iter = (1u << hc_strtoul ((const char *) iter_pos, NULL, 10));
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
 
   // memcpy ((char *) salt->salt_sign, line_buf, 26);
 

--- a/src/modules/module_33800.c
+++ b/src/modules/module_33800.c
@@ -133,8 +133,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
-  salt->salt_iter2 = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
+  salt->salt_iter2 = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
   //have a copy of that for second round to prevent from calculating it inside kernel

--- a/src/modules/module_33800.c
+++ b/src/modules/module_33800.c
@@ -132,8 +132,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
-  salt->salt_iter2 = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
+  salt->salt_iter2 = 1u << iter;
 
   memcpy ((char *) salt->salt_sign, line_buf, 6);
   //have a copy of that for second round to prevent from calculating it inside kernel

--- a/src/modules/module_35500.c
+++ b/src/modules/module_35500.c
@@ -115,8 +115,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
-  
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
+
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 
   u8 *salt_buf_ptr = (u8 *) salt->salt_buf;

--- a/src/modules/module_35500.c
+++ b/src/modules/module_35500.c
@@ -114,8 +114,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   const int hash_len = token.len[3];
 
   salt->salt_len  = 16;
-  salt->salt_iter = 1u << hc_strtoul ((const char *) iter_pos, NULL, 10);
-  
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter > 31) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = 1u << iter;
+
   memcpy ((char *) salt->salt_sign, line_buf, 6);
 
   u8 *salt_buf_ptr = (u8 *) salt->salt_buf;

--- a/src/modules/module_35700.c
+++ b/src/modules/module_35700.c
@@ -204,11 +204,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *iter_pos = token.buf[1];
 
-  u32 salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  const u32 iter = itoa64_to_int (iter_pos[0]);
 
-  if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
+  if (iter > 31) return (PARSER_SALT_ITERATION);
 
-  salt->salt_iter = salt_iter;
+  salt->salt_iter = 1u << iter;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];

--- a/src/modules/module_35700.c
+++ b/src/modules/module_35700.c
@@ -203,11 +203,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *iter_pos = token.buf[1];
 
-  u32 salt_iter = 1u << itoa64_to_int (iter_pos[0]);
+  const u32 iter = itoa64_to_int (iter_pos[0]);
 
-  if (salt_iter > 0x80000000) return (PARSER_SALT_ITERATION);
+  if (iter > 31) return (PARSER_SALT_ITERATION);
 
-  salt->salt_iter = salt_iter;
+  salt->salt_iter = 1u << iter;
 
   const u8 *salt_pos = token.buf[2];
   const int salt_len = token.len[2];


### PR DESCRIPTION
16 of our current modules compute `salt->salt_iter = 1u << N` where N comes from hash input. When N >= 32, this is undefined behavior. On x86 platforms, the CPU wraps the value to N % 32, silently producing a wrong iteration count and leading to both false positives in the case of malformed hashes, and false negatives in the case of hashes with > 31 values for their salt iterations.

False positive example:

Normal test hash with cost 5:
```
Status...........: Cracked
Hash.Mode........: 3200 (bcrypt $2*$, Blowfish (Unix))
Hash.Target......: $2b$05$D6v6rODHDtBrd6n7Xllc8O9v7Lnr2b2empE7jn0rb4VF...tjHKEe
Time.Started.....: Fri May 22 19:58:59 2026 (0 secs)
Time.Estimated...: Fri May 22 19:58:59 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 0-72 bytes)
```

Same test hash with cost intentionally malformed to 37 (wraps to cost 5 silently):
```
Status...........: Cracked
Hash.Mode........: 3200 (bcrypt $2*$, Blowfish (Unix))
Hash.Target......: $2b$37$D6v6rODHDtBrd6n7Xllc8O9v7Lnr2b2empE7jn0rb4VF...tjHKEe
Time.Started.....: Fri May 22 19:59:14 2026 (0 secs)
Time.Estimated...: Fri May 22 19:59:14 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 0-72 bytes)
```

2 modules also contain the potential for false negatives, 7-Zip 11600 and RAR5 13000, as these do not have a spec limit of < 32 for salt iterations and a value higher than 31 for salt iter, while technically valid, will wrap to a lower value silently and the hash will not be crackable. These hashes, while valid, are correctly rejected now due to downstream types being u32 and thus unable to handle larger values. If we want to support these higher iteration hashes in the future we will need to make larger changes.