### PR TITLE
Fix PKZIP module heap overflow causing crashes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,7 +10,6 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
-- Fixed overflow in PKZIP modules from hex data field and unchecked data_length
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed overflow in PKZIP modules from hex data field and unchecked data_length
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/modules/module_17200.c
+++ b/src/modules/module_17200.c
@@ -295,6 +295,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   if (p == NULL) return PARSER_HASH_LENGTH;
   pkzip->hash.data_length = strtoul (p, NULL, 16);
 
+  if (pkzip->hash.data_length > MAX_DATA) return (PARSER_TOKEN_LENGTH);
+
   p = strtok_r (NULL, "*", &saveptr);
   if (p == NULL) return PARSER_HASH_LENGTH;
   u16 checksum_from_crc = 0;
@@ -317,7 +319,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   p = strtok_r (NULL, "*", &saveptr);
   if (p == NULL) return PARSER_HASH_LENGTH;
 
-  hex_to_binary (p, strlen (p), (char *) &(pkzip->hash.data));
+  const size_t data_hex_len = strlen (p);
+
+  if (data_hex_len > MAX_DATA * 2) return (PARSER_TOKEN_LENGTH);
+  if (data_hex_len % 2)            return (PARSER_TOKEN_LENGTH);
+
+  hex_to_binary (p, data_hex_len, (char *) &(pkzip->hash.data));
 
   // fake salt
   salt->salt_buf[0] = pkzip->hash.data[0];

--- a/src/modules/module_17210.c
+++ b/src/modules/module_17210.c
@@ -263,6 +263,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   if (p == NULL) return PARSER_HASH_LENGTH;
   pkzip->hash.data_length = strtoul (p, NULL, 16);
 
+  if (pkzip->hash.data_length > MAX_DATA) return (PARSER_TOKEN_LENGTH);
+
   p = strtok_r (NULL, "*", &saveptr);
   if (p == NULL) return PARSER_HASH_LENGTH;
   u16 checksum_from_crc = 0;
@@ -285,7 +287,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   p = strtok_r (NULL, "*", &saveptr);
   if (p == NULL) return PARSER_HASH_LENGTH;
 
-  hex_to_binary (p, strlen (p), (char *) &(pkzip->hash.data));
+  const size_t data_hex_len = strlen (p);
+
+  if (data_hex_len > MAX_DATA * 2) return (PARSER_TOKEN_LENGTH);
+  if (data_hex_len % 2)            return (PARSER_TOKEN_LENGTH);
+
+  hex_to_binary (p, data_hex_len, (char *) &(pkzip->hash.data));
 
   // fake salt
   salt->salt_buf[0] = pkzip->hash.data[0];

--- a/src/modules/module_17220.c
+++ b/src/modules/module_17220.c
@@ -296,6 +296,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     if (p == NULL) return PARSER_HASH_LENGTH;
     pkzip->hashes[i].data_length = strtoul (p, NULL, 16);
 
+    if (pkzip->hashes[i].data_length > MAX_DATA) return (PARSER_TOKEN_LENGTH);
+
     p = strtok_r (NULL, "*", &saveptr);
     if (p == NULL) return PARSER_HASH_LENGTH;
     u16 checksum_from_crc = 0;
@@ -318,7 +320,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     p = strtok_r (NULL, "*", &saveptr);
     if (p == NULL) return PARSER_HASH_LENGTH;
 
-    hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
+    const size_t data_hex_len = strlen (p);
+
+    if (data_hex_len > MAX_DATA * 2) return (PARSER_TOKEN_LENGTH);
+    if (data_hex_len % 2)            return (PARSER_TOKEN_LENGTH);
+
+    hex_to_binary (p, data_hex_len, (char *) &(pkzip->hashes[i].data));
 
     // fake salt
     salt->salt_buf[i] = pkzip->hashes[i].data[0];

--- a/src/modules/module_17225.c
+++ b/src/modules/module_17225.c
@@ -296,6 +296,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     if (p == NULL) return PARSER_HASH_LENGTH;
     pkzip->hashes[i].data_length = strtoul (p, NULL, 16);
 
+    if (pkzip->hashes[i].data_length > MAX_DATA) return (PARSER_TOKEN_LENGTH);
+
     p = strtok_r (NULL, "*", &saveptr);
     if (p == NULL) return PARSER_HASH_LENGTH;
     u16 checksum_from_crc = 0;
@@ -318,7 +320,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     p = strtok_r (NULL, "*", &saveptr);
     if (p == NULL) return PARSER_HASH_LENGTH;
 
-    hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
+    const size_t data_hex_len = strlen (p);
+
+    if (data_hex_len > MAX_DATA * 2) return (PARSER_TOKEN_LENGTH);
+    if (data_hex_len % 2)            return (PARSER_TOKEN_LENGTH);
+
+    hex_to_binary (p, data_hex_len, (char *) &(pkzip->hashes[i].data));
 
     // fake salt
     salt->salt_buf[i] = pkzip->hashes[i].data[0];

--- a/src/modules/module_17230.c
+++ b/src/modules/module_17230.c
@@ -279,6 +279,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     if (p == NULL) return PARSER_HASH_LENGTH;
     pkzip->hashes[i].data_length = strtoul (p, NULL, 16);
 
+    if (pkzip->hashes[i].data_length > MAX_DATA) return (PARSER_TOKEN_LENGTH);
+
     p = strtok_r (NULL, "*", &saveptr);
     if (p == NULL) return PARSER_HASH_LENGTH;
     u16 checksum_from_crc = 0;
@@ -301,7 +303,12 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     p = strtok_r (NULL, "*", &saveptr);
     if (p == NULL) return PARSER_HASH_LENGTH;
 
-    hex_to_binary (p, strlen (p), (char *) &(pkzip->hashes[i].data));
+    const size_t data_hex_len = strlen (p);
+
+    if (data_hex_len > MAX_DATA * 2) return (PARSER_TOKEN_LENGTH);
+    if (data_hex_len % 2)            return (PARSER_TOKEN_LENGTH);
+
+    hex_to_binary (p, data_hex_len, (char *) &(pkzip->hashes[i].data));
 
     // fake salt
     salt->salt_buf[i] = pkzip->hashes[i].data[0];


### PR DESCRIPTION
PKZIP modules use the `hex_to_binary()` function to decode hex data from the hash string into a fixed size esalt buffer `data[MAX_DATA/4] = 327,680 bytes`. The length of the hex data blob is determined by strlen(p) with no bounds check against the buffer size.

With a crafted PKZIP test hash with 700,000 hex characters will lead to placing 350,000 decoded bytes into a 327,680 byte buffer. This will cause a 22,320-byte overflow, causing crash on the next allocation/free. Behavior with native Linux build with DEBUG=2:

`munmap_chunk(): invalid pointer`

This issue was also identified here: https://github.com/hashcat/hashcat/issues/4664