### PR TITLE
Fix Kerberos etype 23 account_info overflow

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed heap overflow in Kerberos etype 23 modules from account_info field with crafted/corrupt hash input
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/modules/module_13100.c
+++ b/src/modules/module_13100.c
@@ -141,6 +141,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
       const int account_info_len = account_info_stop - account_info_start;
 
+      if (account_info_len > (int) sizeof (krb5tgs->account_info)) return (PARSER_SALT_LENGTH);
+
       token.token_cnt++;
 
       // etype

--- a/src/modules/module_18200.c
+++ b/src/modules/module_18200.c
@@ -148,6 +148,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const int account_info_len = account_info_stop - account_info_start;
 
+  if (account_info_len > (int) sizeof (krb5asrep->account_info)) return (PARSER_SALT_LENGTH);
+
   token.token_cnt  = 4;
 
   if (krb5asrep->format == 1)

--- a/src/modules/module_35300.c
+++ b/src/modules/module_35300.c
@@ -165,6 +165,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig,
       const char *acct_stop_incl = star2 + 2;                 // include "*$"
       const int   acct_len       = (int) (acct_stop_incl - acct_start);
 
+      if (acct_len > (int) sizeof (krb5tgs->account_info)) return (PARSER_SALT_LENGTH);
+
       token.token_cnt++;
 
       // etype

--- a/src/modules/module_35400.c
+++ b/src/modules/module_35400.c
@@ -169,6 +169,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const int account_info_len = (int) (account_info_stop - account_info_start);
 
+  if (account_info_len > (int) sizeof (krb5asrep->account_info)) return (PARSER_SALT_LENGTH);
+
   token.token_cnt  = 4;
 
   if (krb5asrep->format == 1)


### PR DESCRIPTION
Kerberos etype 23 modules compute `account_info_len` from the distance between two * delimiters in the hash string using strchr. No upper bound or limit check is enforced on this length before it's used in a memcpy into the fixed sized account_info[512] esalt field.

An input hash with an arbitrarily long `*user$realm$spn*` section causes a heap overflow. Small overflows (< ~20KB) land within the module's own struct fields and are partially overwritten by subsequent parsing. Large overflows (> ~22KB) write past the struct into adjacent allocations, corrupting heap metadata and causing a crash or unexpected behavior.

Behavior with a Kerberos etype 23 hash with 23,000-byte account_info section designed to overflow past entire 22KB struct on a native Linux build with DEBUG=2:

```
double free or corruption (out)
Aborted (core dumped)
```