### PR TITLE
Fix buffer overflow in WPA2 modules causing crashes with .hccapx files

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,7 +10,6 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
-- Fixed buffer overflow in WPA modules 22000/22001 from unchecked eapol_len/essid_len in hccapx binary parsing
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed buffer overflow in WPA modules 22000/22001 from unchecked eapol_len/essid_len in hccapx binary parsing
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/modules/module_22000.c
+++ b/src/modules/module_22000.c
@@ -643,6 +643,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     if ((hccapx->signature == HCCAPX_SIGNATURE) && (hccapx->version == HCCAPX_VERSION))
     {
+      if (hccapx->essid_len > 32) return (PARSER_SALT_LENGTH);
+      if (hccapx->eapol_len < 1 || hccapx->eapol_len > 256) return (PARSER_HCCAPX_EAPOL_LEN);
+
       tmp_len = 0;
 
       tmp_len += snprintf (tmp_buf, sizeof (tmp_buf) - tmp_len, "WPA*02*");

--- a/src/modules/module_22001.c
+++ b/src/modules/module_22001.c
@@ -645,6 +645,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     if ((hccapx->signature == HCCAPX_SIGNATURE) && (hccapx->version == HCCAPX_VERSION))
     {
+      if (hccapx->essid_len > 32) return (PARSER_SALT_LENGTH);
+      if (hccapx->eapol_len < 1 || hccapx->eapol_len > 256) return (PARSER_HCCAPX_EAPOL_LEN);
+
       tmp_len = 0;
 
       tmp_len += snprintf (tmp_buf, sizeof (tmp_buf) - tmp_len, "WPA*02*");


### PR DESCRIPTION
The current WPA2 modules 22000 and 22001 have a backward-compatibility code path that parses raw .hccapx binary files. The eapol_len and essid_len fields from the binary struct are used directly as lengths for hex_encode into a 1024 byte buffer (tmp_buf[1024]) without any validation.

With a corrupt or otherwise out of spec .hccapx file containing eapol_len = 65535, hex_encode writes 65535 * 2 = 131070 hex characters into the 1024 byte buffer leading to a ~130KB overflow. The overflow triggers during hash loading before we make it to kernel launch.

The older modules 2500/2501 correctly validate these fields like this:

```
if (in.eapol_len < 1 || in.eapol_len > 255) return (PARSER_HCCAPX_EAPOL_LEN);
if (salt_len > 32) return (PARSER_SALT_LENGTH);
```

Modules 22000/22001 were missing these checks.

