### PR TITLE
Fix Keepass v1 contents_len underflow GPU hang

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,7 +10,6 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
-- Fixed GPU hang in KeePass v1 modules 13400/29700 from contents_len underflow
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed GPU hang in KeePass v1 modules 13400/29700 from contents_len underflow
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/modules/module_13400.c
+++ b/src/modules/module_13400.c
@@ -366,6 +366,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     keepass->contents_len = contents_len / 2;
 
+    if (keepass->contents_len < 16)     return (PARSER_SALT_LENGTH);
+    if (keepass->contents_len % 16 != 0) return (PARSER_SALT_LENGTH);
+
     for (int i = 0, j = 0; j < contents_len; i += 1, j += 8)
     {
       keepass->contents[i] = hex_to_u32 (&contents_pos[j]);

--- a/src/modules/module_29700.c
+++ b/src/modules/module_29700.c
@@ -384,6 +384,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
     keepass->contents_len = contents_len / 2;
 
+    if (keepass->contents_len < 16)     return (PARSER_SALT_LENGTH);
+    if (keepass->contents_len % 16 != 0) return (PARSER_SALT_LENGTH);
+
     for (int i = 0, j = 0; j < contents_len; i += 1, j += 8)
     {
       keepass->contents[i] = hex_to_u32 (&contents_pos[j]);


### PR DESCRIPTION
KeePass v1 GPU kernels 13400 and 29700 decrypt contents data in a loop bounded by `contents_len - 16`, where contents_len is u32. The parser allows contents_len as small as 1 byte `token.len_min[10] = 2 hex chars`. When `contents_len < 16`, the subtraction underflows and (on x86 at least) wraps to a very large number, causing the GPU kernel to loop millions or billions of times reading far past the contents buffer. Both the AES and Twofish paths in both kernels are affected by this.
