### PR TITLE
Fix rare outfile-check race condition

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,7 +10,6 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
-- Fixed race on shared hash counters in outfile_check thread, undercount, double count, failure to exhaust
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed race on shared hash counters in outfile_check thread, undercount, double count, failure to exhaust
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/outfile_check.c
+++ b/src/outfile_check.c
@@ -159,8 +159,6 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
       if (hc_fopen (&fp, out_info[j].file_name, "rb") == false) continue;
 
-      //hc_thread_mutex_lock (status_ctx->mux_display);
-
       struct stat outfile_stat;
 
       if (hc_fstat (&fp, &outfile_stat))
@@ -268,20 +266,27 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
 
           if (cracked == true)
           {
-            hashes->digests_shown[idx] = 1;
+            hc_thread_mutex_lock (status_ctx->mux_display);
 
-            hashes->digests_done++;
-
-            salt_buf->digests_done++;
-
-            if (salt_buf->digests_done == salt_buf->digests_cnt)
+            if (hashes->digests_shown[idx] == 0)
             {
-              hashes->salts_shown[salt_pos] = 1;
+              hashes->digests_shown[idx] = 1;
 
-              hashes->salts_done++;
+              hashes->digests_done++;
 
-              if (hashes->salts_done == salts_cnt) mycracked (hashcat_ctx);
+              salt_buf->digests_done++;
+
+              if (salt_buf->digests_done == salt_buf->digests_cnt)
+              {
+                hashes->salts_shown[salt_pos] = 1;
+
+                hashes->salts_done++;
+
+                if (hashes->salts_done == salts_cnt) mycracked (hashcat_ctx);
+              }
             }
+
+            hc_thread_mutex_unlock (status_ctx->mux_display);
 
             break;
           }
@@ -293,8 +298,6 @@ static int outfile_remove (hashcat_ctx_t *hashcat_ctx)
       hcfree (line_buf);
 
       out_info[j].seek = hc_ftell (&fp);
-
-      //hc_thread_mutex_unlock (status_ctx->mux_display);
 
       hc_fclose (&fp);
 


### PR DESCRIPTION
The outfile-check thread modifies shared hash counters (digests_done, salts_done, digests_shown[], salts_shown[]) without holding the `mux_display` mutex. The main cracking thread modifies the exact same counters under that mutex in `check_cracked`. This creates a race condition that has existed seemingly since the very first commits to the repo. The mutex was commented out deliberately at some point due to performance concerns based on some commit messages around the original lock.

This race happens in an exceptionally tight window and is extremely difficult to notice when it triggers, which may explain why it has survived so long. There are a few possible outcomes if it does trigger:

- Both threads read digests_done = N, both write N + 1 instead of N + 2, hashcat never detects all hashes are cracked, runs until keyspace exhausted but all hashes are cracked and all cracks are in the potfile
- Both threads see digests_shown[idx] == 0, both mark and increment, salts_done ends up over counting, premature termination via `mycracked()` while hashes remain uncracked but hashcat thinks all hashes were cracked
- Some variation of both due to partial updates and conflicting values being observable to both threads

This may impact any distributed cracking system using --outfile-check-dir for co-operation like Hashtopolis, Fitcrack, etc.