### PR TITLE
Fix u32 multiplication overflow causing missed cracks/false negatives on large hash lists

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,7 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed u32 overflow in digest/esalt buffer offset calculations causing silent missed cracks with large hashlists
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/backend.c
+++ b/src/backend.c
@@ -14176,7 +14176,7 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
     u64 size_plains  = (u64) hashes->digests_cnt * sizeof (plain_t);
     u64 size_salts   = (u64) hashes->salts_cnt   * sizeof (salt_t);
-    u64 size_esalts  = (u64) hashes->digests_cnt * hashconfig->esalt_size;
+    u64 size_esalts  = (u64) hashes->digests_cnt * (u64) hashconfig->esalt_size;
     u64 size_shown   = (u64) hashes->digests_cnt * sizeof (u32);
     u64 size_digests = (u64) hashes->digests_cnt * (u64) hashconfig->dgst_size;
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -140,9 +140,9 @@ int hash_encode (const user_options_t *user_options, const hashconfig_t *hashcon
   char       *hook_salts_buf_ptr = (char *) hook_salts_buf;
   hashinfo_t *hash_info_ptr      = NULL;
 
-  digests_buf_ptr    += digest_cur * hashconfig->dgst_size;
-  esalts_buf_ptr     += digest_cur * hashconfig->esalt_size;
-  hook_salts_buf_ptr += digest_cur * hashconfig->hook_salt_size;
+  digests_buf_ptr    += (u64) digest_cur * (u64) hashconfig->dgst_size;
+  esalts_buf_ptr     += (u64) digest_cur * (u64) hashconfig->esalt_size;
+  hook_salts_buf_ptr += (u64) digest_cur * (u64) hashconfig->hook_salt_size;
 
   if (hash_info) hash_info_ptr = hash_info[digest_cur];
 
@@ -523,9 +523,9 @@ int check_hash (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pla
     char       *hook_salts_buf_ptr = (char *) hook_salts_buf;
     hashinfo_t *hash_info_ptr      = NULL;
 
-    digests_buf_ptr    += digest_cur * hashconfig->dgst_size;
-    esalts_buf_ptr     += digest_cur * hashconfig->esalt_size;
-    hook_salts_buf_ptr += digest_cur * hashconfig->hook_salt_size;
+    digests_buf_ptr    += (u64) digest_cur * (u64) hashconfig->dgst_size;
+    esalts_buf_ptr     += (u64) digest_cur * (u64) hashconfig->esalt_size;
+    hook_salts_buf_ptr += (u64) digest_cur * (u64) hashconfig->hook_salt_size;
 
     if (hash_info) hash_info_ptr = hash_info[digest_cur];
 
@@ -1102,7 +1102,7 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
     hashes_buf[hash_pos].orig_line_pos = hash_pos;
 
-    hashes_buf[hash_pos].digest = ((char *) digests_buf) + (hash_pos * hashconfig->dgst_size);
+    hashes_buf[hash_pos].digest = ((char *) digests_buf) + ((u64) hash_pos * (u64) hashconfig->dgst_size);
 
     if (hashconfig->is_salted == true)
     {
@@ -1110,12 +1110,12 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
       if (hashconfig->esalt_size > 0)
       {
-        hashes_buf[hash_pos].esalt = ((char *) esalts_buf) + (hash_pos * hashconfig->esalt_size);
+        hashes_buf[hash_pos].esalt = ((char *) esalts_buf) + ((u64) hash_pos * (u64) hashconfig->esalt_size);
       }
 
       if (hashconfig->hook_salt_size > 0)
       {
-        hashes_buf[hash_pos].hook_salt = ((char *) hook_salts_buf) + (hash_pos * hashconfig->hook_salt_size);
+        hashes_buf[hash_pos].hook_salt = ((char *) hook_salts_buf) + ((u64) hash_pos * (u64) hashconfig->hook_salt_size);
       }
     }
     else
@@ -2050,7 +2050,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
     if (hashconfig->hook_salt_size > 0)
     {
-      char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + (salts_cnt * hashconfig->hook_salt_size);
+      char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + ((u64) salts_cnt * (u64) hashconfig->hook_salt_size);
 
       memcpy (hook_salts_buf_new_ptr, hashes_buf[0].hook_salt, hashconfig->hook_salt_size);
 
@@ -2102,7 +2102,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
         if (hashconfig->hook_salt_size > 0)
         {
-          char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + (salts_cnt * hashconfig->hook_salt_size);
+          char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + ((u64) salts_cnt * (u64) hashconfig->hook_salt_size);
 
           memcpy (hook_salts_buf_new_ptr, hashes_buf[hashes_pos].hook_salt, hashconfig->hook_salt_size);
 
@@ -2120,7 +2120,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
       if (hashconfig->hook_salt_size > 0)
       {
-        char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + (salts_cnt * hashconfig->hook_salt_size);
+        char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + ((u64) salts_cnt * (u64) hashconfig->hook_salt_size);
 
         hashes_buf[hashes_pos].hook_salt = hook_salts_buf_new_ptr;
       }
@@ -2128,7 +2128,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
     salt_buf->digests_cnt++;
 
-    digests_buf_new_ptr = ((char *) digests_buf_new) + (hashes_pos * hashconfig->dgst_size);
+    digests_buf_new_ptr = ((char *) digests_buf_new) + ((u64) hashes_pos * (u64) hashconfig->dgst_size);
 
     memcpy (digests_buf_new_ptr, hashes_buf[hashes_pos].digest, hashconfig->dgst_size);
 
@@ -2136,7 +2136,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
     if (hashconfig->esalt_size > 0)
     {
-      char *esalts_buf_new_ptr = ((char *) esalts_buf_new) + (hashes_pos * hashconfig->esalt_size);
+      char *esalts_buf_new_ptr = ((char *) esalts_buf_new) + ((u64) hashes_pos * (u64) hashconfig->esalt_size);
 
       memcpy (esalts_buf_new_ptr, hashes_buf[hashes_pos].esalt, hashconfig->esalt_size);
 


### PR DESCRIPTION
The digest and esalt buffer offset calculations in `hashes_init_stage2` use `u32 * u32` multiplication to compute byte offsets. When the total buffer size exceeds 2 ^ 32 bytes (4 GB), this multiplication silently overflows, causing digest entries to be written to incorrect positions in the buffer due to the wrapped value. The sorted digest array becomes corrupted and the GPU binary search silently fails to find entries at corrupted positions causing missed cracks with no error or warning. 

This is also the root cause of https://github.com/hashcat/hashcat/issues/3612 and this fixes that issue. Conveniently, 99999 is one of the easier places to spot this issue due to the larger dgst_size it uses.

The threshold number of hashes for triggering this issue is hash mode dependent as it depends on the specific mode's dgst_size. For mode 99999 the digest size is 128 which means it takes a bit over 33.5M hashes to cause the overflow. For SHA512 with dgst_size 64 it's ~67M hashes. For MD5 dgst_size is only 16 and it takes ~268M hashes. 

The wrapping behavior is seemingly deterministic and we can track the offsets as this bug corrupts the array. Hash entry at sorted position 33,554,432: offset 33554432 × 128 = 2 ^ 32 wraps to 0, overwriting position 0. Hash entries at positions 33,554,432 - 33,999,999 begin overwriting the array after position 0 and the corruption spreads until it consumes the entire array or your GPU hits an OOM due to the size of the hash list. Both the overwritten "victim" hashes and overflowed "perpetrator" hashes become uncrackable because the binary search done by the GPU fails to find them during cracking. This means the GPU will miss the hashes that "overflowed" as well as the hashes that got trampled by the overwrites.

Tested in mode 99999 with 100 test passwords distributed through the list to track the missed cracks from this issue:

Hashes loaded | Cracks with overflow | Cracks with overflow fixed
-- | -- | --
33,554,432 (exactly 2^32 bytes) | 100/100 | 100/100
34,000,000 (2^32 + 57MB) | 96/100 | 100/100
40,000,000 (2^32 + 825MB) | 47/100 | 100/100
45,000,000 (2^32 + 1.47GB) | 0/100 | 100/100


