### PR TITLE
Fix LM hash corruption, improve LM hash processing speed

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,6 +10,8 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
+- Fixed orphaned LM split hash causing corrupted hash output in --show/--left with malformed input hashes
+- Fixed O(n^2) LM split_neighbor fixup loop causing significant hangs with large hashlists
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -10,8 +10,6 @@ Docker: Add hashcat-toolchain
 ## Bugs
 ##
 
-- Fixed orphaned LM split hash causing corrupted hash output in --show/--left with malformed input hashes
-- Fixed O(n^2) LM split_neighbor fixup loop causing significant hangs with large hashlists
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -1602,6 +1602,8 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
 
               hcfree (tmp_line_buf);
 
+              hashes_cnt--;
+
               continue;
             }
 
@@ -1627,6 +1629,8 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
                 }
 
                 hcfree (tmp_line_buf);
+
+                hashes_cnt--;
 
                 continue;
               }
@@ -1900,26 +1904,87 @@ int hashes_init_stage1 (hashcat_ctx_t *hashcat_ctx)
     // update split split_neighbor after sorting
     // see https://github.com/hashcat/hashcat/issues/1034 for good examples for testing
 
+    u32 rights_cnt = 0;
+
+    for (u32 i = 0; i < hashes_cnt; i++)
+    {
+      if (hashes_buf[i].hash_info->split->split_origin == SPLIT_ORIGIN_RIGHT) rights_cnt++;
+    }
+
+    int *rights_group = (int *) hcmalloc (rights_cnt * sizeof (int));
+    u32 *rights_index = (u32 *) hcmalloc (rights_cnt * sizeof (u32));
+
+    u32 rights_pos = 0;
+
+    for (u32 i = 0; i < hashes_cnt; i++)
+    {
+      if (hashes_buf[i].hash_info->split->split_origin != SPLIT_ORIGIN_RIGHT) continue;
+
+      rights_group[rights_pos] = hashes_buf[i].hash_info->split->split_group;
+      rights_index[rights_pos] = i;
+
+      rights_pos++;
+    }
+
+    for (u32 i = 1; i < rights_cnt; i++)
+    {
+      int  key_group = rights_group[i];
+      u32  key_index = rights_index[i];
+      u32  j         = i;
+
+      while (j > 0 && rights_group[j - 1] > key_group)
+      {
+        rights_group[j] = rights_group[j - 1];
+        rights_index[j] = rights_index[j - 1];
+
+        j--;
+      }
+
+      rights_group[j] = key_group;
+      rights_index[j] = key_index;
+    }
+
+    // for each LEFT entry, binary search for its partner in the sorted RIGHT array
+
     for (u32 i = 0; i < hashes_cnt; i++)
     {
       split_t *split1 = hashes_buf[i].hash_info->split;
 
       if (split1->split_origin != SPLIT_ORIGIN_LEFT) continue;
 
-      for (u32 j = 0; j < hashes_cnt; j++)
+      const int target = split1->split_group;
+
+      // binary search
+
+      u32 lo = 0;
+      u32 hi = rights_cnt;
+
+      while (lo < hi)
       {
-        split_t *split2 = hashes_buf[j].hash_info->split;
+        u32 mid = lo + (hi - lo) / 2;
 
-        if (split2->split_origin != SPLIT_ORIGIN_RIGHT) continue;
+        if (rights_group[mid] < target)
+        {
+          lo = mid + 1;
+        }
+        else
+        {
+          hi = mid;
+        }
+      }
 
-        if (split1->split_group != split2->split_group) continue;
+      if (lo < rights_cnt && rights_group[lo] == target)
+      {
+        const u32 j = rights_index[lo];
 
         split1->split_neighbor = j;
-        split2->split_neighbor = i;
 
-        break;
+        hashes_buf[j].hash_info->split->split_neighbor = i;
       }
     }
+
+    hcfree (rights_group);
+    hcfree (rights_index);
   }
 
   if (hashes->parser_token_length_cnt > 0)


### PR DESCRIPTION
When parsing a 32 character LM hash, the left half is committed to the hash buffer before the right half is parsed. If the right half fails to parse due to something like invalid characters, the left half remains orphaned with split_neighbor = 0. When running --show with this corrupted hash included in a list of hashes, this causes the orphaned left half to be paired with whatever unrelated hash is at index 0, producing a corrupt/false hash that never existed in the input list.

For example, a hashfile with `E52CAC67419A9A22GGGGGGGGGGGGGGGG` included can produce this output:

`e52cac67419a9a22a4f49c406510bdcb:PASSWOR[notfound]`

This takes the correct left side but the right side from a completely unrelated hash ends up appended to it incorrectly.

I've also updated the split_neighbor fixup loop to address https://github.com/hashcat/hashcat/issues/2752 and https://github.com/hashcat/hashcat/issues/4688. The previous behavior was to sort the left sides and then effectively bruteforce the hashes back together. This lead to the reported 300k hashes taking about 27.5 minutes in testing, matching the reported "half an hour". With the updated search, we can now do 300k hashes in about 14 seconds.
