### PR TITLE
Fix off by 1, encode buffer overflow causing crashes with --show

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -13,6 +13,8 @@ Docker: Add hashcat-toolchain
 - Added workaround for CUDA memory leak in benchmark mode caused by register spilling
 - Fixed bugs on multiple DES based modules when used with CPU devices
 - Fixed MSYS2 build
+- Fixed encode buffer overflow in module 16900 causing crashes when --show
+- Fixed encode off by one in Kerberos etype 17/18 modules
 - Disable setShouldMaximizeConcurrentCompilation on ext_metal.m, due to segfault on macos Tahoe
 
 * changes v7.1.1 -> v7.1.2

--- a/src/modules/module_16900.c
+++ b/src/modules/module_16900.c
@@ -242,7 +242,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const ansible_vault_t *ansible_vault = (const ansible_vault_t *) esalt_buf;
 
-  u8 *ct_data = (u8 *) hcmalloc (16384 + 1);
+  u8 *ct_data = (u8 *) hcmalloc (16384 * 2 + 1);
 
   const u32 *ct_data_ptr = ansible_vault->ct_data_buf;
 

--- a/src/modules/module_19600.c
+++ b/src/modules/module_19600.c
@@ -262,7 +262,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 {
   const krb5tgs_17_t *krb5tgs = (const krb5tgs_17_t *) esalt_buf;
 
-  char *data = (char *) hcmalloc (5120 * 4 * 2);
+  char *data = (char *) hcmalloc (5120 * 4 * 2 + 1);
 
   for (u32 i = 0, j = 0; i < krb5tgs->edata2_len; i += 1, j += 2)
   {

--- a/src/modules/module_19700.c
+++ b/src/modules/module_19700.c
@@ -279,7 +279,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 {
   const krb5tgs_18_t *krb5tgs = (const krb5tgs_18_t *) esalt_buf;
 
-  char *data = (char *) hcmalloc (5120 * 4 * 2);
+  char *data = (char *) hcmalloc (5120 * 4 * 2 + 1);
 
   for (u32 i = 0, j = 0; i < krb5tgs->edata2_len; i += 1, j += 2)
   {

--- a/src/modules/module_32100.c
+++ b/src/modules/module_32100.c
@@ -320,7 +320,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 {
   const krb5asrep_17_t *krb5asrep = (const krb5asrep_17_t *) esalt_buf;
 
-  char *data = (char *) hcmalloc (5120 * 4 * 2);
+  char *data = (char *) hcmalloc (5120 * 4 * 2 + 1);
 
   for (u32 i = 0, j = 0; i < krb5asrep->edata2_len; i += 1, j += 2)
   {

--- a/src/modules/module_32200.c
+++ b/src/modules/module_32200.c
@@ -320,7 +320,7 @@ int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 {
   const krb5asrep_18_t *krb5asrep = (const krb5asrep_18_t *) esalt_buf;
 
-  char *data = (char *) hcmalloc (5120 * 4 * 2);
+  char *data = (char *) hcmalloc (5120 * 4 * 2 + 1);
 
   for (u32 i = 0, j = 0; i < krb5asrep->edata2_len; i += 1, j += 2)
   {


### PR DESCRIPTION
The encode functions in several modules allocate buffers that are too small for the hex encoded output they produce, causing buffer overflows during --show/--left/potfile operations with hashes that have large data fields.

Module 16900 allocates `hcmalloc(16384 + 1)` for hex encoding ct_data_buf[4096]. Each u32 produces 8 hex chars via u32_to_hex, so max output is 4096 * 8 = 32768 bytes. The allocation is 2x undersized. With ct_data > 8 KB, --show crashes:

```
==97236==ERROR: AddressSanitizer: heap-buffer-overflow in u32_to_hex
src/modules/module_16900.c:251
0x529000013201 is located 0 bytes to the right of 16385-byte region
```


Kerberos etype 17/18 modules allocate `hcmalloc(5120 * 4 * 2)` = 40960 bytes for hex encoding edata2. At max edata2 (20480 bytes = 40960 hex chars), snprintf writes a null terminator 1 byte past the buffer:

```
==97273==ERROR: AddressSanitizer: heap-buffer-overflow
src/modules/module_19600.c:271
0x52e00000a400 is located 0 bytes to the right of 40960-byte region
```