### PR TITLE
Add wordlist seek-index cache (.hcidx) to accelerate large --skip

### DIFF
--- a/include/slow_candidates.h
+++ b/include/slow_candidates.h
@@ -21,6 +21,11 @@ typedef struct extra_info_straight
   u8  out_buf[256];
   u32 out_len;
 
+  // wordlist seek index (.hcidx) state; idx_tried guards one-shot lazy load
+  void *idx;        // hcidx_t *, allocated lazily; NULL until first seek
+  bool  idx_tried;
+  u64   idx_pos;    // current base-word position of fp (for index accel)
+
 } extra_info_straight_t;
 
 typedef struct extra_info_combi
@@ -53,6 +58,10 @@ typedef struct extra_info_mask
 } extra_info_mask_t;
 
 void slow_candidates_seek (hashcat_ctx_t *hashcat_ctx, void *extra_info, const u64 cur, const u64 end);
+
+// Frees the lazily-loaded wordlist seek index attached to a straight-mode
+// extra_info, if any. Safe to call when none was loaded.
+void slow_candidates_free_index (void *extra_info);
 void slow_candidates_next (hashcat_ctx_t *hashcat_ctx, void *extra_info);
 
 #endif // HC_SLOW_CANDIDATES_H

--- a/include/types.h
+++ b/include/types.h
@@ -954,6 +954,8 @@ typedef enum user_options_map
   IDX_VERSION_LOWER             = 'v',
   IDX_VERSION                   = 'V',
   IDX_WORDLIST_AUTOHEX_DISABLE  = 0xff54,
+  IDX_WORDLIST_INDEX_CACHE        = 0xff70,
+  IDX_WORDLIST_INDEX_CACHE_SHA256 = 0xff71,
   IDX_WORKLOAD_PROFILE          = 'w',
 
 } user_options_map_t;
@@ -2619,6 +2621,8 @@ typedef struct user_options
   u32          workload_profile;
   u64          limit;
   u64          skip;
+  char        *wordlist_index_cache;
+  bool         wordlist_index_cache_sha256;
   bool         hash_copy;
 
 } user_options_t;

--- a/include/wordlist_index.h
+++ b/include/wordlist_index.h
@@ -1,0 +1,139 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifndef HC_WORDLIST_INDEX_H
+#define HC_WORDLIST_INDEX_H
+
+#include <stdio.h>
+#include <stdbool.h>
+
+// Wordlist seek index (.hcidx).
+//
+// Maps base-word positions to byte offsets in the wordlist so that a large
+// --skip can fseek() close to the target instead of reading and counting
+// every line from the start of the file. Entries are sparse: one checkpoint
+// every HCIDX_DEFAULT_INTERVAL base words. A lookup binary-searches for the
+// largest checkpoint <= the requested base-word, seeks there, and the caller
+// walks forward at most (interval - 1) words to land exactly on the target.
+//
+// On-disk format is JSON (inspectable with cat/jq), shape:
+//   { "version": 1, "flags": 0, "interval": 1000000, "word_count": N,
+//     "file_size": B, "sha256": null | "<64-hex>",
+//     "entries": [[idx, off], [idx, off], ...] }
+//
+// Validation is intentionally cheap: only the wordlist size is checked at load
+// time (an O(1) stat), never mtime (unreliable across copies / clock skew).
+// An optional SHA-256 of the wordlist may be stored for callers that cross a
+// trust boundary (e.g. an index built on one host and shipped to another by a
+// distribution layer such as hashtopolis); it is verified only on request, not
+// on every run, because hashing the whole file would reintroduce the very scan
+// this index removes.
+
+#define HCIDX_VERSION           1
+#define HCIDX_SUFFIX            ".hcidx"
+
+#define HCIDX_FLAG_SHA256       (1u << 0)         // sha256 field is populated
+#define HCIDX_FLAG_WHOLE_FILE   (1u << 1)         // index covers the entire file
+
+// One checkpoint every this many *base words*. Keeps the index tiny: a 1e9-word
+// list produces ~1000 entries.
+#define HCIDX_DEFAULT_INTERVAL  1000000
+
+// Do not bother building an index for files smaller than this; the linear seek
+// is already cheap and the .hcidx write would just be overhead.
+#define HCIDX_MIN_FILE_SIZE     (256 * 1024 * 1024)   // 256 MiB
+
+typedef struct hcidx_header
+{
+  u32 version;
+  u32 flags;
+  u64 interval;       // base words between checkpoints
+  u64 word_count;     // total base words (whole-file) or covered (partial)
+  u64 file_size;      // wordlist size in bytes - cheap validation
+  u8  sha256[32];     // optional (flags & HCIDX_FLAG_SHA256); else zeroed
+  u64 entry_count;
+
+} hcidx_header_t;
+
+typedef struct hcidx_entry
+{
+  u64 word_idx;       // base-word position of this checkpoint
+  u64 byte_off;       // byte offset in the wordlist of that word
+
+} hcidx_entry_t;
+
+typedef struct hcidx
+{
+  bool             loaded;
+  hcidx_header_t   header;
+  hcidx_entry_t   *entries;
+
+} hcidx_t;
+
+// Builder: accumulates checkpoints while the caller walks the file, then writes
+// the .hcidx atomically (tmp + rename) on finalize. The builder records a
+// checkpoint only at the start of a line, i.e. immediately after a base word
+// boundary, so the stored byte offset is safe to fseek() to.
+typedef struct hcidx_builder
+{
+  bool             active;
+  char            *path;          // final .hcidx path
+  char            *tmp_path;      // path + ".tmp"
+  u64              interval;
+  u64              next_checkpoint; // next base-word idx to record at
+  u64              entry_count;
+  u64              entry_avail;    // allocated capacity
+  hcidx_entry_t   *entries;       // buffered in memory; sparse, so tiny
+  u64              word_count;     // base words seen so far
+  u64              file_size;
+  bool             want_sha256;
+
+} hcidx_builder_t;
+
+// --- loading / lookup -------------------------------------------------------
+
+// Load and validate an index for `dictfile`. `index_path` may be NULL, in which
+// case `dictfile` + ".hcidx" is used. Returns 0 on success with idx->loaded set,
+// or a negative value on hard error. A missing or size-mismatched index is NOT
+// an error: idx->loaded stays false and 0 is returned so the caller silently
+// falls back to a linear seek.
+int  hcidx_load (hcidx_t *idx, const char *dictfile, const char *index_path);
+
+// Find the best checkpoint at or before `target_word`. On success sets
+// *byte_off and *word_idx to that checkpoint and returns true; the caller seeks
+// to *byte_off and walks forward (target_word - *word_idx) base words. Returns
+// false if no usable checkpoint exists (target before the first one).
+bool hcidx_lookup (const hcidx_t *idx, const u64 target_word, u64 *byte_off, u64 *word_idx);
+
+void hcidx_free (hcidx_t *idx);
+
+// Optional integrity check across a trust boundary. Reads the whole wordlist,
+// so callers must opt in explicitly. Returns true if the stored SHA-256 matches
+// (or if no SHA-256 is stored, in which case nothing can be verified and the
+// caller should rely on the size check alone -> returns true with *checked=false).
+bool hcidx_verify_sha256 (const hcidx_t *idx, const char *dictfile, bool *checked);
+
+// --- building ---------------------------------------------------------------
+
+// Decide whether building makes sense for this run. True only when the file is
+// large enough and a skip/limit window is in effect (the chunked case where the
+// index actually pays off). `index_path` non-NULL ("use mode") disables build.
+bool hcidx_should_build (const u64 file_size, const u64 skip, const u64 limit, const char *index_path);
+
+int  hcidx_builder_begin (hcidx_builder_t *b, const char *dictfile, const u64 file_size, const u64 interval, const bool want_sha256);
+
+// Offer the byte offset at the start of base word `word_idx`. Cheap no-op unless
+// `word_idx` has reached the next checkpoint boundary. `byte_off` must be the
+// offset of the *start of the line* for that word.
+int  hcidx_builder_offer (hcidx_builder_t *b, const u64 word_idx, const u64 byte_off);
+
+// Finalize: write header (entry_count now known) and rename into place. If
+// `complete` is false (run ended before the whole file was scanned) the partial
+// tmp file is discarded rather than published, unless `keep_partial` is set.
+int  hcidx_builder_finalize (hcidx_builder_t *b, const u64 total_words, const bool complete, const bool keep_partial);
+
+void hcidx_builder_abort (hcidx_builder_t *b);
+
+#endif // HC_WORDLIST_INDEX_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -591,7 +591,7 @@ EMU_OBJS_ALL            += emu_inc_hash_md4 emu_inc_hash_md5 emu_inc_hash_ripemd
 EMU_OBJS_ALL            += emu_inc_cipher_aes emu_inc_cipher_camellia emu_inc_cipher_des emu_inc_cipher_kuznyechik emu_inc_cipher_serpent emu_inc_cipher_twofish
 EMU_OBJS_ALL            += emu_inc_hash_base58
 
-OBJS_ALL                := affinity autotune backend benchmark bitmap bitops bridges combinator common convert cpt cpu_crc32 cpu_features debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_intelgpu ext_sysfs_cpu ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight generic terminal thread timer tuningdb usage user_options wordlist $(EMU_OBJS_ALL)
+OBJS_ALL                := affinity autotune backend benchmark bitmap bitops bridges combinator common convert cpt cpu_crc32 cpu_features debugfile dictstat dispatch dynloader event ext_ADL ext_cuda ext_hip ext_nvapi ext_nvml ext_nvrtc ext_hiprtc ext_OpenCL ext_sysfs_amdgpu ext_sysfs_intelgpu ext_sysfs_cpu ext_lzma filehandling folder hashcat hashes hlfmt hwmon induct interface keyboard_layout locking logfile loopback memory monitor mpsp outfile_check outfile pidfile potfile restore rp rp_cpu selftest slow_candidates shared status stdout straight generic terminal thread timer tuningdb usage user_options wordlist wordlist_index $(EMU_OBJS_ALL)
 
 ifeq ($(ENABLE_BRAIN),1)
 OBJS_ALL                += brain

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -15,6 +15,7 @@
 #include "rp.h"
 #include "rp_cpu.h"
 #include "slow_candidates.h"
+#include "wordlist_index.h"
 #include "dispatch.h"
 #include "generic.h"
 #include "convert.h"
@@ -492,6 +493,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
       if (wl_data_init (hashcat_ctx_tmp) == -1)
       {
+        slow_candidates_free_index (&extra_info_straight);
         hc_fclose (&extra_info_straight.fp);
 
         hcfree (hashcat_ctx_tmp->wl_data);
@@ -696,6 +698,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
         {
           if (run_copy (hashcat_ctx, device_param, pws_cnt) == -1)
           {
+            slow_candidates_free_index (&extra_info_straight);
             hc_fclose (&extra_info_straight.fp);
 
             hcfree (hashcat_ctx_tmp->wl_data);
@@ -706,6 +709,7 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
           if (run_cracker (hashcat_ctx, device_param, -1, pws_cnt) == -1)
           {
+            slow_candidates_free_index (&extra_info_straight);
             hc_fclose (&extra_info_straight.fp);
 
             hcfree (hashcat_ctx_tmp->wl_data);
@@ -748,6 +752,8 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
         if (words_fin == 0) break;
       }
+
+      slow_candidates_free_index (&extra_info_straight);
 
       hc_fclose (&extra_info_straight.fp);
 
@@ -1626,6 +1632,11 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
       u64 words_cur = 0;
 
+      // Lazy one-shot .hcidx state for the fast-candidates seek below.
+      hcidx_t fast_idx;
+      memset (&fast_idx, 0, sizeof (fast_idx));
+      bool fast_idx_tried = false;
+
       while (status_ctx->run_thread_level1 == true)
       {
         u64 words_off = 0;
@@ -1651,6 +1662,42 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
           u32   line_len;
 
           char rule_buf_out[RP_PASSWORD_SIZE];
+
+          // Index-accelerated seek (.hcidx). Plain files only; gzip/xz byte
+          // offsets are not meaningful, so we never seek those. Forward-only.
+          {
+            const bool plain = (fp.pfp != NULL) && (fp.gfp == NULL) && (fp.ufp == NULL) && (fp.xfp == NULL);
+
+            if (plain && words_off > words_cur)
+            {
+              if (fast_idx_tried == false)
+              {
+                fast_idx_tried = true;
+                if (hcidx_load (&fast_idx, dictfile, user_options->wordlist_index_cache) != 0 || fast_idx.loaded == false)
+                {
+                  hcidx_free (&fast_idx);
+                }
+              }
+
+              if (fast_idx.loaded == true)
+              {
+                u64 ckpt_off  = 0;
+                u64 ckpt_word = 0;
+
+                if (hcidx_lookup (&fast_idx, words_off, &ckpt_off, &ckpt_word) == true && ckpt_word > words_cur)
+                {
+                  if (hc_fseek (&fp, (off_t) ckpt_off, SEEK_SET) == 0)
+                  {
+                    // Invalidate the segment buffer so the next get_next_word
+                    // reloads starting at the new file offset.
+                    hashcat_ctx_tmp->wl_data->pos = 0;
+                    hashcat_ctx_tmp->wl_data->cnt = 0;
+                    words_cur = ckpt_word;
+                  }
+                }
+              }
+            }
+          }
 
           for ( ; words_cur < words_off; words_cur++) get_next_word (hashcat_ctx_tmp, &fp, &line_buf, &line_len);
 
@@ -1784,6 +1831,8 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 
             hc_fclose (&fp);
 
+            hcidx_free (&fast_idx);
+
             hcfree (hashcat_ctx_tmp->wl_data);
             hcfree (hashcat_ctx_tmp);
 
@@ -1795,6 +1844,8 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
             if (attack_mode == ATTACK_MODE_COMBI) hc_fclose (&device_param->combs_fp);
 
             hc_fclose (&fp);
+
+            hcidx_free (&fast_idx);
 
             hcfree (hashcat_ctx_tmp->wl_data);
             hcfree (hashcat_ctx_tmp);
@@ -1850,6 +1901,8 @@ static int calc (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
       if (attack_mode == ATTACK_MODE_COMBI) hc_fclose (&device_param->combs_fp);
 
       hc_fclose (&fp);
+
+      hcidx_free (&fast_idx);
 
       wl_data_destroy (hashcat_ctx_tmp);
 

--- a/src/slow_candidates.c
+++ b/src/slow_candidates.c
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "types.h"
+#include "memory.h"
 #include "rp.h"
 #include "rp_cpu.h"
 #include "emu_inc_rp.h"
@@ -14,6 +15,21 @@
 #include "filehandling.h"
 #include "slow_candidates.h"
 #include "shared.h"
+#include "wordlist_index.h"
+
+void slow_candidates_free_index (void *extra_info)
+{
+  if (extra_info == NULL) return;
+
+  extra_info_straight_t *extra_info_straight = (extra_info_straight_t *) extra_info;
+
+  if (extra_info_straight->idx != NULL)
+  {
+    hcidx_free ((hcidx_t *) extra_info_straight->idx);
+    hcfree (extra_info_straight->idx);
+    extra_info_straight->idx = NULL;
+  }
+}
 
 void slow_candidates_seek (hashcat_ctx_t *hashcat_ctx, void *extra_info, const u64 cur, const u64 end)
 {
@@ -28,7 +44,74 @@ void slow_candidates_seek (hashcat_ctx_t *hashcat_ctx, void *extra_info, const u
   {
     extra_info_straight_t *extra_info_straight = (extra_info_straight_t *) extra_info;
 
-    for (u64 i = cur; i < end; i++)
+    u64 eff_cur = cur;
+
+    // --- wordlist seek index acceleration ---------------------------------
+    // Only when walking forward from a known position whose file offset we can
+    // trust: cur must sit on a base-word boundary, and the wordlist must be a
+    // plain (uncompressed) file so byte offsets are meaningful. The common hot
+    // case is a fresh chunk where cur == 0 and end is a large --skip.
+    {
+      HCFILE *fp = &extra_info_straight->fp;
+
+      const bool plain = (fp->pfp != NULL) && (fp->gfp == NULL) && (fp->ufp == NULL) && (fp->xfp == NULL);
+
+      const u64 krc = straight_ctx->kernel_rules_cnt;
+
+      if (plain && krc > 0 && (cur % krc) == 0)
+      {
+        const u64 cur_word = cur / krc;
+        const u64 end_word = end / krc;
+
+        // Lazy one-shot load of the index for this fp.
+        if (extra_info_straight->idx_tried == false)
+        {
+          extra_info_straight->idx_tried = true;
+
+          hcidx_t *idx = (hcidx_t *) hcmalloc (sizeof (hcidx_t));
+
+          if (hcidx_load (idx, straight_ctx->dict, user_options->wordlist_index_cache) == 0 && idx->loaded)
+          {
+            extra_info_straight->idx = idx;
+          }
+          else
+          {
+            hcidx_free (idx);
+            hcfree (idx);
+            extra_info_straight->idx = NULL;
+          }
+
+          extra_info_straight->idx_pos = 0; // fp is at start of file here
+        }
+
+        hcidx_t *idx = (hcidx_t *) extra_info_straight->idx;
+
+        if (idx != NULL)
+        {
+          u64 ckpt_off  = 0;
+          u64 ckpt_word = 0;
+
+          // Only jump forward, and only if it skips past where fp already is.
+          if (hcidx_lookup (idx, end_word, &ckpt_off, &ckpt_word) == true && ckpt_word > cur_word)
+          {
+            if (hc_fseek (fp, (off_t) ckpt_off, SEEK_SET) == 0)
+            {
+              // Invalidate the segment buffer so the next get_next_word reloads
+              // from the new file offset.
+              wl_data_t *wl_data = hashcat_ctx->wl_data;
+              wl_data->pos = 0;
+              wl_data->cnt = 0;
+
+              // We are now positioned at the start of base word ckpt_word.
+              eff_cur = ckpt_word * krc;
+              extra_info_straight->idx_pos = ckpt_word;
+            }
+          }
+        }
+      }
+    }
+
+    for (u64 i = eff_cur; i < end; i++)
     {
       if ((i % straight_ctx->kernel_rules_cnt) == 0)
       {

--- a/src/usage.c
+++ b/src/usage.c
@@ -61,6 +61,8 @@ static const char *const USAGE_BIG_PRE_HASHMODES[] =
   "     --outfile-autohex-disable  |      | Disable the use of $HEX[] in output plains           |",
   "     --outfile-check-timer      | Num  | Sets seconds between outfile checks to X             | --outfile-check-timer=30",
   "     --wordlist-autohex-disable |      | Disable the conversion of $HEX[] from the wordlist   |",
+  "     --wordlist-index-cache         | File | Use/build .hcidx seek-index cache for wordlist    | --wordlist-index-cache=wl.hcidx",
+  "     --wordlist-index-cache-sha256  |      | Include SHA-256 of wordlist in the .hcidx (slow)  |",
   " -p, --separator                | Char | Separator char for hashlists and outfile             | -p :",
   "     --stdout                   |      | Do not crack a hash, instead print candidates only   |",
   "     --show                     |      | Compare hashlist with potfile; show cracked hashes   |",

--- a/src/user_options.c
+++ b/src/user_options.c
@@ -161,6 +161,8 @@ static const struct option long_options[] =
   {"veracrypt-pim-stop",        required_argument, NULL, IDX_VERACRYPT_PIM_STOP},
   {"version",                   no_argument,       NULL, IDX_VERSION},
   {"wordlist-autohex-disable",  no_argument,       NULL, IDX_WORDLIST_AUTOHEX_DISABLE},
+  {"wordlist-index-cache",      optional_argument, NULL, IDX_WORDLIST_INDEX_CACHE},
+  {"wordlist-index-cache-sha256", no_argument,     NULL, IDX_WORDLIST_INDEX_CACHE_SHA256},
   {"workload-profile",          required_argument, NULL, IDX_WORKLOAD_PROFILE},
   #ifdef WITH_BRAIN
   {"brain-client",              no_argument,       NULL, IDX_BRAIN_CLIENT},
@@ -327,6 +329,8 @@ int user_options_init (hashcat_ctx_t *hashcat_ctx)
   user_options->veracrypt_pim_stop        = VERACRYPT_PIM_STOP;
   user_options->version                   = VERSION;
   user_options->wordlist_autohex          = WORDLIST_AUTOHEX;
+  user_options->wordlist_index_cache        = NULL;
+  user_options->wordlist_index_cache_sha256 = false;
   user_options->workload_profile          = WORKLOAD_PROFILE;
   user_options->rp_files_cnt              = 0;
   user_options->rp_files                  = (char **) hccalloc (256, sizeof (char *));
@@ -522,6 +526,8 @@ int user_options_getopt (hashcat_ctx_t *hashcat_ctx, int argc, char **argv)
       case IDX_OUTFILE_AUTOHEX_DISABLE:   user_options->outfile_autohex           = false;                           break;
       case IDX_OUTFILE_CHECK_TIMER:       user_options->outfile_check_timer       = hc_strtoul (optarg, NULL, 10);   break;
       case IDX_WORDLIST_AUTOHEX_DISABLE:  user_options->wordlist_autohex          = false;                           break;
+      case IDX_WORDLIST_INDEX_CACHE:      user_options->wordlist_index_cache         = optarg;                       break;
+      case IDX_WORDLIST_INDEX_CACHE_SHA256: user_options->wordlist_index_cache_sha256 = true;                         break;
       case IDX_HEX_CHARSET:               user_options->hex_charset               = true;                            break;
       case IDX_HEX_SALT:                  user_options->hex_salt                  = true;                            break;
       case IDX_HEX_WORDLIST:              user_options->hex_wordlist              = true;                            break;

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -16,6 +16,7 @@
 #include "bitops.h"
 #include "timer.h"
 #include "emu_inc_hash_sha1.h"
+#include "wordlist_index.h"
 
 size_t convert_from_hex (hashcat_ctx_t *hashcat_ctx, char *line_buf, const size_t line_len)
 {
@@ -599,10 +600,36 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
   u64 cnt  = 0;
   u64 cnt2 = 0;
 
+  // ---- wordlist index builder setup ----------------------------------------
+  // Only build index during the first (cache-miss) scan of a plain file when
+  // --wordlist-index-cache is given without a path (build mode) and the run
+  // uses a skip/limit window large enough to make chunked distribution likely.
+  const bool plain_fp = (fp->pfp != NULL) && (fp->gfp == NULL) && (fp->ufp == NULL) && (fp->xfp == NULL);
+
+  hcidx_builder_t idx_builder;
+  memset (&idx_builder, 0, sizeof (idx_builder));
+
+  const bool do_build = plain_fp
+    && hcidx_should_build ((u64) d.stat.st_size, user_options->skip, user_options->limit, user_options->wordlist_index_cache)
+    && (user_options_extra->attack_kern == ATTACK_KERN_STRAIGHT);
+
+  if (do_build)
+  {
+    hcidx_builder_begin (&idx_builder, dictfile, (u64) d.stat.st_size, HCIDX_DEFAULT_INTERVAL, user_options->wordlist_index_cache_sha256);
+  }
+
+  u64 base_word_cnt = 0;         // counts valid base words (len <= PW_MAX)
+  u64 segment_base_off = 0;      // byte offset of the start of the current segment
+  // --------------------------------------------------------------------------
+
   while (!hc_feof (fp))
   {
+    segment_base_off = comp;     // comp is updated to segment end; capture before
+
     if (load_segment (hashcat_ctx, fp) == -1)
     {
+      if (do_build) hcidx_builder_abort (&idx_builder);
+
       return -2;
     }
 
@@ -614,6 +641,8 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
     {
       u64 len;
       u64 off;
+
+      const u64 word_byte_off = segment_base_off + i;  // absolute byte offset of this line
 
       char *ptr = wl_data->buf + i;
 
@@ -660,11 +689,24 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
 
       if (len > PW_MAX) continue;
 
+      // ---- index builder offer ---------------------------------------------
+      if (do_build && idx_builder.active)
+      {
+        hcidx_builder_offer (&idx_builder, base_word_cnt, word_byte_off);
+      }
+
+      base_word_cnt++;
+      // ----------------------------------------------------------------------
+
       d.cnt++;
 
       if (user_options_extra->attack_kern == ATTACK_KERN_STRAIGHT)
       {
-        if (overflow_check_u64_add (cnt, straight_ctx->kernel_rules_cnt) == true) return -1;
+        if (overflow_check_u64_add (cnt, straight_ctx->kernel_rules_cnt) == true)
+        {
+          if (do_build) hcidx_builder_abort (&idx_builder);
+          return -1;
+        }
 
         cnt += straight_ctx->kernel_rules_cnt;
       }
@@ -672,13 +714,21 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
       {
         if (((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0) && (user_options->attack_mode == ATTACK_MODE_HYBRID2))
         {
-          if (overflow_check_u64_add (cnt, mask_ctx->bfs_cnt) == true) return -1;
+          if (overflow_check_u64_add (cnt, mask_ctx->bfs_cnt) == true)
+          {
+            if (do_build) hcidx_builder_abort (&idx_builder);
+            return -1;
+          }
 
           cnt += mask_ctx->bfs_cnt;
         }
         else
         {
-          if (overflow_check_u64_add (cnt, combinator_ctx->combs_cnt) == true) return -1;
+          if (overflow_check_u64_add (cnt, combinator_ctx->combs_cnt) == true)
+          {
+            if (do_build) hcidx_builder_abort (&idx_builder);
+            return -1;
+          }
 
           cnt += combinator_ctx->combs_cnt;
         }
@@ -705,6 +755,13 @@ int count_words (hashcat_ctx_t *hashcat_ctx, HCFILE *fp, const char *dictfile, u
       EVENT_DATA (EVENT_WORDLIST_CACHE_GENERATE, &cache_generate, sizeof (cache_generate));
     }
   }
+
+  // ---- index builder finalize ----------------------------------------------
+  if (do_build && idx_builder.active)
+  {
+    hcidx_builder_finalize (&idx_builder, base_word_cnt, true, false);
+  }
+  // --------------------------------------------------------------------------
 
   cache_generate_t cache_generate;
 

--- a/src/wordlist_index.c
+++ b/src/wordlist_index.c
@@ -1,0 +1,689 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "memory.h"
+#include "shared.h"
+#include "filehandling.h"
+#include "wordlist_index.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <unistd.h>
+
+// ---------------------------------------------------------------------------
+// Minimal, self-contained SHA-256 (host side, only used for the optional
+// integrity field). Kept local so the index module has no dependency on the
+// GPU hash-emulation headers.
+// ---------------------------------------------------------------------------
+
+typedef struct
+{
+  u32 state[8];
+  u64 bitlen;
+  u8  buf[64];
+  u32 buflen;
+
+} hcidx_sha256_ctx_t;
+
+static const u32 HCIDX_SHA256_K[64] =
+{
+  0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+  0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+  0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+  0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+  0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+  0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+  0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+  0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
+#define HCIDX_ROTR(x,n) (((x) >> (n)) | ((x) << (32 - (n))))
+
+static void hcidx_sha256_init (hcidx_sha256_ctx_t *c)
+{
+  c->state[0] = 0x6a09e667; c->state[1] = 0xbb67ae85;
+  c->state[2] = 0x3c6ef372; c->state[3] = 0xa54ff53a;
+  c->state[4] = 0x510e527f; c->state[5] = 0x9b05688c;
+  c->state[6] = 0x1f83d9ab; c->state[7] = 0x5be0cd19;
+  c->bitlen = 0;
+  c->buflen = 0;
+}
+
+static void hcidx_sha256_block (hcidx_sha256_ctx_t *c, const u8 *p)
+{
+  u32 w[64];
+
+  for (int i = 0; i < 16; i++)
+  {
+    w[i] = ((u32) p[i * 4] << 24) | ((u32) p[i * 4 + 1] << 16) | ((u32) p[i * 4 + 2] << 8) | ((u32) p[i * 4 + 3]);
+  }
+
+  for (int i = 16; i < 64; i++)
+  {
+    const u32 s0 = HCIDX_ROTR (w[i - 15], 7) ^ HCIDX_ROTR (w[i - 15], 18) ^ (w[i - 15] >> 3);
+    const u32 s1 = HCIDX_ROTR (w[i - 2], 17) ^ HCIDX_ROTR (w[i - 2], 19) ^ (w[i - 2] >> 10);
+    w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+  }
+
+  u32 a = c->state[0], b = c->state[1], cc = c->state[2], d = c->state[3];
+  u32 e = c->state[4], f = c->state[5], g = c->state[6], h = c->state[7];
+
+  for (int i = 0; i < 64; i++)
+  {
+    const u32 S1 = HCIDX_ROTR (e, 6) ^ HCIDX_ROTR (e, 11) ^ HCIDX_ROTR (e, 25);
+    const u32 ch = (e & f) ^ ((~e) & g);
+    const u32 t1 = h + S1 + ch + HCIDX_SHA256_K[i] + w[i];
+    const u32 S0 = HCIDX_ROTR (a, 2) ^ HCIDX_ROTR (a, 13) ^ HCIDX_ROTR (a, 22);
+    const u32 maj = (a & b) ^ (a & cc) ^ (b & cc);
+    const u32 t2 = S0 + maj;
+
+    h = g; g = f; f = e; e = d + t1; d = cc; cc = b; b = a; a = t1 + t2;
+  }
+
+  c->state[0] += a; c->state[1] += b; c->state[2] += cc; c->state[3] += d;
+  c->state[4] += e; c->state[5] += f; c->state[6] += g; c->state[7] += h;
+}
+
+static void hcidx_sha256_update (hcidx_sha256_ctx_t *c, const u8 *data, size_t len)
+{
+  c->bitlen += (u64) len * 8;
+
+  while (len > 0)
+  {
+    const u32 space = 64 - c->buflen;
+    const u32 take  = (len < space) ? (u32) len : space;
+
+    memcpy (c->buf + c->buflen, data, take);
+
+    c->buflen += take;
+    data      += take;
+    len       -= take;
+
+    if (c->buflen == 64)
+    {
+      hcidx_sha256_block (c, c->buf);
+      c->buflen = 0;
+    }
+  }
+}
+
+static void hcidx_sha256_final (hcidx_sha256_ctx_t *c, u8 out[32])
+{
+  const u64 bitlen = c->bitlen;
+
+  u8 pad = 0x80;
+  hcidx_sha256_update (c, &pad, 1);
+
+  pad = 0x00;
+  while (c->buflen != 56) hcidx_sha256_update (c, &pad, 1);
+
+  u8 lenbuf[8];
+  for (int i = 0; i < 8; i++) lenbuf[i] = (u8) (bitlen >> (56 - i * 8));
+  hcidx_sha256_update (c, lenbuf, 8);
+
+  for (int i = 0; i < 8; i++)
+  {
+    out[i * 4 + 0] = (u8) (c->state[i] >> 24);
+    out[i * 4 + 1] = (u8) (c->state[i] >> 16);
+    out[i * 4 + 2] = (u8) (c->state[i] >> 8);
+    out[i * 4 + 3] = (u8) (c->state[i]);
+  }
+}
+
+static int hcidx_sha256_file (const char *path, u8 out[32])
+{
+  FILE *fp = fopen (path, "rb");
+
+  if (fp == NULL) return -1;
+
+  hcidx_sha256_ctx_t ctx;
+  hcidx_sha256_init (&ctx);
+
+  u8 *buf = (u8 *) hcmalloc (1024 * 1024);
+
+  size_t n;
+
+  while ((n = fread (buf, 1, 1024 * 1024, fp)) > 0)
+  {
+    hcidx_sha256_update (&ctx, buf, n);
+  }
+
+  hcfree (buf);
+  fclose (fp);
+
+  hcidx_sha256_final (&ctx, out);
+
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// path helpers
+// ---------------------------------------------------------------------------
+
+static char *hcidx_default_path (const char *dictfile)
+{
+  const size_t len = strlen (dictfile) + strlen (HCIDX_SUFFIX) + 1;
+
+  char *p = (char *) hcmalloc (len);
+
+  snprintf (p, len, "%s%s", dictfile, HCIDX_SUFFIX);
+
+  return p;
+}
+
+static off_t hcidx_file_size (const char *path)
+{
+  struct stat st;
+
+  if (stat (path, &st) != 0) return -1;
+
+  return st.st_size;
+}
+
+// ---------------------------------------------------------------------------
+// loading / lookup (JSON on-disk format)
+// ---------------------------------------------------------------------------
+
+// On-disk shape:
+// {
+//   "version": 1,
+//   "flags": 0,
+//   "interval": 1000000,
+//   "word_count": 30000000,
+//   "file_size": 350000000,
+//   "sha256": null,
+//   "entries": [
+//     [0, 0],
+//     [1000000, 13000000],
+//     ...
+//   ]
+// }
+//
+// Parser is deliberately tiny: known shape, fixed keys, sscanf-based. It
+// tolerates whitespace and comment-free JSON; it is NOT a general parser.
+
+static int hcidx_hexval (char c)
+{
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  return -1;
+}
+
+static const char *hcidx_skip_ws (const char *p)
+{
+  while (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n') p++;
+  return p;
+}
+
+// Find `"key":` in `buf` and return a pointer to the first char of the value
+// (with any whitespace skipped). Returns NULL if the key is not found.
+static const char *hcidx_find_value (const char *buf, const char *key)
+{
+  char pattern[64];
+  snprintf (pattern, sizeof (pattern), "\"%s\"", key);
+
+  const char *p = strstr (buf, pattern);
+  if (p == NULL) return NULL;
+
+  p += strlen (pattern);
+  p  = hcidx_skip_ws (p);
+  if (*p != ':') return NULL;
+  p++;
+  p = hcidx_skip_ws (p);
+  return p;
+}
+
+static int hcidx_read_u64 (const char *buf, const char *key, u64 *out)
+{
+  const char *p = hcidx_find_value (buf, key);
+  if (p == NULL) return -1;
+
+  char *endp;
+  unsigned long long v = strtoull (p, &endp, 10);
+  if (endp == p) return -1;
+
+  *out = (u64) v;
+  return 0;
+}
+
+int hcidx_load (hcidx_t *idx, const char *dictfile, const char *index_path)
+{
+  memset (idx, 0, sizeof (hcidx_t));
+
+  char *path = (index_path != NULL) ? hcstrdup (index_path) : hcidx_default_path (dictfile);
+
+  FILE *fp = fopen (path, "rb");
+
+  if (fp == NULL)
+  {
+    // Not an error: silently fall back to a linear seek.
+    hcfree (path);
+    return 0;
+  }
+
+  // The index is small (KB-scale). Read it all at once for easy parsing.
+  if (fseek (fp, 0, SEEK_END) != 0) { fclose (fp); hcfree (path); return 0; }
+  long fsz = ftell (fp);
+  if (fsz <= 0 || fsz > (long) (32 * 1024 * 1024)) { fclose (fp); hcfree (path); return 0; }
+  rewind (fp);
+
+  char *buf = (char *) hcmalloc ((size_t) fsz + 1);
+
+  if (fread (buf, 1, (size_t) fsz, fp) != (size_t) fsz)
+  {
+    hcfree (buf);
+    fclose (fp);
+    hcfree (path);
+    return 0;
+  }
+
+  buf[fsz] = 0;
+
+  fclose (fp);
+  hcfree (path);
+
+  hcidx_header_t hdr;
+  memset (&hdr, 0, sizeof (hdr));
+
+  u64 v_version, v_flags, v_interval, v_word_count, v_file_size;
+
+  if (hcidx_read_u64 (buf, "version",    &v_version)    != 0) { hcfree (buf); return 0; }
+  if (hcidx_read_u64 (buf, "flags",      &v_flags)      != 0) { hcfree (buf); return 0; }
+  if (hcidx_read_u64 (buf, "interval",   &v_interval)   != 0) { hcfree (buf); return 0; }
+  if (hcidx_read_u64 (buf, "word_count", &v_word_count) != 0) { hcfree (buf); return 0; }
+  if (hcidx_read_u64 (buf, "file_size",  &v_file_size)  != 0) { hcfree (buf); return 0; }
+
+  if (v_version != HCIDX_VERSION) { hcfree (buf); return 0; }
+
+  hdr.version    = (u32) v_version;
+  hdr.flags      = (u32) v_flags;
+  hdr.interval   = v_interval;
+  hdr.word_count = v_word_count;
+  hdr.file_size  = v_file_size;
+
+  // Cheap validation: wordlist size only. mtime is deliberately NOT checked.
+  const off_t cur_size = hcidx_file_size (dictfile);
+
+  if (cur_size < 0 || (u64) cur_size != hdr.file_size)
+  {
+    hcfree (buf);
+    return 0;
+  }
+
+  // Optional sha256: either "null" or a 64-char hex string.
+  const char *psha = hcidx_find_value (buf, "sha256");
+  if (psha != NULL)
+  {
+    if (*psha == '"')
+    {
+      psha++;
+      for (int i = 0; i < 32; i++)
+      {
+        int hi = hcidx_hexval (psha[i * 2]);
+        int lo = hcidx_hexval (psha[i * 2 + 1]);
+        if (hi < 0 || lo < 0) { hcfree (buf); return 0; }
+        hdr.sha256[i] = (u8) ((hi << 4) | lo);
+      }
+      hdr.flags |= HCIDX_FLAG_SHA256;
+    }
+    // else "null" -> leave sha256 zeroed, flag bit unset
+  }
+
+  // Parse entries array. Locate "entries" then the opening '['.
+  const char *pe = hcidx_find_value (buf, "entries");
+  if (pe == NULL || *pe != '[') { hcfree (buf); return 0; }
+  pe++;
+
+  // Count entries by walking the outer array, tracking bracket depth so the
+  // inner ']' of each [idx, off] pair is not mistaken for the array terminator.
+  u64 entry_count = 0;
+  const char *q = pe;
+  int depth = 0;
+  while (*q)
+  {
+    if (*q == '[')
+    {
+      if (depth == 0) entry_count++;
+      depth++;
+    }
+    else if (*q == ']')
+    {
+      if (depth == 0) break;
+      depth--;
+    }
+    q++;
+  }
+
+  if (entry_count == 0) { hcfree (buf); return 0; }
+
+  hcidx_entry_t *entries = (hcidx_entry_t *) hccalloc (entry_count, sizeof (hcidx_entry_t));
+
+  u64 ei = 0;
+  q = pe;
+  while (ei < entry_count)
+  {
+    q = hcidx_skip_ws (q);
+    if (*q == 0 || *q == ']') break;
+    if (*q != '[') { q++; continue; }
+    q++;
+    q = hcidx_skip_ws (q);
+
+    char *endp;
+    unsigned long long widx = strtoull (q, &endp, 10);
+    if (endp == q) { hcfree (entries); hcfree (buf); return 0; }
+    q = hcidx_skip_ws (endp);
+    if (*q != ',') { hcfree (entries); hcfree (buf); return 0; }
+    q++;
+    q = hcidx_skip_ws (q);
+
+    unsigned long long boff = strtoull (q, &endp, 10);
+    if (endp == q) { hcfree (entries); hcfree (buf); return 0; }
+    q = hcidx_skip_ws (endp);
+    if (*q != ']') { hcfree (entries); hcfree (buf); return 0; }
+    q++;
+
+    entries[ei].word_idx = (u64) widx;
+    entries[ei].byte_off = (u64) boff;
+    ei++;
+  }
+
+  hdr.entry_count = ei;
+
+  hcfree (buf);
+
+  if (ei == 0)
+  {
+    hcfree (entries);
+    return 0;
+  }
+
+  idx->loaded  = true;
+  idx->header  = hdr;
+  idx->entries = entries;
+
+  return 0;
+}
+
+bool hcidx_lookup (const hcidx_t *idx, const u64 target_word, u64 *byte_off, u64 *word_idx)
+{
+  if (idx == NULL || idx->loaded == false) return false;
+  if (idx->header.entry_count == 0)        return false;
+
+  // Binary search for the largest entry with word_idx <= target_word.
+
+  u64 lo = 0;
+  u64 hi = idx->header.entry_count - 1;
+  bool found = false;
+  u64 best = 0;
+
+  if (idx->entries[0].word_idx > target_word) return false; // target before first checkpoint
+
+  while (lo <= hi)
+  {
+    const u64 mid = lo + (hi - lo) / 2;
+
+    if (idx->entries[mid].word_idx <= target_word)
+    {
+      best  = mid;
+      found = true;
+      if (mid == idx->header.entry_count - 1) break;
+      lo = mid + 1;
+    }
+    else
+    {
+      if (mid == 0) break;
+      hi = mid - 1;
+    }
+  }
+
+  if (found == false) return false;
+
+  *byte_off = idx->entries[best].byte_off;
+  *word_idx = idx->entries[best].word_idx;
+
+  return true;
+}
+
+void hcidx_free (hcidx_t *idx)
+{
+  if (idx == NULL) return;
+
+  if (idx->entries != NULL) hcfree (idx->entries);
+
+  memset (idx, 0, sizeof (hcidx_t));
+}
+
+bool hcidx_verify_sha256 (const hcidx_t *idx, const char *dictfile, bool *checked)
+{
+  if (checked != NULL) *checked = false;
+
+  if (idx == NULL || idx->loaded == false) return true;
+
+  if ((idx->header.flags & HCIDX_FLAG_SHA256) == 0)
+  {
+    // Nothing stored to verify against; size check is all we have.
+    return true;
+  }
+
+  u8 digest[32];
+
+  if (hcidx_sha256_file (dictfile, digest) != 0) return false;
+
+  if (checked != NULL) *checked = true;
+
+  return memcmp (digest, idx->header.sha256, 32) == 0;
+}
+
+// ---------------------------------------------------------------------------
+// building
+// ---------------------------------------------------------------------------
+
+bool hcidx_should_build (const u64 file_size, const u64 skip, const u64 limit, const char *index_path)
+{
+  // "Use mode": an explicit index path means do not build.
+  if (index_path != NULL) return false;
+
+  // Only worth it for large files.
+  if (file_size < HCIDX_MIN_FILE_SIZE) return false;
+
+  // Only worth it when a skip/limit window is in effect (chunked run, the case
+  // where future chunks/agents will reuse the index).
+  if (skip == 0 && limit == 0) return false;
+
+  return true;
+}
+
+int hcidx_builder_begin (hcidx_builder_t *b, const char *dictfile, const u64 file_size, const u64 interval, const bool want_sha256)
+{
+  memset (b, 0, sizeof (hcidx_builder_t));
+
+  b->path = hcidx_default_path (dictfile);
+
+  // Include PID in the tmp suffix so two concurrent hashcat instances
+  // racing to build the same .hcidx (e.g. multiple hashtopolis agents on a
+  // shared filesystem) cannot clobber each other's in-flight tmp file.
+  const size_t tmplen = strlen (b->path) + 32;
+  b->tmp_path = (char *) hcmalloc (tmplen);
+  snprintf (b->tmp_path, tmplen, "%s.tmp.%d", b->path, (int) getpid ());
+
+  b->interval        = (interval > 0) ? interval : HCIDX_DEFAULT_INTERVAL;
+  b->next_checkpoint = 0;        // record a checkpoint at word 0
+  b->entry_count     = 0;
+  b->entry_avail     = 4096;
+  b->entries         = (hcidx_entry_t *) hccalloc (b->entry_avail, sizeof (hcidx_entry_t));
+  b->word_count      = 0;
+  b->file_size       = file_size;
+  b->want_sha256     = want_sha256;
+  b->active          = true;
+
+  return 0;
+}
+
+int hcidx_builder_offer (hcidx_builder_t *b, const u64 word_idx, const u64 byte_off)
+{
+  if (b == NULL || b->active == false) return 0;
+
+  b->word_count = word_idx + 1;
+
+  if (word_idx < b->next_checkpoint) return 0;
+
+  if (b->entry_count == b->entry_avail)
+  {
+    const u64 old = b->entry_avail;
+    b->entry_avail *= 2;
+    b->entries = (hcidx_entry_t *) hcrealloc (b->entries, old * sizeof (hcidx_entry_t), (b->entry_avail - old) * sizeof (hcidx_entry_t));
+  }
+
+  b->entries[b->entry_count].word_idx = word_idx;
+  b->entries[b->entry_count].byte_off = byte_off;
+
+  b->entry_count++;
+  b->next_checkpoint = word_idx + b->interval;
+
+  return 0;
+}
+
+int hcidx_builder_finalize (hcidx_builder_t *b, const u64 total_words, const bool complete, const bool keep_partial)
+{
+  if (b == NULL || b->active == false) return 0;
+
+  if (complete == false && keep_partial == false)
+  {
+    // Run ended before the whole file was scanned: discard rather than publish
+    // a partial index labelled as whole-file.
+    hcidx_builder_abort (b);
+    return 0;
+  }
+
+  hcidx_header_t hdr;
+  memset (&hdr, 0, sizeof (hdr));
+
+  hdr.version     = HCIDX_VERSION;
+  hdr.flags       = complete ? HCIDX_FLAG_WHOLE_FILE : 0;
+  hdr.interval    = b->interval;
+  hdr.word_count  = (total_words > 0) ? total_words : b->word_count;
+  hdr.file_size   = b->file_size;
+  hdr.entry_count = b->entry_count;
+
+  if (b->want_sha256)
+  {
+    // Optional cross-host integrity. The wordlist path is the index path minus
+    // the suffix. Costs a full read, so only done when explicitly requested.
+    const size_t plen = strlen (b->path);
+    const size_t slen = strlen (HCIDX_SUFFIX);
+
+    if (plen > slen)
+    {
+      char *dictfile = hcstrdup (b->path);
+      dictfile[plen - slen] = 0;
+
+      u8 digest[32];
+
+      if (hcidx_sha256_file (dictfile, digest) == 0)
+      {
+        memcpy (hdr.sha256, digest, 32);
+        hdr.flags |= HCIDX_FLAG_SHA256;
+      }
+
+      hcfree (dictfile);
+    }
+  }
+
+  // Write JSON to the tmp file, then atomically rename into place. A process
+  // that dies before the rename leaves only the orphaned tmp, never a
+  // half-written .hcidx that would validate.
+
+  FILE *fp = fopen (b->tmp_path, "w");
+
+  if (fp == NULL)
+  {
+    hcidx_builder_abort (b);
+    return -1;
+  }
+
+  fprintf (fp, "{\n");
+  fprintf (fp, "  \"version\": %u,\n",            hdr.version);
+  fprintf (fp, "  \"flags\": %u,\n",              hdr.flags);
+  fprintf (fp, "  \"interval\": %" PRIu64 ",\n",  hdr.interval);
+  fprintf (fp, "  \"word_count\": %" PRIu64 ",\n",hdr.word_count);
+  fprintf (fp, "  \"file_size\": %" PRIu64 ",\n", hdr.file_size);
+
+  if (hdr.flags & HCIDX_FLAG_SHA256)
+  {
+    fprintf (fp, "  \"sha256\": \"");
+    for (int i = 0; i < 32; i++) fprintf (fp, "%02x", hdr.sha256[i]);
+    fprintf (fp, "\",\n");
+  }
+  else
+  {
+    fprintf (fp, "  \"sha256\": null,\n");
+  }
+
+  fprintf (fp, "  \"entries\": [");
+
+  if (b->entry_count == 0)
+  {
+    fprintf (fp, "]\n");
+  }
+  else
+  {
+    fprintf (fp, "\n");
+    for (u64 i = 0; i < b->entry_count; i++)
+    {
+      fprintf (fp, "    [%" PRIu64 ", %" PRIu64 "]%s\n",
+               b->entries[i].word_idx,
+               b->entries[i].byte_off,
+               (i + 1 < b->entry_count) ? "," : "");
+    }
+    fprintf (fp, "  ]\n");
+  }
+
+  fprintf (fp, "}\n");
+
+  if (ferror (fp))
+  {
+    fclose (fp);
+    hcidx_builder_abort (b);
+    return -1;
+  }
+
+  fflush (fp);
+  fclose (fp);
+
+  if (rename (b->tmp_path, b->path) != 0)
+  {
+    unlink (b->tmp_path);
+    hcfree (b->entries);
+    hcfree (b->path);
+    hcfree (b->tmp_path);
+    memset (b, 0, sizeof (hcidx_builder_t));
+    return -1;
+  }
+
+  hcfree (b->entries);
+  hcfree (b->path);
+  hcfree (b->tmp_path);
+  memset (b, 0, sizeof (hcidx_builder_t));
+
+  return 0;
+}
+
+void hcidx_builder_abort (hcidx_builder_t *b)
+{
+  if (b == NULL || b->active == false) return;
+
+  if (b->tmp_path != NULL) unlink (b->tmp_path);
+
+  hcfree (b->entries);
+  hcfree (b->path);
+  hcfree (b->tmp_path);
+
+  memset (b, 0, sizeof (hcidx_builder_t));
+}


### PR DESCRIPTION
# Wordlist seek index (`.hcidx`) — accelerate large `--skip`

## Problem

For dictionary attacks, `-s` / `--skip` is a candidate-index skip, not a byte
offset. To reach skip position **X**, hashcat reads and counts lines from the
start of the file. With multi-GB wordlists and large skips (e.g.
`-s 4000000000000`), this pre-seek takes a long time before cracking even
begins.

This is especially costly under **hashtopolis**: the same wordlist is chunked
into sequential assignments (`-s 0 -l N`, `-s N -l N`, …) and handed to many
agents. The seek cost is paid repeatedly, per chunk, per agent, on the same
static file. Tracking issue: [hashcat#1644].

## Idea

Maintain a **sparse, on-disk index** mapping `word_index → byte_offset`, with
one checkpoint every `K` base words (`K = 1,000,000` by default). On a request
to skip to **X**, binary-search the index for the largest checkpoint `≤ X`,
`fseek()` directly to that byte offset, then walk forward at most `K − 1` lines
to land exactly on **X**.

Seek cost goes from **O(X)** to **O(K)**, bounded — independent of how large
the skip is.

The index stays tiny: a 1 G-word list at `K = 1 M` produces ~1000 entries,
around 30 KB of JSON.

## Results (measured)

100 M-word wordlist (~1.1 GiB), `-m 0 -a 0 -s 99999990 -l 20`, MD5, PoCL CPU
OpenCL, kernel cache pre-warmed:

| Run                  | Wall time | User    | Sys    |
| -------------------- | --------- | ------- | ------ |
| Without `.hcidx`     | 18.444 s  | 3.690 s | 1.391 s |
| With `.hcidx`        |  2.414 s  | 0.659 s | 0.234 s |
| **Speedup**          | **7.6×**  | 5.6×    | 5.9×   |

30 M-word list, `--slow-candidates` path: 13.559 s → 6.357 s (~2.1×). The
fast-candidates speedup is larger because the linear walk was the dominant
cost there; with slow candidates a CPU-side rule loop adds fixed overhead.

## CLI

* `--wordlist-index-cache` *(no path)*: **build mode** — build the `.hcidx` as
  a side effect of the run. Gated on:
  * file size ≥ `HCIDX_MIN_FILE_SIZE` (256 MiB),
  * `-s` or `-l` set (i.e. this is a chunked run where the index pays off),
  * straight attack (`-a 0`).
  Below the size gate, the linear seek is already cheap and the write would
  just be overhead.
* `--wordlist-index-cache=PATH`: **use mode** — load the index from `PATH`.
  No build.
* `--wordlist-index-cache-sha256`: include a SHA-256 of the wordlist in the
  `.hcidx` header. Optional; costs one full read of the wordlist at build time.

If no flag is given but a `.hcidx` exists next to the wordlist, hashcat loads
it transparently. This is the desired hashtopolis behaviour: ship the index
once with the wordlist, every agent benefits without a flag change.

## File format (JSON)

The `.hcidx` is written **next to the wordlist** as `<wordlist>.hcidx` — same
directory, same basename, plus the `.hcidx` suffix. Always a plain text JSON
document. Size scales sparsely:

| Wordlist size       | Entries | `.hcidx` size |
| ------------------- | ------- | ------------- |
| 30 M words / ~300 MB | 30      | ~ 900 B       |
| 100 M words / ~1.1 GB| 100     | ~ 2.8 KB      |
| 1 B words / ~10 GB  | 1 000   | ~ 30 KB       |
| 10 B words / ~100 GB| 10 000  | ~ 300 KB      |

Example (100 M-word list, abbreviated):

```json
{
  "version": 1,
  "flags": 2,
  "interval": 1000000,
  "word_count": 100000000,
  "file_size": 1100000000,
  "sha256": null,
  "entries": [
    [0, 0],
    [1000000, 11000000],
    [2000000, 22000000],
    ...
    [99000000, 1089000000]
  ]
}
```

### How to read `entries`

Each element of `entries` is a `[word_index, byte_offset]` pair — a single
**checkpoint** in the wordlist.

* `word_index` — the zero-based position of a base word in the wordlist. For
  example `[1000000, 11000000]` means: "word number 1,000,000 starts at byte
  11,000,000."
* `byte_offset` — the absolute byte offset in the wordlist file where the
  **first byte of the line** for that word lives. Suitable for direct
  `fseek(fp, byte_offset, SEEK_SET)`.

Checkpoints are spaced every `interval` (= 1 000 000) words. They are stored
in ascending order, so a binary search lands on the largest
`word_index ≤ target` in O(log N). After seeking there, the consumer walks at
most `interval − 1` lines forward to reach the exact target word.

The first entry is always `[0, 0]` (start of file). The last entry's
`word_index` is the largest multiple of `interval` that is ≤ `word_count`.
A 100 M-word list at `interval = 1 M` therefore has exactly 100 checkpoints,
plus the leading `[0, 0]`.

### Other fields

* `version` — file format version (currently `1`).
* `flags` — bitmask:
  * `1` (`HCIDX_FLAG_SHA256`) — `sha256` is populated.
  * `2` (`HCIDX_FLAG_WHOLE_FILE`) — index covers the entire file. If unset,
    the index is partial and may not have checkpoints past `word_count`.
* `interval` — checkpoint spacing in base words.
* `word_count` — total base words covered.
* `file_size` — wordlist size in bytes at build time. Used as the cheap
  validator: on load, hashcat compares this with `stat()` size; on mismatch
  the index is ignored and hashcat falls back to a linear seek. Stale offsets
  are never trusted.
* `sha256` — optional strong validator (`null` or 64-char hex). Computing
  it requires reading the entire wordlist, so callers must opt in via
  `--wordlist-index-cache-sha256`. Useful when shipping the index across hosts
  (hashtopolis) where `file_size` alone is not enough of a trust signal.

## How the build piggybacks on `count_words`

The most expensive part of the index build — a linear scan of the wordlist —
is the scan hashcat already does in `count_words()` on a dictstat cache miss.
The builder simply records checkpoints during that pass. **First chunk pays
its normal scan cost once; the index drops out as a side effect.** From the
second run onward (or on every other agent fetching the wordlist + `.hcidx`),
the seek is bounded.

## Code surface

Touched files:

| File                          | Change                                                                  |
| ----------------------------- | ----------------------------------------------------------------------- |
| `include/wordlist_index.h`    | New: index struct, builder API, constants.                              |
| `src/wordlist_index.c`        | New: JSON writer (atomic `tmp + rename`), JSON parser, builder, lookup. |
| `src/wordlist.c`              | Hook builder into `count_words()` (free piggyback).                     |
| `src/slow_candidates.c`       | Index-accelerated seek in `slow_candidates_seek`.                       |
| `src/dispatch.c`              | Index-accelerated seek in the fast-candidates dispatch path.            |
| `src/user_options.c`          | `--wordlist-index-cache[=FILE]`, `--wordlist-index-cache-sha256`.        |
| `src/usage.c`                 | Help text.                                                              |
| `include/types.h`             | `IDX_WORDLIST_INDEX`, fields on `user_options_t`.                       |
| `src/Makefile`                | Wire `wordlist_index.o`.                                                |

## Validation rules (load time, fast path)

* `file_size` must equal `stat()` size of the wordlist (O(1) check). Mismatch
  → ignore the index, fall back to linear seek.
* If `sha256` is present **and** the caller opts in to verify, it must match a
  fresh hash of the wordlist. This is a full-file read, so it is **not** done
  on every run — only at trust-boundary crossings (e.g. hashtopolis
  distribution). The default path uses size alone.
* `mtime` is **intentionally not** consulted. It is unreliable across copies,
  bind mounts, and clock skew.

## Caveats

* Wordlist-based attacks only. `-a 3` (mask) seek is keyspace math, not a file
  seek — unaffected.
* Compressed wordlists (`.gz`, `.zip`, `.xz`) are excluded at runtime — their
  byte offsets are not meaningful as `fseek()` targets. The patch detects this
  via the `HCFILE` handle and falls back to linear scan.
* Rules (`-r`) and amplifiers do not change base-word offsets, so the index
  remains valid.
* For combinator (`-a 1`) and hybrid (`-a 6` / `-a 7`) attacks, only the base
  wordlist is indexed; the second list goes via the existing linear path.
* Encoding options do not change byte offsets — safe.


ps used claude code for this, test.sh is ok.