### PR TITLE
New Algorithms: SASL DIGEST-MD5 and POP3 APOP from Responder

### DIFF
--- a/OpenCL/m61000_a0-pure.cl
+++ b/OpenCL/m61000_a0-pure.cl
@@ -1,0 +1,288 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+typedef struct digest_md5
+{
+  u32 salt_buf[64];
+  u32 salt_len;
+
+  u32 a1_buf[64];
+  u32 a1_len;
+
+  u32 esalt_buf[64];
+  u32 esalt_len;
+
+} digest_md5_t;
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ KERNEL_FA void m61000_mxx (KERN_ATTR_RULES_ESALT (digest_md5_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    md5_ctx_t ctx1 = ctx0;
+
+    md5_update (&ctx1, tmp.i, tmp.pw_len);
+
+    md5_final (&ctx1);
+
+    const u32 a = ctx1.h[0];
+    const u32 b = ctx1.h[1];
+    const u32 c = ctx1.h[2];
+    const u32 d = ctx1.h[3];
+
+    md5_ctx_t ctx2;
+
+    md5_init (&ctx2);
+
+    ctx2.w0[0] = a;
+    ctx2.w0[1] = b;
+    ctx2.w0[2] = c;
+    ctx2.w0[3] = d;
+    ctx2.len   = 16;
+
+    md5_update_global (&ctx2, esalt_bufs[DIGESTS_OFFSET_HOST].a1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].a1_len);
+
+    md5_final (&ctx2);
+
+    const u32 e = ctx2.h[0];
+    const u32 f = ctx2.h[1];
+    const u32 g = ctx2.h[2];
+    const u32 h = ctx2.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((e >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((e >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((e >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((e >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((f >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((f >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((f >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((f >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((g >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((g >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((g >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((g >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((h >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((h >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((h >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((h >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_global (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m61000_sxx (KERN_ATTR_RULES_ESALT (digest_md5_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  COPY_PW (pws[gid]);
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    md5_ctx_t ctx1 = ctx0;
+
+    md5_update (&ctx1, tmp.i, tmp.pw_len);
+
+    md5_final (&ctx1);
+
+    const u32 a = ctx1.h[0];
+    const u32 b = ctx1.h[1];
+    const u32 c = ctx1.h[2];
+    const u32 d = ctx1.h[3];
+
+    md5_ctx_t ctx2;
+
+    md5_init (&ctx2);
+
+    ctx2.w0[0] = a;
+    ctx2.w0[1] = b;
+    ctx2.w0[2] = c;
+    ctx2.w0[3] = d;
+    ctx2.len   = 16;
+
+    md5_update_global (&ctx2, esalt_bufs[DIGESTS_OFFSET_HOST].a1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].a1_len);
+
+    md5_final (&ctx2);
+
+    const u32 e = ctx2.h[0];
+    const u32 f = ctx2.h[1];
+    const u32 g = ctx2.h[2];
+    const u32 h = ctx2.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((e >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((e >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((e >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((e >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((f >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((f >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((f >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((f >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((g >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((g >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((g >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((g >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((h >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((h >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((h >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((h >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_global (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m61000_a1-pure.cl
+++ b/OpenCL/m61000_a1-pure.cl
@@ -1,0 +1,278 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+typedef struct digest_md5
+{
+  u32 salt_buf[64];
+  u32 salt_len;
+
+  u32 a1_buf[64];
+  u32 a1_len;
+
+  u32 esalt_buf[64];
+  u32 esalt_len;
+
+} digest_md5_t;
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ KERNEL_FA void m61000_mxx (KERN_ATTR_ESALT (digest_md5_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    md5_ctx_t ctx1 = ctx0;
+
+    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_final (&ctx1);
+
+    const u32 a = ctx1.h[0];
+    const u32 b = ctx1.h[1];
+    const u32 c = ctx1.h[2];
+    const u32 d = ctx1.h[3];
+
+    md5_ctx_t ctx2;
+
+    md5_init (&ctx2);
+
+    ctx2.w0[0] = a;
+    ctx2.w0[1] = b;
+    ctx2.w0[2] = c;
+    ctx2.w0[3] = d;
+    ctx2.len   = 16;
+
+    md5_update_global (&ctx2, esalt_bufs[DIGESTS_OFFSET_HOST].a1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].a1_len);
+
+    md5_final (&ctx2);
+
+    const u32 e = ctx2.h[0];
+    const u32 f = ctx2.h[1];
+    const u32 g = ctx2.h[2];
+    const u32 h = ctx2.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((e >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((e >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((e >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((e >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((f >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((f >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((f >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((f >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((g >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((g >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((g >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((g >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((h >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((h >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((h >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((h >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_global (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m61000_sxx (KERN_ATTR_ESALT (digest_md5_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+  md5_update_global (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    md5_ctx_t ctx1 = ctx0;
+
+    md5_update_global (&ctx1, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md5_final (&ctx1);
+
+    const u32 a = ctx1.h[0];
+    const u32 b = ctx1.h[1];
+    const u32 c = ctx1.h[2];
+    const u32 d = ctx1.h[3];
+
+    md5_ctx_t ctx2;
+
+    md5_init (&ctx2);
+
+    ctx2.w0[0] = a;
+    ctx2.w0[1] = b;
+    ctx2.w0[2] = c;
+    ctx2.w0[3] = d;
+    ctx2.len   = 16;
+
+    md5_update_global (&ctx2, esalt_bufs[DIGESTS_OFFSET_HOST].a1_buf, esalt_bufs[DIGESTS_OFFSET_HOST].a1_len);
+
+    md5_final (&ctx2);
+
+    const u32 e = ctx2.h[0];
+    const u32 f = ctx2.h[1];
+    const u32 g = ctx2.h[2];
+    const u32 h = ctx2.h[3];
+
+    md5_ctx_t ctx;
+
+    md5_init (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((e >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((e >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((e >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((e >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((f >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((f >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((f >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((f >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((g >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((g >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((g >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((g >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((h >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((h >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((h >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((h >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_global (&ctx, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].esalt_len);
+
+    md5_final (&ctx);
+
+    const u32 r0 = ctx.h[DGST_R0];
+    const u32 r1 = ctx.h[DGST_R1];
+    const u32 r2 = ctx.h[DGST_R2];
+    const u32 r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m61000_a3-pure.cl
+++ b/OpenCL/m61000_a3-pure.cl
@@ -1,0 +1,348 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#endif
+
+typedef struct digest_md5
+{
+  u32 salt_buf[64];
+  u32 salt_len;
+
+  u32 a1_buf[64];
+  u32 a1_len;
+
+  u32 esalt_buf[64];
+  u32 esalt_len;
+
+} digest_md5_t;
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#elif VECT_SIZE == 2
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1])
+#elif VECT_SIZE == 4
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3])
+#elif VECT_SIZE == 8
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7])
+#elif VECT_SIZE == 16
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i).s0], l_bin2asc[(i).s1], l_bin2asc[(i).s2], l_bin2asc[(i).s3], l_bin2asc[(i).s4], l_bin2asc[(i).s5], l_bin2asc[(i).s6], l_bin2asc[(i).s7], l_bin2asc[(i).s8], l_bin2asc[(i).s9], l_bin2asc[(i).sa], l_bin2asc[(i).sb], l_bin2asc[(i).sc], l_bin2asc[(i).sd], l_bin2asc[(i).se], l_bin2asc[(i).sf])
+#endif
+
+KERNEL_FQ KERNEL_FA void m61000_mxx (KERN_ATTR_VECTOR_ESALT (digest_md5_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 a1_len = esalt_bufs[DIGESTS_OFFSET_HOST].a1_len;
+
+  u32x a1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < a1_len; i += 4, idx += 1)
+  {
+    a1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].a1_buf[idx];
+  }
+
+  const u32 esalt_len = esalt_bufs[DIGESTS_OFFSET_HOST].esalt_len;
+
+  u32x esalt_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < esalt_len; i += 4, idx += 1)
+  {
+    esalt_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].esalt_buf[idx];
+  }
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    md5_ctx_vector_t ctx1;
+
+    md5_init_vector_from_scalar (&ctx1, &ctx0);
+
+    md5_update_vector (&ctx1, w, pw_len);
+
+    md5_final_vector (&ctx1);
+
+    const u32x a = ctx1.h[0];
+    const u32x b = ctx1.h[1];
+    const u32x c = ctx1.h[2];
+    const u32x d = ctx1.h[3];
+
+    md5_ctx_vector_t ctx2;
+
+    md5_init_vector (&ctx2);
+
+    ctx2.w0[0] = a;
+    ctx2.w0[1] = b;
+    ctx2.w0[2] = c;
+    ctx2.w0[3] = d;
+    ctx2.len   = 16;
+
+    md5_update_vector (&ctx2, a1_buf, a1_len);
+
+    md5_final_vector (&ctx2);
+
+    const u32x e = ctx2.h[0];
+    const u32x f = ctx2.h[1];
+    const u32x g = ctx2.h[2];
+    const u32x h = ctx2.h[3];
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((e >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((e >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((e >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((e >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((f >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((f >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((f >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((f >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((g >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((g >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((g >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((g >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((h >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((h >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((h >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((h >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, esalt_buf, esalt_len);
+
+    md5_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m61000_sxx (KERN_ATTR_VECTOR_ESALT (digest_md5_t))
+{
+  /**
+   * modifier
+   */
+
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * bin2asc table
+   */
+
+  LOCAL_VK u32 l_bin2asc[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    const u32 i0 = (i >> 0) & 15;
+    const u32 i1 = (i >> 4) & 15;
+
+    l_bin2asc[i] = ((i0 < 10) ? '0' + i0 : 'a' - 10 + i0) << 8
+                 | ((i1 < 10) ? '0' + i1 : 'a' - 10 + i1) << 0;
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  const u32 a1_len = esalt_bufs[DIGESTS_OFFSET_HOST].a1_len;
+
+  u32x a1_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < a1_len; i += 4, idx += 1)
+  {
+    a1_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].a1_buf[idx];
+  }
+
+  const u32 esalt_len = esalt_bufs[DIGESTS_OFFSET_HOST].esalt_len;
+
+  u32x esalt_buf[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < esalt_len; i += 4, idx += 1)
+  {
+    esalt_buf[idx] = esalt_bufs[DIGESTS_OFFSET_HOST].esalt_buf[idx];
+  }
+
+  md5_ctx_t ctx0;
+
+  md5_init (&ctx0);
+
+  md5_update_global (&ctx0, esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf, esalt_bufs[DIGESTS_OFFSET_HOST].salt_len);
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    md5_ctx_vector_t ctx1;
+
+    md5_init_vector_from_scalar (&ctx1, &ctx0);
+
+    md5_update_vector (&ctx1, w, pw_len);
+
+    md5_final_vector (&ctx1);
+
+    const u32x a = ctx1.h[0];
+    const u32x b = ctx1.h[1];
+    const u32x c = ctx1.h[2];
+    const u32x d = ctx1.h[3];
+
+    md5_ctx_vector_t ctx2;
+
+    md5_init_vector (&ctx2);
+
+    ctx2.w0[0] = a;
+    ctx2.w0[1] = b;
+    ctx2.w0[2] = c;
+    ctx2.w0[3] = d;
+    ctx2.len   = 16;
+
+    md5_update_vector (&ctx2, a1_buf, a1_len);
+
+    md5_final_vector (&ctx2);
+
+    const u32x e = ctx2.h[0];
+    const u32x f = ctx2.h[1];
+    const u32x g = ctx2.h[2];
+    const u32x h = ctx2.h[3];
+
+    md5_ctx_vector_t ctx;
+
+    md5_init_vector (&ctx);
+
+    ctx.w0[0] = uint_to_hex_lower8 ((e >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((e >>  8) & 255) << 16;
+    ctx.w0[1] = uint_to_hex_lower8 ((e >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((e >> 24) & 255) << 16;
+    ctx.w0[2] = uint_to_hex_lower8 ((f >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((f >>  8) & 255) << 16;
+    ctx.w0[3] = uint_to_hex_lower8 ((f >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((f >> 24) & 255) << 16;
+    ctx.w1[0] = uint_to_hex_lower8 ((g >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((g >>  8) & 255) << 16;
+    ctx.w1[1] = uint_to_hex_lower8 ((g >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((g >> 24) & 255) << 16;
+    ctx.w1[2] = uint_to_hex_lower8 ((h >>  0) & 255) <<  0
+              | uint_to_hex_lower8 ((h >>  8) & 255) << 16;
+    ctx.w1[3] = uint_to_hex_lower8 ((h >> 16) & 255) <<  0
+              | uint_to_hex_lower8 ((h >> 24) & 255) << 16;
+
+    ctx.len = 32;
+
+    md5_update_vector (&ctx, esalt_buf, esalt_len);
+
+    md5_final_vector (&ctx);
+
+    const u32x r0 = ctx.h[DGST_R0];
+    const u32x r1 = ctx.h[DGST_R1];
+    const u32x r2 = ctx.h[DGST_R2];
+    const u32x r3 = ctx.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/src/modules/module_61000.c
+++ b/src/modules/module_61000.c
@@ -1,0 +1,362 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "emu_inc_hash_md5.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 3;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 1;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "SASL DIGEST-MD5";
+static const u64   KERN_TYPE      = 61000;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_HASH_COPY;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$sasl$DIGEST-MD5$WORKGROUP$admin$OA9BSXrbuRhWay$YDgMb0MHFhY9LOl9Tg5hH4GD8JHF8MaZ$00000001$auth$ldap/dc01.workgroup.local$ce9c97bcd0f0bf9d00c456514496814f";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+typedef struct digest_md5
+{
+  u32 salt_buf[64];
+  u32 salt_len;
+
+  u32 a1_buf[64];
+  u32 a1_len;
+
+  u32 esalt_buf[64];
+  u32 esalt_len;
+
+} digest_md5_t;
+
+static const char *SIGNATURE_SASL_DIGEST_MD5 = "$sasl$";
+
+static void md5_complete_no_limit (u32 digest[4], const u32 *plain, const u32 plain_len)
+{
+  md5_ctx_t md5_ctx;
+
+  md5_init (&md5_ctx);
+  md5_update (&md5_ctx, plain, plain_len);
+  md5_final (&md5_ctx);
+
+  digest[0] = md5_ctx.h[0];
+  digest[1] = md5_ctx.h[1];
+  digest[2] = md5_ctx.h[2];
+  digest[3] = md5_ctx.h[3];
+}
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (digest_md5_t);
+
+  return esalt_size;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  digest_md5_t *digest_md5 = (digest_md5_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  // $sasl$DIGEST-MD5$realm$username$nonce$cnonce$nc$qop$uri$response
+
+  token.token_cnt  = 10;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_SASL_DIGEST_MD5;
+
+  token.len[0]     = 6;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // DIGEST-MD5
+  token.sep[1]     = '$';
+  token.len[1]     = 10;
+  token.attr[1]    = TOKEN_ATTR_FIXED_LENGTH;
+
+  // realm
+  token.sep[2]     = '$';
+  token.len_min[2] = 0;
+  token.len_max[2] = 128;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // username
+  token.sep[3]     = '$';
+  token.len_min[3] = 1;
+  token.len_max[3] = 128;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // nonce
+  token.sep[4]     = '$';
+  token.len_min[4] = 1;
+  token.len_max[4] = 128;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // cnonce
+  token.sep[5]     = '$';
+  token.len_min[5] = 1;
+  token.len_max[5] = 128;
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // nc
+  token.sep[6]     = '$';
+  token.len_min[6] = 1;
+  token.len_max[6] = 16;
+  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // qop
+  token.sep[7]     = '$';
+  token.len_min[7] = 1;
+  token.len_max[7] = 16;
+  token.attr[7]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // uri
+  token.sep[8]     = '$';
+  token.len_min[8] = 1;
+  token.len_max[8] = 256;
+  token.attr[8]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // response
+  token.len[9]     = 32;
+  token.attr[9]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // verify sub-signature
+
+  if (memcmp (token.buf[1], "DIGEST-MD5", 10) != 0) return (PARSER_SIGNATURE_UNMATCHED);
+
+  const u8 *realm_pos    = token.buf[2];
+  const u8 *user_pos     = token.buf[3];
+  const u8 *nonce_pos    = token.buf[4];
+  const u8 *cnonce_pos   = token.buf[5];
+  const u8 *nc_pos       = token.buf[6];
+  const u8 *qop_pos      = token.buf[7];
+  const u8 *uri_pos      = token.buf[8];
+  const u8 *response_pos = token.buf[9];
+
+  const int realm_len    = token.len[2];
+  const int user_len     = token.len[3];
+  const int nonce_len    = token.len[4];
+  const int cnonce_len   = token.len[5];
+  const int nc_len       = token.len[6];
+  const int qop_len      = token.len[7];
+  const int uri_len      = token.len[8];
+
+  const int salt_total_len = user_len + 1 + realm_len + 1;
+
+  if (salt_total_len > 255) return (PARSER_SALT_LENGTH);
+
+  u8 *salt_buf_ptr = (u8 *) digest_md5->salt_buf;
+
+  memcpy (salt_buf_ptr, user_pos, user_len);
+  salt_buf_ptr[user_len] = ':';
+  memcpy (salt_buf_ptr + user_len + 1, realm_pos, realm_len);
+  salt_buf_ptr[user_len + 1 + realm_len] = ':';
+
+  digest_md5->salt_len = salt_total_len;
+
+  const int a1_total_len = 1 + nonce_len + 1 + cnonce_len;
+
+  if (a1_total_len > 255) return (PARSER_SALT_LENGTH);
+
+  u8 *a1_buf_ptr = (u8 *) digest_md5->a1_buf;
+
+  a1_buf_ptr[0] = ':';
+  memcpy (a1_buf_ptr + 1, nonce_pos, nonce_len);
+  a1_buf_ptr[1 + nonce_len] = ':';
+  memcpy (a1_buf_ptr + 1 + nonce_len + 1, cnonce_pos, cnonce_len);
+
+  digest_md5->a1_len = a1_total_len;
+
+  static u8 *auth_prefix = (u8 *) "AUTHENTICATE:";
+
+  const int ha2_input_len = 13 + uri_len;
+
+  if (ha2_input_len > 255) return (PARSER_SALT_LENGTH);
+
+  u32 tmp_ha2_buf[64] = { 0 };
+
+  u8 *tmp_ha2_ptr = (u8 *) tmp_ha2_buf;
+
+  memcpy (tmp_ha2_ptr, auth_prefix, 13);
+  memcpy (tmp_ha2_ptr + 13, uri_pos, uri_len);
+
+  u32 tmp_ha2_digest[4];
+
+  md5_complete_no_limit (tmp_ha2_digest, tmp_ha2_buf, ha2_input_len);
+
+  tmp_ha2_digest[0] = byte_swap_32 (tmp_ha2_digest[0]);
+  tmp_ha2_digest[1] = byte_swap_32 (tmp_ha2_digest[1]);
+  tmp_ha2_digest[2] = byte_swap_32 (tmp_ha2_digest[2]);
+  tmp_ha2_digest[3] = byte_swap_32 (tmp_ha2_digest[3]);
+
+  const int esalt_total_len = 1 + nonce_len + 1 + nc_len + 1 + cnonce_len + 1 + qop_len + 1 + 32;
+
+  if (esalt_total_len > 255) return (PARSER_SALT_LENGTH);
+
+  u8 *esalt_buf_ptr = (u8 *) digest_md5->esalt_buf;
+
+  int esalt_off = 0;
+
+  esalt_buf_ptr[esalt_off++] = ':';
+  memcpy (esalt_buf_ptr + esalt_off, nonce_pos, nonce_len);
+  esalt_off += nonce_len;
+  esalt_buf_ptr[esalt_off++] = ':';
+  memcpy (esalt_buf_ptr + esalt_off, nc_pos, nc_len);
+  esalt_off += nc_len;
+  esalt_buf_ptr[esalt_off++] = ':';
+  memcpy (esalt_buf_ptr + esalt_off, cnonce_pos, cnonce_len);
+  esalt_off += cnonce_len;
+  esalt_buf_ptr[esalt_off++] = ':';
+  memcpy (esalt_buf_ptr + esalt_off, qop_pos, qop_len);
+  esalt_off += qop_len;
+  esalt_buf_ptr[esalt_off++] = ':';
+
+  snprintf ((char *) esalt_buf_ptr + esalt_off, 33, "%08x%08x%08x%08x",
+    tmp_ha2_digest[0],
+    tmp_ha2_digest[1],
+    tmp_ha2_digest[2],
+    tmp_ha2_digest[3]);
+
+  digest_md5->esalt_len = esalt_total_len;
+
+  u8 *fake_salt_ptr = (u8 *) salt->salt_buf;
+
+  int fake_salt_len = nonce_len;
+
+  if (fake_salt_len > 55) fake_salt_len = 55;
+
+  memcpy (fake_salt_ptr, nonce_pos, fake_salt_len);
+
+  salt->salt_len = fake_salt_len;
+
+  digest[0] = hex_to_u32 (&response_pos[ 0]);
+  digest[1] = hex_to_u32 (&response_pos[ 8]);
+  digest[2] = hex_to_u32 (&response_pos[16]);
+  digest[3] = hex_to_u32 (&response_pos[24]);
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  return snprintf (line_buf, line_size, "%s", hash_info->orighash);
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/src/modules/module_61100.c
+++ b/src/modules/module_61100.c
@@ -1,0 +1,220 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 3;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 1;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_NETWORK_PROTOCOL;
+static const char *HASH_NAME      = "POP3 APOP";
+static const u64   KERN_TYPE      = 20;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_REGISTER_LIMIT
+                                  | OPTI_TYPE_PRECOMPUTE_INIT
+                                  | OPTI_TYPE_EARLY_SKIP
+                                  | OPTI_TYPE_NOT_ITERATED
+                                  | OPTI_TYPE_PREPENDED_SALT
+                                  | OPTI_TYPE_RAW_HASH;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_PT_ADD80
+                                  | OPTS_TYPE_PT_ADDBITS14;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$apop$<1234.1234567890@DESKTOP-RESPONDER>$2a4fe2feddb704ea75cd7c773509dcb0";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+static const char *SIGNATURE_APOP = "$apop$";
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt  = 3;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_APOP;
+
+  token.len[0]     = 6;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '$';
+  token.len_min[1] = 1;
+  token.len_max[1] = 128;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  token.len[2]     = 32;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  const u8 *hash_pos = token.buf[2];
+
+  digest[0] = hex_to_u32 (hash_pos +  0);
+  digest[1] = hex_to_u32 (hash_pos +  8);
+  digest[2] = hex_to_u32 (hash_pos + 16);
+  digest[3] = hex_to_u32 (hash_pos + 24);
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    digest[0] -= MD5M_A;
+    digest[1] -= MD5M_B;
+    digest[2] -= MD5M_C;
+    digest[3] -= MD5M_D;
+  }
+
+  const u8 *salt_pos = token.buf[1];
+  const int salt_len = token.len[1];
+
+  memcpy (salt->salt_buf, salt_pos, salt_len);
+
+  salt->salt_len = salt_len;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  u32 tmp[4];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = digest[2];
+  tmp[3] = digest[3];
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    tmp[0] += MD5M_A;
+    tmp[1] += MD5M_B;
+    tmp[2] += MD5M_C;
+    tmp[3] += MD5M_D;
+  }
+
+  const int out_len = snprintf (line_buf, line_size, "%s%.*s$%08x%08x%08x%08x",
+    SIGNATURE_APOP,
+    salt->salt_len,
+    (const char *) salt->salt_buf,
+    byte_swap_32 (tmp[0]),
+    byte_swap_32 (tmp[1]),
+    byte_swap_32 (tmp[2]),
+    byte_swap_32 (tmp[3]));
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_dictstat_disable         = MODULE_DEFAULT;
+  module_ctx->module_esalt_size               = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable        = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m61000.pm
+++ b/tools/test_modules/m61000.pm
@@ -1,0 +1,87 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::MD5 qw (md5 md5_hex);
+
+sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $realm = shift;
+  my $nonce = shift;
+  my $cnonce = shift;
+  my $nc = shift;
+  my $qop = shift;
+  my $uri = shift;
+  my $username = shift;
+
+  if (! defined $realm)
+  {
+    $realm    = "REALM-" . random_hex_string (6);
+    $nonce    = random_hex_string (28);
+    $cnonce   = random_hex_string (32);
+    $nc       = "00000001";
+    $qop      = "auth";
+    $uri      = "ldap/" . lc (random_hex_string (8)) . ".local";
+    $username = "user" . int (rand (9999));
+  }
+
+  my $ha2 = md5_hex ("AUTHENTICATE:" . $uri);
+
+  my $h_raw = md5 ($username . ":" . $realm . ":" . $word);
+
+  my $ha1 = md5_hex ($h_raw . ":" . $nonce . ":" . $cnonce);
+
+  my $response = md5_hex ($ha1 . ":" . $nonce . ":" . $nc . ":" . $cnonce . ":" . $qop . ":" . $ha2);
+
+  my $hash = sprintf ("\$sasl\$DIGEST-MD5\$%s\$%s\$%s\$%s\$%s\$%s\$%s\$%s",
+    $realm, $username, $nonce, $cnonce, $nc, $qop, $uri, $response);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless length ($word) gt 0;
+  return unless substr ($hash, 0, 6) eq '$sasl$';
+
+  my (undef, $sig, $subsig, $realm, $username, $nonce, $cnonce, $nc, $qop, $uri, $response) = split '\$', $hash;
+
+  return unless defined $sig;
+  return unless defined $subsig;
+  return unless defined $realm;
+  return unless defined $username;
+  return unless defined $nonce;
+  return unless defined $cnonce;
+  return unless defined $nc;
+  return unless defined $qop;
+  return unless defined $uri;
+  return unless defined $response;
+  return unless $subsig eq "DIGEST-MD5";
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, undef, $realm, $nonce, $cnonce, $nc, $qop, $uri, $username);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m61100.pm
+++ b/tools/test_modules/m61100.pm
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::MD5 qw (md5_hex);
+
+sub module_constraints { [[0, 256], [10, 128], [0, 55], [0, 55], [0, 55]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  if (! defined $salt)
+  {
+    my $pid  = int (rand (9999)) + 1;
+    my $time = int (rand (9999999999)) + 1000000000;
+    my $host = "RESPONDER-" . random_hex_string (6);
+
+    $salt = sprintf ("<%d.%d\@%s>", $pid, $time, $host);
+  }
+
+  my $digest = md5_hex ($salt . $word);
+
+  my $hash = sprintf ("\$apop\$%s\$%s", $salt, $digest);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless length ($word) gt 0;
+  return unless substr ($hash, 0, 6) eq '$apop$';
+
+  my (undef, $signature, $salt, $digest) = split '\$', $hash;
+
+  return unless defined $signature;
+  return unless defined $salt;
+  return unless defined $digest;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This PR adds 2 new algorithms, SASL DIGEST-MD5 as 61000, and POP3 APOP as 61100. Both modes will need to have their numbers reassigned to next available before merge.

Password is `hashcat` for both of the test hashes:

`$sasl$DIGEST-MD5$WORKGROUP$admin$OA9BSXrbuRhWay$YDgMb0MHFhY9LOl9Tg5hH4GD8JHF8MaZ$00000001$auth$ldap/dc01.workgroup.local$ce9c97bcd0f0bf9d00c456514496814f`

```
Status...........: Cracked
Hash.Mode........: 61000 (SASL DIGEST-MD5)
Hash.Target......: $sasl$DIGEST-MD5$WORKGROUP$admin$OA9BSXrbuRhWay$YDg...96814f
Time.Started.....: Wed Jun 10 01:46:42 2026 (0 secs)
Time.Estimated...: Wed Jun 10 01:46:42 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 0-256 bytes)
```

`$apop$<1234.1234567890@DESKTOP-RESPONDER>$2a4fe2feddb704ea75cd7c773509dcb0`
```
Status...........: Cracked
Hash.Mode........: 61100 (POP3 APOP)
Hash.Target......: $apop$<1234.1234567890@DESKTOP-RESPONDER>$2a4fe2fed...09dcb0
Time.Started.....: Wed Jun 10 01:39:56 2026 (0 secs)
Time.Estimated...: Wed Jun 10 01:39:56 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 0-256 bytes)
```

These kernels, specifically the SASL one, have a related change to Responder: https://github.com/lgandx/Responder/pull/342