### PR TITLE
Added hash-mode: LastPass Vault (Chrome IndexedDB)

### DIFF
--- a/OpenCL/m99000-pure.cl
+++ b/OpenCL/m99000-pure.cl
@@ -1,0 +1,575 @@
+/**
+ * Author......: Ben Carmitchel (Datarecovery.com)
+ * License.....: MIT
+ *
+ * LastPass Vault (Chrome IndexedDB) - kernel
+ *
+ *   key = PBKDF2-HMAC-SHA256(password, email.lower(), iterations, 32)
+ *   pt  = AES-256-CBC-Decrypt(verify_ct, key, iv)   // 2 blocks
+ *   match = PKCS7-valid(pt[16:32]) AND ASCII-printable(pt[0:16])
+ *
+ * On match, write the magic digest {0xdeadbeef, 0xfeedface,
+ * 0xcafebabe, 0xbaadf00d} via COMPARE_M_SCALAR.
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha256.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct lpvault
+{
+  u32 iv[4];
+  u32 ct[8];
+} lpvault_t;
+
+typedef struct pbkdf2_sha256_tmp
+{
+  u32 ipad[8];
+  u32 opad[8];
+
+  u32 dgst[8];
+  u32 out[8];
+
+} pbkdf2_sha256_tmp_t;
+
+// hmac_sha256_run_V - defined per-module in hashcat (not in a header).
+// Copied verbatim from m15600-pure.cl.
+DECLSPEC void hmac_sha256_run_V (PRIVATE_AS u32x *w0, PRIVATE_AS u32x *w1, PRIVATE_AS u32x *w2, PRIVATE_AS u32x *w3, PRIVATE_AS u32x *ipad, PRIVATE_AS u32x *opad, PRIVATE_AS u32x *digest)
+{
+  digest[0] = ipad[0];
+  digest[1] = ipad[1];
+  digest[2] = ipad[2];
+  digest[3] = ipad[3];
+  digest[4] = ipad[4];
+  digest[5] = ipad[5];
+  digest[6] = ipad[6];
+  digest[7] = ipad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+
+  w0[0] = digest[0];
+  w0[1] = digest[1];
+  w0[2] = digest[2];
+  w0[3] = digest[3];
+  w1[0] = digest[4];
+  w1[1] = digest[5];
+  w1[2] = digest[6];
+  w1[3] = digest[7];
+  w2[0] = 0x80000000;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = (64 + 32) * 8;
+
+  digest[0] = opad[0];
+  digest[1] = opad[1];
+  digest[2] = opad[2];
+  digest[3] = opad[3];
+  digest[4] = opad[4];
+  digest[5] = opad[5];
+  digest[6] = opad[6];
+  digest[7] = opad[7];
+
+  sha256_transform_vector (w0, w1, w2, w3, digest);
+}
+
+
+// ============================================================
+// _init - first HMAC iteration of PBKDF2
+// ============================================================
+KERNEL_FQ void m99000_init (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, lpvault_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  // HMAC-SHA256 init with password as key
+  sha256_hmac_ctx_t sha256_hmac_ctx;
+
+  sha256_hmac_init_global_swap (&sha256_hmac_ctx, pws[gid].i, pws[gid].pw_len);
+
+  // Save ipad / opad for reuse in _loop
+  tmps[gid].ipad[0] = sha256_hmac_ctx.ipad.h[0];
+  tmps[gid].ipad[1] = sha256_hmac_ctx.ipad.h[1];
+  tmps[gid].ipad[2] = sha256_hmac_ctx.ipad.h[2];
+  tmps[gid].ipad[3] = sha256_hmac_ctx.ipad.h[3];
+  tmps[gid].ipad[4] = sha256_hmac_ctx.ipad.h[4];
+  tmps[gid].ipad[5] = sha256_hmac_ctx.ipad.h[5];
+  tmps[gid].ipad[6] = sha256_hmac_ctx.ipad.h[6];
+  tmps[gid].ipad[7] = sha256_hmac_ctx.ipad.h[7];
+
+  tmps[gid].opad[0] = sha256_hmac_ctx.opad.h[0];
+  tmps[gid].opad[1] = sha256_hmac_ctx.opad.h[1];
+  tmps[gid].opad[2] = sha256_hmac_ctx.opad.h[2];
+  tmps[gid].opad[3] = sha256_hmac_ctx.opad.h[3];
+  tmps[gid].opad[4] = sha256_hmac_ctx.opad.h[4];
+  tmps[gid].opad[5] = sha256_hmac_ctx.opad.h[5];
+  tmps[gid].opad[6] = sha256_hmac_ctx.opad.h[6];
+  tmps[gid].opad[7] = sha256_hmac_ctx.opad.h[7];
+
+  // Append salt (the email, stored in standard salt_buf)
+  sha256_hmac_update_global_swap (&sha256_hmac_ctx, salt_bufs[SALT_POS_HOST].salt_buf, salt_bufs[SALT_POS_HOST].salt_len);
+
+  // Append PBKDF2 counter "1" as 4-byte big-endian, then finalize first HMAC
+  sha256_hmac_ctx_t sha256_hmac_ctx2 = sha256_hmac_ctx;
+
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
+
+  w0[0] = 1;
+  w0[1] = 0;
+  w0[2] = 0;
+  w0[3] = 0;
+  w1[0] = 0;
+  w1[1] = 0;
+  w1[2] = 0;
+  w1[3] = 0;
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
+
+  sha256_hmac_update_64 (&sha256_hmac_ctx2, w0, w1, w2, w3, 4);
+
+  sha256_hmac_final (&sha256_hmac_ctx2);
+
+  // First PBKDF2 round result goes into both dgst (loop input) and out (XOR accumulator)
+  tmps[gid].dgst[0] = sha256_hmac_ctx2.opad.h[0];
+  tmps[gid].dgst[1] = sha256_hmac_ctx2.opad.h[1];
+  tmps[gid].dgst[2] = sha256_hmac_ctx2.opad.h[2];
+  tmps[gid].dgst[3] = sha256_hmac_ctx2.opad.h[3];
+  tmps[gid].dgst[4] = sha256_hmac_ctx2.opad.h[4];
+  tmps[gid].dgst[5] = sha256_hmac_ctx2.opad.h[5];
+  tmps[gid].dgst[6] = sha256_hmac_ctx2.opad.h[6];
+  tmps[gid].dgst[7] = sha256_hmac_ctx2.opad.h[7];
+
+  tmps[gid].out[0] = tmps[gid].dgst[0];
+  tmps[gid].out[1] = tmps[gid].dgst[1];
+  tmps[gid].out[2] = tmps[gid].dgst[2];
+  tmps[gid].out[3] = tmps[gid].dgst[3];
+  tmps[gid].out[4] = tmps[gid].dgst[4];
+  tmps[gid].out[5] = tmps[gid].dgst[5];
+  tmps[gid].out[6] = tmps[gid].dgst[6];
+  tmps[gid].out[7] = tmps[gid].dgst[7];
+}
+
+
+// ============================================================
+// _loop - main PBKDF2 iteration loop (called multiple times,
+//         total iterations = salt->salt_iter + 1, minus the
+//         first one done in _init)
+// ============================================================
+KERNEL_FQ void m99000_loop (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, lpvault_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if ((gid * VECT_SIZE) >= GID_CNT) return;
+
+  u32x ipad[8];
+  u32x opad[8];
+
+  ipad[0] = packv (tmps, ipad, gid, 0);
+  ipad[1] = packv (tmps, ipad, gid, 1);
+  ipad[2] = packv (tmps, ipad, gid, 2);
+  ipad[3] = packv (tmps, ipad, gid, 3);
+  ipad[4] = packv (tmps, ipad, gid, 4);
+  ipad[5] = packv (tmps, ipad, gid, 5);
+  ipad[6] = packv (tmps, ipad, gid, 6);
+  ipad[7] = packv (tmps, ipad, gid, 7);
+
+  opad[0] = packv (tmps, opad, gid, 0);
+  opad[1] = packv (tmps, opad, gid, 1);
+  opad[2] = packv (tmps, opad, gid, 2);
+  opad[3] = packv (tmps, opad, gid, 3);
+  opad[4] = packv (tmps, opad, gid, 4);
+  opad[5] = packv (tmps, opad, gid, 5);
+  opad[6] = packv (tmps, opad, gid, 6);
+  opad[7] = packv (tmps, opad, gid, 7);
+
+  u32x dgst[8];
+  u32x out[8];
+
+  dgst[0] = packv (tmps, dgst, gid, 0);
+  dgst[1] = packv (tmps, dgst, gid, 1);
+  dgst[2] = packv (tmps, dgst, gid, 2);
+  dgst[3] = packv (tmps, dgst, gid, 3);
+  dgst[4] = packv (tmps, dgst, gid, 4);
+  dgst[5] = packv (tmps, dgst, gid, 5);
+  dgst[6] = packv (tmps, dgst, gid, 6);
+  dgst[7] = packv (tmps, dgst, gid, 7);
+
+  out[0] = packv (tmps, out, gid, 0);
+  out[1] = packv (tmps, out, gid, 1);
+  out[2] = packv (tmps, out, gid, 2);
+  out[3] = packv (tmps, out, gid, 3);
+  out[4] = packv (tmps, out, gid, 4);
+  out[5] = packv (tmps, out, gid, 5);
+  out[6] = packv (tmps, out, gid, 6);
+  out[7] = packv (tmps, out, gid, 7);
+
+  for (u32 j = 0; j < LOOP_CNT; j++)
+  {
+    u32x w0[4];
+    u32x w1[4];
+    u32x w2[4];
+    u32x w3[4];
+
+    w0[0] = dgst[0];
+    w0[1] = dgst[1];
+    w0[2] = dgst[2];
+    w0[3] = dgst[3];
+    w1[0] = dgst[4];
+    w1[1] = dgst[5];
+    w1[2] = dgst[6];
+    w1[3] = dgst[7];
+    w2[0] = 0x80000000;
+    w2[1] = 0;
+    w2[2] = 0;
+    w2[3] = 0;
+    w3[0] = 0;
+    w3[1] = 0;
+    w3[2] = 0;
+    w3[3] = (64 + 32) * 8;
+
+    hmac_sha256_run_V (w0, w1, w2, w3, ipad, opad, dgst);
+
+    out[0] ^= dgst[0];
+    out[1] ^= dgst[1];
+    out[2] ^= dgst[2];
+    out[3] ^= dgst[3];
+    out[4] ^= dgst[4];
+    out[5] ^= dgst[5];
+    out[6] ^= dgst[6];
+    out[7] ^= dgst[7];
+  }
+
+  unpackv (tmps, dgst, gid, 0, dgst[0]);
+  unpackv (tmps, dgst, gid, 1, dgst[1]);
+  unpackv (tmps, dgst, gid, 2, dgst[2]);
+  unpackv (tmps, dgst, gid, 3, dgst[3]);
+  unpackv (tmps, dgst, gid, 4, dgst[4]);
+  unpackv (tmps, dgst, gid, 5, dgst[5]);
+  unpackv (tmps, dgst, gid, 6, dgst[6]);
+  unpackv (tmps, dgst, gid, 7, dgst[7]);
+
+  unpackv (tmps, out, gid, 0, out[0]);
+  unpackv (tmps, out, gid, 1, out[1]);
+  unpackv (tmps, out, gid, 2, out[2]);
+  unpackv (tmps, out, gid, 3, out[3]);
+  unpackv (tmps, out, gid, 4, out[4]);
+  unpackv (tmps, out, gid, 5, out[5]);
+  unpackv (tmps, out, gid, 6, out[6]);
+  unpackv (tmps, out, gid, 7, out[7]);
+}
+
+
+// ============================================================
+// _comp - take derived key, AES-256-CBC decrypt 2 blocks of esalt
+//         ciphertext, verify PKCS7 + ASCII printable, write magic
+//         if matched
+// ============================================================
+KERNEL_FQ void m99000_comp (KERN_ATTR_TMPS_ESALT (pbkdf2_sha256_tmp_t, lpvault_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  // Load AES tables into local memory.
+  // CRITICAL: This must happen BEFORE the gid >= GID_CNT early-return so that
+  // all threads in the workgroup participate. Otherwise with few candidates,
+  // most threads exit before loading and the tables end up mostly zeros.
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+  }
+
+  SYNC_THREADS ();
+
+  if (gid >= GID_CNT) return;
+
+  // ========================================================================
+  // Inline AES-256 implementation - bypasses hashcat AES library functions
+  // which fail to populate the middle key schedule in this kernel context.
+  // Convention: u32s use BIG-ENDIAN byte order (byte 0 = high bits).
+  // ========================================================================
+
+  // -- Load key (8 u32s) directly from PBKDF2 output, no byte_swap.
+  // SHA256 already produces BE form which is what AES wants.
+  u32 key[8];
+  key[0] = tmps[gid].out[0];
+  key[1] = tmps[gid].out[1];
+  key[2] = tmps[gid].out[2];
+  key[3] = tmps[gid].out[3];
+  key[4] = tmps[gid].out[4];
+  key[5] = tmps[gid].out[5];
+  key[6] = tmps[gid].out[6];
+  key[7] = tmps[gid].out[7];
+
+  // -- Key expansion: produce 60-u32 encryption schedule
+  u32 ks[60];
+
+  ks[0] = key[0]; ks[1] = key[1]; ks[2] = key[2]; ks[3] = key[3];
+  ks[4] = key[4]; ks[5] = key[5]; ks[6] = key[6]; ks[7] = key[7];
+
+  const u32 rcon[7] = {0x01000000, 0x02000000, 0x04000000, 0x08000000,
+                       0x10000000, 0x20000000, 0x40000000};
+
+  for (u32 i = 8; i < 60; i++)
+  {
+    u32 t = ks[i - 1];
+
+    if ((i & 7) == 0)
+    {
+      // RotWord: rotate bytes left by 1 (in BE u32: byte0 moves to byte3)
+      t = (t << 8) | (t >> 24);
+      // SubWord: extract s[x] from s_te0[x] via (val >> 16) & 0xff.
+      // s_te0[x] = (s[x]*2, s[x], s[x], s[x]*3) in BE byte order, so byte 1 = s[x].
+      u32 b3 = (s_te0[(t >> 24) & 0xff] >> 16) & 0xff;
+      u32 b2 = (s_te0[(t >> 16) & 0xff] >> 16) & 0xff;
+      u32 b1 = (s_te0[(t >>  8) & 0xff] >> 16) & 0xff;
+      u32 b0 = (s_te0[(t >>  0) & 0xff] >> 16) & 0xff;
+      t = (b3 << 24) | (b2 << 16) | (b1 << 8) | b0;
+      t ^= rcon[(i >> 3) - 1];
+    }
+    else if ((i & 7) == 4)
+    {
+      // SubWord only
+      u32 b3 = (s_te0[(t >> 24) & 0xff] >> 16) & 0xff;
+      u32 b2 = (s_te0[(t >> 16) & 0xff] >> 16) & 0xff;
+      u32 b1 = (s_te0[(t >>  8) & 0xff] >> 16) & 0xff;
+      u32 b0 = (s_te0[(t >>  0) & 0xff] >> 16) & 0xff;
+      t = (b3 << 24) | (b2 << 16) | (b1 << 8) | b0;
+    }
+
+    ks[i] = ks[i - 8] ^ t;
+  }
+
+  // Apply InvMixColumns to middle round keys ks[4..55] to convert the
+  // encryption schedule into the Equivalent Inverse Cipher schedule. This
+  // lets us use td0..td3 T-tables (which combine InvSubBytes+InvShiftRows+
+  // InvMixColumns) with simple round-key XOR in the decrypt loop.
+  //
+  // Trick: td0[s[x]] = (x*0x0e, x*0x09, x*0x0d, x*0x0b) since sinv(s(x))=x.
+  // So InvMixColumns(b0,b1,b2,b3) = td0[s[b0]] ^ td1[s[b1]] ^ td2[s[b2]] ^ td3[s[b3]].
+  for (u32 i = 4; i < 56; i++)
+  {
+    u32 v = ks[i];
+    u32 b0 = (v >> 24) & 0xff;
+    u32 b1 = (v >> 16) & 0xff;
+    u32 b2 = (v >>  8) & 0xff;
+    u32 b3 =  v        & 0xff;
+
+    // s[x] via s_te0 (byte 1 in BE position = s[x])
+    u32 sb0 = (s_te0[b0] >> 16) & 0xff;
+    u32 sb1 = (s_te0[b1] >> 16) & 0xff;
+    u32 sb2 = (s_te0[b2] >> 16) & 0xff;
+    u32 sb3 = (s_te0[b3] >> 16) & 0xff;
+
+    ks[i] = s_td0[sb0] ^ s_td1[sb1] ^ s_td2[sb2] ^ s_td3[sb3];
+  }
+
+  // -- Load IV and ciphertext (BE form already, no swap)
+  u32 iv[4];
+  iv[0] = esalt_bufs[DIGESTS_OFFSET_HOST].iv[0];
+  iv[1] = esalt_bufs[DIGESTS_OFFSET_HOST].iv[1];
+  iv[2] = esalt_bufs[DIGESTS_OFFSET_HOST].iv[2];
+  iv[3] = esalt_bufs[DIGESTS_OFFSET_HOST].iv[3];
+
+  u32 ct1[4];
+  ct1[0] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[0];
+  ct1[1] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[1];
+  ct1[2] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[2];
+  ct1[3] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[3];
+
+  u32 ct2[4];
+  ct2[0] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[4];
+  ct2[1] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[5];
+  ct2[2] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[6];
+  ct2[3] = esalt_bufs[DIGESTS_OFFSET_HOST].ct[7];
+
+  // ========================================================================
+  // AES-256 inverse cipher (decrypt) for block 1
+  // ========================================================================
+  u32 s0, s1, s2, s3, t0, t1, t2, t3;
+
+  // Initial: state = ct XOR ks[56..59] (last encrypt round key)
+  s0 = ct1[0] ^ ks[56];
+  s1 = ct1[1] ^ ks[57];
+  s2 = ct1[2] ^ ks[58];
+  s3 = ct1[3] ^ ks[59];
+
+  // 13 middle rounds (descending key schedule order)
+  for (int r = 13; r >= 1; r--)
+  {
+    t0 = s_td0[(s0 >> 24) & 0xff] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[r*4 + 0];
+    t1 = s_td0[(s1 >> 24) & 0xff] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[r*4 + 1];
+    t2 = s_td0[(s2 >> 24) & 0xff] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[r*4 + 2];
+    t3 = s_td0[(s3 >> 24) & 0xff] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[r*4 + 3];
+    s0 = t0; s1 = t1; s2 = t2; s3 = t3;
+  }
+
+  // Final round: InvShiftRows + InvSubBytes + AddRoundKey (no InvMixColumns)
+  // Use s_td4 for inverse S-box. Extract sinv[x] via low byte of entry to be
+  // robust to whether td4 is broadcast or single-byte form.
+  u32 pt1[4];
+  {
+    u32 a0 = s_td4[(s0 >> 24) & 0xff] & 0xff;
+    u32 a1 = s_td4[(s3 >> 16) & 0xff] & 0xff;
+    u32 a2 = s_td4[(s2 >>  8) & 0xff] & 0xff;
+    u32 a3 = s_td4[ s1        & 0xff] & 0xff;
+    pt1[0] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[0];
+
+    a0 = s_td4[(s1 >> 24) & 0xff] & 0xff;
+    a1 = s_td4[(s0 >> 16) & 0xff] & 0xff;
+    a2 = s_td4[(s3 >>  8) & 0xff] & 0xff;
+    a3 = s_td4[ s2        & 0xff] & 0xff;
+    pt1[1] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[1];
+
+    a0 = s_td4[(s2 >> 24) & 0xff] & 0xff;
+    a1 = s_td4[(s1 >> 16) & 0xff] & 0xff;
+    a2 = s_td4[(s0 >>  8) & 0xff] & 0xff;
+    a3 = s_td4[ s3        & 0xff] & 0xff;
+    pt1[2] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[2];
+
+    a0 = s_td4[(s3 >> 24) & 0xff] & 0xff;
+    a1 = s_td4[(s2 >> 16) & 0xff] & 0xff;
+    a2 = s_td4[(s1 >>  8) & 0xff] & 0xff;
+    a3 = s_td4[ s0        & 0xff] & 0xff;
+    pt1[3] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[3];
+  }
+
+  // CBC: XOR with IV for block 1
+  pt1[0] ^= iv[0];
+  pt1[1] ^= iv[1];
+  pt1[2] ^= iv[2];
+  pt1[3] ^= iv[3];
+
+  // ========================================================================
+  // AES-256 inverse cipher for block 2
+  // ========================================================================
+  s0 = ct2[0] ^ ks[56];
+  s1 = ct2[1] ^ ks[57];
+  s2 = ct2[2] ^ ks[58];
+  s3 = ct2[3] ^ ks[59];
+
+  for (int r = 13; r >= 1; r--)
+  {
+    t0 = s_td0[(s0 >> 24) & 0xff] ^ s_td1[(s3 >> 16) & 0xff] ^ s_td2[(s2 >>  8) & 0xff] ^ s_td3[s1 & 0xff] ^ ks[r*4 + 0];
+    t1 = s_td0[(s1 >> 24) & 0xff] ^ s_td1[(s0 >> 16) & 0xff] ^ s_td2[(s3 >>  8) & 0xff] ^ s_td3[s2 & 0xff] ^ ks[r*4 + 1];
+    t2 = s_td0[(s2 >> 24) & 0xff] ^ s_td1[(s1 >> 16) & 0xff] ^ s_td2[(s0 >>  8) & 0xff] ^ s_td3[s3 & 0xff] ^ ks[r*4 + 2];
+    t3 = s_td0[(s3 >> 24) & 0xff] ^ s_td1[(s2 >> 16) & 0xff] ^ s_td2[(s1 >>  8) & 0xff] ^ s_td3[s0 & 0xff] ^ ks[r*4 + 3];
+    s0 = t0; s1 = t1; s2 = t2; s3 = t3;
+  }
+
+  u32 pt2[4];
+  {
+    u32 a0 = s_td4[(s0 >> 24) & 0xff] & 0xff;
+    u32 a1 = s_td4[(s3 >> 16) & 0xff] & 0xff;
+    u32 a2 = s_td4[(s2 >>  8) & 0xff] & 0xff;
+    u32 a3 = s_td4[ s1        & 0xff] & 0xff;
+    pt2[0] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[0];
+
+    a0 = s_td4[(s1 >> 24) & 0xff] & 0xff;
+    a1 = s_td4[(s0 >> 16) & 0xff] & 0xff;
+    a2 = s_td4[(s3 >>  8) & 0xff] & 0xff;
+    a3 = s_td4[ s2        & 0xff] & 0xff;
+    pt2[1] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[1];
+
+    a0 = s_td4[(s2 >> 24) & 0xff] & 0xff;
+    a1 = s_td4[(s1 >> 16) & 0xff] & 0xff;
+    a2 = s_td4[(s0 >>  8) & 0xff] & 0xff;
+    a3 = s_td4[ s3        & 0xff] & 0xff;
+    pt2[2] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[2];
+
+    a0 = s_td4[(s3 >> 24) & 0xff] & 0xff;
+    a1 = s_td4[(s2 >> 16) & 0xff] & 0xff;
+    a2 = s_td4[(s1 >>  8) & 0xff] & 0xff;
+    a3 = s_td4[ s0        & 0xff] & 0xff;
+    pt2[3] = ((a0 << 24) | (a1 << 16) | (a2 << 8) | a3) ^ ks[3];
+  }
+
+  // CBC: XOR with previous ciphertext block (ct1) for block 2
+  pt2[0] ^= ct1[0];
+  pt2[1] ^= ct1[1];
+  pt2[2] ^= ct1[2];
+  pt2[3] ^= ct1[3];
+
+  // ========================================================================
+  // Verification (BE byte order: byte n is at (3 - n%4)*8 of u32)
+  // ========================================================================
+  // Block 2 PKCS7 check: last byte = pad value (1..16), and pad bytes match
+  const u32 pad = pt2[3] & 0xff;  // byte 15 (last byte in BE = low bits)
+
+  u32 ok_pkcs7 = (pad >= 1) & (pad <= 16);
+
+  for (u32 n = 0; n < 16; n++)
+  {
+    const u32 byte_val = (pt2[n / 4] >> ((3 - (n % 4)) * 8)) & 0xff;
+    const u32 should_match = (n >= (16 - pad));
+    const u32 matches = (byte_val == pad);
+    ok_pkcs7 &= (!should_match) | matches;
+  }
+
+  // Block 1 ASCII-printable check: every byte in 0x20..0x7E
+  u32 ok_ascii = 1;
+
+  for (u32 n = 0; n < 16; n++)
+  {
+    const u32 byte_val = (pt1[n / 4] >> ((3 - (n % 4)) * 8)) & 0xff;
+    ok_ascii &= (byte_val >= 0x20) & (byte_val <= 0x7E);
+  }
+
+  const u32 verified = ok_pkcs7 & ok_ascii;
+
+  // Write magic digest only on verification success
+  const u32 r0 = verified ? 0xdeadbeef : 0;
+  const u32 r1 = verified ? 0xfeedface : 0;
+  const u32 r2 = verified ? 0xcafebabe : 0;
+  const u32 r3 = verified ? 0xbaadf00d : 0;
+
+  #define il_pos 0
+
+  #include COMPARE_M
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -23,6 +23,7 @@ Docker: Add hashcat-toolchain
 
 - Added hash-mode: Generic Hash [Bridged: Rust] with the new Rust Bridge
 - Added hash-mode: Besder Authentication MD5
+- Added hash-mode: LastPass Vault (Chrome IndexedDB)
 
 ##
 ## Improvements

--- a/src/modules/module_99000.c
+++ b/src/modules/module_99000.c
@@ -1,0 +1,321 @@
+/**
+ * Author......: Ben Carmitchel (Datarecovery.com)
+ * License.....: MIT
+ *
+ * LastPass Vault (Chrome IndexedDB) — local vault decryption oracle
+ *
+ * Hash format:
+ *   $lpvault$0$<iterations>$<email>$<iv_hex>$<verify_ct_hex>
+ *
+ * Algorithm:
+ *   key = PBKDF2-HMAC-SHA256(password, email.lower(), iterations, 32)
+ *   pt  = AES-256-CBC-Decrypt(verify_ct, key, iv)
+ *   if PKCS7(pt[16:32]) && printable_ascii(pt[0:16]) then MATCH
+ *
+ * The verification ciphertext is field 7 (username) of the first ACCT
+ * chunk in the local LastPass vault. Exactly 2 AES blocks (32 bytes).
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "memory.h"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PASSWORD_MANAGER;
+static const char *HASH_NAME      = "LastPass Vault (Chrome IndexedDB)";
+static const u64   KERN_TYPE      = 99000;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP
+                                  | OPTI_TYPE_USES_BITS_64;
+static const u64   OPTS_TYPE      = OPTS_TYPE_PT_GENERATE_LE;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$lpvault$0$5000$test@hashcat.net$0102030405060708090a0b0c0d0e0f10$253f9eb1020fb7f1be5fc63ddb1e13f4d23cba2f1cfcbc1c1febadab58eb71fa";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+/*
+ * Per-hash extended salt:
+ *   - iv:  16 bytes of AES-CBC IV
+ *   - ct:  32 bytes of ciphertext (2 CBC blocks) we'll try to decrypt
+ */
+typedef struct lpvault
+{
+  u32 iv[4];
+  u32 ct[8];
+} lpvault_t;
+
+/*
+ * Temporary state shared between kernel passes for PBKDF2-HMAC-SHA256.
+ * Same layout as Bitwarden (23400) and the generic PBKDF2-SHA256 modes.
+ */
+typedef struct pbkdf2_sha256_tmp
+{
+  u32 ipad[8];
+  u32 opad[8];
+
+  u32 dgst[8];
+  u32 out[8];
+
+} pbkdf2_sha256_tmp_t;
+
+static const char *SIGNATURE_LPVAULT = "$lpvault$";
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (lpvault_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (pbkdf2_sha256_tmp_t);
+
+  return tmp_size;
+}
+
+u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  // PBKDF2-HMAC-SHA256 with SHA256 block size of 64 bytes —
+  // when password > 64 it gets pre-hashed, so we cap at 256 for sanity.
+  const u32 pw_max = 256;
+
+  return pw_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  lpvault_t *lpvault = (lpvault_t *) esalt_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt = 6;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_LPVAULT;
+
+  // [0] "$lpvault$" signature - no separator before it, length includes both $
+  token.len[0]  = 9;             // strlen("$lpvault$")
+  token.attr[0] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  // [1] format version (single digit)
+  token.sep[1]  = '$';
+  token.len[1]  = 1;
+  token.attr[1] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // [2] iterations
+  token.sep[2]     = '$';
+  token.len_min[2] = 1;
+  token.len_max[2] = 8;
+  token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // [3] email (PBKDF2 salt)
+  token.sep[3]     = '$';
+  token.len_min[3] = 3;
+  token.len_max[3] = 64;
+  token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH;
+
+  // [4] IV (16 bytes hex)
+  token.sep[4]  = '$';
+  token.len[4]  = 32;
+  token.attr[4] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_HEX;
+
+  // [5] verification ciphertext (32 bytes hex = 2 CBC blocks)
+  token.sep[5]  = '$';
+  token.len[5]  = 64;
+  token.attr[5] = TOKEN_ATTR_FIXED_LENGTH
+                | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // --- format version (must be '0') ---
+  const u8 *version_pos = token.buf[1];
+  if (version_pos[0] != '0') return (PARSER_SIGNATURE_UNMATCHED);
+
+  // --- iterations ---
+  const u8 *iter_pos = token.buf[2];
+
+  const u32 iter = hc_strtoul ((const char *) iter_pos, NULL, 10);
+
+  if (iter < 1) return (PARSER_SALT_ITERATION);
+
+  salt->salt_iter = iter - 1;
+
+  // --- email (salt) ---
+  const u8 *email_pos = token.buf[3];
+  const int email_len = token.len[3];
+
+  memcpy ((u8 *) salt->salt_buf, email_pos, email_len);
+
+  salt->salt_len = email_len;
+
+  // --- IV (16 bytes hex -> 4 x u32) ---
+  const u8 *iv_pos = token.buf[4];
+
+  for (int i = 0, j = 0; i < 4; i += 1, j += 8)
+  {
+    lpvault->iv[i] = hex_to_u32 (iv_pos + j);
+
+    lpvault->iv[i] = byte_swap_32 (lpvault->iv[i]);
+  }
+
+  // --- verification ciphertext (32 bytes hex -> 8 x u32) ---
+  const u8 *ct_pos = token.buf[5];
+
+  for (int i = 0, j = 0; i < 8; i += 1, j += 8)
+  {
+    lpvault->ct[i] = hex_to_u32 (ct_pos + j);
+
+    lpvault->ct[i] = byte_swap_32 (lpvault->ct[i]);
+  }
+
+  /*
+   * Synthetic digest. The kernel writes this magic value via
+   * COMPARE_M_SCALAR only when verification succeeds.
+   */
+  digest[0] = 0xdeadbeef;
+  digest[1] = 0xfeedface;
+  digest[2] = 0xcafebabe;
+  digest[3] = 0xbaadf00d;
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const lpvault_t *lpvault = (const lpvault_t *) esalt_buf;
+
+  // Reconstruct big-endian hex for IV and ciphertext
+  u32 iv_be[4];
+  for (int i = 0; i < 4; i++) iv_be[i] = byte_swap_32 (lpvault->iv[i]);
+
+  u32 ct_be[8];
+  for (int i = 0; i < 8; i++) ct_be[i] = byte_swap_32 (lpvault->ct[i]);
+
+  const int line_len = snprintf (line_buf, line_size,
+    "%s0$%u$%s$%08x%08x%08x%08x$%08x%08x%08x%08x%08x%08x%08x%08x",
+    SIGNATURE_LPVAULT,
+    salt->salt_iter + 1,
+    (char *) salt->salt_buf,
+    iv_be[0], iv_be[1], iv_be[2], iv_be[3],
+    ct_be[0], ct_be[1], ct_be[2], ct_be[3],
+    ct_be[4], ct_be[5], ct_be[6], ct_be[7]);
+
+  return line_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size              = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version         = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec               = module_attack_exec;
+  module_ctx->module_benchmark_esalt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name               = MODULE_DEFAULT;
+  module_ctx->module_bridge_type               = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt       = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask            = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset         = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt            = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess   = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel          = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice         = MODULE_DEFAULT;
+  module_ctx->module_usage_notice              = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                 = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                 = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                 = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                 = module_dgst_pos3;
+  module_ctx->module_dgst_size                 = module_dgst_size;
+  module_ctx->module_dictstat_disable          = MODULE_DEFAULT;
+  module_ctx->module_esalt_size                = module_esalt_size;
+  module_ctx->module_extra_buffer_size         = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size            = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block      = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format     = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count         = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse         = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save          = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess   = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile       = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash     = MODULE_DEFAULT;
+  module_ctx->module_hash_decode               = module_hash_decode;
+  module_ctx->module_hash_encode_status        = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode               = module_hash_encode;
+  module_ctx->module_hash_init_selftest        = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                 = MODULE_DEFAULT;
+  module_ctx->module_hash_category             = module_hash_category;
+  module_ctx->module_hash_name                 = module_hash_name;
+  module_ctx->module_hashes_count_min          = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max          = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable             = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size     = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init     = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term     = MODULE_DEFAULT;
+  module_ctx->module_hook12                    = MODULE_DEFAULT;
+  module_ctx->module_hook23                    = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size            = MODULE_DEFAULT;
+  module_ctx->module_hook_size                 = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options         = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max          = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min          = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max          = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min          = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max        = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min        = MODULE_DEFAULT;
+  module_ctx->module_kern_type                 = module_kern_type;
+  module_ctx->module_kern_type_dynamic         = MODULE_DEFAULT;
+  module_ctx->module_opti_type                 = module_opti_type;
+  module_ctx->module_opts_type                 = module_opts_type;
+  module_ctx->module_outfile_check_disable     = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp      = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check      = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable           = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes   = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column             = MODULE_DEFAULT;
+  module_ctx->module_pw_max                    = module_pw_max;
+  module_ctx->module_pw_min                    = MODULE_DEFAULT;
+  module_ctx->module_salt_max                  = MODULE_DEFAULT;
+  module_ctx->module_salt_min                  = MODULE_DEFAULT;
+  module_ctx->module_salt_type                 = module_salt_type;
+  module_ctx->module_separator                 = MODULE_DEFAULT;
+  module_ctx->module_st_hash                   = module_st_hash;
+  module_ctx->module_st_pass                   = module_st_pass;
+  module_ctx->module_tmp_size                  = module_tmp_size;
+  module_ctx->module_unstable_warning          = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable            = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m99000.pm
+++ b/tools/test_modules/m99000.pm
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+
+##
+## Author......: Datarecovery.com
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Crypt::PBKDF2;
+use Crypt::Mode::CBC;
+
+sub module_constraints { [[8, 30], [6, 64], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $iter = shift // 5000;
+  my $iv   = shift;
+  my $ct   = shift;
+
+  # Derive 32-byte key via PBKDF2-HMAC-SHA256
+  my $pbkdf2 = Crypt::PBKDF2->new (
+    hash_class => 'HMACSHA2',
+    hash_args  => { sha_size => 256 },
+    iterations => $iter,
+    output_len => 32,
+  );
+
+  my $key = $pbkdf2->PBKDF2 ($salt, $word);
+
+  # If no IV/CT provided, generate them by encrypting a known test plaintext
+  if (! defined $iv || ! defined $ct)
+  {
+    $iv = pack ('H*', '0102030405060708090a0b0c0d0e0f10');
+
+    my $pt = "TESTVECTOR______TESTPAD!" . (chr (8) x 8);
+
+    my $cbc = Crypt::Mode::CBC->new ('AES', 0);
+
+    $ct = $cbc->encrypt ($pt, $key, $iv);
+  }
+
+  my $iv_hex = unpack ('H*', $iv);
+  my $ct_hex = unpack ('H*', substr ($ct, 0, 32));
+
+  my $hash = sprintf ('$lpvault$0$%u$%s$%s$%s', $iter, $salt, $iv_hex, $ct_hex);
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @parts = split (/\$/, $hash);
+
+  return unless scalar @parts == 7;
+  return unless $parts[1] eq 'lpvault';
+  return unless $parts[2] eq '0';
+
+  my $iter = $parts[3];
+  my $salt = $parts[4];
+  my $iv   = pack ('H*', $parts[5]);
+  my $ct   = pack ('H*', $parts[6]);
+
+  my $word_packed = pack ('a*', $word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $iter, $iv, $ct);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
This plugin recovers a LastPass master password from the Chrome extension's local IndexedDB SQLite file (`chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0`), without requiring server contact.

The verification format is:

```
$lpvault$0$<iterations>$<email>$<iv_hex>$<verify_ct_hex>
```

Where:
- `iterations`: PBKDF2 iteration count from the LastPass vault metadata
- `email`: Account email (used as the PBKDF2 salt, lowercased)
- `iv_hex`: 16-byte AES-CBC IV from the first ACCT chunk's username field (hex)
- `verify_ct_hex`: 32 bytes (2 AES blocks) of ciphertext from the same field (hex)

The kernel:
1. Derives a 32-byte key via PBKDF2-HMAC-SHA256(password, email, iterations)
2. Decrypts the two-block verification ciphertext via AES-256-CBC
3. Verifies via PKCS7 padding validity + ASCII-printable check on block 1

Existing mode 6800 (LastPass + LastPass sniffed) does not cover this case because it requires the server-side auth hash, which isn't stored locally.

Test vector included in `tools/test_modules/m99000.pm` (password: `hashcat`).

Speed on RTX 4090 at 5000 iterations: ~1.7 MH/s.

Note: the kernel deliberately places the T-table loading loop **before** the `if (gid >= GID_CNT) return;` early-return so all workgroup threads participate in loading. With small candidate counts (e.g. self-tests), placing the load after the early-return causes most threads to exit and only one entry of each table to be populated — producing silently wrong AES output.