### PR TITLE
Fix title separator class rule parity

### DIFF
--- a/src/rp_cpu.c
+++ b/src/rp_cpu.c
@@ -753,26 +753,17 @@ static int mangle_title_sep_class_l (char arr[RP_PASSWORD_SIZE], int arr_len)
 
   for (int pos = 0; pos < arr_len; pos++)
   {
-    if (class_lower (arr[pos]))
+    const int upper = upper_next;
+
+    upper_next = class_lower (arr[pos]);
+
+    MANGLE_LOWER_AT (arr, pos);
+
+    if (upper)
     {
-      upper_next = 1;
-
-      continue;
-    }
-
-    if (upper_next)
-    {
-      upper_next = 0;
-
       MANGLE_UPPER_AT (arr, pos);
     }
-    else
-    {
-      MANGLE_LOWER_AT (arr, pos);
-    }
   }
-
-  MANGLE_UPPER_AT (arr, 0);
 
   return arr_len;
 }
@@ -783,26 +774,17 @@ static int mangle_title_sep_class_u (char arr[RP_PASSWORD_SIZE], int arr_len)
 
   for (int pos = 0; pos < arr_len; pos++)
   {
-    if (class_upper (arr[pos]))
+    const int upper = upper_next;
+
+    upper_next = class_upper (arr[pos]);
+
+    MANGLE_LOWER_AT (arr, pos);
+
+    if (upper)
     {
-      upper_next = 1;
-
-      continue;
-    }
-
-    if (upper_next)
-    {
-      upper_next = 0;
-
       MANGLE_UPPER_AT (arr, pos);
     }
-    else
-    {
-      MANGLE_LOWER_AT (arr, pos);
-    }
   }
-
-  MANGLE_UPPER_AT (arr, 0);
 
   return arr_len;
 }
@@ -843,26 +825,17 @@ static int mangle_title_sep_class_lh (char arr[RP_PASSWORD_SIZE], int arr_len)
 
   for (int pos = 0; pos < arr_len; pos++)
   {
-    if (class_lower_hex (arr[pos]))
+    const int upper = upper_next;
+
+    upper_next = class_lower_hex (arr[pos]);
+
+    MANGLE_LOWER_AT (arr, pos);
+
+    if (upper)
     {
-      upper_next = 1;
-
-      continue;
-    }
-
-    if (upper_next)
-    {
-      upper_next = 0;
-
       MANGLE_UPPER_AT (arr, pos);
     }
-    else
-    {
-      MANGLE_LOWER_AT (arr, pos);
-    }
   }
-
-  MANGLE_UPPER_AT (arr, 0);
 
   return arr_len;
 }
@@ -873,26 +846,17 @@ static int mangle_title_sep_class_uh (char arr[RP_PASSWORD_SIZE], int arr_len)
 
   for (int pos = 0; pos < arr_len; pos++)
   {
-    if (class_upper_hex (arr[pos]))
+    const int upper = upper_next;
+
+    upper_next = class_upper_hex (arr[pos]);
+
+    MANGLE_LOWER_AT (arr, pos);
+
+    if (upper)
     {
-      upper_next = 1;
-
-      continue;
-    }
-
-    if (upper_next)
-    {
-      upper_next = 0;
-
       MANGLE_UPPER_AT (arr, pos);
     }
-    else
-    {
-      MANGLE_LOWER_AT (arr, pos);
-    }
   }
-
-  MANGLE_UPPER_AT (arr, 0);
 
   return arr_len;
 }

--- a/tools/rules-test-cases.yaml
+++ b/tools/rules-test-cases.yaml
@@ -914,3 +914,43 @@ e-:
     A-Bc
     Ab-C
     Abc
+
+'~e?l':
+  input: |
+    p@ssW0rd
+
+  expected_cpu: |
+    P@sSW0rD
+
+  expected_opencl: |
+    P@sSW0rD
+
+'~e?u':
+  input: |
+    hAShcAt
+
+  expected_cpu: |
+    HaSHcaT
+
+  expected_opencl: |
+    HaSHcaT
+
+'~e?h':
+  input: |
+    aGbcD
+
+  expected_cpu: |
+    AGbCD
+
+  expected_opencl: |
+    AGbCD
+
+'~e?H':
+  input: |
+    abCDefGHij
+
+  expected_cpu: |
+    AbcDEfghij
+
+  expected_opencl: |
+    AbcDEfghij


### PR DESCRIPTION
Fix inconsistent behavior of the ~e?C rule between -j and -r.

The host rule engine now produces the same results as the rule-file path for:
- ?l
- ?u
- ?h
- ?H

Added regression tests for all four cases.

Validation:
- make -j4
- perl tools/test_rules.pl

Closes #4508.