### PR TITLE
add hash-mode 89100 NTLM(NTLM_bin($pass))

### DIFF
--- a/OpenCL/m89100_a0-pure.cl
+++ b/OpenCL/m89100_a0-pure.cl
@@ -29,10 +29,17 @@ KERNEL_FQ void m89100_mxx (KERN_ATTR_RULES ())
     md4_init (&c0); md4_update_utf16le (&c0, tmp.i, tmp.pw_len); md4_final (&c0);
 
     u32 w[16] = { 0 };
-    w[0]=c0.h[0]; w[1]=c0.h[1]; w[2]=c0.h[2]; w[3]=c0.h[3];
+    w[0] = (c0.h[0] & 0x000000ff) <<  0 | (c0.h[0] & 0x0000ff00) <<  8;
+    w[1] = (c0.h[0] & 0x00ff0000) >> 16 | (c0.h[0] & 0xff000000) >>  8;
+    w[2] = (c0.h[1] & 0x000000ff) <<  0 | (c0.h[1] & 0x0000ff00) <<  8;
+    w[3] = (c0.h[1] & 0x00ff0000) >> 16 | (c0.h[1] & 0xff000000) >>  8;
+    w[4] = (c0.h[2] & 0x000000ff) <<  0 | (c0.h[2] & 0x0000ff00) <<  8;
+    w[5] = (c0.h[2] & 0x00ff0000) >> 16 | (c0.h[2] & 0xff000000) >>  8;
+    w[6] = (c0.h[3] & 0x000000ff) <<  0 | (c0.h[3] & 0x0000ff00) <<  8;
+    w[7] = (c0.h[3] & 0x00ff0000) >> 16 | (c0.h[3] & 0xff000000) >>  8;
 
     md4_ctx_t c1;
-    md4_init (&c1); md4_update_utf16le (&c1, w, 16); md4_final (&c1);   // outer NTLM
+    md4_init (&c1); md4_update (&c1, w, 32); md4_final (&c1);
 
     const u32 r0=c1.h[DGST_R0], r1=c1.h[DGST_R1], r2=c1.h[DGST_R2], r3=c1.h[DGST_R3];
     COMPARE_M_SCALAR (r0, r1, r2, r3);
@@ -63,14 +70,14 @@ KERNEL_FQ void m89100_sxx (KERN_ATTR_RULES ())
     md4_init (&c0); md4_update_utf16le (&c0, tmp.i, tmp.pw_len); md4_final (&c0);
 
     u32 w[16] = { 0 };
-    w[DGST_R0] = (c0.h[0] & 0x000000ff) <<  0 | (c0.h[0] & 0x0000ff00) <<  8;
-    w[DGST_R1] = (c0.h[0] & 0x00ff0000) >> 16 | (c0.h[0] & 0xff000000) >>  8;
-    w[DGST_R2] = (c0.h[1] & 0x000000ff) <<  0 | (c0.h[1] & 0x0000ff00) <<  8;
-    w[DGST_R3] = (c0.h[1] & 0x00ff0000) >> 16 | (c0.h[1] & 0xff000000) >>  8;
-    w[DGST_R4] = (c0.h[2] & 0x000000ff) <<  0 | (c0.h[2] & 0x0000ff00) <<  8;
-    w[DGST_R5] = (c0.h[2] & 0x00ff0000) >> 16 | (c0.h[2] & 0xff000000) >>  8;
-    w[DGST_R6] = (c0.h[3] & 0x000000ff) <<  0 | (c0.h[3] & 0x0000ff00) <<  8;
-    w[DGST_R7] = (c0.h[3] & 0x00ff0000) >> 16 | (c0.h[3] & 0xff000000) >>  8;
+    w[0] = (c0.h[0] & 0x000000ff) <<  0 | (c0.h[0] & 0x0000ff00) <<  8;
+    w[1] = (c0.h[0] & 0x00ff0000) >> 16 | (c0.h[0] & 0xff000000) >>  8;
+    w[2] = (c0.h[1] & 0x000000ff) <<  0 | (c0.h[1] & 0x0000ff00) <<  8;
+    w[3] = (c0.h[1] & 0x00ff0000) >> 16 | (c0.h[1] & 0xff000000) >>  8;
+    w[4] = (c0.h[2] & 0x000000ff) <<  0 | (c0.h[2] & 0x0000ff00) <<  8;
+    w[5] = (c0.h[2] & 0x00ff0000) >> 16 | (c0.h[2] & 0xff000000) >>  8;
+    w[6] = (c0.h[3] & 0x000000ff) <<  0 | (c0.h[3] & 0x0000ff00) <<  8;
+    w[7] = (c0.h[3] & 0x00ff0000) >> 16 | (c0.h[3] & 0xff000000) >>  8;
 
     md4_ctx_t c1;
     md4_init (&c1); md4_update (&c1, w, 32); md4_final (&c1);

--- a/OpenCL/m89100_a0-pure.cl
+++ b/OpenCL/m89100_a0-pure.cl
@@ -1,0 +1,74 @@
+/**
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_rp.h)
+#include M2S(INCLUDE_PATH/inc_rp.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md4.cl)
+#endif
+
+KERNEL_FQ void m89100_mxx (KERN_ATTR_RULES ())
+{
+  const u64 gid = get_global_id (0);
+  if (gid >= GID_CNT) return;
+
+  COPY_PW (pws[gid]);
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    md4_ctx_t c0;
+    md4_init (&c0); md4_update_utf16le (&c0, tmp.i, tmp.pw_len); md4_final (&c0);
+
+    u32 w[16] = { 0 };
+    w[0]=c0.h[0]; w[1]=c0.h[1]; w[2]=c0.h[2]; w[3]=c0.h[3];
+
+    md4_ctx_t c1;
+    md4_init (&c1); md4_update (&c1, w, 16); md4_final (&c1);   // no swap: MD4 is LE
+
+    const u32 r0=c1.h[DGST_R0], r1=c1.h[DGST_R1], r2=c1.h[DGST_R2], r3=c1.h[DGST_R3];
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ void m89100_sxx (KERN_ATTR_RULES ())
+{
+  const u64 gid = get_global_id (0);
+  if (gid >= GID_CNT) return;
+
+  COPY_PW (pws[gid]);
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    pw_t tmp = PASTE_PW;
+    tmp.pw_len = apply_rules (rules_buf[il_pos].cmds, tmp.i, tmp.pw_len);
+
+    md4_ctx_t c0;
+    md4_init (&c0); md4_update_utf16le (&c0, tmp.i, tmp.pw_len); md4_final (&c0);
+
+    u32 w[16] = { 0 };
+    w[0]=c0.h[0]; w[1]=c0.h[1]; w[2]=c0.h[2]; w[3]=c0.h[3];
+
+    md4_ctx_t c1;
+    md4_init (&c1); md4_update (&c1, w, 16); md4_final (&c1);
+
+    const u32 r0=c1.h[DGST_R0], r1=c1.h[DGST_R1], r2=c1.h[DGST_R2], r3=c1.h[DGST_R3];
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m89100_a0-pure.cl
+++ b/OpenCL/m89100_a0-pure.cl
@@ -32,7 +32,7 @@ KERNEL_FQ void m89100_mxx (KERN_ATTR_RULES ())
     w[0]=c0.h[0]; w[1]=c0.h[1]; w[2]=c0.h[2]; w[3]=c0.h[3];
 
     md4_ctx_t c1;
-    md4_init (&c1); md4_update (&c1, w, 16); md4_final (&c1);   // no swap: MD4 is LE
+    md4_init (&c1); md4_update_utf16le (&c1, w, 16); md4_final (&c1);   // outer NTLM
 
     const u32 r0=c1.h[DGST_R0], r1=c1.h[DGST_R1], r2=c1.h[DGST_R2], r3=c1.h[DGST_R3];
     COMPARE_M_SCALAR (r0, r1, r2, r3);
@@ -63,10 +63,18 @@ KERNEL_FQ void m89100_sxx (KERN_ATTR_RULES ())
     md4_init (&c0); md4_update_utf16le (&c0, tmp.i, tmp.pw_len); md4_final (&c0);
 
     u32 w[16] = { 0 };
-    w[0]=c0.h[0]; w[1]=c0.h[1]; w[2]=c0.h[2]; w[3]=c0.h[3];
+    w[DGST_R0] = (c0.h[0] & 0x000000ff) <<  0 | (c0.h[0] & 0x0000ff00) <<  8;
+    w[DGST_R1] = (c0.h[0] & 0x00ff0000) >> 16 | (c0.h[0] & 0xff000000) >>  8;
+    w[DGST_R2] = (c0.h[1] & 0x000000ff) <<  0 | (c0.h[1] & 0x0000ff00) <<  8;
+    w[DGST_R3] = (c0.h[1] & 0x00ff0000) >> 16 | (c0.h[1] & 0xff000000) >>  8;
+    w[DGST_R4] = (c0.h[2] & 0x000000ff) <<  0 | (c0.h[2] & 0x0000ff00) <<  8;
+    w[DGST_R5] = (c0.h[2] & 0x00ff0000) >> 16 | (c0.h[2] & 0xff000000) >>  8;
+    w[DGST_R6] = (c0.h[3] & 0x000000ff) <<  0 | (c0.h[3] & 0x0000ff00) <<  8;
+    w[DGST_R7] = (c0.h[3] & 0x00ff0000) >> 16 | (c0.h[3] & 0xff000000) >>  8;
 
     md4_ctx_t c1;
-    md4_init (&c1); md4_update (&c1, w, 16); md4_final (&c1);
+    md4_init (&c1); md4_update (&c1, w, 32); md4_final (&c1);
+
 
     const u32 r0=c1.h[DGST_R0], r1=c1.h[DGST_R1], r2=c1.h[DGST_R2], r3=c1.h[DGST_R3];
     COMPARE_S_SCALAR (r0, r1, r2, r3);

--- a/OpenCL/m89100_a1-pure.cl
+++ b/OpenCL/m89100_a1-pure.cl
@@ -1,0 +1,141 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+//#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_scalar.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md4.cl)
+#endif
+
+KERNEL_FQ KERNEL_FA void m89100_mxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  md4_ctx_t ctx0;
+
+  md4_init (&ctx0);
+
+  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    md4_ctx_t ctx = ctx0;
+
+    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md4_final (&ctx);
+
+    u32 t[16] = { 0 };
+    t[0] = (ctx.h[0] & 0x000000ff) <<  0 | (ctx.h[0] & 0x0000ff00) <<  8;
+    t[1] = (ctx.h[0] & 0x00ff0000) >> 16 | (ctx.h[0] & 0xff000000) >>  8;
+    t[2] = (ctx.h[1] & 0x000000ff) <<  0 | (ctx.h[1] & 0x0000ff00) <<  8;
+    t[3] = (ctx.h[1] & 0x00ff0000) >> 16 | (ctx.h[1] & 0xff000000) >>  8;
+    t[4] = (ctx.h[2] & 0x000000ff) <<  0 | (ctx.h[2] & 0x0000ff00) <<  8;
+    t[5] = (ctx.h[2] & 0x00ff0000) >> 16 | (ctx.h[2] & 0xff000000) >>  8;
+    t[6] = (ctx.h[3] & 0x000000ff) <<  0 | (ctx.h[3] & 0x0000ff00) <<  8;
+    t[7] = (ctx.h[3] & 0x00ff0000) >> 16 | (ctx.h[3] & 0xff000000) >>  8;
+
+    md4_ctx_t ctx2;
+    md4_init   (&ctx2);
+    md4_update (&ctx2, t, 32);
+    md4_final  (&ctx2);
+
+    const u32 r0 = ctx2.h[DGST_R0];
+    const u32 r1 = ctx2.h[DGST_R1];
+    const u32 r2 = ctx2.h[DGST_R2];
+    const u32 r3 = ctx2.h[DGST_R3];
+
+    COMPARE_M_SCALAR (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m89100_sxx (KERN_ATTR_BASIC ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  md4_ctx_t ctx0;
+
+  md4_init (&ctx0);
+
+  md4_update_global_utf16le (&ctx0, pws[gid].i, pws[gid].pw_len);
+
+  /**
+   * loop
+   */
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
+  {
+    md4_ctx_t ctx = ctx0;
+
+    md4_update_global_utf16le (&ctx, combs_buf[il_pos].i, combs_buf[il_pos].pw_len);
+
+    md4_final (&ctx);
+
+    u32 t[16] = { 0 };
+    t[0] = (ctx.h[0] & 0x000000ff) <<  0 | (ctx.h[0] & 0x0000ff00) <<  8;
+    t[1] = (ctx.h[0] & 0x00ff0000) >> 16 | (ctx.h[0] & 0xff000000) >>  8;
+    t[2] = (ctx.h[1] & 0x000000ff) <<  0 | (ctx.h[1] & 0x0000ff00) <<  8;
+    t[3] = (ctx.h[1] & 0x00ff0000) >> 16 | (ctx.h[1] & 0xff000000) >>  8;
+    t[4] = (ctx.h[2] & 0x000000ff) <<  0 | (ctx.h[2] & 0x0000ff00) <<  8;
+    t[5] = (ctx.h[2] & 0x00ff0000) >> 16 | (ctx.h[2] & 0xff000000) >>  8;
+    t[6] = (ctx.h[3] & 0x000000ff) <<  0 | (ctx.h[3] & 0x0000ff00) <<  8;
+    t[7] = (ctx.h[3] & 0x00ff0000) >> 16 | (ctx.h[3] & 0xff000000) >>  8;
+
+    md4_ctx_t ctx2;
+    md4_init   (&ctx2);
+    md4_update (&ctx2, t, 32);
+    md4_final  (&ctx2);
+
+    const u32 r0 = ctx2.h[DGST_R0];
+    const u32 r1 = ctx2.h[DGST_R1];
+    const u32 r2 = ctx2.h[DGST_R2];
+    const u32 r3 = ctx2.h[DGST_R3];
+
+    COMPARE_S_SCALAR (r0, r1, r2, r3);
+  }
+}

--- a/OpenCL/m89100_a3-pure.cl
+++ b/OpenCL/m89100_a3-pure.cl
@@ -1,0 +1,221 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_simd.cl)
+#include M2S(INCLUDE_PATH/inc_hash_md4.cl)
+#endif
+
+KERNEL_FQ KERNEL_FA void m89100_mxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    #if VECT_SIZE == 1
+
+    md4_ctx_t ctx;
+
+    md4_init (&ctx);
+
+    md4_update_utf16le (&ctx, w, pw_len);
+
+    md4_final (&ctx);
+
+    #else
+
+    md4_ctx_vector_t ctx;
+
+    md4_init_vector (&ctx);
+
+    md4_update_vector_utf16le (&ctx, w, pw_len);
+
+    md4_final_vector (&ctx);
+
+    #endif
+
+    u32x t[16] = { 0 };
+    t[0] = (ctx.h[0] & 0x000000ff) <<  0 | (ctx.h[0] & 0x0000ff00) <<  8;
+    t[1] = (ctx.h[0] & 0x00ff0000) >> 16 | (ctx.h[0] & 0xff000000) >>  8;
+    t[2] = (ctx.h[1] & 0x000000ff) <<  0 | (ctx.h[1] & 0x0000ff00) <<  8;
+    t[3] = (ctx.h[1] & 0x00ff0000) >> 16 | (ctx.h[1] & 0xff000000) >>  8;
+    t[4] = (ctx.h[2] & 0x000000ff) <<  0 | (ctx.h[2] & 0x0000ff00) <<  8;
+    t[5] = (ctx.h[2] & 0x00ff0000) >> 16 | (ctx.h[2] & 0xff000000) >>  8;
+    t[6] = (ctx.h[3] & 0x000000ff) <<  0 | (ctx.h[3] & 0x0000ff00) <<  8;
+    t[7] = (ctx.h[3] & 0x00ff0000) >> 16 | (ctx.h[3] & 0xff000000) >>  8;
+
+    #if VECT_SIZE == 1
+
+    md4_ctx_t ctx2;
+
+    md4_init   (&ctx2);
+    md4_update (&ctx2, t, 32);
+    md4_final  (&ctx2);
+
+    #else
+
+    md4_ctx_vector_t ctx2;
+
+    md4_init_vector   (&ctx2);
+    md4_update_vector (&ctx2, t, 32);
+    md4_final_vector  (&ctx2);
+
+    #endif
+
+    const u32x r0 = ctx2.h[DGST_R0];
+    const u32x r1 = ctx2.h[DGST_R1];
+    const u32x r2 = ctx2.h[DGST_R2];
+    const u32x r3 = ctx2.h[DGST_R3];
+
+    COMPARE_M_SIMD (r0, r1, r2, r3);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m89100_sxx (KERN_ATTR_VECTOR ())
+{
+  /**
+   * modifier
+   */
+
+  const u64 lid = get_local_id (0);
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * digest
+   */
+
+  const u32 search[4] =
+  {
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R0],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R1],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R2],
+    digests_buf[DIGESTS_OFFSET_HOST].digest_buf[DGST_R3]
+  };
+
+  /**
+   * base
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32x w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  /**
+   * loop
+   */
+
+  u32x w0l = w[0];
+
+  for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
+  {
+    const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
+
+    const u32x w0 = w0l | w0r;
+
+    w[0] = w0;
+
+    #if VECT_SIZE == 1
+
+    md4_ctx_t ctx;
+
+    md4_init (&ctx);
+
+    md4_update_utf16le (&ctx, w, pw_len);
+
+    md4_final (&ctx);
+
+    #else
+
+    md4_ctx_vector_t ctx;
+
+    md4_init_vector (&ctx);
+
+    md4_update_vector_utf16le (&ctx, w, pw_len);
+
+    md4_final_vector (&ctx);
+
+    #endif
+
+    u32x t[16] = { 0 };
+    t[0] = (ctx.h[0] & 0x000000ff) <<  0 | (ctx.h[0] & 0x0000ff00) <<  8;
+    t[1] = (ctx.h[0] & 0x00ff0000) >> 16 | (ctx.h[0] & 0xff000000) >>  8;
+    t[2] = (ctx.h[1] & 0x000000ff) <<  0 | (ctx.h[1] & 0x0000ff00) <<  8;
+    t[3] = (ctx.h[1] & 0x00ff0000) >> 16 | (ctx.h[1] & 0xff000000) >>  8;
+    t[4] = (ctx.h[2] & 0x000000ff) <<  0 | (ctx.h[2] & 0x0000ff00) <<  8;
+    t[5] = (ctx.h[2] & 0x00ff0000) >> 16 | (ctx.h[2] & 0xff000000) >>  8;
+    t[6] = (ctx.h[3] & 0x000000ff) <<  0 | (ctx.h[3] & 0x0000ff00) <<  8;
+    t[7] = (ctx.h[3] & 0x00ff0000) >> 16 | (ctx.h[3] & 0xff000000) >>  8;
+
+    #if VECT_SIZE == 1
+
+    md4_ctx_t ctx2;
+
+    md4_init   (&ctx2);
+    md4_update (&ctx2, t, 32);
+    md4_final  (&ctx2);
+
+    #else
+
+    md4_ctx_vector_t ctx2;
+
+    md4_init_vector   (&ctx2);
+    md4_update_vector (&ctx2, t, 32);
+    md4_final_vector  (&ctx2);
+
+    #endif
+
+    const u32x r0 = ctx2.h[DGST_R0];
+    const u32x r1 = ctx2.h[DGST_R1];
+    const u32x r2 = ctx2.h[DGST_R2];
+    const u32x r3 = ctx2.h[DGST_R3];
+
+    COMPARE_S_SIMD (r0, r1, r2, r3);
+  }
+}

--- a/src/modules/module_89100.c
+++ b/src/modules/module_89100.c
@@ -23,6 +23,7 @@ static const u32 OPTI_TYPE = OPTI_TYPE_ZERO_BYTE
                            | OPTI_TYPE_NOT_SALTED
                            | OPTI_TYPE_RAW_HASH;
 static const u32 SALT_TYPE = SALT_TYPE_NONE;
+static const u32 PWDUMP_COLUMN = PWDUMP_COLUMN_NTLM_HASH;
 static const char *ST_PASS = "hashcat";
 static const char *HASH_NAME = "NTLM(NTLM_bin($pass))";
 static const u64 KERN_TYPE = 89100;
@@ -83,6 +84,11 @@ u32 module_opti_type (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED 
 u64 module_opts_type (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
 {
   return OPTS_TYPE;
+}
+
+u32 module_pwdump_column (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return PWDUMP_COLUMN;
 }
 
 u32 module_salt_type (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
@@ -238,7 +244,7 @@ void module_init (module_ctx_t *module_ctx)
   module_ctx->module_potfile_custom_check = MODULE_DEFAULT;
   module_ctx->module_potfile_disable = MODULE_DEFAULT;
   module_ctx->module_potfile_keep_all_hashes = MODULE_DEFAULT;
-  module_ctx->module_pwdump_column = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column = module_pwdump_column;
   module_ctx->module_pw_max = MODULE_DEFAULT;
   module_ctx->module_pw_min = MODULE_DEFAULT;
   module_ctx->module_salt_max = MODULE_DEFAULT;

--- a/src/modules/module_89100.c
+++ b/src/modules/module_89100.c
@@ -24,10 +24,10 @@ static const u32 OPTI_TYPE = OPTI_TYPE_ZERO_BYTE
                            | OPTI_TYPE_RAW_HASH;
 static const u32 SALT_TYPE = SALT_TYPE_NONE;
 static const char *ST_PASS = "hashcat";
-static const char *HASH_NAME = "NTLM(NTLM($pass))";
+static const char *HASH_NAME = "NTLM(NTLM_bin($pass))";
 static const u64 KERN_TYPE = 89100;
 static const u64 OPTS_TYPE = OPTS_TYPE_PT_GENERATE_LE;
-static const char *ST_HASH = "7f30a0c84b2a806d93c39cea3b760716";  // NTLM(NTLM("hashcat"))
+static const char *ST_HASH = "7f30a0c84b2a806d93c39cea3b760716";  // NTLM(NTLM_bin("hashcat"))
 
 
 u32 module_attack_exec (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)

--- a/src/modules/module_89100.c
+++ b/src/modules/module_89100.c
@@ -16,14 +16,18 @@ static const u32 DGST_POS1 = 3;
 static const u32 DGST_POS2 = 2;
 static const u32 DGST_POS3 = 1;
 static const u32 DGST_SIZE = DGST_SIZE_4_4;
-static const u32 HASH_CATEGORY = HASH_CATEGORY_RAW_HASH;
-static const u32 OPTI_TYPE = OPTI_TYPE_ZERO_BYTE | OPTI_TYPE_PRECOMPUTE_INIT | OPTI_TYPE_MEET_IN_MIDDLE | OPTI_TYPE_EARLY_SKIP | OPTI_TYPE_NOT_ITERATED | OPTI_TYPE_NOT_SALTED | OPTI_TYPE_RAW_HASH;
+static const u32 HASH_CATEGORY = HASH_CATEGORY_OS;
+static const u32 OPTI_TYPE = OPTI_TYPE_ZERO_BYTE
+                           | OPTI_TYPE_EARLY_SKIP
+                           | OPTI_TYPE_NOT_ITERATED
+                           | OPTI_TYPE_NOT_SALTED
+                           | OPTI_TYPE_RAW_HASH;
 static const u32 SALT_TYPE = SALT_TYPE_NONE;
 static const char *ST_PASS = "hashcat";
 static const char *HASH_NAME = "NTLM(NTLM($pass))";
 static const u64 KERN_TYPE = 89100;
 static const u64 OPTS_TYPE = OPTS_TYPE_PT_GENERATE_LE;
-static const char *ST_HASH = "0b892dde26cafb0441b6f2c8948f4417";  // md4(NTLM("hashcat"))
+static const char *ST_HASH = "7f30a0c84b2a806d93c39cea3b760716";  // NTLM(NTLM("hashcat"))
 
 
 u32 module_attack_exec (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)

--- a/src/modules/module_89100.c
+++ b/src/modules/module_89100.c
@@ -1,0 +1,249 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+
+static const u32 ATTACK_EXEC = ATTACK_EXEC_INSIDE_KERNEL;
+static const u32 DGST_POS0 = 0;
+static const u32 DGST_POS1 = 3;
+static const u32 DGST_POS2 = 2;
+static const u32 DGST_POS3 = 1;
+static const u32 DGST_SIZE = DGST_SIZE_4_4;
+static const u32 HASH_CATEGORY = HASH_CATEGORY_RAW_HASH;
+static const u32 OPTI_TYPE = OPTI_TYPE_ZERO_BYTE | OPTI_TYPE_PRECOMPUTE_INIT | OPTI_TYPE_MEET_IN_MIDDLE | OPTI_TYPE_EARLY_SKIP | OPTI_TYPE_NOT_ITERATED | OPTI_TYPE_NOT_SALTED | OPTI_TYPE_RAW_HASH;
+static const u32 SALT_TYPE = SALT_TYPE_NONE;
+static const char *ST_PASS = "hashcat";
+static const char *HASH_NAME = "NTLM(NTLM($pass))";
+static const u64 KERN_TYPE = 89100;
+static const u64 OPTS_TYPE = OPTS_TYPE_PT_GENERATE_LE;
+static const char *ST_HASH = "0b892dde26cafb0441b6f2c8948f4417";  // md4(NTLM("hashcat"))
+
+
+u32 module_attack_exec (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return ATTACK_EXEC;
+}
+
+u32 module_dgst_pos0 (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return DGST_POS0;
+}
+
+u32 module_dgst_pos1 (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return DGST_POS1;
+}
+
+u32 module_dgst_pos2 (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return DGST_POS2;
+}
+
+u32 module_dgst_pos3 (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return DGST_POS3;
+}
+
+u32 module_dgst_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return DGST_SIZE;
+}
+
+u32 module_hash_category (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return HASH_CATEGORY;
+}
+
+const char *module_hash_name (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return HASH_NAME;
+}
+
+u64 module_kern_type (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return KERN_TYPE;
+}
+
+u32 module_opti_type (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return OPTI_TYPE;
+}
+
+u64 module_opts_type (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return OPTS_TYPE;
+}
+
+u32 module_salt_type (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return SALT_TYPE;
+}
+
+const char *module_st_hash (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return ST_HASH;
+}
+
+const char *module_st_pass (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  return ST_PASS;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  hc_token_t token;
+
+  memset (&token, 0, sizeof (hc_token_t));
+
+  token.token_cnt = 1;
+
+  token.len[0] = 32;
+  token.attr[0] = TOKEN_ATTR_FIXED_LENGTH | TOKEN_ATTR_VERIFY_HEX;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK)
+    return (rc_tokenizer);
+
+  const u8 *hash_pos = token.buf[0];
+
+  digest[0] = hex_to_u32 (hash_pos + 0);
+  digest[1] = hex_to_u32 (hash_pos + 8);
+  digest[2] = hex_to_u32 (hash_pos + 16);
+  digest[3] = hex_to_u32 (hash_pos + 24);
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    digest[0] -= MD4M_A;
+    digest[1] -= MD4M_B;
+    digest[2] -= MD4M_C;
+    digest[3] -= MD4M_D;
+  }
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const u32 *digest = (const u32 *) digest_buf;
+
+  // we can not change anything in the original buffer, otherwise destroying sorting
+  // therefore create some local buffer
+
+  u32 tmp[4];
+
+  tmp[0] = digest[0];
+  tmp[1] = digest[1];
+  tmp[2] = digest[2];
+  tmp[3] = digest[3];
+
+  if (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL)
+  {
+    tmp[0] += MD4M_A;
+    tmp[1] += MD4M_B;
+    tmp[2] += MD4M_C;
+    tmp[3] += MD4M_D;
+  }
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  u32_to_hex (tmp[0], out_buf + 0);
+  u32_to_hex (tmp[1], out_buf + 8);
+  u32_to_hex (tmp[2], out_buf + 16);
+  u32_to_hex (tmp[3], out_buf + 24);
+
+  const int out_len = 32;
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec = module_attack_exec;
+  module_ctx->module_benchmark_esalt = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt = MODULE_DEFAULT;
+  module_ctx->module_bridge_name = MODULE_DEFAULT;
+  module_ctx->module_bridge_type = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0 = module_dgst_pos0;
+  module_ctx->module_dgst_pos1 = module_dgst_pos1;
+  module_ctx->module_dgst_pos2 = module_dgst_pos2;
+  module_ctx->module_dgst_pos3 = module_dgst_pos3;
+  module_ctx->module_dgst_size = module_dgst_size;
+  module_ctx->module_dictstat_disable = MODULE_DEFAULT;
+  module_ctx->module_esalt_size = MODULE_DEFAULT;
+  module_ctx->module_extra_buffer_size = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash = MODULE_DEFAULT;
+  module_ctx->module_hash_decode = module_hash_decode;
+  module_ctx->module_hash_encode_status = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile = MODULE_DEFAULT;
+  module_ctx->module_hash_encode = module_hash_encode;
+  module_ctx->module_hash_init_selftest = MODULE_DEFAULT;
+  module_ctx->module_hash_mode = MODULE_DEFAULT;
+  module_ctx->module_hash_category = module_hash_category;
+  module_ctx->module_hash_name = module_hash_name;
+  module_ctx->module_hashes_count_min = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term = MODULE_DEFAULT;
+  module_ctx->module_hook12 = MODULE_DEFAULT;
+  module_ctx->module_hook23 = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size = MODULE_DEFAULT;
+  module_ctx->module_hook_size = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options = MODULE_DEFAULT;
+  module_ctx->module_jit_cache_disable = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_max = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_min = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_max = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min = MODULE_DEFAULT;
+  module_ctx->module_kern_type = module_kern_type;
+  module_ctx->module_kern_type_dynamic = MODULE_DEFAULT;
+  module_ctx->module_opti_type = module_opti_type;
+  module_ctx->module_opts_type = module_opts_type;
+  module_ctx->module_outfile_check_disable = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column = MODULE_DEFAULT;
+  module_ctx->module_pw_max = MODULE_DEFAULT;
+  module_ctx->module_pw_min = MODULE_DEFAULT;
+  module_ctx->module_salt_max = MODULE_DEFAULT;
+  module_ctx->module_salt_min = MODULE_DEFAULT;
+  module_ctx->module_salt_type = module_salt_type;
+  module_ctx->module_separator = MODULE_DEFAULT;
+  module_ctx->module_st_hash = module_st_hash;
+  module_ctx->module_st_pass = module_st_pass;
+  module_ctx->module_tmp_size = MODULE_DEFAULT;
+  module_ctx->module_unstable_warning = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m89100.pm
+++ b/tools/test_modules/m89100.pm
@@ -17,11 +17,10 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $ntlm = md4 (encode ("UTF-16LE", $word));
+  my $inner = md4 (encode ("UTF-16LE", $word));
+  my $hash  = unpack ("H*", md4 (encode ("UTF-16LE", $inner)));
 
-  my $digest = md4_hex ($ntlm);
-
-  return $digest;
+  return $hash;
 }
 
 sub module_verify_hash

--- a/tools/test_modules/m89100.pm
+++ b/tools/test_modules/m89100.pm
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Encode;
+use Digest::MD4 qw (md4 md4_hex);
+
+sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word = shift;
+
+  my $ntlm = md4 (encode ("UTF-16LE", $word));
+
+  my $digest = md4_hex ($ntlm);
+
+  return $digest;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
Adds `-m 89100 = NTLM(NTLM_bin($pass))`. Derived from m01000, supports attack modes a0, a1, a3. Hashcat already supports numerous nested/iterated variants of common hash primitives (i.e. md5(md5($pass)), sha1(sha1($pass))), this adds the equivalent variant for NTLM. 

Test output:
```
 ./tools/test.sh -m 89100 -a all -t all -P
[ test_1783083456 ] > Init test for hash type 89100.
[ test_1783083456 ] [ Type 89100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1783083456 ] [ Type 89100, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1783083456 ] [ Type 89100, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1783083456 ] [ Type 89100, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1783083456 ] [ Type 89100, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 1 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1783083456 ] [ Type 89100, Attack 0, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1783083456 ] [ Type 89100, Attack 1, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 1, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1783083456 ] [ Type 89100, Attack 3, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 3, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/1 not found, 0/1 not matched, 0/1 timeout, 0/1 skipped
[ test_1783083456 ] [ Type 89100, Attack 6, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 6, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 7, Mode single, Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
[ test_1783083456 ] [ Type 89100, Attack 7, Mode multi,  Device-Type Gpu, Kernel-Type Pure, Vector-Width 4 ] > OK : 0/7 not found, 0/7 not matched, 0/7 timeout, 0/7 skipped
```