### PR TITLE
Accept short SNMPv3 authoritative engine IDs (< 13 bytes)

### DIFF
--- a/src/modules/module_25000.c
+++ b/src/modules/module_25000.c
@@ -174,7 +174,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // engineid
-  token.len_min[3] = 26;
+  token.len_min[3] = 10;
   token.len_max[3] = SNMPV3_ENGINEID_MAX;
   token.sep[3]     = '$';
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH

--- a/src/modules/module_25100.c
+++ b/src/modules/module_25100.c
@@ -170,7 +170,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // engineid
-  token.len_min[3] = 26;
+  token.len_min[3] = 10;
   token.len_max[3] = SNMPV3_ENGINEID_MAX;
   token.sep[3]     = '$';
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH

--- a/src/modules/module_25200.c
+++ b/src/modules/module_25200.c
@@ -171,7 +171,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // engineid
   token.sep[3]     = '$';
-  token.len_min[3] = 26;
+  token.len_min[3] = 10;
   token.len_max[3] = SNMPV3_ENGINEID_MAX;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;

--- a/src/modules/module_26700.c
+++ b/src/modules/module_26700.c
@@ -167,7 +167,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // engineid
   token.sep[3]     = '$';
-  token.len_min[3] = 26;
+  token.len_min[3] = 10;
   token.len_max[3] = SNMPV3_ENGINEID_MAX;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;

--- a/src/modules/module_26800.c
+++ b/src/modules/module_26800.c
@@ -167,7 +167,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // engineid
   token.sep[3]     = '$';
-  token.len_min[3] = 26;
+  token.len_min[3] = 10;
   token.len_max[3] = SNMPV3_ENGINEID_MAX;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;

--- a/src/modules/module_26900.c
+++ b/src/modules/module_26900.c
@@ -29,7 +29,7 @@ static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_PT_GENERATE_LE;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat1";
-static const char *ST_HASH        = "$SNMPv3$5$45889431$3081a70201033011020455c0c85c020300ffe30401010201030450304e041180001f88808106d566db57fd600000000002011002020118040e6d61747269785f5348412d333834042000000000000000000000000000000000000000000000000000000000000000000400303d041180001f88808106d566db57fd60000000000400a226020411b3c3590201000201003018301606082b06010201010200060a2b06010401bf0803020a$80001f88808106d566db57fd60$89424907553231aaa27055f4b3b0a97c626ed4cdc4b660d903765b607af792a5";
+static const char *ST_HASH        = "$SNMPv3$5$45889431$3081a70201033011020455c0c85c020300ffe30401010201030450304e041180001f88808106d566db57fd600000000002011002020118040e6d61747269785f5348412d333834042000000000000000000000000000000000000000000000000000000000000000000400303d041180001f88808106d566db57fd60000000000400a226020411b3c3590201000201003018301606082b06010201010200060a2b06010401bf0803020a$80001f88808106d566db57fd6000000000$89424907553231aaa27055f4b3b0a97c626ed4cdc4b660d903765b607af792a5";
 
 u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
 u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
@@ -200,8 +200,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
                    | TOKEN_ATTR_VERIFY_HEX;
 
   // engineid
+  // len_min lowered from 26 to 10 to accept short (>=5 byte) engine IDs (RFC 3411)
   token.sep[3]     = '$';
-  token.len_min[3] = 26;
+  token.len_min[3] = 10;
   token.len_max[3] = SNMPV3_ENGINEID_MAX;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
@@ -259,10 +260,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 *engineID_ptr = (u8 *) snmpv3->engineID_buf;
 
-  hex_decode (engineID_pos, engineID_len, engineID_ptr);
-
-  // force len to 17, zero padding
-  snmpv3->engineID_len = SNMPV3_ENGINEID_MAX / 2;
+  // use the real decoded length so engine IDs != 17 bytes localize correctly
+  snmpv3->engineID_len = hex_decode (engineID_pos, engineID_len, engineID_ptr);
 
   // digest
 

--- a/src/modules/module_27300.c
+++ b/src/modules/module_27300.c
@@ -201,7 +201,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // engineid
   token.sep[3]     = '$';
-  token.len_min[3] = 26;
+  // len_min lowered from 26 to 10 to accept short (>=5 byte) engine IDs (RFC 3411)
+  token.len_min[3] = 10;
   token.len_max[3] = SNMPV3_ENGINEID_MAX;
   token.attr[3]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;
@@ -259,10 +260,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   u8 *engineID_ptr = (u8 *) snmpv3->engineID_buf;
 
-  hex_decode (engineID_pos, engineID_len, engineID_ptr);
-
-  // force len to 17, zero padding
-  snmpv3->engineID_len = SNMPV3_ENGINEID_MAX / 2;
+  // use the real decoded length so engine IDs != 17 bytes localize correctly
+  snmpv3->engineID_len = hex_decode (engineID_pos, engineID_len, engineID_ptr);
 
   // digest
 


### PR DESCRIPTION
# Summary

The SNMPv3 hash modes reject captures whose SNMP **authoritative engine ID** is shorter than 13 bytes. The parser hardcodes a minimum engine-ID token length of `26` hex characters (13 bytes), so any hash produced from a device using a shorter engine ID fails to load with a **"Token length exception"** before cracking even starts.

Per [RFC 3411](https://www.rfc-editor.org/rfc/rfc3411#section-5), the `SnmpEngineID` textual convention is `OCTET STRING (SIZE(5..32))` - i.e. a valid engine ID is **5 to 32 bytes**. hashcat's hardcoded 13-byte (`26` hex) minimum rejects valid engine IDs in the 5–12 byte range. Such engine IDs are common in the field - e.g. the older RFC 1910 layout and several real appliances/agents.

This PR lowers the minimum so those hashes load, and additionally fixes modes 26900/27300 (SHA-384/512) which ignored the real engine-ID length entirely.

# Affected hash modes

| Mode  | Module            | Algorithm            |
|-------|-------------------|----------------------|
| 25000 | `module_25000.c`  | HMAC-MD5-96/SHA1-96  |
| 25100 | `module_25100.c`  | HMAC-MD5-96          |
| 25200 | `module_25200.c`  | HMAC-SHA1-96         |
| 26700 | `module_26700.c`  | HMAC-SHA224-128      |
| 26800 | `module_26800.c`  | HMAC-SHA256-192      |
| 26900 | `module_26900.c`  | HMAC-SHA384-256      |
| 27300 | `module_27300.c`  | HMAC-SHA512-384      |

# Root cause & fixes

## 1. Engine-ID minimum length (all 7 modules)

In each module's `module_hash_decode()`, the engine-ID token (index 3) is constrained by:

```c
// engineid
token.len_min[3] = 26;                    // 26 hex = 13 bytes minimum
token.len_max[3] = SNMPV3_ENGINEID_MAX;   // 34 hex = 17 bytes maximum
```

Any hash whose engine-ID field is shorter than 26 hex chars is rejected by `input_tokenizer()` (`TOKEN_ATTR_VERIFY_LENGTH`) with `Token length exception`.

**Fix:** lower the minimum to `10` (5 bytes, the RFC 3411 minimum):

```c
token.len_min[3] = 10;                    // 10 hex = 5 bytes (RFC 3411 minimum)
```

`token.len_max[3]` is unchanged. The engine-ID buffer already covers this range, and salt/digest handling is unaffected.

## 2. Forced 17-byte engine ID (modes 26900 & 27300 only)

Unlike the other modules, `module_26900.c` and `module_27300.c` discard the decoded engine-ID length and force it to 17 bytes:

```c
hex_decode (engineID_pos, engineID_len, engineID_ptr);

// force len to 17, zero padding
snmpv3->engineID_len = SNMPV3_ENGINEID_MAX / 2;   // = 17 bytes
```

The GPU kernels (`m26900-pure.cl`, `m27300-pure.cl`) already consume the engine ID generically via `engineID_len` (`shaXXX_update_global_swap(..., engineID_buf, engineID_len)`), exactly like the SHA-256 kernel - so the fixed length is **not** a
kernel requirement. With it, a real capture using a non-17-byte engine ID is localized with the wrong key (real bytes + trailing zeros) and never cracks, even when the correct password is in the wordlist.

**Fix:** use the actual decoded length, like every other module:

```c
// use the real decoded length so engine IDs != 17 bytes localize correctly
snmpv3->engineID_len = hex_decode (engineID_pos, engineID_len, engineID_ptr);
```

**Self-test consistency:** the 26900 self-test hash stored only the 13 significant engine-ID bytes in its engine-ID field while its whole-message blob embeds a 17-byte (zero-padded) engine ID - the old code re-padded to match. With the real length now used, the 26900 `ST_HASH` engine-ID field is extended to the full 17 bytes it always represented, so the digest is unchanged and the self-test still passes:

```
$SNMPv3$5$45889431$...$80001f88808106d566db57fd60$...
                    ->
$SNMPv3$5$45889431$...$80001f88808106d566db57fd6000000000$...
```

27300's self-test hash already carries a 17-byte engine-ID field, so `hex_decode` returns 17 (identical to the old forced value) - no `ST_HASH` change needed there.

# Testing

Built from source (`v7.1.2`) with the patch and verified end-to-end against real captures whose authoritative engine ID is 12 bytes (`0000000060e9aa6fc07b0001`, 24 hex).

### Before

```
$ hashcat -m 25000 hash.txt wordlist.txt

Hashfile 'hash.txt' on line 1 ($SNMPv...07b0001$8588a48acb5bc48fc38bd8b8): Token length exception

* Token length exception: 1/1 hashes
  This error happens if the wrong hash type is specified, if the hashes are
  malformed, or if input is otherwise not as expected (for example, if the
  --username or --dynamic-x option is used but no username or dynamic-tag is present)
```

For 27300 the hash *loaded* but stayed `Exhausted` even with the correct password present (wrong key due to the forced 17-byte length).

### After (patched)

- `-m 25000`, `-m 26800`, `-m 27300`: all crack the 12-byte-engine-ID captures to the correct password.
- Module self-tests pass on startup (not disabled).
- Regression: existing example hashes (17-byte engine IDs) still load and crack.

```
$ hashcat -m 25000 hash.txt wordlist.txt

Session..........: hashcat
Status...........: Cracked
Hash.Mode........: 25000 (SNMPv3 HMAC-MD5-96/HMAC-SHA1-96)
Hash.Target......: $SNMPv3$0$191$3081b80201033011020410e4f788020300ffe...8bd8b8
Time.Started.....: Sat Jul  4 13:32:19 2026 (0 secs)
Time.Estimated...: Sat Jul  4 13:32:19 2026 (0 secs)
Kernel.Feature...: Pure Kernel (password length 8-256 bytes)
Guess.Base.......: File (wordlist.txt)
Guess.Queue......: 1/1 (100.00%)
Speed.#01........:     1052 H/s (1.31ms) @ Accel:33 Loops:131072 Thr:1 Vec:8
Recovered........: 1/1 (100.00%) Digests (total), 1/1 (100.00%) Digests (new)
Progress.........: 24/24 (100.00%)
Rejected.........: 11/24 (45.83%)
Restore.Point....: 0/24 (0.00%)
Restore.Sub.#01..: Salt:0 Amplifier:0-1 Iteration:917504-1048576
Candidate.Engine.: Device Generator
Candidates.#01...: raspberry -> hashcat1
Hardware.Mon.#01.: Util: 43%
```

## Reproducible test vectors

In a lab setup, a printer was configured with various authentication protocols. Device interaction was simulated using the SNMPwalk tool, and network traffic was captured with Wireshark. The resulting PCAP file was analyzed using the [snmpv3brute](https://github.com/matrix/snmpv3brute) tool to extract authentication hashes observed during the communication.


**Mode 25000** (HMAC-MD5-96/SHA1-96) — password `hashcat1`:

```
$SNMPv3$0$191$3081b80201033011020410e4f788020300ffe304010302010304363034040c0000000060e9aa6fc07b0001020200ab02010a040561646d696e040c0000000000000000000000000408000000abd3cb3e48046892637269f5d810f467897fb9d36337c8f57141214bb67b741c4c247d47f4782ce938fef6ab819a223d60ff9b42b56bde187abfe68e68c8d2c4188606442b9ce9ee5c97920162d5724f92c13d03f56d7e1518dc2ae38b194af281945b6eb1522ea8114ce81fa17e67$0000000060e9aa6fc07b0001$8588a48acb5bc48fc38bd8b8
```

**Mode 26800** (HMAC-SHA256-192) — password `hashcat1`:

```
$SNMPv3$4$111$3081bf0201033011020428839670020300ffe304010302010304423040040c0000000060e9aa6fc07b0001020200a902013c040561646d696e04180000000000000000000000000000000000000000000000000408a7967c914f2dfc11046394a6c40feb4ad75ba7ad076b3f63f8edc2b536bde3761fb843a7188a9e4dec625ffe9ad296d3e58bbe0a08f105303e948238f1ba9a2d9367971dc10d051dac18e7691dbb33a55e766d900408f70ea6ad20f42768cbc884ed323a06bd881f227b11f08d$0000000060e9aa6fc07b0001$5a2959a2e8e57c8c6483225c516643177c3065063eb8ab93
```

**Mode 27300** (HMAC-SHA512-384) — password `hashcat1`:

```
$SNMPv3$6$73$3081d7020103301102042e4c2b57020300ffe3040103020103045a3058040c0000000060e9aa6fc07b0001020200a802016c040561646d696e04300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000408a7967c914f2df95804633f6c155122b726e809840e040977d07145160c9cfa7668ef75dceb04398bf787d3c36778e8b1e76bbec2a33caf878d4da891eae116e818f0f6be613081ab24343f34896223ae31ab80c598e0a6495bbb8637fbc42028119c6638b79232b0476877befd$0000000060e9aa6fc07b0001$ed8ba8246e4eb743e051b4a735731b7a2da666cae093a00fc374e0b892a7a7b6cee180358a41f163e52b6513f85ec633
```
