### PR TITLE
docs: fix capitalization of 'hashcat' to follow official naming convention

### DIFF
--- a/docs/hashcat-assimilation-bridge.md
+++ b/docs/hashcat-assimilation-bridge.md
@@ -1,8 +1,8 @@
-# Assimilation Bridge in Hashcat v7
+# Assimilation Bridge in hashcat v7
 
 ## Overview
 
-Hashcat has historically optimized password cracking GPU and CPU compute backends. However, other types of hardware compute systems or pure software solutions were not supported. The Assimilation Bridge is a feature introduced in Hashcat v7 that extends the compute pipeline beyond traditional backends. It enables the integration of additional compute resources and software solutions such as FPGAs, remote TPMs, CPU reference implementations, or embedded runtimes into new or existing hash mode plugins.
+hashcat has historically optimized password cracking GPU and CPU compute backends. However, other types of hardware compute systems or pure software solutions were not supported. The Assimilation Bridge is a feature introduced in hashcat v7 that extends the compute pipeline beyond traditional backends. It enables the integration of additional compute resources and software solutions such as FPGAs, remote TPMs, CPU reference implementations, or embedded runtimes into new or existing hash mode plugins.
 
 All existing hash-mode plugins continue to function as before. Bridges are optional and only active when explicitly declared within a plugin's configuration. This ensures full backward compatibility with existing setups.
 
@@ -10,7 +10,7 @@ All existing hash-mode plugins continue to function as before. Bridges are optio
 
 ### Embedded Language Runtimes
 
-Hashcat v7 introduces support for an embedded Python interpreter as its premier demonstration example:
+hashcat v7 introduces support for an embedded Python interpreter as its premier demonstration example:
 
 - Hash modes `-m 72000` and `-m 73000` use embedded Python; start with `-m 73000`.
 - These demonstrate a "generic hash" model, enabling full hash mode creation in Python.
@@ -29,7 +29,7 @@ This is just a preview. See `docs/hashcat-python-plugin-quickstart.md` for detai
 
 ### Hybrid Architecture
 
-Note that in the Python example, only CPU resources are used and Hashcat does not transform Python into GPU code. However, the Bridge supports hybrid setups, where part of the workload runs on a traditional backend and another part on the Bridge. This model allows performance-critical components to be handled by the most suitable type of compute unit.
+Note that in the Python example, only CPU resources are used and hashcat does not transform Python into GPU code. However, the Bridge supports hybrid setups, where part of the workload runs on a traditional backend and another part on the Bridge. This model allows performance-critical components to be handled by the most suitable type of compute unit.
 
 For example, in hash mode `-m 70100`, a demonstration of SCRYPT, the PBKDF2 stage runs on a GPU using OpenCL/CUDA/HIP/Metal, while the memory-intensive `smix()` runs on the CPU through a bridge using the scrypt-jane implementation. This could just as easily be offloaded to an FPGA instead, which would benefit from reduced code complexity and increased parallelization boosting performance significantly.
 
@@ -61,13 +61,13 @@ Depending on interface compatibility, code from other password cracking tools (e
 ## Limitations and Status
 
 - Bridges are optional and configured on a per-plugin basis.
-- Hashcat v7 includes working bridges for CPU and Python.
+- hashcat v7 includes working bridges for CPU and Python.
 - FPGA support has been verified internally but is excluded from this release due to licensing issues.
 
-> **Call to FPGA Developers**: Contribute an open FPGA implementation and bitstream and the Hashcat Developer Team will support in integrating it into a bridge. Please contact us on Discord.
+> **Call to FPGA Developers**: Contribute an open FPGA implementation and bitstream and the hashcat Developer Team will support in integrating it into a bridge. Please contact us on Discord.
 
 ## Conclusion
 
-The Assimilation Bridge introduces a highly extensible mechanism to integrate custom compute resources and logic into Hashcat.
+The Assimilation Bridge introduces a highly extensible mechanism to integrate custom compute resources and logic into hashcat.
 
 For hands-on examples and developer guidance, refer to the accompanying documentation in `docs/hashcat-assimilation-bridge-development.md` (first draft).

--- a/docs/hashcat-brain.md
+++ b/docs/hashcat-brain.md
@@ -6,9 +6,9 @@ From a technical perspective, the hashcat brain consists of two in-memory databa
 
 Put simply, the hashcat brain persistently remembers the attacks you've executed against a particular hashlist in the past ... but on a low level.
 
-Hashcat will check each password candidate against the "brain" to find out if that candidate was already checked in the past and then accept it or reject it. The brain will check each candidate for existence in both the long-term and short-term memory areas. The nice thing is that it does not matter which attack-mode originally was used - it can be straight attack, mask attack or any of the advanced future generators.
+hashcat will check each password candidate against the "brain" to find out if that candidate was already checked in the past and then accept it or reject it. The brain will check each candidate for existence in both the long-term and short-term memory areas. The nice thing is that it does not matter which attack-mode originally was used - it can be straight attack, mask attack or any of the advanced future generators.
 
-The brain computes a hash (a very fast one called xxHash) of every password candidate and store it in the short-term memory first. Hashcat then starts cracking the usual way. Once it's done cracking, it sends a "commit" signal to the hashcat brain, which then moves the candidates from the short-term memory into the long-term memory.
+The brain computes a hash (a very fast one called xxHash) of every password candidate and store it in the short-term memory first. hashcat then starts cracking the usual way. Once it's done cracking, it sends a "commit" signal to the hashcat brain, which then moves the candidates from the short-term memory into the long-term memory.
 
 The hashcat brain feature uses a client/server architecture. That means that the hashcat brain itself is actually a network server. I know, I know - you don't want any network sockets in your hashcat process? No problem, then disable the feature in the __makefile__ by setting `ENABLE_BRAIN=0` and it will be gone forever.
 
@@ -52,7 +52,7 @@ $ ./hashcat -z example0.hash example.dict -r rules/best66.rule
 Rejected.........: 2379391/9888032 (24.06%)
 ```
 
-> __Notes:__ Hashcat brain rejects dynamically created duplicate candidates
+> __Notes:__ hashcat brain rejects dynamically created duplicate candidates
 >
 > Average dynamically created duplicate candidates is around 25%
 >

--- a/docs/hashcat-generic-attack-mode-development-guide.md
+++ b/docs/hashcat-generic-attack-mode-development-guide.md
@@ -71,7 +71,7 @@ bool thread_seek     (generic_global_ctx_t *global_ctx, generic_thread_ctx_t *th
 
 ### hashcat_ctx_t
 
-Hashcat will provide the full `hashcat_ctx_t` context. In most cases you do not need it. It is complex and not suitable for wrapper languages. For that reason it is only optionally available to global functions.
+hashcat will provide the full `hashcat_ctx_t` context. In most cases you do not need it. It is complex and not suitable for wrapper languages. For that reason it is only optionally available to global functions.
 
 If you do use it, you can call the `EVENT_DATA()` functions to write messages that follow the hashcat API format. This allows external applications that use the hashcat API to receive callbacks. This is optional.
 
@@ -101,7 +101,7 @@ typedef struct generic_global_ctx
 Notes:
 
 - This structure may change over time as we learn more about what developers need.
-- To handle compatibility, your feed library will be built with a version string. Hashcat will use this to check if your feed matches the current structures.
+- To handle compatibility, your feed library will be built with a version string. hashcat will use this to check if your feed matches the current structures.
 - Attributes `workc` and `workv` contain the command line arguments that belong to attack mode -a 8. For example, if your feed reads a wordlist, the filename can be passed on the hashcat command line and you can retrieve it from these variables. The feed plugin name is always workv[0], so for the wordlist example you would find this in workv[1].
 - The error field should be set to true only if a real error occurs. An end of file condition is not an error. When you set this field, you may also provide an error message in error_msg.
 - If you print messages to the console, check the quiet flag first. This flag is set when the user runs hashcat with `--quiet`.
@@ -126,9 +126,9 @@ typedef struct generic_thread_ctx
 
 Some explanations:
 
-Hashcat can use multiple compute devices. Each device has its own candidate generator thread. This improves performance and keeps the design simple. Hashcat will handle synchronization by calling your `thread_seek()` function.
+hashcat can use multiple compute devices. Each device has its own candidate generator thread. This improves performance and keeps the design simple. hashcat will handle synchronization by calling your `thread_seek()` function.
 
-For example, if your feed reads from a wordlist, the normal way is to open the file once per thread. Each thread maintains its own file handle. Hashcat calls `thread_seek()` with the offset where each thread should start.
+For example, if your feed reads from a wordlist, the normal way is to open the file once per thread. Each thread maintains its own file handle. hashcat calls `thread_seek()` with the offset where each thread should start.
 
 It is also possible to open the file only once in the global function and then distribute data to threads using pipes. This is more complex but can be done if needed.
 
@@ -172,7 +172,7 @@ This function is mandatory.
 
 ## Global vs Thread Context
 
-Hashcat supports compute devices of very different performance levels. For example, a session may include one CPU and five GPUs, each with different speeds. To feed each device efficiently, hashcat creates a separate thread per device.
+hashcat supports compute devices of very different performance levels. For example, a session may include one CPU and five GPUs, each with different speeds. To feed each device efficiently, hashcat creates a separate thread per device.
 
 This is why there are two context structures:
 

--- a/docs/hashcat-generic-attack-mode.md
+++ b/docs/hashcat-generic-attack-mode.md
@@ -45,7 +45,7 @@ Keep in mind that hashcat always parses the full command line first. All options
 
 We debated how useful such an interface is, given that hashcat already provides a generic `STDIN` interface for connecting custom generators. However, there are several reasons why STDIN is good but not optimal.
 
-With STDIN, there is only one input channel feeding multiple output channels. Output channels in this context mean compute devices. Hashcat spawns a unique thread for each compute device so it can handle devices of different speeds. This requires synchronization. The same is true for attack modes 0, 1, 3, 6, and 7, but the difference is that in those modes there is no single input channel.
+With STDIN, there is only one input channel feeding multiple output channels. Output channels in this context mean compute devices. hashcat spawns a unique thread for each compute device so it can handle devices of different speeds. This requires synchronization. The same is true for attack modes 0, 1, 3, 6, and 7, but the difference is that in those modes there is no single input channel.
 
 For example, when attack-mode 0 is run on four GPUs, hashcat spawns four threads. Each thread opens its own file handle to the wordlist and reads independently. The synchronizer only tells each thread where to start and stop, so parallelization works smoothly.
 
@@ -83,7 +83,7 @@ These modifiers are always enabled with STDIN, but in a feed they can be disable
 
 A generator feeding candidates through STDIN may or may not support session restore.
 
-With attack-mode 8, restore is guaranteed. Hashcat can seek directly to the needed candidate within the generator. Depending on the generator architecture, seeking may be slow, but no third program is required to emulate restore.
+With attack-mode 8, restore is guaranteed. hashcat can seek directly to the needed candidate within the generator. Depending on the generator architecture, seeking may be slow, but no third program is required to emulate restore.
 
 ## 4. Interface Design
 

--- a/docs/hashcat-plugin-development-guide.md
+++ b/docs/hashcat-plugin-development-guide.md
@@ -1,4 +1,4 @@
-# Hashcat Plugin Development Guide #
+# hashcat Plugin Development Guide #
 
 The purpose of this document is to introduce you to the development of plugins for hashcat 6.0.0 and newer. We will update this document regularly and add more detailed content. The content in its current state includes enough details to write easy, medium and hard plugins.
 
@@ -257,7 +257,7 @@ module_ctx->module_hash_name = module_hash_name;
 
 As you can see here, there is a so-called module_ctx object. Here you register all functions that you have implemented in your module and which should be used by hashcat. A list of all functions and their prototypes can be found under `include/modules.h`.
 
-Hashcat will automatically call the module_init() function when it loads your module. In this function, you simply register all the functions that you have programmed by assigning it to module_ctx.
+hashcat will automatically call the module_init() function when it loads your module. In this function, you simply register all the functions that you have programmed by assigning it to module_ctx.
 
 Example:
 
@@ -313,7 +313,7 @@ For slow hashes, you will normally set the "order" to 0, 1, 2 and 3, because suc
 
 As you can see in the previous section, only 128 bits of the target hash are tested, but the hash must be saved entirely so that it can later be converted from its binary form back to its original form. Only you can know the size of the hash you are storing, but hashcat needs this information so that it can allocate necessary memory buffers.
 
-Important: Hashcat will provide this buffer of the size you specified in a void buffer which you will use as *digest_buf in the decoder/encoder.
+Important: hashcat will provide this buffer of the size you specified in a void buffer which you will use as *digest_buf in the decoder/encoder.
 
 Some macros already exist because they have already been used in many modules before. A list of the well known digest sizes already defined can be found in `include/types.h`.
 
@@ -435,7 +435,7 @@ Note: the general rule is that the kernel code should not do any unnecessary rep
 
 ### module_hash_decode_postprocess() ###
 
-This module can be used when you have certain configuration items of a hash that you want to override with a command line parameter. A good example is the --hccapx-message-pair, where the user can add additional filter criteria so that Hashcat doesn't load a specific set of hashes from the hash list.
+This module can be used when you have certain configuration items of a hash that you want to override with a command line parameter. A good example is the --hccapx-message-pair, where the user can add additional filter criteria so that hashcat doesn't load a specific set of hashes from the hash list.
 
 ### module_opts_type() ###
 
@@ -473,7 +473,7 @@ This configuration item is a bitmask field and is very similar to the module_opt
 * OPTS_TYPE_HASH_SPLIT: This needs to be used if the hash actually contains multiple hashes in the same hash line. A good example is the LM hash which is typically stored as a 128 bit hash, but actually is built on two 64 bit hashes.
 * OPTS_TYPE_LOOP_PREPARE: TBD
 * OPTS_TYPE_LOOP_EXTENDED: This flag can be used if you want to execute a *_loop_extended kernel directly each time a _loop kernel is finished. This actually means directly after each _loop kernel invocation when no final values are ready. The _loop kernel typically only iterates for a maximum of 1024 iterations and then returns. This provides low kernel runtimes, which reduces GPU screen lags and avoids driver watchdog events. However, some algorithms can be exploited by working on exactly these intermediate values.
-* OPTS_TYPE_HOOK12: Execute a hook kernel (CPU code) between _init and _loop kernel. A hook kernel is a normal kernel which can be used to select/copy very specific intermediate data and copy it to a so-called hook transfer buffer. This transfer buffer exists on both GPU and CPU. After the kernel is completed, the GPU buffer is copied to the corresponding CPU buffer so it can be processed. Then, the real hook function from your module is called from which you can read the intermediate data, process it as you need and then store it back. After your CPU function is finished, the buffer is copied back to the GPU automatically. The typical use case for this is if you need to deal with algorithms which include libraries which have no GPU implementation. Hashcat will automatically spawn a number of threads for you, so this is a multi threaded process. All buffers which are not constant buffers are thread-safe.
+* OPTS_TYPE_HOOK12: Execute a hook kernel (CPU code) between _init and _loop kernel. A hook kernel is a normal kernel which can be used to select/copy very specific intermediate data and copy it to a so-called hook transfer buffer. This transfer buffer exists on both GPU and CPU. After the kernel is completed, the GPU buffer is copied to the corresponding CPU buffer so it can be processed. Then, the real hook function from your module is called from which you can read the intermediate data, process it as you need and then store it back. After your CPU function is finished, the buffer is copied back to the GPU automatically. The typical use case for this is if you need to deal with algorithms which include libraries which have no GPU implementation. hashcat will automatically spawn a number of threads for you, so this is a multi threaded process. All buffers which are not constant buffers are thread-safe.
 * OPTS_TYPE_HOOK23: Same as OPTS_TYPE_HOOK12 but the hook is between the _loop and the _comp kernel. Do not confuse this with OPTS_TYPE_LOOP_EXTENDED. A hook is always when the final values are ready to be processed. We believe most algorithms that need hook code will use this hook instead of OPTS_TYPE_HOOK12.
 * OPTS_TYPE_INIT2: Some algorithms (usually updated from previous crypto schemes) execute two different types of compute intensive derivation functions. A good example is iTunes 10+. In iTunes 9 there is an algorithm with 10,000 iterations of SHA256. However, Apple updated this algorithm to be backward compatible. They use the output of the iTunes 9 KDF as the password to a new KDF which is 10,000,000 iterations of SHA256. The problem is that even for a KDF with 10,000 iteration we need to split this. In this instance we split this into 10 calls to a _loop kernel with 1,000 iteration otherwise users get massive screen lags or some watchdogs restart the drivers. In such a case, you can use OPTS_TYPE_INIT2 and OPTS_TYPE_LOOP2 kernels where you can execute the updated KDF with 10,000,000 iterations and also split it into 1,000 iteration chunks.
 * OPTS_TYPE_LOOP2_PREPARE: TBD
@@ -605,7 +605,7 @@ In most cases, however, the code for the hash is exactly the same. In these case
 
 ### Kernel parameters ###
 
-Hashcat will call all kernels with exactly the same parameters. In most cases only a few of the parameters are used, but on the other hand they do not have a negative impact on the performance. Having a fixed prototype for all kernels makes it easier to work with all the different buffers and generally makes it easier to read kernels from other people.
+hashcat will call all kernels with exactly the same parameters. In most cases only a few of the parameters are used, but on the other hand they do not have a negative impact on the performance. Having a fixed prototype for all kernels makes it easier to work with all the different buffers and generally makes it easier to read kernels from other people.
 
 There is no need for you to change anything. This section is only for information. While it is not relevant for you to know all the different parameters, at least some of them are important to know. Never write to any of them directly unless you know about the implications. Use the macros provided if you want to write something. Most of the buffer you do not even need to read from. The ones that are interesting for reading I will mark in the description.
 
@@ -663,7 +663,7 @@ The large number of kernel parameters can be confusing when writing a kernel. Bu
 
 The fast hash type is needed if we are cracking a hash that is so fast to compute that the PCI express bottleneck is taking more time than to compute the hash. These raw hashes are designed to compute very fast intentionally. They typically consist of only binary or arithmetic operations either with none or limited memory access. That means they often can be implemented on register level. On the other hand, if we need to access any memory structures just to provide the password candidates, it will hurt the performance significantly. Therefore the general concept of a fast hash kernel is to load a base password candidate directly onto a register and run a for() loop within the kernel which modifies the base password candidate.
 
-The modification is depending on the attack-mode. Hashcat supports 5 different attack-modes with the -a command line flag (0, 1, 3, 6 and 7) but attack-mode 6 and attack-mode 7 share the same kernel code with attack-mode 1. This means we have to implement three kernels. These kernels are implemented in three kernel source files (0, 1, 3). Based on the attack-mode selected by the user on startup, hashcat will load the corresponding kernel.
+The modification is depending on the attack-mode. hashcat supports 5 different attack-modes with the -a command line flag (0, 1, 3, 6 and 7) but attack-mode 6 and attack-mode 7 share the same kernel code with attack-mode 1. This means we have to implement three kernels. These kernels are implemented in three kernel source files (0, 1, 3). Based on the attack-mode selected by the user on startup, hashcat will load the corresponding kernel.
 
 The file name convention for fast hashes is: `OpenCL/mXXXXX_a[0|1|3]-[pure|optimized].cl`
 
@@ -718,7 +718,7 @@ Typically it goes like this:
 
 For slow hashes it is recommended to use vector data types if your algorithm allows to do so. If you use vector data types, use it in the _loop kernel only. Make sure to inform hashcat about using the appropriate opts_type option (see modules section).
 
-## Hashcat Crypto Library ##
+## hashcat Crypto Library ##
 
 The hashcat crypto library interface is very close to the OpenSSL interface with the typical Init(), Update() and Final() calls. But there are some important differences:
 
@@ -781,7 +781,7 @@ Important: In case you write a slow hash, you need to set the salt_iter element.
 
 ## Data Structures: salt_t vs esalt ##
 
-Hashcat has a generic data structure to handle "easy" salts (salt_t) and an open data structure one, that you can define yourself in case the generic data structure does not fit your needs (esalt). An "easy" salt is a single buffer salt of less than 256 byte (can be binary). The open data structure is called "esalt".
+hashcat has a generic data structure to handle "easy" salts (salt_t) and an open data structure one, that you can define yourself in case the generic data structure does not fit your needs (esalt). An "easy" salt is a single buffer salt of less than 256 byte (can be binary). The open data structure is called "esalt".
 
 It is important to understand the difference between the generic salt_t struct and the esalt struct (which you create on your own). In fact it is essential to distinguish them. Based on the data we assign to the salt_t struct, hashcat sorts and groups all digests belonging to this particular salt_t first by the salt buffer content in salt->salt_buf[]. We can see it as a top level grouping. With the data we assign to the esalt, hashcat sorts and groups all hashes, but on a level below. Like in a SQL Statement when we do something like:
 

--- a/docs/hashcat-python-plugin-development-guide.md
+++ b/docs/hashcat-python-plugin-development-guide.md
@@ -1,10 +1,10 @@
-# Hashcat Python Plugin Development Guide
+# hashcat Python Plugin Development Guide
 
-This document is a comprehensive guide for writing custom hash modes in Python via Hashcat's Assimilation Bridge plugin.
+This document is a comprehensive guide for writing custom hash modes in Python via hashcat's Assimilation Bridge plugin.
 
 ## 1. Introduction
 
-The Assimilation Bridge enables developers to implement complete hash mode logic in languages other than C, most notably Python. Traditionally, customizing Hashcat required writing a module in C and a kernel in OpenCL/CUDA. With the bridge, you can now implement a complete hash mode in Python.
+The Assimilation Bridge enables developers to implement complete hash mode logic in languages other than C, most notably Python. Traditionally, customizing hashcat required writing a module in C and a kernel in OpenCL/CUDA. With the bridge, you can now implement a complete hash mode in Python.
 
 The bridge supports two hash modes to run python code:
 
@@ -19,15 +19,15 @@ Ideally, start by walking through `hashcat-python-plugin-quickstart.md`, or read
 
 ## 3. Python Bridge basics
 
-Hashcat implements the CPython interface, loading the embedded interpreter via dynamic loading mechanisms (`dlopen()`, `LoadLibrary()`, etc). This enables runtime flexibility, allowing Hashcat to use whatever Python version is installed on the system. Users of the precompiled Hashcat binaries don’t need Python headers and just a working Python interpreter. Compatibility is checked at runtime, not compile time. If hashcat detect an invalid python version it will stop and print informative instructions on what to do next.
+Hashcat implements the CPython interface, loading the embedded interpreter via dynamic loading mechanisms (`dlopen()`, `LoadLibrary()`, etc). This enables runtime flexibility, allowing hashcat to use whatever Python version is installed on the system. Users of the precompiled hashcat binaries don't need Python headers and just a working Python interpreter. Compatibility is checked at runtime, not compile time. If hashcat detect an invalid python version it will stop and print informative instructions on what to do next.
 
-In general, when using any assimilation bridge "application" (such as the Python bridge), the hash mode determines which bridge plugin is loaded (this is a 1:1 relationship). From there, the bridge decides how to proceed. In the case of the Python bridge, it loads the Python library, sets up the interpreter, and finally selects which Python script to execute. Understanding this flow is essential, especially if you plan to contribute to upstream Hashcat on GitHub or want to register a dedicated hash mode number.
+In general, when using any assimilation bridge "application" (such as the Python bridge), the hash mode determines which bridge plugin is loaded (this is a 1:1 relationship). From there, the bridge decides how to proceed. In the case of the Python bridge, it loads the Python library, sets up the interpreter, and finally selects which Python script to execute. Understanding this flow is essential, especially if you plan to contribute to upstream hashcat on GitHub or want to register a dedicated hash mode number.
 
 You can decide to use the generic hash mode and only contribute the .py file itself with your implementation, or you copy the bridge code and hardcode the path to you .py implementation in there. The advantage in the generic mode is that it's super simple, but it will run a little slower and you have less control about workload tuning. Also having a dedicated mode allows you to implement a unit test, because you have a dedicated hash mode that you can refer to.
 
-Hashcat includes a top-level `Python/` directory with standard helpers and bridge modules:
+hashcat includes a top-level `Python/` directory with standard helpers and bridge modules:
 
-The following three files are relevant regardless of whether you plan to create a generic or a dedicated hash mode. These modules do the heavy lifting to interact with Hashcat internals from Python. Basically you should not need to change them, and instead you import them from your implementation:
+The following three files are relevant regardless of whether you plan to create a generic or a dedicated hash mode. These modules do the heavy lifting to interact with hashcat internals from Python. Basically you should not need to change them, and instead you import them from your implementation:
 
 ```text
 - hcsp.py: Helper for single-threaded mode. Manages queue handling, function invocation, and context propagation.
@@ -142,7 +142,7 @@ Remember, the extract_esalts() was given as function pointer to hcsp.init(). Tha
 
 ### Salts Appear as Binary Blobs using 32 bit datatypes
 
-Hashcat is optimized for performance, especially on GPUs. To improve performance, it mostly works on 32 bit datatypes instead of 8 bit datatypes. In python the helper scripts convert these binary blobs into byte[] objects that are easier to work with. As you can see from the above example: `16384 * 4 = 65536`
+hashcat is optimized for performance, especially on GPUs. To improve performance, it mostly works on 32 bit datatypes instead of 8 bit datatypes. In python the helper scripts convert these binary blobs into byte[] objects that are easier to work with. As you can see from the above example: `16384 * 4 = 65536`
 
 ### Fixed salt datatypes
 
@@ -180,7 +180,7 @@ The `salt` variable is one of the parameters from the calc_hash():
 def calc_hash(password: bytes, salt: dict) -> str:
 ```
 
-Note that if you fully exhaust the Hashcat keyspace, your function has been called X times Y.. X is the number of candidates, and Y is all the salts (except if a salt has been cracked). What's important to realize that within your function, you implement hashing logic only for precisely that situation where you have one password and one salt.
+Note that if you fully exhaust the hashcat keyspace, your function has been called X times Y.. X is the number of candidates, and Y is all the salts (except if a salt has been cracked). What's important to realize that within your function, you implement hashing logic only for precisely that situation where you have one password and one salt.
 
 
 ### Merging Salts and Esalts into a Single Object
@@ -208,7 +208,7 @@ Notes:
 - Even though `-m 72000` uses single-threaded Python, the bridge plugin above it manages multiple Python interpreters (one per thread) making it effectively multi-threaded.
 - On Windows/macOS, if `-m 73000` is selected, it silently falls back to `generic_hash_sp.py` due to limitations with multiprocessing. This behavior is important to understand and you might otherwise wonder why your code changes have no effect.
 
-If you modify one of these plugin files, there's a trade-off: you won’t be able to contribute that code directly to the upstream Hashcat repository, since those files are meant to remain clean for demonstration purposes.
+If you modify one of these plugin files, there's a trade-off: you won't be able to contribute that code directly to the upstream hashcat repository, since those files are meant to remain clean for demonstration purposes.
 
 To address this, the assimilation bridge provides a generic parameter that users can specify via the command line. In the case of the Python bridge, only the first parameter is used. Using `--bridge-parameter1` allows you to override the Python script to be loaded:
 
@@ -216,7 +216,7 @@ To address this, the assimilation bridge provides a generic parameter that users
 $ ./hashcat -m 73000 --bridge-parameter1 ./Python/myimplementation.py hash.txt wordlist.txt ...
 ```
 
-This tells the Python bridge plugin to load `myimplementation.py` located in the local `Python` subdirectory instead of the default `generic_hash_mp.py`. This approach is especially useful if you plan to contribute `myimplementation.py` to the upstream Hashcat repository. If you choose to stay within the generic mode, your Python code won’t have a dedicated hash mode, and you'll need to instruct users to use the `--bridge-parameter1` flag to load your implementation.
+This tells the Python bridge plugin to load `myimplementation.py` located in the local `Python` subdirectory instead of the default `generic_hash_mp.py`. This approach is especially useful if you plan to contribute `myimplementation.py` to the upstream hashcat repository. If you choose to stay within the generic mode, your Python code won't have a dedicated hash mode, and you'll need to instruct users to use the `--bridge-parameter1` flag to load your implementation.
 
 ### Design Tradeoffs and Format Considerations
 
@@ -233,14 +233,14 @@ However, it is crucial to highlight:
 - You are **not obligated to follow this generic approach**. In fact, it's generally preferable to implement proper hash line decoding and encoding logic.
 - For instance, a proper Yescrypt implementation (unlike the quickstart document) would ideally decode hash lines into clear, separate components (digest, salt, parameters) and encode them accordingly upon successful cracking.
 
-The reason the generic hash mode provided by Hashcat employs a simplified approach is to:
+The reason the generic hash mode provided by hashcat employs a simplified approach is to:
 
 - Demonstrate a flexible, format-agnostic solution suitable for initial prototyping or unfamiliar hash formats.
 - Avoid complexity and make it easy for plugin developers to get started quickly without deep understanding of specific hash format parsing logic.
 
 In summary, while the generic mode is quick and easy, robust real-world plugins **should implement proper hash decoding and encoding logic** to ensure accuracy, efficiency, and maintainability.
 
-## 7. Debugging Without Hashcat
+## 7. Debugging Without hashcat
 
 You can run your plugin as a standalone script:
 ```

--- a/docs/hashcat-python-plugin-quickstart.md
+++ b/docs/hashcat-python-plugin-quickstart.md
@@ -1,10 +1,10 @@
-# Hashcat Python Plugin Quickstart
+# hashcat Python Plugin Quickstart
 
 ## Introduction
 
-Hashcat v7 introduces a `Python plugin bridge` that allows you to write and integrate custom hash-matching algorithms directly in Python. This plugin system fits into the regular cracking workflow by replacing or extending internal kernel routines.
+hashcat v7 introduces a `Python plugin bridge` that allows you to write and integrate custom hash-matching algorithms directly in Python. This plugin system fits into the regular cracking workflow by replacing or extending internal kernel routines.
 
-When enabled, Hashcat uses the plugin’s `calc_hash()` function to compute hash candidates for verification, making it easy to experiment with new or obscure algorithms without modifying core C code or writing OpenCL/CUDA kernels.
+When enabled, hashcat uses the plugin's `calc_hash()` function to compute hash candidates for verification, making it easy to experiment with new or obscure algorithms without modifying core C code or writing OpenCL/CUDA kernels.
 
 This guide demonstrates how to quickly customize such an algorithm using pure Python. Whether you're prototyping a new hash mode, supporting a proprietary format, or simply prefer high-level development, Python plugins make the process fast and straightforward.
 
@@ -16,7 +16,7 @@ You can use any Python modules you like.
 
 A benchmark is a good way to verify that your setup is working correctly.
 
-Hashcat mode `73000` is preconfigured to load a generic Python plugin from the source file `Python/generic_hash_mp.py`:
+hashcat mode `73000` is preconfigured to load a generic Python plugin from the source file `Python/generic_hash_mp.py`:
 
 ```
 hashcat -m 73000 -b
@@ -40,7 +40,7 @@ Example output:
 $y$j9T$uxVFACnNnGBakt9MLrpFf0$SmbSZAge5oa1BfHPBxYGq3mITgHeO/iG2Mdfgo93UN0
 ```
 
-### Prepare the Hash Line for Hashcat
+### Prepare the Hash Line for hashcat
 
 ```
 $y$j9T$uxVFACnNnGBakt9MLrpFf0$SmbSZAge5oa1BfHPBxYGq3mITgHeO/iG2Mdfgo93UN0*$y$j9T$uxVFACnNnGBakt9MLrpFf0$
@@ -48,7 +48,7 @@ $y$j9T$uxVFACnNnGBakt9MLrpFf0$SmbSZAge5oa1BfHPBxYGq3mITgHeO/iG2Mdfgo93UN0*$y$j9T
 
 (Use the full hash before the `*` and the salt portion after the `*`.)
 
-Hashcat modes `73000` and `72000` are generic modes that do not parse the hash, which can lead to redundancy.
+hashcat modes `73000` and `72000` are generic modes that do not parse the hash, which can lead to redundancy.
 
 Refer to `hashcat-python-plugin-development-guide.md` to learn how to develop plugins for the generic hash mode.
 

--- a/docs/hashcat-python-plugin-requirements.md
+++ b/docs/hashcat-python-plugin-requirements.md
@@ -1,4 +1,4 @@
-# Hashcat Python Plugin Requirements
+# hashcat Python Plugin Requirements
 
 ## Windows/macOS and Linux
 
@@ -14,7 +14,7 @@ The `multiprocessing` module is not fully supported in this embedded environment
 
 ### On Linux
 
-The `multiprocessing` module functions correctly, allowing full CPU utilization through parallel worker processes. However, since threading is managed by Python, it relies on `fork()` and inter-process communication (IPC). This adds complexity and code bloat to Hashcat, effectively duplicating modules and bridge plugins, making the codebase harder to understand for those exploring how it all works. We could switch to a free-threaded Python runtime, but it's still unstable at the time of writing even on Linux (see the `cffi` problem below). For now, we’ve chosen to use the `multiprocessing` module as a more practical solution.
+The `multiprocessing` module functions correctly, allowing full CPU utilization through parallel worker processes. However, since threading is managed by Python, it relies on `fork()` and inter-process communication (IPC). This adds complexity and code bloat to hashcat, effectively duplicating modules and bridge plugins, making the codebase harder to understand for those exploring how it all works. We could switch to a free-threaded Python runtime, but it's still unstable at the time of writing even on Linux (see the `cffi` problem below). For now, we've chosen to use the `multiprocessing` module as a more practical solution.
 
 **On Linux**: Use `pyenv`. It's the easiest way to install and manage Python versions, see below section
 

--- a/docs/hashcat-rust-plugin-quickstart.md
+++ b/docs/hashcat-rust-plugin-quickstart.md
@@ -1,13 +1,13 @@
-# Hashcat Rust Plugin Quickstart
+# hashcat Rust Plugin Quickstart
 
 ## Introduction
 
-Hashcat v7.1.2 introduces a new assimilation bridge plugin, the Rust
+hashcat v7.1.2 introduces a new assimilation bridge plugin, the Rust
 bridge, that allows you to write custom hash-matching algorithms in
 Rust. This plugin system fits into the regular cracking workflow,
 replacing or extending internal kernel routines.
 
-When enabled, Hashcat uses the plugin’s `calc_hash()` function to
+When enabled, hashcat uses the plugin's `calc_hash()` function to
 compute hash candidates. This makes it easy to experiment with new or
 obscure algorithms without modifying core C code or writing
 OpenCL/CUDA kernels.
@@ -17,14 +17,14 @@ Rust. You simply:
 
 1. Write your logic in `calc_hash()`.
 2. Build your plugin with `cargo build --release`.
-3. Load it into Hashcat and start cracking.
+3. Load it into hashcat and start cracking.
 
 You can use any Rust crates you like.
 
 ## Quick Start
 
 A benchmark is a simple way to verify that your setup works correctly.
-Hashcat mode `74000` is preconfigured to load a generic Rust plugin
+hashcat mode `74000` is preconfigured to load a generic Rust plugin
 from a dynamic library:
 
     hashcat -m 74000 -b
@@ -42,7 +42,7 @@ Example output:
 
     $y$j9T$uxVFACnNnGBakt9MLrpFf0$SmbSZAge5oa1BfHPBxYGq3mITgHeO/iG2Mdfgo93UN0
 
-### Prepare the Hash Line for Hashcat
+### Prepare the Hash Line for hashcat
 
 Take the full hash and append a `*` followed by the salt (settings)
 portion to it. The appended settings must start and end with a `$`.

--- a/docs/hashcat-rust-plugin-requirements.md
+++ b/docs/hashcat-rust-plugin-requirements.md
@@ -1,6 +1,6 @@
-# Hashcat Rust Plugin Requirements
+# hashcat Rust Plugin Requirements
 
-This document explains how to build and use the Hashcat Rust plugin on
+This document explains how to build and use the hashcat Rust plugin on
 Linux, Windows, and macOS.
 
 ## Linux
@@ -10,9 +10,9 @@ Linux, Windows, and macOS.
    Rust **1.88 or newer** is recommended. Older versions may not work
    reliably.
 
-2. **Build Hashcat**
+2. **Build hashcat**
 
-   If you are building Hashcat from source, run:
+   If you are building hashcat from source, run:
 
    ```
    make linux
@@ -45,7 +45,7 @@ Linux, Windows, and macOS.
 
    This produces `libgeneric_hash.so` in `Rust/bridges/generic_hash/target/release`.
 
-5. **Run Hashcat**
+5. **Run hashcat**
 
    ```
    hashcat -a 0 -m 74000 hashfile wordlist
@@ -67,7 +67,7 @@ Linux, Windows, and macOS.
    installed via `rustup`, you already have them.  Prefer **Rust 1.88
    or newer**.
 
-2. **Build Hashcat**
+2. **Build hashcat**
 
    You only have to do this if you're building from sources.
 
@@ -112,7 +112,7 @@ Linux, Windows, and macOS.
    This produces `generic_hash.dll` in
    `Rust/bridges/generic_hash/target/x86_64-pc-windows-gnu/release`.
 
-5. **Run Hashcat**
+5. **Run hashcat**
 
    ```
    hashcat -a 0 -m 74000 hashfile wordlist
@@ -126,7 +126,7 @@ Linux, Windows, and macOS.
 
 ## macOS
 
-Hashcat does not ship prebuilt macOS binaries, so you must build both
+hashcat does not ship prebuilt macOS binaries, so you must build both
 the bridge and the plugin yourself.
 
 1. Follow the same steps as in the **Linux** section.
@@ -137,7 +137,7 @@ the bridge and the plugin yourself.
      mv Rust/bridges/generic_hash/target/release/libgeneric_hash.dylib \
         Rust/bridges/generic_hash/target/release/libgeneric_hash.so
      ```
-   - Or run Hashcat with:
+   - Or run hashcat with:
      ```
      --bridge-parameter1 /path/to/libgeneric_hash.dylib
      ```

--- a/docs/releases_notes_v7.1.0.md
+++ b/docs/releases_notes_v7.1.0.md
@@ -1,5 +1,5 @@
 
-# Hashcat 7.1.0 - Release Notes
+# hashcat 7.1.0 - Release Notes
 
 This is a minor release, but an important one. It comes just two weeks after the major v7.0.0 update, as part of our effort to keep release cycles shorter than in the past.
 
@@ -59,7 +59,7 @@ In preparation for the Jabbercracky Password Cracking Contest at DEF CON 33, we 
 
 ### 2.1. Attack-Modes: Use 64-bit counters for amplifier keyspace
 
-Hashcat now uses 64-bit counters for the amplifier keyspace (previously limited to 32-bit), allowing greater flexibility in attack design. All attack-modes are supported, but the primary impact is on the combinator and both hybrid attack-modes. This change could be especially relevant if you have ever seen the following message in previous hashcat runs:
+hashcat now uses 64-bit counters for the amplifier keyspace (previously limited to 32-bit), allowing greater flexibility in attack design. All attack-modes are supported, but the primary impact is on the combinator and both hybrid attack-modes. This change could be especially relevant if you have ever seen the following message in previous hashcat runs:
 
   `Integer overflow detected in ...`
 
@@ -134,7 +134,7 @@ This issue often arises when users copy hashcat examples from tutorials written 
 
 This leads to an invalid rule being applied to every word in the wordlist, which causes internal syntax errors.
 
-Previously these errors were not shown, resulting in an empty wordlist without explanation. Hashcat now reports these rule parsing errors clearly, making it easier to debug solo-rule related issues.
+Previously these errors were not shown, resulting in an empty wordlist without explanation. hashcat now reports these rule parsing errors clearly, making it easier to debug solo-rule related issues.
 
 ### 2.7. Device Memory: Do not disable hardware-monitor interface by default in speed-only and progress-only mode
 


### PR DESCRIPTION
## Summary

This PR fixes inconsistent capitalization of 'hashcat' throughout the documentation files. The official project name is lowercase 'hashcat' (as shown in releases_notes_v7.0.0.md and other core files), but many documentation files incorrectly used 'Hashcat' with a capital H.

## Changes

- Changed 'Hashcat' to 'hashcat' in 11 documentation files
- Affected files include:
  - hashcat-assimilation-bridge.md
  - hashcat-brain.md
  - hashcat-generic-attack-mode*.md
  - hashcat-plugin-development-guide.md
  - hashcat-python-plugin-*.md
  - hashcat-rust-plugin-*.md
  - releases_notes_v7.1.0.md

This ensures consistency with the official naming convention across all documentation.

## Checklist

- [x] Documentation changes only
- [x] No functional code changes
- [x] Consistent with official project naming convention