### PR TITLE
Fix memory safety issues: use-after-free, fd leaks, integer overflow, missing null termination

### DIFF
--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -275,7 +275,13 @@ bool hc_fopen (HCFILE *fp, const char *path, const char *mode)
   }
   else
   {
-    if ((fp->pfp = fdopen (fp->fd, mode)) == NULL) return false;
+    if ((fp->pfp = fdopen (fp->fd, mode)) == NULL)
+    {
+      // fdopen failed, close the file descriptor to avoid resource leak
+      close (fp->fd);
+      fp->fd = -1;
+      return false;
+    }
 
     if (fp->bom_size)
     {
@@ -353,7 +359,13 @@ bool hc_fopen_raw (HCFILE *fp, const char *path, const char *mode)
 
   if (fp->fd == -1) return false;
 
-  if ((fp->pfp = fdopen (fp->fd, mode)) == NULL) return false;
+  if ((fp->pfp = fdopen (fp->fd, mode)) == NULL)
+  {
+    // fdopen failed, close the file descriptor to avoid resource leak
+    close (fp->fd);
+    fp->fd = -1;
+    return false;
+  }
 
   fp->path = path;
   fp->mode = mode;

--- a/src/memory.c
+++ b/src/memory.c
@@ -124,7 +124,11 @@ void *hcmalloc_bridge_aligned (const size_t sz, const int align)
 {
   uintptr_t align_mask = (uintptr_t) (align - 1);
 
-  void *raw = malloc (sz + align + sizeof (void *));
+  // Check for integer overflow before allocation
+  size_t total_size = sz + align + sizeof (void *);
+  if (total_size < sz) return NULL; // Overflow detected
+
+  void *raw = malloc (total_size);
 
   if (raw == NULL) return NULL;
 

--- a/src/modules/module_13100.c
+++ b/src/modules/module_13100.c
@@ -243,6 +243,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     data_len = token.len[4];
 
     memcpy (krb5tgs->account_info, token.buf[2], token.len[2]);
+    // Ensure null termination for string operations
+    ((u8 *) krb5tgs->account_info)[token.len[2]] = '\0';
   }
   else if (krb5tgs->format == 2)
   {
@@ -261,6 +263,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
     data_len = token.len[3];
 
     memcpy (krb5tgs->account_info, token.buf[1], token.len[1]);
+    // Ensure null termination for string operations
+    ((u8 *) krb5tgs->account_info)[token.len[1]] = '\0';
   }
 
   if (checksum_pos == NULL || data_pos == NULL) return (PARSER_SALT_VALUE);

--- a/src/modules/module_22000.c
+++ b/src/modules/module_22000.c
@@ -850,6 +850,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   wpa->essid_len = hex_decode (essid_buf, essid_len, (u8 *) wpa->essid_buf);
 
+  // Ensure null termination for string operations
+  ((u8 *) wpa->essid_buf)[wpa->essid_len] = '\0';
+
   // salt
 
   memcpy (salt->salt_buf, wpa->essid_buf, wpa->essid_len);

--- a/src/shared.c
+++ b/src/shared.c
@@ -587,7 +587,9 @@ void setup_environment_variables (const folder_config_t *folder_config, const us
 
     putenv (display);
 
-    hcfree (display);
+    // we can't free display at this point! POSIX specifies that putenv()
+    // places the string in the environment, and the string becomes part
+    // of the environment. Freeing it would cause use-after-free.
   }
   else
   {


### PR DESCRIPTION
## Summary

This PR fixes several memory safety issues in hashcat core code that could lead to crashes, resource leaks, or undefined behavior.

## Changes

### 1. Use-after-free in src/shared.c (line 590)

**Problem**: After calling putenv(display), the code immediately calls hcfree(display). However, POSIX specifies that putenv() places the string directly into the environment (not a copy), so freeing it causes use-after-free when the environment variable is later accessed.

**Fix**: Remove the hcfree(display) call and add a comment explaining why the memory cannot be freed (similar to the existing comment on line 617 for 	mpdir).

### 2. File descriptor leaks in src/filehandling.c (lines 278, 356)

**Problem**: When dopen() fails and returns NULL, the code returns false without closing the already-opened file descriptor p->fd, causing resource leaks.

**Fix**: Add close(fp->fd) and reset p->fd = -1 in the error path before returning false.

### 3. Integer overflow in src/memory.c (line 127)

**Problem**: The calculation sz + align + sizeof(void*) in hcmalloc_bridge_aligned() can overflow for large values of sz, leading to a smaller-than-expected allocation and potential buffer overflow.

**Fix**: Add overflow check before allocation: if (total_size < sz) return NULL;

### 4. Missing null termination in src/modules/module_22000.c (line 851) and src/modules/module_13100.c (lines 245, 263)

**Problem**: After hex_decode() or memcpy() operations, the buffers are later used as strings (with %s format specifier) but lack explicit null termination. While the structures may be zero-initialized, this is unsafe practice and could lead to reading beyond buffer bounds.

**Fix**: Add explicit null terminators after the copy operations: ((u8 *) buffer)[len] = '\0';

## Impact

- **Security**: Prevents potential use-after-free, buffer overflows, and information disclosure
- **Stability**: Fixes resource leaks that could cause failures under heavy load
- **Performance**: No performance impact; changes are in error paths or one-time initialization

## Testing

Changes are defensive fixes in error handling and initialization paths. The fixes follow established patterns already present in the codebase (e.g., the comment on line 617 of shared.c already notes that 	mpdir cannot be freed after putenv()).
