### PR TITLE
Fix -cl-std= build option to use per-device OpenCL version instead of platform version

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -7070,37 +7070,17 @@ static void backend_ctx_devices_init_opencl (hashcat_ctx_t *hashcat_ctx, int *vi
         device_param->opencl_platform_id = opencl_platforms_idx;
 
         // check OpenCL version
+        //
+        // note: the actual flag derivation happens further below, once the
+        // per-device CL_DEVICE_VERSION has been queried. the platform version
+        // is not a reliable source since a single OpenCL platform can expose
+        // devices that individually support a lower OpenCL version than the
+        // platform as a whole (for example remote/heterogeneous platforms)
 
         device_param->use_opencl11 = false;
         device_param->use_opencl12 = false;
         device_param->use_opencl20 = false;
         device_param->use_opencl30 = false;
-
-        int opencl_version_maj = 0;
-        int opencl_version_min = 0;
-
-        if (sscanf (opencl_platform_version, "OpenCL %d.%d", &opencl_version_maj, &opencl_version_min) == 2)
-        {
-          if (opencl_version_maj == 1)
-          {
-            device_param->use_opencl11 = true;
-          }
-
-          if ((opencl_version_maj == 1) && (opencl_version_min == 2))
-          {
-            device_param->use_opencl12 = true;
-          }
-
-          if (opencl_version_maj == 2)
-          {
-            device_param->use_opencl20 = true;
-          }
-
-          if (opencl_version_maj == 3)
-          {
-            device_param->use_opencl30 = true;
-          }
-        }
 
         size_t param_value_size = 0;
 
@@ -7292,6 +7272,36 @@ static void backend_ctx_devices_init_opencl (hashcat_ctx_t *hashcat_ctx, int *vi
         }
 
         device_param->opencl_device_version = opencl_device_version;
+
+        // derive the -cl-std= build option from the device's own OpenCL
+        // version instead of the platform's, since a platform can expose
+        // devices with a lower individually supported OpenCL version
+
+        int opencl_version_maj = 0;
+        int opencl_version_min = 0;
+
+        if (sscanf (opencl_device_version, "OpenCL %d.%d", &opencl_version_maj, &opencl_version_min) == 2)
+        {
+          if (opencl_version_maj == 1)
+          {
+            device_param->use_opencl11 = true;
+          }
+
+          if ((opencl_version_maj == 1) && (opencl_version_min == 2))
+          {
+            device_param->use_opencl12 = true;
+          }
+
+          if (opencl_version_maj == 2)
+          {
+            device_param->use_opencl20 = true;
+          }
+
+          if (opencl_version_maj == 3)
+          {
+            device_param->use_opencl30 = true;
+          }
+        }
 
         // opencl_device_c_version
 


### PR DESCRIPTION
Fixes #4670.

## Problem

Hashcat derives the `-cl-std=` OpenCL kernel build flag from the **platform's** `CL_PLATFORM_VERSION`, not from each individual **device's** `CL_DEVICE_VERSION`. A single OpenCL platform can expose multiple devices that don't all support the same OpenCL version — this is the case with heterogeneous/remote platforms such as PoCL-Remote, where the platform itself reports version 3.0 but an individual device behind it may only support a lower version. Hashcat then passes `-cl-std=CL3.0` to that device's compiler and kernel compilation fails.

Root cause in `backend_ctx_devices_init_opencl` (`src/backend.c`): the `use_opencl11/12/20/30` flags that select the `-cl-std=` flag were computed from `opencl_platform_version` *before* the per-device `CL_DEVICE_VERSION` was even queried. The per-device version was already being queried into `opencl_device_version` a few lines later, but never used for this purpose.

## Fix

Move the flag derivation to run after `CL_DEVICE_VERSION` is queried, and parse that value instead of the platform string. No new OpenCL symbols or header changes — minimal, surgical diff (36 insertions / 26 deletions, all in one function).

A device's `CL_DEVICE_VERSION` is always ≤ its platform's version, so switching platform → device can only correct a mismatch, never introduce a new one on setups where the two already agree.

### Why not `CL_DEVICE_OPENCL_C_ALL_VERSIONS`?

That query would be the spec-precise way to pick an OpenCL *C language* version (as opposed to the API version `CL_DEVICE_VERSION` reports), and I considered it. Two things ruled it out for this PR:

1. hashcat pins `CL_TARGET_OPENCL_VERSION` to `120` in `include/ext_OpenCL.h`, which gates `CL_DEVICE_OPENCL_C_ALL_VERSIONS` / `cl_name_version` out of the vendored headers entirely. Using it would require either a local symbol-redefinition workaround or bumping that target globally — the latter risks tripping the project's `-W -Wall` clean-build requirement via new deprecation warnings, which is likely why it's pinned at 120 in the first place.
2. It's also risky as a straight swap: on both an NVIDIA RTX 5060 and an Intel iGPU tested here, `CL_DEVICE_OPENCL_C_VERSION` (the older, single-value field) reports `"OpenCL C 1.2"` even though both devices fully support 3.0 — that's only visible via `ALL_VERSIONS`. Deriving from that legacy field alone would have silently downgraded both vendors from `CL3.0` to `CL1.2`.

Given that, I went with the device-version fix as the correctly-scoped, low-risk change, and left the `ALL_VERSIONS` precedence question (raised in the issue thread) open for maintainers to weigh in on separately if a more precise fix is wanted later.

## Testing

Tested on Windows 11 (MSYS2/mingw-w64), with an NVIDIA GeForce RTX 5060 Laptop GPU (CUDA + OpenCL) and an Intel RaptorLake-S iGPU (OpenCL).

- Builds clean with `-std=gnu99 -W -Wall -Wextra`, no warnings.
- `hashcat -I` device enumeration unaffected.
- Instrumented build confirmed the flag computation itself: both devices report `CL_DEVICE_VERSION = "OpenCL 3.0 ..."`, correctly resolving to `use_opencl30=1` → `-cl-std=CL3.0`.
- Functional check: `hashcat -b -m 100` (SHA1) — kernels (`shared.cl`, `m00100_a3-optimized.cl`, `markov_be.cl`) compile and link successfully on both vendors, benchmarked without error.
- Confirmed **no regression**: on this hardware the fix produces byte-identical `-cl-std=` output to master, since there's no platform/device version mismatch to trigger a behavior change here.

**What I could not verify:** the exact reported scenario — a PoCL-Remote platform reporting a higher version than an individual device behind it — since I don't have that setup available, and neither did the person who diagnosed the root cause in the issue thread. If a maintainer or the original reporter can confirm against a real PoCL-Remote setup, that would close the loop.
