### PR TITLE
Fix embedded NUL truncation in stdin mode

### DIFF
--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -145,6 +145,34 @@ static u64 get_work (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
   return work;
 }
 
+static bool stdin_readline (char *buf, const size_t buf_sz, size_t *line_len)
+{
+  size_t len = 0;
+
+  int c = 0;
+
+  while (len < buf_sz)
+  {
+    c = fgetc (stdin);
+
+    if (c == EOF) break;
+
+    buf[len] = (char) c;
+
+    len++;
+
+    if (c == '\n') break;
+  }
+
+  if ((c == EOF) && (len == 0)) return false;
+
+  buf[len] = 0;
+
+  *line_len = superchop_with_length (buf, len);
+
+  return true;
+}
+
 static int calc_stdin (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param)
 {
   user_options_t       *user_options       = hashcat_ctx->user_options;
@@ -223,11 +251,11 @@ static int calc_stdin (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_par
         selects_returned++;
       }
 
-      char *line_buf = fgets (buf, HCBUFSIZ_LARGE - 1, stdin);
+      size_t line_len = 0;
 
-      if (line_buf == NULL) break;
+      if (stdin_readline (buf, HCBUFSIZ_LARGE - 1, &line_len) == false) break;
 
-      size_t line_len = in_superchop (line_buf);
+      char *line_buf = buf;
 
       line_len = convert_from_hex (hashcat_ctx, line_buf, (u32) line_len);
 


### PR DESCRIPTION
## Summary

The stdin path determines candidate length using in_superchop(), which
uses strlen(). This truncates candidates containing embedded NUL bytes.

This patch reads stdin while tracking the actual byte count and uses
superchop_with_length() instead, making stdin behave identically to
regular wordlist files.

## Reproducer

printf 'a\0a\n' > /tmp/word.txt

Before:

hashcat --stdout < /tmp/word.txt

Output:

61 0a

After:

61 00 61 0a

This also fixes the corresponding cracking behavior.