### PR TITLE
Clamp OpenCL work size to the size of the first dimension (fix #4550)

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -9397,6 +9397,20 @@ static int get_opencl_kernel_wgs (hashcat_ctx_t *hashcat_ctx, hc_device_param_t 
     kernel_threads = cwgs_total;
   }
 
+  // Most likely just 3 dimensions, but let's support more since the API permits that
+  cl_uint max_dimensions = 0;
+
+  if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, sizeof (max_dimensions), &max_dimensions, NULL) == -1) return -1;
+
+  if (max_dimensions > 16) return -1; // Should never happen
+
+  size_t work_item_sizes[16] = { 0 };
+
+  if (hc_clGetDeviceInfo (hashcat_ctx, device_param->opencl_device, CL_DEVICE_MAX_WORK_ITEM_SIZES, sizeof (work_item_sizes[0]) * max_dimensions, work_item_sizes, NULL) == -1) return -1;
+
+  // Clamp because the first dimension is not guaranteed to be smaller than total work group size
+  kernel_threads = (u32) MIN (kernel_threads, work_item_sizes[0]);
+
   *result = kernel_threads;
 
   return 0;


### PR DESCRIPTION
Hashcat currently only uses the first dimension of local_work_size and wrongly assumes that the CL_KERNEL_WORK_GROUP_SIZE will always fit into it, e.g. it would submit a 2048x1x1 grid for a reported WGS of 2048. The OpenCL API does *not* guarantee this, hashcat was just lucky that on most hardware the per-dimension limits were not smaller. However on Qualcomm Adreno GPUs, they are: the total limit is 2048 but per-dimension limits are 1024x1024x64. So to submit 2048 threads, 1024x2x1 would have to be used.

Let's just clamp the work group size to the first dimension for now.