### PR TITLE
make output of hashcat-example-hashes_machine-readable2md.py deterministic

### DIFF
--- a/.github/workflows/hashcat-example-hashes_machine-readable2md.py
+++ b/.github/workflows/hashcat-example-hashes_machine-readable2md.py
@@ -61,7 +61,7 @@ def find_opencl(zfilled_key, visited=None):
 
     kernels = []
     if os.path.isdir(OPENCL_DIR):
-        for filename in os.listdir(OPENCL_DIR):
+        for filename in sorted(os.listdir(OPENCL_DIR)):
             if zfilled_key in filename:
                 for key, abbr in OPENCL_ABBREV.items():
                     if key in filename:
@@ -140,7 +140,7 @@ def find_test(zfilled_key):
         return f"[:white_check_mark:](/tools/test.sh)"
 
     if os.path.isdir(TESTS_DIR):
-        for filename in os.listdir(TESTS_DIR):
+        for filename in sorted(os.listdir(TESTS_DIR)):
             if zfilled_key in filename:
                 return f"[:white_check_mark:](/{TESTS_DIR}/{filename})"
 

--- a/.github/workflows/hashcat-example-hashes_md2docuwiki.sh
+++ b/.github/workflows/hashcat-example-hashes_md2docuwiki.sh
@@ -8,6 +8,6 @@ set -euo pipefail
 cat ../../docs/hashcat-example-hashes.md |
     sed -E 's/\[\^(.+)\]/<sup>\1<\/sup>/g' | # Replace footnotes
     sed 's/| hash-Mode | hash-Name | Example |/\^ hash-Mode \^ hash-Name \^ Example \^/g' | # Replace header
-    grep -Fv '-----------' |  # Remove unnecessary table style
+    grep -Fv -- '-----------' |  # Remove unnecessary table style
     sed 's/`//g' | # Remove backticks
     sed -E 's/\[([0-9]+)\]\(\/src\/modules\/module_([0-9]{5})\.c\)/[[\1|https:\/\/github.com\/hashcat\/hashcat\/tree\/master\/src\/modules\/module_\2.c]]/'   # Replace URLs to GitHub modules


### PR DESCRIPTION
Prevent commits like this one: https://github.com/hashcat/hashcat/commit/af8e248920b0dbadfc7d72400f48d93037262139 the only difference is `.pm` vs `.sh` (but that's difficult to spot with regular line-by-line git diff)

```
git diff --word-diff=plain \
  fae02a89fde8f55e4c92dba98f9750a8244c81a5 \
  af8e248920b0dbadfc7d72400f48d93037262139 \
  -- docs/hashcat-example-hashes.md

[-[:white_check_mark:](/tools/test_modules/m34100.pm)-]
{+[:white_check_mark:](/tools/test_modules/m34100.sh)+}
```

-----------------

also make sure `hashcat-example-hashes_md2docuwiki.sh` actually runs instead of error:
```
bash ./hashcat-example-hashes_md2docuwiki.sh 
grep: unrecognized option '-----------' 
Usage: grep [OPTION]... PATTERNS [FILE]... 
Try 'grep --help' for more information.
```