### PR TITLE
Optimize RC4 kernels for Office, PDF, and Kerberos modes

### DIFF
--- a/OpenCL/inc_cipher_rc4.cl
+++ b/OpenCL/inc_cipher_rc4.cl
@@ -249,57 +249,153 @@ DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u3
   j += GET_KEY8(S, 255, lid) + d8;  rc4_swap(S, 255, j, lid);
 }
 
+#define RC4_KSA_PREFETCH_STEP(d)            \
+{                                           \
+  const u8 s_next = GET_KEY8 (S, idx + 1, lid); \
+  j += s_i + (d);                           \
+  const u8 s_j = GET_KEY8 (S, j, lid);      \
+  SET_KEY8 (S, idx, s_j, lid);              \
+  SET_KEY8 (S, j, s_i, lid);                \
+  idx++;                                    \
+  s_i = (j == idx) ? s_i : s_next;          \
+}
+
 DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
 {
-  u32 v = 0x03020100;
+  u32 v = 0x07060504;
   u32 a = 0x04040404;
 
   #ifdef _unroll
   #pragma unroll
   #endif
-  for (u8 i = 0; i < 64; i++)
+  for (u8 i = 1; i < 64; i++)
   {
     SET_KEY32 (S, i, v, lid); v += a;
   }
 
-  u8 j = 0;
+  v = key[0];
+
+  const u8 d0 = v8a_from_v32_S (v);
+  const u8 d1 = v8b_from_v32_S (v);
+  const u8 d2 = v8c_from_v32_S (v);
+  const u8 d3 = v8d_from_v32_S (v);
+
+  const u8 j0 = d0;
+
+  const u8 s1  = (j0 == 1) ? 0 : 1;
+  const u8 j1  = j0 + s1 + d1;
+  const u8 sj1 = (j1 == j0) ? 0 : ((j1 == 0) ? j0 : j1);
+
+  const u8 s2  = (j1 == 2) ? s1 : ((j0 == 2) ? 0 : 2);
+  const u8 j2  = j1 + s2 + d2;
+  const u8 sj2 = (j2 == j1) ? s1
+               : (j2 == 1)  ? sj1
+               : (j2 == j0) ? 0
+               : (j2 == 0)  ? j0
+               : j2;
+
+  const u8 s3  = (j2 == 3) ? s2
+               : (j1 == 3) ? s1
+               : (j0 == 3) ? 0
+               : 3;
+  const u8 j3  = j2 + s3 + d3;
+  const u8 sj3 = (j3 == j2) ? s2
+               : (j3 == 2)  ? sj2
+               : (j3 == j1) ? s1
+               : (j3 == 1)  ? sj1
+               : (j3 == j0) ? 0
+               : (j3 == 0)  ? j0
+               : j3;
+
+  SET_KEY8 (S, j0,  0, lid);
+  SET_KEY8 (S, j1, s1, lid);
+  SET_KEY8 (S, j2, s2, lid);
+  SET_KEY8 (S, j3, s3, lid);
+
+  const u8 s0 = (j3 == 0) ? s3
+              : (j2 == 0) ? s2
+              : (j1 == 0) ? s1
+              : (j0 == 0) ? 0
+              : j0;
+  const u8 s1_final = (j3 == 1) ? s3
+                    : (j2 == 1) ? s2
+                    : sj1;
+  const u8 s2_final = (j3 == 2) ? s3 : sj2;
+
+  const u8 s4 = (j3 == 4) ? s3
+              : (j2 == 4) ? s2
+              : (j1 == 4) ? s1
+              : (j0 == 4) ? 0
+              : 4;
+
+  const u32 sbox03 = ((u32) s0       <<  0)
+                   | ((u32) s1_final <<  8)
+                   | ((u32) s2_final << 16)
+                   | ((u32) sj3      << 24);
+
+  SET_KEY32 (S, 0, sbox03, lid);
+
+  u8 j   = j3;
+  u8 idx = 4;
+  u8 s_i = s4;
+
+  v = key[1];
+
+  RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+  v = key[2];
+
+  RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+  v = key[3];
+
+  RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+  RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
 
   #pragma unroll 8
-  for (u32 i = 0; i < 16; i++)
+  for (u32 i = 1; i < 16; i++)
   {
-    u8 idx = i * 16;
-
-    u32 v;
+    idx = i * 16;
 
     v = key[0];
 
-    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
 
     v = key[1];
 
-    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
 
     v = key[2];
 
-    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
 
     v = key[3];
 
-    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
-    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
   }
 }
+
+#undef RC4_KSA_PREFETCH_STEP
 
 DECLSPEC void rc4_swap (LOCAL_AS u32 *S, const u8 i, const u8 j, const u32 lid)
 {

--- a/OpenCL/inc_cipher_rc4.cl
+++ b/OpenCL/inc_cipher_rc4.cl
@@ -78,7 +78,7 @@ DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, MAYBE_UNUSED 
 // Finally we can select the actual target byte from (1 out of 4) from this chunk:
 //   (k & 3)
 
-#define KEY8(t,k) (((k) & 3) + (((k) / 4) * 128) + (((t) & 31) * 4) + (((t) / 32) * 8192))
+#define KEY8(t,k) (((k) & 3) | (((k) / 4) * 128) | (((t) & 31) * 4) | (((t) / 32) * 8192))
 
 DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u64 lid)
 {
@@ -94,7 +94,7 @@ DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, const u64 lid)
   S8[KEY8 (lid, k)] = v;
 }
 
-#define KEY32(t,k) (((k) * 32) + ((t) & 31) + (((t) / 32) * 2048))
+#define KEY32(t,k) (((k) * 32) | ((t) & 31) | (((t) / 32) * 2048))
 
 DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u64 lid)
 {
@@ -335,6 +335,8 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
   u8 a = i;
   u8 b = j;
 
+  u8 s_prefetch = GET_KEY8 (S, a + 1, lid);
+
   #ifdef _unroll
   #pragma unroll
   #endif
@@ -345,48 +347,67 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
     u32 tmp;
 
     u8 idx;
+    u8 next;
+    u8 sa;
+    u8 sb;
+    u8 s_next;
+
+    // fused swap: after swapping S[a]<->S[b], S[a]+S[b] == sa+sb (values already loaded),
+    // so the two post-swap shared-mem reads for idx are replaced by a register add.
 
     a += 1;
-    b += GET_KEY8 (S, a, lid);
-
-    rc4_swap (S, a, b, lid);
-
-    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
-
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
     tmp = GET_KEY8 (S, idx, lid);
+    s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp <<  0;
 
     a += 1;
-    b += GET_KEY8 (S, a, lid);
-
-    rc4_swap (S, a, b, lid);
-
-    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
-
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
     tmp = GET_KEY8 (S, idx, lid);
+    s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp <<  8;
 
     a += 1;
-    b += GET_KEY8 (S, a, lid);
-
-    rc4_swap (S, a, b, lid);
-
-    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
-
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
     tmp = GET_KEY8 (S, idx, lid);
+    s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp << 16;
 
     a += 1;
-    b += GET_KEY8 (S, a, lid);
-
-    rc4_swap (S, a, b, lid);
-
-    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
-
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
     tmp = GET_KEY8 (S, idx, lid);
+    s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp << 24;
 

--- a/OpenCL/inc_cipher_rc4.cl
+++ b/OpenCL/inc_cipher_rc4.cl
@@ -14,21 +14,21 @@
 
 // Pattern linear
 
-DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, MAYBE_UNUSED const u64 lid)
+DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, MAYBE_UNUSED const u32 lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
   return S8[k];
 }
 
-DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, MAYBE_UNUSED const u64 lid)
+DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, MAYBE_UNUSED const u32 lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
   S8[k] = v;
 }
 
-DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, MAYBE_UNUSED const u64 lid)
+DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, MAYBE_UNUSED const u32 lid)
 {
   S[k] = v;
 }
@@ -80,14 +80,14 @@ DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, MAYBE_UNUSED 
 
 #define KEY8(t,k) (((k) & 3) | (((k) / 4) * 128) | (((t) & 31) * 4) | (((t) / 32) * 8192))
 
-DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u64 lid)
+DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u32 lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
   return S8[KEY8 (lid, k)];
 }
 
-DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, const u64 lid)
+DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, const u32 lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
@@ -96,7 +96,7 @@ DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, const u64 lid)
 
 #define KEY32(t,k) (((k) * 32) | ((t) & 31) | (((t) / 32) * 2048))
 
-DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u64 lid)
+DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u32 lid)
 {
   S[KEY32 (lid, k)] = v;
 }
@@ -106,7 +106,7 @@ DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u64 lid
 
 #endif
 
-DECLSPEC void rc4_init_40 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid)
+DECLSPEC void rc4_init_40 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
 {
   u32 v = 0x03020100;
   u32 a = 0x04040404;
@@ -142,7 +142,7 @@ DECLSPEC void rc4_init_40 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64
   j += GET_KEY8 (S, 255, lid) + d0; rc4_swap (S, 255, j, lid);
 }
 
-DECLSPEC void rc4_init_72 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid)
+DECLSPEC void rc4_init_72 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
 {
   u32 v = 0x03020100;
   u32 a = 0x04040404;
@@ -189,7 +189,7 @@ DECLSPEC void rc4_init_72 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64
   j += GET_KEY8 (S, 255, lid) + d3; rc4_swap (S, 255, j, lid);
 }
 
-DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid)
+DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
 {
   u32 v = 0x03020100;
   u32 a = 0x04040404;
@@ -249,7 +249,7 @@ DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u6
   j += GET_KEY8(S, 255, lid) + d8;  rc4_swap(S, 255, j, lid);
 }
 
-DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid)
+DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
 {
   u32 v = 0x03020100;
   u32 a = 0x04040404;
@@ -264,6 +264,7 @@ DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u6
 
   u8 j = 0;
 
+  #pragma unroll 8
   for (u32 i = 0; i < 16; i++)
   {
     u8 idx = i * 16;
@@ -300,7 +301,7 @@ DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u6
   }
 }
 
-DECLSPEC void rc4_swap (LOCAL_AS u32 *S, const u8 i, const u8 j, const u64 lid)
+DECLSPEC void rc4_swap (LOCAL_AS u32 *S, const u8 i, const u8 j, const u32 lid)
 {
   u8 tmp;
 
@@ -309,7 +310,7 @@ DECLSPEC void rc4_swap (LOCAL_AS u32 *S, const u8 i, const u8 j, const u64 lid)
   SET_KEY8 (S, j, tmp, lid);
 }
 
-DECLSPEC void rc4_dropN (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const u64 lid)
+DECLSPEC void rc4_dropN (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const u32 lid)
 {
   u8 a = *i;
   u8 b = *j;
@@ -330,16 +331,74 @@ DECLSPEC void rc4_dropN (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, co
   *j = b;
 }
 
-DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u64 lid)
+DECLSPEC u8 rc4_next_4 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
+{
+  u8 a = i;
+  u8 b = j;
+
+  u32 xor4 = 0;
+
+  u32 tmp;
+
+  u8 idx;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp <<  0;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp <<  8;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 16;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 24;
+
+  out[0] = in[0] ^ xor4;
+
+  return b;
+}
+
+DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
 {
   u8 a = i;
   u8 b = j;
 
   u8 s_prefetch = GET_KEY8 (S, a + 1, lid);
 
-  #ifdef _unroll
-  #pragma unroll
-  #endif
+  #pragma unroll 2
   for (int k = 0; k < 4; k++)
   {
     u32 xor4 = 0;
@@ -352,9 +411,6 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
     u8 sb;
     u8 s_next;
 
-    // fused swap: after swapping S[a]<->S[b], S[a]+S[b] == sa+sb (values already loaded),
-    // so the two post-swap shared-mem reads for idx are replaced by a register add.
-
     a += 1;
     next = a + 1;
     s_next = GET_KEY8 (S, next, lid);
@@ -364,7 +420,9 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
     SET_KEY8 (S, a, sb, lid);
     SET_KEY8 (S, b, sa, lid);
     idx = sa + sb;
+
     tmp = GET_KEY8 (S, idx, lid);
+
     s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp <<  0;
@@ -378,7 +436,9 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
     SET_KEY8 (S, a, sb, lid);
     SET_KEY8 (S, b, sa, lid);
     idx = sa + sb;
+
     tmp = GET_KEY8 (S, idx, lid);
+
     s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp <<  8;
@@ -392,7 +452,9 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
     SET_KEY8 (S, a, sb, lid);
     SET_KEY8 (S, b, sa, lid);
     idx = sa + sb;
+
     tmp = GET_KEY8 (S, idx, lid);
+
     s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp << 16;
@@ -406,7 +468,9 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
     SET_KEY8 (S, a, sb, lid);
     SET_KEY8 (S, b, sa, lid);
     idx = sa + sb;
+
     tmp = GET_KEY8 (S, idx, lid);
+
     s_prefetch = (b == next) ? sa : s_next;
 
     xor4 |= tmp << 24;
@@ -417,7 +481,7 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
   return b;
 }
 
-DECLSPEC RC4_NOINLINE u8 rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u64 lid)
+DECLSPEC RC4_NOINLINE u8 rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
 {
   u8 a = i;
   u8 b = j;

--- a/OpenCL/inc_cipher_rc4.cl
+++ b/OpenCL/inc_cipher_rc4.cl
@@ -577,6 +577,170 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
   return b;
 }
 
+DECLSPEC RC4_NOINLINE int rc4_next_12_global_krb5_staged (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, const u32 lid)
+{
+  u8 a = i;
+  u8 b = j;
+  u8 sa = GET_KEY8 (S, i + 1, lid);
+  u8 sb;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int k = 0; k < 8; k++)
+  {
+    a += 1;
+    const u8 next = a + 1;
+    const u8 s_next = GET_KEY8 (S, next, lid);
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+
+    sa = (b == next) ? sa : s_next;
+  }
+
+  u32 xor4 = 0;
+
+  u32 tmp;
+
+  u8 idx;
+
+  a += 1;
+  b += sa;
+  sb = GET_KEY8 (S, b, lid);
+
+  SET_KEY8 (S, a, sb, lid);
+  SET_KEY8 (S, b, sa, lid);
+
+  idx = sa + sb;
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 0;
+
+  if (((in[2] ^ xor4) & 0xff) != 0x63) return -1;
+
+  a += 1;
+  sa = GET_KEY8 (S, a, lid);
+  b += sa;
+  sb = GET_KEY8 (S, b, lid);
+
+  SET_KEY8 (S, a, sb, lid);
+  SET_KEY8 (S, b, sa, lid);
+
+  idx = sa + sb;
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 8;
+
+  const u32 prefix = (in[2] ^ xor4) & 0xffff;
+
+  if ((prefix != 0x8163) && (prefix != 0x8263)) return -1;
+
+  a += 1;
+  sa = GET_KEY8 (S, a, lid);
+  b += sa;
+  sb = GET_KEY8 (S, b, lid);
+
+  SET_KEY8 (S, a, sb, lid);
+  SET_KEY8 (S, b, sa, lid);
+
+  idx = sa + sb;
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 16;
+
+  a += 1;
+  sa = GET_KEY8 (S, a, lid);
+  b += sa;
+  sb = GET_KEY8 (S, b, lid);
+
+  SET_KEY8 (S, a, sb, lid);
+  SET_KEY8 (S, b, sa, lid);
+
+  idx = sa + sb;
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 24;
+
+  const u32 out = in[2] ^ xor4;
+
+  if (((out & 0xff00ffff) != 0x30008163) && ((out & 0x0000ffff) != 0x00008263)) return -1;
+
+  return b;
+}
+
+DECLSPEC RC4_NOINLINE u8 rc4_next_12_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
+{
+  u8 a = i;
+  u8 b = j;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int k = 0; k < 3; k++)
+  {
+    u32 xor4 = 0;
+
+    u32 tmp;
+
+    u8 idx;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp <<  0;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp <<  8;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 16;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 24;
+
+    out[k] = in[k] ^ xor4;
+  }
+
+  return b;
+}
+
 DECLSPEC RC4_NOINLINE u8 rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
 {
   u8 a = i;

--- a/OpenCL/inc_cipher_rc4.cl
+++ b/OpenCL/inc_cipher_rc4.cl
@@ -2,6 +2,12 @@
 #include "inc_types.h"
 #include "inc_platform.h"
 #include "inc_common.h"
+
+#ifndef RC4_LID_TYPE
+#define RC4_LID_TYPE u32
+#define RC4_LID_TYPE_DEFAULT
+#endif
+
 #include "inc_cipher_rc4.h"
 
 #ifdef IS_HIP
@@ -14,21 +20,21 @@
 
 // Pattern linear
 
-DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, MAYBE_UNUSED const u32 lid)
+DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, MAYBE_UNUSED const RC4_LID_TYPE lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
   return S8[k];
 }
 
-DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, MAYBE_UNUSED const u32 lid)
+DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, MAYBE_UNUSED const RC4_LID_TYPE lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
   S8[k] = v;
 }
 
-DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, MAYBE_UNUSED const u32 lid)
+DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, MAYBE_UNUSED const RC4_LID_TYPE lid)
 {
   S[k] = v;
 }
@@ -78,25 +84,33 @@ DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, MAYBE_UNUSED 
 // Finally we can select the actual target byte from (1 out of 4) from this chunk:
 //   (k & 3)
 
+#ifdef RC4_USE_BITWISE_ADDRESSING
 #define KEY8(t,k) (((k) & 3) | (((k) / 4) * 128) | (((t) & 31) * 4) | (((t) / 32) * 8192))
+#else
+#define KEY8(t,k) (((k) & 3) + (((k) / 4) * 128) + (((t) & 31) * 4) + (((t) / 32) * 8192))
+#endif
 
-DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u32 lid)
+DECLSPEC u8 GET_KEY8 (LOCAL_AS u32 *S, const u8 k, const RC4_LID_TYPE lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
   return S8[KEY8 (lid, k)];
 }
 
-DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, const u32 lid)
+DECLSPEC void SET_KEY8 (LOCAL_AS u32 *S, const u8 k, const u8 v, const RC4_LID_TYPE lid)
 {
   LOCAL_AS u8 *S8 = (LOCAL_AS u8 *) S;
 
   S8[KEY8 (lid, k)] = v;
 }
 
+#ifdef RC4_USE_BITWISE_ADDRESSING
 #define KEY32(t,k) (((k) * 32) | ((t) & 31) | (((t) / 32) * 2048))
+#else
+#define KEY32(t,k) (((k) * 32) + ((t) & 31) + (((t) / 32) * 2048))
+#endif
 
-DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u32 lid)
+DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const RC4_LID_TYPE lid)
 {
   S[KEY32 (lid, k)] = v;
 }
@@ -106,7 +120,7 @@ DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u32 lid
 
 #endif
 
-DECLSPEC void rc4_init_40 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
+DECLSPEC void rc4_init_40 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid)
 {
   u32 v = 0x03020100;
   u32 a = 0x04040404;
@@ -142,7 +156,7 @@ DECLSPEC void rc4_init_40 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32
   j += GET_KEY8 (S, 255, lid) + d0; rc4_swap (S, 255, j, lid);
 }
 
-DECLSPEC void rc4_init_72 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
+DECLSPEC void rc4_init_72 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid)
 {
   u32 v = 0x03020100;
   u32 a = 0x04040404;
@@ -189,7 +203,7 @@ DECLSPEC void rc4_init_72 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32
   j += GET_KEY8 (S, 255, lid) + d3; rc4_swap (S, 255, j, lid);
 }
 
-DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
+DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid)
 {
   u32 v = 0x03020100;
   u32 a = 0x04040404;
@@ -249,6 +263,64 @@ DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u3
   j += GET_KEY8(S, 255, lid) + d8;  rc4_swap(S, 255, j, lid);
 }
 
+#ifndef RC4_INIT_128_PREFETCH
+
+DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid)
+{
+  u32 v = 0x03020100;
+  u32 a = 0x04040404;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u8 i = 0; i < 64; i++)
+  {
+    SET_KEY32 (S, i, v, lid); v += a;
+  }
+
+  u8 j = 0;
+
+  #ifdef RC4_INIT_128_UNROLL8
+  #pragma unroll 8
+  #endif
+  for (u32 i = 0; i < 16; i++)
+  {
+    u8 idx = i * 16;
+
+    u32 v;
+
+    v = key[0];
+
+    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+
+    v = key[1];
+
+    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+
+    v = key[2];
+
+    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+
+    v = key[3];
+
+    j += GET_KEY8 (S, idx, lid) + v8a_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8b_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8c_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+    j += GET_KEY8 (S, idx, lid) + v8d_from_v32_S (v); rc4_swap (S, idx, j, lid); idx++;
+  }
+}
+
+#else
+
 #define RC4_KSA_PREFETCH_STEP(d)            \
 {                                           \
   const u8 s_next = GET_KEY8 (S, idx + 1, lid); \
@@ -260,7 +332,7 @@ DECLSPEC void rc4_init_104 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u3
   s_i = (j == idx) ? s_i : s_next;          \
 }
 
-DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
+DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid)
 {
   u32 v = 0x07060504;
   u32 a = 0x04040404;
@@ -360,7 +432,9 @@ DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u3
   RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
   RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
 
+  #ifdef RC4_INIT_128_PREFETCH_UNROLL8
   #pragma unroll 8
+  #endif
   for (u32 i = 1; i < 16; i++)
   {
     idx = i * 16;
@@ -397,7 +471,9 @@ DECLSPEC void rc4_init_128 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u3
 
 #undef RC4_KSA_PREFETCH_STEP
 
-DECLSPEC void rc4_swap (LOCAL_AS u32 *S, const u8 i, const u8 j, const u32 lid)
+#endif
+
+DECLSPEC void rc4_swap (LOCAL_AS u32 *S, const u8 i, const u8 j, const RC4_LID_TYPE lid)
 {
   u8 tmp;
 
@@ -406,7 +482,7 @@ DECLSPEC void rc4_swap (LOCAL_AS u32 *S, const u8 i, const u8 j, const u32 lid)
   SET_KEY8 (S, j, tmp, lid);
 }
 
-DECLSPEC void rc4_dropN (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const u32 lid)
+DECLSPEC void rc4_dropN (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const RC4_LID_TYPE lid)
 {
   u8 a = *i;
   u8 b = *j;
@@ -427,7 +503,9 @@ DECLSPEC void rc4_dropN (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, co
   *j = b;
 }
 
-DECLSPEC u8 rc4_next_4 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
+#ifdef RC4_ENABLE_NEXT_4
+
+DECLSPEC u8 rc4_next_4 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid)
 {
   u8 a = i;
   u8 b = j;
@@ -487,14 +565,24 @@ DECLSPEC u8 rc4_next_4 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS cons
   return b;
 }
 
-DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
+#endif
+
+#ifdef RC4_NEXT_16_PREFETCH
+
+DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid)
 {
   u8 a = i;
   u8 b = j;
 
   u8 s_prefetch = GET_KEY8 (S, a + 1, lid);
 
+  #ifdef RC4_NEXT_16_UNROLL2
   #pragma unroll 2
+  #else
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  #endif
   for (int k = 0; k < 4; k++)
   {
     u32 xor4 = 0;
@@ -577,7 +665,79 @@ DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS con
   return b;
 }
 
-DECLSPEC RC4_NOINLINE int rc4_next_12_global_krb5_staged (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, const u32 lid)
+#else
+
+DECLSPEC u8 rc4_next_16 (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid)
+{
+  u8 a = i;
+  u8 b = j;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int k = 0; k < 4; k++)
+  {
+    u32 xor4 = 0;
+
+    u32 tmp;
+
+    u8 idx;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp <<  0;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp <<  8;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 16;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 24;
+
+    out[k] = in[k] ^ xor4;
+  }
+
+  return b;
+}
+
+#endif
+
+#ifdef RC4_ENABLE_KRB5_HELPERS
+
+DECLSPEC RC4_NOINLINE int rc4_next_12_global_krb5_staged (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, const RC4_LID_TYPE lid)
 {
   u8 a = i;
   u8 b = j;
@@ -675,7 +835,7 @@ DECLSPEC RC4_NOINLINE int rc4_next_12_global_krb5_staged (LOCAL_AS u32 *S, const
   return b;
 }
 
-DECLSPEC RC4_NOINLINE u8 rc4_next_12_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
+DECLSPEC RC4_NOINLINE u8 rc4_next_12_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid)
 {
   u8 a = i;
   u8 b = j;
@@ -741,7 +901,9 @@ DECLSPEC RC4_NOINLINE u8 rc4_next_12_global (LOCAL_AS u32 *S, const u8 i, const 
   return b;
 }
 
-DECLSPEC RC4_NOINLINE u8 rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
+#endif
+
+DECLSPEC RC4_NOINLINE u8 rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid)
 {
   u8 a = i;
   u8 b = j;
@@ -806,3 +968,8 @@ DECLSPEC RC4_NOINLINE u8 rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const 
 
   return b;
 }
+
+#ifdef RC4_LID_TYPE_DEFAULT
+#undef RC4_LID_TYPE_DEFAULT
+#undef RC4_LID_TYPE
+#endif

--- a/OpenCL/inc_cipher_rc4.h
+++ b/OpenCL/inc_cipher_rc4.h
@@ -6,17 +6,18 @@
 #ifndef INC_CIPHER_RC4_H
 #define INC_CIPHER_RC4_H
 
-DECLSPEC u8   GET_KEY8  (LOCAL_AS u32 *S, const u8 k, const u64 lid);
-DECLSPEC void SET_KEY8  (LOCAL_AS u32 *S, const u8 k, const u8 v, const u64 lid);
-DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u64 lid);
+DECLSPEC u8   GET_KEY8  (LOCAL_AS u32 *S, const u8 k, const u32 lid);
+DECLSPEC void SET_KEY8  (LOCAL_AS u32 *S, const u8 k, const u8 v, const u32 lid);
+DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u32 lid);
 
-DECLSPEC void rc4_init_40        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid);
-DECLSPEC void rc4_init_72        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid);
-DECLSPEC void rc4_init_104       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid);
-DECLSPEC void rc4_init_128       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u64 lid);
-DECLSPEC void rc4_swap           (LOCAL_AS u32 *S, const u8 i, const u8 j, const u64 lid);
-DECLSPEC void rc4_dropN          (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const u64 lid);
-DECLSPEC u8   rc4_next_16        (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u64 lid);
-DECLSPEC u8   rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u64 lid);
+DECLSPEC void rc4_init_40        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
+DECLSPEC void rc4_init_72        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
+DECLSPEC void rc4_init_104       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
+DECLSPEC void rc4_init_128       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
+DECLSPEC void rc4_swap           (LOCAL_AS u32 *S, const u8 i, const u8 j, const u32 lid);
+DECLSPEC void rc4_dropN          (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const u32 lid);
+DECLSPEC u8   rc4_next_4         (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid);
+DECLSPEC u8   rc4_next_16        (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid);
+DECLSPEC u8   rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid);
 
 #endif // INC_CIPHER_RC4_H

--- a/OpenCL/inc_cipher_rc4.h
+++ b/OpenCL/inc_cipher_rc4.h
@@ -6,18 +6,20 @@
 #ifndef INC_CIPHER_RC4_H
 #define INC_CIPHER_RC4_H
 
-DECLSPEC u8   GET_KEY8  (LOCAL_AS u32 *S, const u8 k, const u32 lid);
-DECLSPEC void SET_KEY8  (LOCAL_AS u32 *S, const u8 k, const u8 v, const u32 lid);
-DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const u32 lid);
+DECLSPEC u8   GET_KEY8  (LOCAL_AS u32 *S, const u8 k, const RC4_LID_TYPE lid);
+DECLSPEC void SET_KEY8  (LOCAL_AS u32 *S, const u8 k, const u8 v, const RC4_LID_TYPE lid);
+DECLSPEC void SET_KEY32 (LOCAL_AS u32 *S, const u8 k, const u32 v, const RC4_LID_TYPE lid);
 
-DECLSPEC void rc4_init_40        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
-DECLSPEC void rc4_init_72        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
-DECLSPEC void rc4_init_104       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
-DECLSPEC void rc4_init_128       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid);
-DECLSPEC void rc4_swap           (LOCAL_AS u32 *S, const u8 i, const u8 j, const u32 lid);
-DECLSPEC void rc4_dropN          (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const u32 lid);
-DECLSPEC u8   rc4_next_4         (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid);
-DECLSPEC u8   rc4_next_16        (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid);
-DECLSPEC u8   rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid);
+DECLSPEC void rc4_init_40        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid);
+DECLSPEC void rc4_init_72        (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid);
+DECLSPEC void rc4_init_104       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid);
+DECLSPEC void rc4_init_128       (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const RC4_LID_TYPE lid);
+DECLSPEC void rc4_swap           (LOCAL_AS u32 *S, const u8 i, const u8 j, const RC4_LID_TYPE lid);
+DECLSPEC void rc4_dropN          (LOCAL_AS u32 *S, PRIVATE_AS u8 *i, PRIVATE_AS u8 *j, const u32 n, const RC4_LID_TYPE lid);
+#ifdef RC4_ENABLE_NEXT_4
+DECLSPEC u8   rc4_next_4         (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid);
+#endif
+DECLSPEC u8   rc4_next_16        (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid);
+DECLSPEC u8   rc4_next_16_global (LOCAL_AS u32 *S, const u8 i, const u8 j, GLOBAL_AS const u32 *in, PRIVATE_AS u32 *out, const RC4_LID_TYPE lid);
 
 #endif // INC_CIPHER_RC4_H

--- a/OpenCL/m09700_a0-optimized.cl
+++ b/OpenCL/m09700_a0-optimized.cl
@@ -15,7 +15,13 @@
 #include M2S(INCLUDE_PATH/inc_rp_optimized.cl)
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_LID_TYPE u64
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_NEXT_16_PREFETCH
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_NEXT_16_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
+#undef RC4_LID_TYPE
 #endif
 
 typedef struct oldoffice01

--- a/OpenCL/m09700_a1-optimized.cl
+++ b/OpenCL/m09700_a1-optimized.cl
@@ -13,7 +13,13 @@
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_LID_TYPE u64
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_NEXT_16_PREFETCH
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_NEXT_16_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
+#undef RC4_LID_TYPE
 #endif
 
 typedef struct oldoffice01

--- a/OpenCL/m09700_a3-optimized.cl
+++ b/OpenCL/m09700_a3-optimized.cl
@@ -13,6 +13,16 @@
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
 #endif
 
+// autoresearch: ncu shows m09700_s is latency-bound (SM & mem both ~64%, not saturated)
+// with only 16.6% occupancy, register-limited to 8 blocks/SM (~255 regs/thread; block =
+// FIXED_LOCAL_SIZE = 32 threads = 1 warp). Raise minBlocksPerMultiprocessor so ptxas trims
+// registers to fit 9 blocks/SM (~227 regs), lifting occupancy 16.6% -> 18.75% while allowing
+// slightly more register headroom than the 10-block setting.
+#if defined IS_CUDA || defined IS_HIP
+#undef  KERNEL_FA
+#define KERNEL_FA __launch_bounds__ (FIXED_LOCAL_SIZE, 9)
+#endif
+
 typedef struct oldoffice01
 {
   u32 version;
@@ -21,6 +31,240 @@ typedef struct oldoffice01
   u32 rc4key[2];
 
 } oldoffice01_t;
+
+// The first MD5 word is complete after step 61.  Keep the working state so the
+// final three steps can be deferred until a candidate survives the two-byte
+// RC4 reject.
+DECLSPEC void m09700_md5_transform_early (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *state)
+{
+  u32 a = state[0];
+  u32 b = state[1];
+  u32 c = state[2];
+  u32 d = state[3];
+
+  u32 w0_t = w0[0];
+  u32 w1_t = w0[1];
+  u32 w2_t = w0[2];
+  u32 w3_t = w0[3];
+  u32 w4_t = w1[0];
+  u32 w5_t = w1[1];
+  u32 w6_t = w1[2];
+  u32 w7_t = w1[3];
+  u32 w8_t = w2[0];
+  u32 w9_t = w2[1];
+  u32 wa_t = w2[2];
+  u32 wb_t = w2[3];
+  u32 wc_t = w3[0];
+  u32 wd_t = w3[1];
+  u32 we_t = w3[2];
+  u32 wf_t = w3[3];
+
+  MD5_STEP_S (MD5_Fo, a, b, c, d, w0_t, MD5C00, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, w1_t, MD5C01, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, w2_t, MD5C02, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, w3_t, MD5C03, MD5S03);
+  MD5_STEP_S (MD5_Fo, a, b, c, d, w4_t, MD5C04, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, w5_t, MD5C05, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, w6_t, MD5C06, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, w7_t, MD5C07, MD5S03);
+  MD5_STEP_S (MD5_Fo, a, b, c, d, w8_t, MD5C08, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, w9_t, MD5C09, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, wa_t, MD5C0a, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, wb_t, MD5C0b, MD5S03);
+  MD5_STEP_S (MD5_Fo, a, b, c, d, wc_t, MD5C0c, MD5S00);
+  MD5_STEP_S (MD5_Fo, d, a, b, c, wd_t, MD5C0d, MD5S01);
+  MD5_STEP_S (MD5_Fo, c, d, a, b, we_t, MD5C0e, MD5S02);
+  MD5_STEP_S (MD5_Fo, b, c, d, a, wf_t, MD5C0f, MD5S03);
+
+  MD5_STEP_S (MD5_Go, a, b, c, d, w1_t, MD5C10, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, w6_t, MD5C11, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, wb_t, MD5C12, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, w0_t, MD5C13, MD5S13);
+  MD5_STEP_S (MD5_Go, a, b, c, d, w5_t, MD5C14, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, wa_t, MD5C15, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, wf_t, MD5C16, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, w4_t, MD5C17, MD5S13);
+  MD5_STEP_S (MD5_Go, a, b, c, d, w9_t, MD5C18, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, we_t, MD5C19, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, w3_t, MD5C1a, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, w8_t, MD5C1b, MD5S13);
+  MD5_STEP_S (MD5_Go, a, b, c, d, wd_t, MD5C1c, MD5S10);
+  MD5_STEP_S (MD5_Go, d, a, b, c, w2_t, MD5C1d, MD5S11);
+  MD5_STEP_S (MD5_Go, c, d, a, b, w7_t, MD5C1e, MD5S12);
+  MD5_STEP_S (MD5_Go, b, c, d, a, wc_t, MD5C1f, MD5S13);
+
+  u32 t;
+
+  MD5_STEP_S (MD5_H1, a, b, c, d, w5_t, MD5C20, MD5S20);
+  MD5_STEP_S (MD5_H2, d, a, b, c, w8_t, MD5C21, MD5S21);
+  MD5_STEP_S (MD5_H1, c, d, a, b, wb_t, MD5C22, MD5S22);
+  MD5_STEP_S (MD5_H2, b, c, d, a, we_t, MD5C23, MD5S23);
+  MD5_STEP_S (MD5_H1, a, b, c, d, w1_t, MD5C24, MD5S20);
+  MD5_STEP_S (MD5_H2, d, a, b, c, w4_t, MD5C25, MD5S21);
+  MD5_STEP_S (MD5_H1, c, d, a, b, w7_t, MD5C26, MD5S22);
+  MD5_STEP_S (MD5_H2, b, c, d, a, wa_t, MD5C27, MD5S23);
+  MD5_STEP_S (MD5_H1, a, b, c, d, wd_t, MD5C28, MD5S20);
+  MD5_STEP_S (MD5_H2, d, a, b, c, w0_t, MD5C29, MD5S21);
+  MD5_STEP_S (MD5_H1, c, d, a, b, w3_t, MD5C2a, MD5S22);
+  MD5_STEP_S (MD5_H2, b, c, d, a, w6_t, MD5C2b, MD5S23);
+  MD5_STEP_S (MD5_H1, a, b, c, d, w9_t, MD5C2c, MD5S20);
+  MD5_STEP_S (MD5_H2, d, a, b, c, wc_t, MD5C2d, MD5S21);
+  MD5_STEP_S (MD5_H1, c, d, a, b, wf_t, MD5C2e, MD5S22);
+  MD5_STEP_S (MD5_H2, b, c, d, a, w2_t, MD5C2f, MD5S23);
+
+  MD5_STEP_S (MD5_I , a, b, c, d, w0_t, MD5C30, MD5S30);
+  MD5_STEP_S (MD5_I , d, a, b, c, w7_t, MD5C31, MD5S31);
+  MD5_STEP_S (MD5_I , c, d, a, b, we_t, MD5C32, MD5S32);
+  MD5_STEP_S (MD5_I , b, c, d, a, w5_t, MD5C33, MD5S33);
+  MD5_STEP_S (MD5_I , a, b, c, d, wc_t, MD5C34, MD5S30);
+  MD5_STEP_S (MD5_I , d, a, b, c, w3_t, MD5C35, MD5S31);
+  MD5_STEP_S (MD5_I , c, d, a, b, wa_t, MD5C36, MD5S32);
+  MD5_STEP_S (MD5_I , b, c, d, a, w1_t, MD5C37, MD5S33);
+  MD5_STEP_S (MD5_I , a, b, c, d, w8_t, MD5C38, MD5S30);
+  MD5_STEP_S (MD5_I , d, a, b, c, wf_t, MD5C39, MD5S31);
+  MD5_STEP_S (MD5_I , c, d, a, b, w6_t, MD5C3a, MD5S32);
+  MD5_STEP_S (MD5_I , b, c, d, a, wd_t, MD5C3b, MD5S33);
+  MD5_STEP_S (MD5_I , a, b, c, d, w4_t, MD5C3c, MD5S30);
+
+  state[0] = a;
+  state[1] = b;
+  state[2] = c;
+  state[3] = d;
+}
+
+DECLSPEC u32 m09700_rc4_next_16_early (LOCAL_AS u32 *S, const u8 i, const u8 j, PRIVATE_AS u32 *state, const u32 verifier2, PRIVATE_AS u32 *out, const u32 search0, const u64 lid)
+{
+  u8 a = i;
+  u8 b = j;
+
+  u32 xor4 = 0;
+
+  u32 tmp;
+
+  u8 idx;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 = tmp;
+
+  const u32 in0 = state[0] + MD5M_A;
+
+  if (((in0 ^ xor4) & 0xff) != (search0 & 0xff)) return 0;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 8;
+
+  if (((in0 ^ xor4) & 0xffff) != (search0 & 0xffff)) return 0;
+
+  u32 md5_a = state[0];
+  u32 md5_b = state[1];
+  u32 md5_c = state[2];
+  u32 md5_d = state[3];
+
+  MD5_STEP_S (MD5_I, md5_d, md5_a, md5_b, md5_c, 0,         MD5C3d, MD5S31);
+  MD5_STEP_S (MD5_I, md5_c, md5_d, md5_a, md5_b, verifier2, MD5C3e, MD5S32);
+  MD5_STEP_S (MD5_I, md5_b, md5_c, md5_d, md5_a, 0,         MD5C3f, MD5S33);
+
+  state[0] = md5_a + MD5M_A;
+  state[1] = md5_b + MD5M_B;
+  state[2] = md5_c + MD5M_C;
+  state[3] = md5_d + MD5M_D;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 16;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 24;
+
+  out[0] = state[0] ^ xor4;
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int k = 1; k < 4; k++)
+  {
+    xor4 = 0;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 0;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 8;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 16;
+
+    a += 1;
+    b += GET_KEY8 (S, a, lid);
+
+    rc4_swap (S, a, b, lid);
+
+    idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    xor4 |= tmp << 24;
+
+    out[k] = state[k] ^ xor4;
+  }
+
+  return 1;
+}
 
 DECLSPEC void m09700m (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const u32 pw_len, KERN_ATTR_FUNC_ESALT (oldoffice01_t))
 {
@@ -820,9 +1064,9 @@ DECLSPEC void m09700s (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
     digest[2] = MD5M_C;
     digest[3] = MD5M_D;
 
-    md5_transform (w0_t, w1_t, w2_t, w3_t, digest);
+    m09700_md5_transform_early (w0_t, w1_t, w2_t, w3_t, digest);
 
-    rc4_next_16 (S, 16, j, digest, out, lid);
+    if (m09700_rc4_next_16_early (S, 16, j, digest, out[2], out, search[0], lid) == 0) continue;
 
     COMPARE_S_SIMD (out[0], out[1], out[2], out[3]);
   }

--- a/OpenCL/m09700_a3-optimized.cl
+++ b/OpenCL/m09700_a3-optimized.cl
@@ -291,27 +291,27 @@ DECLSPEC void m09700m (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
 
   u32 salt_buf_t1[5];
 
-  salt_buf_t1[0] =                        salt_buf_t0[0] <<  8;
-  salt_buf_t1[1] = salt_buf_t0[0] >> 24 | salt_buf_t0[1] <<  8;
-  salt_buf_t1[2] = salt_buf_t0[1] >> 24 | salt_buf_t0[2] <<  8;
-  salt_buf_t1[3] = salt_buf_t0[2] >> 24 | salt_buf_t0[3] <<  8;
-  salt_buf_t1[4] = salt_buf_t0[3] >> 24;
+  salt_buf_t1[0] = hc_bytealign_S (            0, salt_buf_t0[0], 1);
+  salt_buf_t1[1] = hc_bytealign_S (salt_buf_t0[0], salt_buf_t0[1], 1);
+  salt_buf_t1[2] = hc_bytealign_S (salt_buf_t0[1], salt_buf_t0[2], 1);
+  salt_buf_t1[3] = hc_bytealign_S (salt_buf_t0[2], salt_buf_t0[3], 1);
+  salt_buf_t1[4] = hc_bytealign_S (salt_buf_t0[3],             0, 1);
 
   u32 salt_buf_t2[5];
 
-  salt_buf_t2[0] =                        salt_buf_t0[0] << 16;
-  salt_buf_t2[1] = salt_buf_t0[0] >> 16 | salt_buf_t0[1] << 16;
-  salt_buf_t2[2] = salt_buf_t0[1] >> 16 | salt_buf_t0[2] << 16;
-  salt_buf_t2[3] = salt_buf_t0[2] >> 16 | salt_buf_t0[3] << 16;
-  salt_buf_t2[4] = salt_buf_t0[3] >> 16;
+  salt_buf_t2[0] = hc_bytealign_S (            0, salt_buf_t0[0], 2);
+  salt_buf_t2[1] = hc_bytealign_S (salt_buf_t0[0], salt_buf_t0[1], 2);
+  salt_buf_t2[2] = hc_bytealign_S (salt_buf_t0[1], salt_buf_t0[2], 2);
+  salt_buf_t2[3] = hc_bytealign_S (salt_buf_t0[2], salt_buf_t0[3], 2);
+  salt_buf_t2[4] = hc_bytealign_S (salt_buf_t0[3],             0, 2);
 
   u32 salt_buf_t3[5];
 
-  salt_buf_t3[0] =                        salt_buf_t0[0] << 24;
-  salt_buf_t3[1] = salt_buf_t0[0] >>  8 | salt_buf_t0[1] << 24;
-  salt_buf_t3[2] = salt_buf_t0[1] >>  8 | salt_buf_t0[2] << 24;
-  salt_buf_t3[3] = salt_buf_t0[2] >>  8 | salt_buf_t0[3] << 24;
-  salt_buf_t3[4] = salt_buf_t0[3] >>  8;
+  salt_buf_t3[0] = hc_bytealign_S (            0, salt_buf_t0[0], 3);
+  salt_buf_t3[1] = hc_bytealign_S (salt_buf_t0[0], salt_buf_t0[1], 3);
+  salt_buf_t3[2] = hc_bytealign_S (salt_buf_t0[1], salt_buf_t0[2], 3);
+  salt_buf_t3[3] = hc_bytealign_S (salt_buf_t0[2], salt_buf_t0[3], 3);
+  salt_buf_t3[4] = hc_bytealign_S (salt_buf_t0[3],             0, 3);
 
   /**
    * esalt
@@ -390,14 +390,14 @@ DECLSPEC void m09700m (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
     digest_t0[2] &= 0x00000000;
     digest_t0[3] &= 0x00000000;
 
-    digest_t1[0] =                      digest_t0[0] <<  8;
-    digest_t1[1] = digest_t0[0] >> 24 | digest_t0[1] <<  8;
+    digest_t1[0] = hc_bytealign_S (           0, digest_t0[0], 1);
+    digest_t1[1] = hc_bytealign_S (digest_t0[0], digest_t0[1], 1);
 
-    digest_t2[0] =                      digest_t0[0] << 16;
-    digest_t2[1] = digest_t0[0] >> 16 | digest_t0[1] << 16;
+    digest_t2[0] = hc_bytealign_S (           0, digest_t0[0], 2);
+    digest_t2[1] = hc_bytealign_S (digest_t0[0], digest_t0[1], 2);
 
-    digest_t3[0] =                      digest_t0[0] << 24;
-    digest_t3[1] = digest_t0[0] >>  8 | digest_t0[1] << 24;
+    digest_t3[0] = hc_bytealign_S (           0, digest_t0[0], 3);
+    digest_t3[1] = hc_bytealign_S (digest_t0[0], digest_t0[1], 3);
 
     // generate the 16 * 21 buffer
 
@@ -688,27 +688,27 @@ DECLSPEC void m09700s (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
 
   u32 salt_buf_t1[5];
 
-  salt_buf_t1[0] =                        salt_buf_t0[0] <<  8;
-  salt_buf_t1[1] = salt_buf_t0[0] >> 24 | salt_buf_t0[1] <<  8;
-  salt_buf_t1[2] = salt_buf_t0[1] >> 24 | salt_buf_t0[2] <<  8;
-  salt_buf_t1[3] = salt_buf_t0[2] >> 24 | salt_buf_t0[3] <<  8;
-  salt_buf_t1[4] = salt_buf_t0[3] >> 24;
+  salt_buf_t1[0] = hc_bytealign_S (            0, salt_buf_t0[0], 1);
+  salt_buf_t1[1] = hc_bytealign_S (salt_buf_t0[0], salt_buf_t0[1], 1);
+  salt_buf_t1[2] = hc_bytealign_S (salt_buf_t0[1], salt_buf_t0[2], 1);
+  salt_buf_t1[3] = hc_bytealign_S (salt_buf_t0[2], salt_buf_t0[3], 1);
+  salt_buf_t1[4] = hc_bytealign_S (salt_buf_t0[3],             0, 1);
 
   u32 salt_buf_t2[5];
 
-  salt_buf_t2[0] =                        salt_buf_t0[0] << 16;
-  salt_buf_t2[1] = salt_buf_t0[0] >> 16 | salt_buf_t0[1] << 16;
-  salt_buf_t2[2] = salt_buf_t0[1] >> 16 | salt_buf_t0[2] << 16;
-  salt_buf_t2[3] = salt_buf_t0[2] >> 16 | salt_buf_t0[3] << 16;
-  salt_buf_t2[4] = salt_buf_t0[3] >> 16;
+  salt_buf_t2[0] = hc_bytealign_S (            0, salt_buf_t0[0], 2);
+  salt_buf_t2[1] = hc_bytealign_S (salt_buf_t0[0], salt_buf_t0[1], 2);
+  salt_buf_t2[2] = hc_bytealign_S (salt_buf_t0[1], salt_buf_t0[2], 2);
+  salt_buf_t2[3] = hc_bytealign_S (salt_buf_t0[2], salt_buf_t0[3], 2);
+  salt_buf_t2[4] = hc_bytealign_S (salt_buf_t0[3],             0, 2);
 
   u32 salt_buf_t3[5];
 
-  salt_buf_t3[0] =                        salt_buf_t0[0] << 24;
-  salt_buf_t3[1] = salt_buf_t0[0] >>  8 | salt_buf_t0[1] << 24;
-  salt_buf_t3[2] = salt_buf_t0[1] >>  8 | salt_buf_t0[2] << 24;
-  salt_buf_t3[3] = salt_buf_t0[2] >>  8 | salt_buf_t0[3] << 24;
-  salt_buf_t3[4] = salt_buf_t0[3] >>  8;
+  salt_buf_t3[0] = hc_bytealign_S (            0, salt_buf_t0[0], 3);
+  salt_buf_t3[1] = hc_bytealign_S (salt_buf_t0[0], salt_buf_t0[1], 3);
+  salt_buf_t3[2] = hc_bytealign_S (salt_buf_t0[1], salt_buf_t0[2], 3);
+  salt_buf_t3[3] = hc_bytealign_S (salt_buf_t0[2], salt_buf_t0[3], 3);
+  salt_buf_t3[4] = hc_bytealign_S (salt_buf_t0[3],             0, 3);
 
   /**
    * esalt
@@ -799,14 +799,14 @@ DECLSPEC void m09700s (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
     digest_t0[2] &= 0x00000000;
     digest_t0[3] &= 0x00000000;
 
-    digest_t1[0] =                      digest_t0[0] <<  8;
-    digest_t1[1] = digest_t0[0] >> 24 | digest_t0[1] <<  8;
+    digest_t1[0] = hc_bytealign_S (           0, digest_t0[0], 1);
+    digest_t1[1] = hc_bytealign_S (digest_t0[0], digest_t0[1], 1);
 
-    digest_t2[0] =                      digest_t0[0] << 16;
-    digest_t2[1] = digest_t0[0] >> 16 | digest_t0[1] << 16;
+    digest_t2[0] = hc_bytealign_S (           0, digest_t0[0], 2);
+    digest_t2[1] = hc_bytealign_S (digest_t0[0], digest_t0[1], 2);
 
-    digest_t3[0] =                      digest_t0[0] << 24;
-    digest_t3[1] = digest_t0[0] >>  8 | digest_t0[1] << 24;
+    digest_t3[0] = hc_bytealign_S (           0, digest_t0[0], 3);
+    digest_t3[1] = hc_bytealign_S (digest_t0[0], digest_t0[1], 3);
 
     // generate the 16 * 21 buffer
 

--- a/OpenCL/m09700_a3-optimized.cl
+++ b/OpenCL/m09700_a3-optimized.cl
@@ -10,7 +10,13 @@
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_LID_TYPE u64
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_NEXT_16_PREFETCH
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_NEXT_16_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
+#undef RC4_LID_TYPE
 #endif
 
 // autoresearch: ncu shows m09700_s is latency-bound (SM & mem both ~64%, not saturated)

--- a/OpenCL/m09800_a0-optimized.cl
+++ b/OpenCL/m09800_a0-optimized.cl
@@ -15,7 +15,15 @@
 #include M2S(INCLUDE_PATH/inc_rp_optimized.cl)
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#define RC4_INIT_128_UNROLL8
+#define RC4_ENABLE_NEXT_4
+#define RC4_NEXT_16_PREFETCH
+#define RC4_NEXT_16_UNROLL2
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_NEXT_16_UNROLL2
+#undef RC4_NEXT_16_PREFETCH
+#undef RC4_ENABLE_NEXT_4
+#undef RC4_INIT_128_UNROLL8
 #endif
 
 #define MIN_NULL_BYTES 10

--- a/OpenCL/m09800_a0-optimized.cl
+++ b/OpenCL/m09800_a0-optimized.cl
@@ -37,7 +37,7 @@ KERNEL_FQ KERNEL_FA void m09800_m04 (KERN_ATTR_RULES_ESALT (oldoffice34_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
 
   /**
    * base
@@ -171,14 +171,17 @@ KERNEL_FQ KERNEL_FA void m09800_m04 (KERN_ATTR_RULES_ESALT (oldoffice34_t))
 
     digest[0] = hc_swap32_S (digest[0]);
     digest[1] = hc_swap32_S (digest[1]);
-    digest[2] = hc_swap32_S (digest[2]);
-    digest[3] = hc_swap32_S (digest[3]);
 
     if (version == 3)
     {
       digest[1] &= 0xff;
       digest[2]  = 0;
       digest[3]  = 0;
+    }
+    else
+    {
+      digest[2] = hc_swap32_S (digest[2]);
+      digest[3] = hc_swap32_S (digest[3]);
     }
 
     rc4_init_128 (S, digest, lid);
@@ -323,7 +326,7 @@ KERNEL_FQ KERNEL_FA void m09800_s04 (KERN_ATTR_RULES_ESALT (oldoffice34_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
 
   /**
    * base
@@ -469,14 +472,17 @@ KERNEL_FQ KERNEL_FA void m09800_s04 (KERN_ATTR_RULES_ESALT (oldoffice34_t))
 
     digest[0] = hc_swap32_S (digest[0]);
     digest[1] = hc_swap32_S (digest[1]);
-    digest[2] = hc_swap32_S (digest[2]);
-    digest[3] = hc_swap32_S (digest[3]);
 
     if (version == 3)
     {
       digest[1] &= 0xff;
       digest[2]  = 0;
       digest[3]  = 0;
+    }
+    else
+    {
+      digest[2] = hc_swap32_S (digest[2]);
+      digest[3] = hc_swap32_S (digest[3]);
     }
 
     rc4_init_128 (S, digest, lid);
@@ -515,14 +521,17 @@ KERNEL_FQ KERNEL_FA void m09800_s04 (KERN_ATTR_RULES_ESALT (oldoffice34_t))
     digest[2] = hc_swap32_S (digest[2]);
     digest[3] = hc_swap32_S (digest[3]);
 
-    rc4_next_16 (S, 16, j, digest, out, lid);
+    j = rc4_next_4 (S, 16, j, digest, out, lid);
 
     // initial compare
 
     if (out[0] != search[0]) continue;
-    if (out[1] != search[1]) continue;
-    if (out[2] != search[2]) continue;
-    if (out[3] != search[3]) continue;
+
+    rc4_next_16 (S, 20, j, digest + 1, out, lid);
+
+    if (out[0] != search[1]) continue;
+    if (out[1] != search[2]) continue;
+    if (out[2] != search[3]) continue;
 
     if (esalt_bufs[DIGESTS_OFFSET_HOST].secondBlockLen != 0)
     {

--- a/OpenCL/m09800_a1-optimized.cl
+++ b/OpenCL/m09800_a1-optimized.cl
@@ -13,7 +13,15 @@
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#define RC4_INIT_128_UNROLL8
+#define RC4_ENABLE_NEXT_4
+#define RC4_NEXT_16_PREFETCH
+#define RC4_NEXT_16_UNROLL2
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_NEXT_16_UNROLL2
+#undef RC4_NEXT_16_PREFETCH
+#undef RC4_ENABLE_NEXT_4
+#undef RC4_INIT_128_UNROLL8
 #endif
 
 #define MIN_NULL_BYTES 10

--- a/OpenCL/m09800_a1-optimized.cl
+++ b/OpenCL/m09800_a1-optimized.cl
@@ -35,7 +35,7 @@ KERNEL_FQ KERNEL_FA void m09800_m04 (KERN_ATTR_ESALT (oldoffice34_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
 
   /**
    * base
@@ -219,14 +219,17 @@ KERNEL_FQ KERNEL_FA void m09800_m04 (KERN_ATTR_ESALT (oldoffice34_t))
 
     digest[0] = hc_swap32_S (digest[0]);
     digest[1] = hc_swap32_S (digest[1]);
-    digest[2] = hc_swap32_S (digest[2]);
-    digest[3] = hc_swap32_S (digest[3]);
 
     if (version == 3)
     {
       digest[1] &= 0xff;
       digest[2]  = 0;
       digest[3]  = 0;
+    }
+    else
+    {
+      digest[2] = hc_swap32_S (digest[2]);
+      digest[3] = hc_swap32_S (digest[3]);
     }
 
     rc4_init_128 (S, digest, lid);
@@ -371,7 +374,7 @@ KERNEL_FQ KERNEL_FA void m09800_s04 (KERN_ATTR_ESALT (oldoffice34_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
 
   /**
    * base
@@ -567,14 +570,17 @@ KERNEL_FQ KERNEL_FA void m09800_s04 (KERN_ATTR_ESALT (oldoffice34_t))
 
     digest[0] = hc_swap32_S (digest[0]);
     digest[1] = hc_swap32_S (digest[1]);
-    digest[2] = hc_swap32_S (digest[2]);
-    digest[3] = hc_swap32_S (digest[3]);
 
     if (version == 3)
     {
       digest[1] &= 0xff;
       digest[2]  = 0;
       digest[3]  = 0;
+    }
+    else
+    {
+      digest[2] = hc_swap32_S (digest[2]);
+      digest[3] = hc_swap32_S (digest[3]);
     }
 
     rc4_init_128 (S, digest, lid);
@@ -613,14 +619,17 @@ KERNEL_FQ KERNEL_FA void m09800_s04 (KERN_ATTR_ESALT (oldoffice34_t))
     digest[2] = hc_swap32_S (digest[2]);
     digest[3] = hc_swap32_S (digest[3]);
 
-    rc4_next_16 (S, 16, j, digest, out, lid);
+    j = rc4_next_4 (S, 16, j, digest, out, lid);
 
     // initial compare
 
     if (out[0] != search[0]) continue;
-    if (out[1] != search[1]) continue;
-    if (out[2] != search[2]) continue;
-    if (out[3] != search[3]) continue;
+
+    rc4_next_16 (S, 20, j, digest + 1, out, lid);
+
+    if (out[0] != search[1]) continue;
+    if (out[1] != search[2]) continue;
+    if (out[2] != search[3]) continue;
 
     if (esalt_bufs[DIGESTS_OFFSET_HOST].secondBlockLen != 0)
     {

--- a/OpenCL/m09800_a3-optimized.cl
+++ b/OpenCL/m09800_a3-optimized.cl
@@ -135,14 +135,17 @@ DECLSPEC void m09800m (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
 
     digest[0] = hc_swap32_S (digest[0]);
     digest[1] = hc_swap32_S (digest[1]);
-    digest[2] = hc_swap32_S (digest[2]);
-    digest[3] = hc_swap32_S (digest[3]);
 
     if (version == 3)
     {
       digest[1] &= 0xff;
       digest[2]  = 0;
       digest[3]  = 0;
+    }
+    else
+    {
+      digest[2] = hc_swap32_S (digest[2]);
+      digest[3] = hc_swap32_S (digest[3]);
     }
 
     rc4_init_128 (S, digest, lid);
@@ -394,14 +397,17 @@ DECLSPEC void m09800s (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
 
     digest[0] = hc_swap32_S (digest[0]);
     digest[1] = hc_swap32_S (digest[1]);
-    digest[2] = hc_swap32_S (digest[2]);
-    digest[3] = hc_swap32_S (digest[3]);
 
     if (version == 3)
     {
       digest[1] &= 0xff;
       digest[2]  = 0;
       digest[3]  = 0;
+    }
+    else
+    {
+      digest[2] = hc_swap32_S (digest[2]);
+      digest[3] = hc_swap32_S (digest[3]);
     }
 
     rc4_init_128 (S, digest, lid);
@@ -440,14 +446,17 @@ DECLSPEC void m09800s (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
     digest[2] = hc_swap32_S (digest[2]);
     digest[3] = hc_swap32_S (digest[3]);
 
-    rc4_next_16 (S, 16, j, digest, out, lid);
+    j = rc4_next_4 (S, 16, j, digest, out, lid);
 
     // initial compare
 
     if (out[0] != search[0]) continue;
-    if (out[1] != search[1]) continue;
-    if (out[2] != search[2]) continue;
-    if (out[3] != search[3]) continue;
+
+    rc4_next_16 (S, 20, j, digest + 1, out, lid);
+
+    if (out[0] != search[1]) continue;
+    if (out[1] != search[2]) continue;
+    if (out[2] != search[3]) continue;
 
     if (esalt_bufs[DIGESTS_OFFSET_HOST].secondBlockLen != 0)
     {
@@ -537,7 +546,7 @@ KERNEL_FQ KERNEL_FA void m09800_m04 (KERN_ATTR_ESALT (oldoffice34_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -588,7 +597,7 @@ KERNEL_FQ KERNEL_FA void m09800_m08 (KERN_ATTR_ESALT (oldoffice34_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -639,7 +648,7 @@ KERNEL_FQ KERNEL_FA void m09800_m16 (KERN_ATTR_ESALT (oldoffice34_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -690,7 +699,7 @@ KERNEL_FQ KERNEL_FA void m09800_s04 (KERN_ATTR_ESALT (oldoffice34_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -741,7 +750,7 @@ KERNEL_FQ KERNEL_FA void m09800_s08 (KERN_ATTR_ESALT (oldoffice34_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -792,7 +801,7 @@ KERNEL_FQ KERNEL_FA void m09800_s16 (KERN_ATTR_ESALT (oldoffice34_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 

--- a/OpenCL/m09800_a3-optimized.cl
+++ b/OpenCL/m09800_a3-optimized.cl
@@ -23,6 +23,68 @@
 
 #define MIN_NULL_BYTES 10
 
+DECLSPEC int m09800_rc4_next_4_staged (LOCAL_AS u32 *S, const u8 i, const u8 j, const u32 in, const u32 search, const u32 lid)
+{
+  u8 a = i;
+  u8 b = j;
+
+  u32 xor4 = 0;
+
+  u32 tmp;
+
+  u8 idx;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 0;
+
+  if (((in ^ xor4) & 0xff) != (search & 0xff)) return -1;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 8;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 16;
+
+  a += 1;
+  b += GET_KEY8 (S, a, lid);
+
+  rc4_swap (S, a, b, lid);
+
+  idx = GET_KEY8 (S, a, lid) + GET_KEY8 (S, b, lid);
+
+  tmp = GET_KEY8 (S, idx, lid);
+
+  xor4 |= tmp << 24;
+
+  if ((in ^ xor4) != search) return -1;
+
+  return b;
+}
+
 typedef struct oldoffice34
 {
   u32 version;
@@ -454,11 +516,11 @@ DECLSPEC void m09800s (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, 
     digest[2] = hc_swap32_S (digest[2]);
     digest[3] = hc_swap32_S (digest[3]);
 
-    j = rc4_next_4 (S, 16, j, digest, out, lid);
+    const int j4 = m09800_rc4_next_4_staged (S, 16, j, digest[0], search[0], lid);
 
-    // initial compare
+    if (j4 == -1) continue;
 
-    if (out[0] != search[0]) continue;
+    j = (u8) j4;
 
     rc4_next_16 (S, 20, j, digest + 1, out, lid);
 

--- a/OpenCL/m09800_a3-optimized.cl
+++ b/OpenCL/m09800_a3-optimized.cl
@@ -10,7 +10,15 @@
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_sha1.cl)
+#define RC4_INIT_128_UNROLL8
+#define RC4_ENABLE_NEXT_4
+#define RC4_NEXT_16_PREFETCH
+#define RC4_NEXT_16_UNROLL2
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_NEXT_16_UNROLL2
+#undef RC4_NEXT_16_PREFETCH
+#undef RC4_ENABLE_NEXT_4
+#undef RC4_INIT_128_UNROLL8
 #endif
 
 #define MIN_NULL_BYTES 10

--- a/OpenCL/m10500-pure.cl
+++ b/OpenCL/m10500-pure.cl
@@ -9,7 +9,11 @@
 #include M2S(INCLUDE_PATH/inc_platform.cl)
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_INIT_128_PREFETCH
+#define RC4_INIT_128_PREFETCH_UNROLL8
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_INIT_128_PREFETCH_UNROLL8
+#undef RC4_INIT_128_PREFETCH
 #endif
 
 #define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)

--- a/OpenCL/m10500-pure.cl
+++ b/OpenCL/m10500-pure.cl
@@ -41,9 +41,99 @@ typedef struct pdf
 typedef struct pdf14_tmp
 {
   u32 digest[4];
-  u32 out[4];
+  u32 out[2];
 
 } pdf14_tmp_t;
+
+DECLSPEC void rc4_next_8_m10500 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *in, PRIVATE_AS u32 *out, const u32 lid)
+{
+  u8 a = 0;
+  u8 b = 0;
+
+  u8 s_prefetch = GET_KEY8 (S, 1, lid);
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int k = 0; k < 2; k++)
+  {
+    u32 xor4 = 0;
+
+    u32 tmp;
+
+    u8 idx;
+    u8 next;
+    u8 sa;
+    u8 sb;
+    u8 s_next;
+
+    a += 1;
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    s_prefetch = (b == next) ? sa : s_next;
+
+    xor4 |= tmp <<  0;
+
+    a += 1;
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    s_prefetch = (b == next) ? sa : s_next;
+
+    xor4 |= tmp <<  8;
+
+    a += 1;
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    s_prefetch = (b == next) ? sa : s_next;
+
+    xor4 |= tmp << 16;
+
+    a += 1;
+    next = a + 1;
+    s_next = GET_KEY8 (S, next, lid);
+    sa = s_prefetch;
+    b += sa;
+    sb = GET_KEY8 (S, b, lid);
+    SET_KEY8 (S, a, sb, lid);
+    SET_KEY8 (S, b, sa, lid);
+    idx = sa + sb;
+
+    tmp = GET_KEY8 (S, idx, lid);
+
+    s_prefetch = (b == next) ? sa : s_next;
+
+    xor4 |= tmp << 24;
+
+    out[k] = in[k] ^ xor4;
+  }
+}
 
 KERNEL_FQ KERNEL_FA void m10500_init (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
 {
@@ -228,8 +318,6 @@ KERNEL_FQ KERNEL_FA void m10500_init (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
 
   tmps[gid].out[0] = rc4data[0];
   tmps[gid].out[1] = rc4data[1];
-  tmps[gid].out[2] = 0;
-  tmps[gid].out[3] = 0;
 }
 
 KERNEL_FQ KERNEL_FA void m10500_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
@@ -239,7 +327,7 @@ KERNEL_FQ KERNEL_FA void m10500_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
    */
 
   const u64 gid = get_global_id (0);
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
 
   if (gid >= GID_CNT) return;
 
@@ -260,12 +348,10 @@ KERNEL_FQ KERNEL_FA void m10500_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
   digest[2] = tmps[gid].digest[2];
   digest[3] = tmps[gid].digest[3];
 
-  u32 out[4];
+  u32 out[2];
 
   out[0] = tmps[gid].out[0];
   out[1] = tmps[gid].out[1];
-  out[2] = tmps[gid].out[2];
-  out[3] = tmps[gid].out[3];
 
   for (u32 i = 0, j = LOOP_POS; i < LOOP_CNT; i++, j++)
   {
@@ -318,7 +404,7 @@ KERNEL_FQ KERNEL_FA void m10500_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
 
       rc4_init_128 (S, tmp, lid);
 
-      rc4_next_16 (S, 0, 0, out, out, lid);
+      rc4_next_8_m10500 (S, out, out, lid);
     }
   }
 
@@ -329,8 +415,6 @@ KERNEL_FQ KERNEL_FA void m10500_loop (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))
 
   tmps[gid].out[0] = out[0];
   tmps[gid].out[1] = out[1];
-  tmps[gid].out[2] = out[2];
-  tmps[gid].out[3] = out[3];
 }
 
 KERNEL_FQ KERNEL_FA void m10500_comp (KERN_ATTR_TMPS_ESALT (pdf14_tmp_t, pdf_t))

--- a/OpenCL/m13100_a0-optimized.cl
+++ b/OpenCL/m13100_a0-optimized.cl
@@ -16,7 +16,13 @@
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md4.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_INIT_128_PREFETCH
+#define RC4_ENABLE_KRB5_HELPERS
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_ENABLE_KRB5_HELPERS
+#undef RC4_INIT_128_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
 #endif
 
 typedef struct krb5tgs

--- a/OpenCL/m13100_a0-optimized.cl
+++ b/OpenCL/m13100_a0-optimized.cl
@@ -114,11 +114,10 @@ DECLSPEC void hmac_md5_run (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u
   md5_transform (w0, w1, w2, w3, digest);
 }
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
 {
   rc4_init_128 (S, data, lid);
 
-  u32 out0[4];
   u32 out1[4];
 
   u8 i = 0;
@@ -135,13 +134,15 @@ DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS
     next headers follow the same ASN1 "type-length-data" scheme
   */
 
-  j = rc4_next_16_global (S, i, j, edata2 + 0, out0, lid); i += 16;
+  const int probe0 = rc4_next_12_global_krb5_staged (S, i, j, edata2 + 0, lid); i += 12;
 
-  if (((out0[2] & 0xff00ffff) != 0x30008163) && ((out0[2] & 0x0000ffff) != 0x00008263)) return 0;
+  if (probe0 < 0) return 0;
 
-  j = rc4_next_16_global (S, i, j, edata2 + 4, out1, lid); i += 16;
+  j = (u8) probe0;
 
-  if (((out1[0] & 0x00ffffff) != 0x00000503) && (out1[0] != 0x050307A0)) return 0;
+  j = rc4_next_12_global (S, i, j, edata2 + 3, out1, lid); i += 12;
+
+  if (((out1[1] & 0x00ffffff) != 0x00000503) && (out1[1] != 0x050307A0)) return 0;
 
   rc4_init_128 (S, data, lid);
 
@@ -460,7 +461,7 @@ KERNEL_FQ KERNEL_FA void m13100_m04 (KERN_ATTR_RULES_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;
@@ -556,7 +557,7 @@ KERNEL_FQ KERNEL_FA void m13100_s04 (KERN_ATTR_RULES_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;

--- a/OpenCL/m13100_a0-pure.cl
+++ b/OpenCL/m13100_a0-pure.cl
@@ -28,7 +28,7 @@ typedef struct krb5tgs
 
 } krb5tgs_t;
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
 {
   rc4_init_128 (S, data, lid);
 
@@ -272,7 +272,7 @@ KERNEL_FQ KERNEL_FA void m13100_mxx (KERN_ATTR_RULES_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;
@@ -332,7 +332,7 @@ KERNEL_FQ KERNEL_FA void m13100_sxx (KERN_ATTR_RULES_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;

--- a/OpenCL/m13100_a0-pure.cl
+++ b/OpenCL/m13100_a0-pure.cl
@@ -15,7 +15,13 @@
 #include M2S(INCLUDE_PATH/inc_rp.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md4.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_INIT_128_PREFETCH
+#define RC4_ENABLE_KRB5_HELPERS
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_ENABLE_KRB5_HELPERS
+#undef RC4_INIT_128_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
 #endif
 
 typedef struct krb5tgs

--- a/OpenCL/m13100_a1-optimized.cl
+++ b/OpenCL/m13100_a1-optimized.cl
@@ -14,7 +14,13 @@
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md4.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_INIT_128_PREFETCH
+#define RC4_ENABLE_KRB5_HELPERS
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_ENABLE_KRB5_HELPERS
+#undef RC4_INIT_128_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
 #endif
 
 typedef struct krb5tgs

--- a/OpenCL/m13100_a1-optimized.cl
+++ b/OpenCL/m13100_a1-optimized.cl
@@ -112,11 +112,10 @@ DECLSPEC void hmac_md5_run (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u
   md5_transform (w0, w1, w2, w3, digest);
 }
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
 {
   rc4_init_128 (S, data, lid);
 
-  u32 out0[4];
   u32 out1[4];
 
   u8 i = 0;
@@ -133,13 +132,15 @@ DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS
     next headers follow the same ASN1 "type-length-data" scheme
   */
 
-  j = rc4_next_16_global (S, i, j, edata2 + 0, out0, lid); i += 16;
+  const int probe0 = rc4_next_12_global_krb5_staged (S, i, j, edata2 + 0, lid); i += 12;
 
-  if (((out0[2] & 0xff00ffff) != 0x30008163) && ((out0[2] & 0x0000ffff) != 0x00008263)) return 0;
+  if (probe0 < 0) return 0;
 
-  j = rc4_next_16_global (S, i, j, edata2 + 4, out1, lid); i += 16;
+  j = (u8) probe0;
 
-  if (((out1[0] & 0x00ffffff) != 0x00000503) && (out1[0] != 0x050307A0)) return 0;
+  j = rc4_next_12_global (S, i, j, edata2 + 3, out1, lid); i += 12;
+
+  if (((out1[1] & 0x00ffffff) != 0x00000503) && (out1[1] != 0x050307A0)) return 0;
 
   rc4_init_128 (S, data, lid);
 
@@ -458,7 +459,7 @@ KERNEL_FQ KERNEL_FA void m13100_m04 (KERN_ATTR_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
 
   /**
    * base
@@ -603,7 +604,7 @@ KERNEL_FQ KERNEL_FA void m13100_s04 (KERN_ATTR_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
 
   /**
    * base

--- a/OpenCL/m13100_a1-pure.cl
+++ b/OpenCL/m13100_a1-pure.cl
@@ -26,7 +26,7 @@ typedef struct krb5tgs
 
 } krb5tgs_t;
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
 {
   rc4_init_128 (S, data, lid);
 
@@ -270,7 +270,7 @@ KERNEL_FQ KERNEL_FA void m13100_mxx (KERN_ATTR_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;
@@ -328,7 +328,7 @@ KERNEL_FQ KERNEL_FA void m13100_sxx (KERN_ATTR_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;

--- a/OpenCL/m13100_a1-pure.cl
+++ b/OpenCL/m13100_a1-pure.cl
@@ -13,7 +13,13 @@
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md4.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_INIT_128_PREFETCH
+#define RC4_ENABLE_KRB5_HELPERS
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_ENABLE_KRB5_HELPERS
+#undef RC4_INIT_128_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
 #endif
 
 typedef struct krb5tgs

--- a/OpenCL/m13100_a3-optimized.cl
+++ b/OpenCL/m13100_a3-optimized.cl
@@ -17,6 +17,13 @@
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
 #endif
 
+// A 32-thread block owns an 8 KiB RC4 S-box. Twelve blocks fill the practical
+// shared-memory residency limit while giving ptxas a mild latency-hiding target.
+#if defined IS_CUDA || defined IS_HIP
+#undef  KERNEL_FA
+#define KERNEL_FA __launch_bounds__ (32, 12)
+#endif
+
 typedef struct krb5tgs
 {
   u32 account_info[512];
@@ -112,11 +119,10 @@ DECLSPEC void hmac_md5_run (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u
   md5_transform (w0, w1, w2, w3, digest);
 }
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
 {
   rc4_init_128 (S, data, lid);
 
-  u32 out0[4];
   u32 out1[4];
 
   u8 i = 0;
@@ -133,13 +139,15 @@ DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS
     next headers follow the same ASN1 "type-length-data" scheme
   */
 
-  j = rc4_next_16_global (S, i, j, edata2 + 0, out0, lid); i += 16;
+  const int probe0 = rc4_next_12_global_krb5_staged (S, i, j, edata2 + 0, lid); i += 12;
 
-  if (((out0[2] & 0xff00ffff) != 0x30008163) && ((out0[2] & 0x0000ffff) != 0x00008263)) return 0;
+  if (probe0 < 0) return 0;
 
-  j = rc4_next_16_global (S, i, j, edata2 + 4, out1, lid); i += 16;
+  j = (u8) probe0;
 
-  if (((out1[0] & 0x00ffffff) != 0x00000503) && (out1[0] != 0x050307A0)) return 0;
+  j = rc4_next_12_global (S, i, j, edata2 + 3, out1, lid); i += 12;
+
+  if (((out1[1] & 0x00ffffff) != 0x00000503) && (out1[1] != 0x050307A0)) return 0;
 
   rc4_init_128 (S, data, lid);
 
@@ -514,7 +522,7 @@ KERNEL_FQ KERNEL_FA void m13100_m04 (KERN_ATTR_ESALT (krb5tgs_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -565,7 +573,7 @@ KERNEL_FQ KERNEL_FA void m13100_m08 (KERN_ATTR_ESALT (krb5tgs_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -620,7 +628,7 @@ KERNEL_FQ KERNEL_FA void m13100_s04 (KERN_ATTR_ESALT (krb5tgs_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -671,7 +679,7 @@ KERNEL_FQ KERNEL_FA void m13100_s08 (KERN_ATTR_ESALT (krb5tgs_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 

--- a/OpenCL/m13100_a3-optimized.cl
+++ b/OpenCL/m13100_a3-optimized.cl
@@ -14,7 +14,13 @@
 #include M2S(INCLUDE_PATH/inc_simd.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md4.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_INIT_128_PREFETCH
+#define RC4_ENABLE_KRB5_HELPERS
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_ENABLE_KRB5_HELPERS
+#undef RC4_INIT_128_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
 #endif
 
 // A 32-thread block owns an 8 KiB RC4 S-box. Twelve blocks fill the practical

--- a/OpenCL/m13100_a3-pure.cl
+++ b/OpenCL/m13100_a3-pure.cl
@@ -26,7 +26,7 @@ typedef struct krb5tgs
 
 } krb5tgs_t;
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
 {
   rc4_init_128 (S, data, lid);
 
@@ -270,7 +270,7 @@ KERNEL_FQ KERNEL_FA void m13100_mxx (KERN_ATTR_VECTOR_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;
@@ -341,7 +341,7 @@ KERNEL_FQ KERNEL_FA void m13100_sxx (KERN_ATTR_VECTOR_ESALT (krb5tgs_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;

--- a/OpenCL/m13100_a3-pure.cl
+++ b/OpenCL/m13100_a3-pure.cl
@@ -13,7 +13,13 @@
 #include M2S(INCLUDE_PATH/inc_common.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md4.cl)
 #include M2S(INCLUDE_PATH/inc_hash_md5.cl)
+#define RC4_USE_BITWISE_ADDRESSING
+#define RC4_INIT_128_PREFETCH
+#define RC4_ENABLE_KRB5_HELPERS
 #include M2S(INCLUDE_PATH/inc_cipher_rc4.cl)
+#undef RC4_ENABLE_KRB5_HELPERS
+#undef RC4_INIT_128_PREFETCH
+#undef RC4_USE_BITWISE_ADDRESSING
 #endif
 
 typedef struct krb5tgs

--- a/OpenCL/m18200_a3-optimized.cl
+++ b/OpenCL/m18200_a3-optimized.cl
@@ -112,33 +112,260 @@ DECLSPEC void hmac_md5_run (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u
   md5_transform (w0, w1, w2, w3, digest);
 }
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+#define M18200_RC4_KSA_PREFETCH_STEP(d)       \
+{                                             \
+  const u8 s_next = GET_KEY8 (S, idx + 1, lid); \
+  j += s_i + (d);                             \
+  const u8 s_j = GET_KEY8 (S, j, lid);        \
+  SET_KEY8 (S, idx, s_j, lid);                \
+  SET_KEY8 (S, j, s_i, lid);                  \
+  idx++;                                      \
+  s_i = (j == idx) ? s_i : s_next;            \
+}
+
+DECLSPEC void rc4_init_128_virtual4 (LOCAL_AS u32 *S, PRIVATE_AS const u32 *key, const u32 lid)
 {
-  rc4_init_128 (S, data, lid);
+  u32 v = 0x07060504;
+  u32 a = 0x04040404;
 
-  u32 out0[4];
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (u8 i = 1; i < 64; i++)
+  {
+    SET_KEY32 (S, i, v, lid); v += a;
+  }
 
-  /*
-    8 first bytes are nonce, then ASN1 structs (DER encoding: TLV)
+  v = key[0];
 
-    The first byte is always 0x79 (01 1 11001, where 01 = "class=APPLICATION", 1 = "form=constructed", 11001 is application type 25)
-    The next byte is the length:
+  const u8 d0 = v8a_from_v32_S (v);
+  const u8 d1 = v8b_from_v32_S (v);
+  const u8 d2 = v8c_from_v32_S (v);
+  const u8 d3 = v8d_from_v32_S (v);
 
-    if length < 128 bytes:
-        length is on 1 byte, and the next byte is 0x30 (class=SEQUENCE)
-    else if length <= 256:
-        length is on 2 bytes, the first byte is 0x81, and the third byte is 0x30 (class=SEQUENCE)
-    else if length > 256:
-        length is on 3 bytes, the first byte is 0x82, and the fourth byte is 0x30 (class=SEQUENCE)
-  */
+  // The first four swaps start from the identity permutation. Track their
+  // sparse updates in registers, then commit them in program order.
 
-  rc4_next_16_global (S, 0, 0, edata2 + 0, out0, lid);
+  const u8 j0 = d0;
 
-  if (((out0[2] & 0x00ff80ff) != 0x00300079) &&
-      ((out0[2] & 0xFF00FFFF) != 0x30008179) &&
-      ((out0[2] & 0x0000FFFF) != 0x00008279 || (out0[3] & 0x000000FF) != 0x00000030))
-      return 0;
+  const u8 s1  = (j0 == 1) ? 0 : 1;
+  const u8 j1  = j0 + s1 + d1;
+  const u8 sj1 = (j1 == j0) ? 0 : ((j1 == 0) ? j0 : j1);
 
+  const u8 s2  = (j1 == 2) ? s1 : ((j0 == 2) ? 0 : 2);
+  const u8 j2  = j1 + s2 + d2;
+  const u8 sj2 = (j2 == j1) ? s1
+               : (j2 == 1)  ? sj1
+               : (j2 == j0) ? 0
+               : (j2 == 0)  ? j0
+               : j2;
+
+  const u8 s3  = (j2 == 3) ? s2
+               : (j1 == 3) ? s1
+               : (j0 == 3) ? 0
+               : 3;
+  const u8 j3  = j2 + s3 + d3;
+  const u8 sj3 = (j3 == j2) ? s2
+               : (j3 == 2)  ? sj2
+               : (j3 == j1) ? s1
+               : (j3 == 1)  ? sj1
+               : (j3 == j0) ? 0
+               : (j3 == 0)  ? j0
+               : j3;
+
+  SET_KEY8 (S, j0,   0, lid);
+  SET_KEY8 (S, j1,  s1, lid);
+  SET_KEY8 (S, j2,  s2, lid);
+  SET_KEY8 (S, j3,  s3, lid);
+
+  // The ordered j writes above establish every update outside positions 0..3.
+  // Commit the final low positions together, replacing four byte stores and
+  // making their identity initialization unnecessary.
+
+  const u8 s0 = (j3 == 0) ? s3
+              : (j2 == 0) ? s2
+              : (j1 == 0) ? s1
+              : (j0 == 0) ? 0
+              : j0;
+  const u8 s1_final = (j3 == 1) ? s3
+                    : (j2 == 1) ? s2
+                    : sj1;
+  const u8 s2_final = (j3 == 2) ? s3 : sj2;
+
+  const u32 sbox03 = ((u32) s0       <<  0)
+                   | ((u32) s1_final <<  8)
+                   | ((u32) s2_final << 16)
+                   | ((u32) sj3      << 24);
+
+  SET_KEY32 (S, 0, sbox03, lid);
+
+  u8 j = j3;
+
+  u8 idx = 4;
+  u8 s_i = GET_KEY8 (S, idx, lid);
+
+  v = key[1];
+
+  M18200_RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+  v = key[2];
+
+  M18200_RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+  v = key[3];
+
+  M18200_RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+  M18200_RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+  for (u32 i = 1; i < 16; i++)
+  {
+    idx = i * 16;
+
+    v = key[0];
+
+    M18200_RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+    v = key[1];
+
+    M18200_RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+    v = key[2];
+
+    M18200_RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+
+    v = key[3];
+
+    M18200_RC4_KSA_PREFETCH_STEP (v8a_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8b_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8c_from_v32_S (v));
+    M18200_RC4_KSA_PREFETCH_STEP (v8d_from_v32_S (v));
+  }
+}
+
+#undef M18200_RC4_KSA_PREFETCH_STEP
+
+DECLSPEC int asrep_early_check (LOCAL_AS u32 *S, const u32 edata2_2, const u32 edata2_3, const u32 lid)
+{
+  u8 a = 0;
+  u8 b = 0;
+  u8 tmp;
+  u8 s_prefetch = GET_KEY8 (S, 1, lid);
+
+  #define RC4_STEP_DISCARD_PREFETCH()             \
+  {                                                \
+    a += 1;                                        \
+    const u8 next = a + 1;                        \
+    const u8 Snext = GET_KEY8 (S, next, lid);     \
+    const u8 Sa = s_prefetch;                     \
+    b += Sa;                                       \
+    const u8 Sb = GET_KEY8 (S, b, lid);           \
+    SET_KEY8 (S, a, Sb, lid);                      \
+    SET_KEY8 (S, b, Sa, lid);                      \
+    s_prefetch = (b == next) ? Sa : Snext;        \
+  }
+
+  #define RC4_STEP_BYTE_CARRIED(out)              \
+  {                                                \
+    a += 1;                                        \
+    const u8 Sa = s_prefetch;                     \
+    b += Sa;                                       \
+    const u8 Sb = GET_KEY8 (S, b, lid);           \
+    SET_KEY8 (S, a, Sb, lid);                      \
+    SET_KEY8 (S, b, Sa, lid);                      \
+    const u8 idx = Sa + Sb;                        \
+    out = GET_KEY8 (S, idx, lid);                  \
+  }
+
+  #define RC4_STEP_DISCARD()             \
+  {                                      \
+    a += 1;                              \
+    const u8 Sa = GET_KEY8 (S, a, lid);  \
+    b += Sa;                             \
+    const u8 Sb = GET_KEY8 (S, b, lid);  \
+    SET_KEY8 (S, a, Sb, lid);            \
+    SET_KEY8 (S, b, Sa, lid);            \
+  }
+
+  #define RC4_STEP_BYTE(out)             \
+  {                                      \
+    a += 1;                              \
+    const u8 Sa = GET_KEY8 (S, a, lid);  \
+    b += Sa;                             \
+    const u8 Sb = GET_KEY8 (S, b, lid);  \
+    SET_KEY8 (S, a, Sb, lid);            \
+    SET_KEY8 (S, b, Sa, lid);            \
+    const u8 idx = Sa + Sb;              \
+    out = GET_KEY8 (S, idx, lid);        \
+  }
+
+  RC4_STEP_DISCARD_PREFETCH ();
+  RC4_STEP_DISCARD_PREFETCH ();
+  RC4_STEP_DISCARD_PREFETCH ();
+  RC4_STEP_DISCARD_PREFETCH ();
+  RC4_STEP_DISCARD_PREFETCH ();
+  RC4_STEP_DISCARD_PREFETCH ();
+  RC4_STEP_DISCARD_PREFETCH ();
+  RC4_STEP_DISCARD_PREFETCH ();
+
+  RC4_STEP_BYTE_CARRIED (tmp);
+
+  if ((((u32) tmp ^ edata2_2) & 0xff) != 0x79) return 0;
+
+  RC4_STEP_BYTE (tmp);
+
+  const u32 len_tag = ((u32) tmp ^ (edata2_2 >> 8)) & 0xff;
+
+  if ((len_tag & 0x80) == 0)
+  {
+    RC4_STEP_BYTE (tmp);
+
+    return ((((u32) tmp ^ (edata2_2 >> 16)) & 0xff) == 0x30);
+  }
+
+  if (len_tag == 0x81)
+  {
+    RC4_STEP_DISCARD ();
+    RC4_STEP_BYTE (tmp);
+
+    return ((((u32) tmp ^ (edata2_2 >> 24)) & 0xff) == 0x30);
+  }
+
+  if (len_tag == 0x82)
+  {
+    RC4_STEP_DISCARD ();
+    RC4_STEP_DISCARD ();
+    RC4_STEP_BYTE (tmp);
+
+    return ((((u32) tmp ^ edata2_3) & 0xff) == 0x30);
+  }
+
+  #undef RC4_STEP_BYTE
+  #undef RC4_STEP_BYTE_CARRIED
+  #undef RC4_STEP_DISCARD
+  #undef RC4_STEP_DISCARD_PREFETCH
+
+  return 0;
+}
+
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
+{
   rc4_init_128 (S, data, lid);
 
   u8 i = 0;
@@ -314,50 +541,21 @@ DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS
   return 1;
 }
 
-DECLSPEC void kerb_prepare (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, const u32 pw_len, PRIVATE_AS const u32 *checksum, PRIVATE_AS u32 *digest, PRIVATE_AS u32 *K2)
+DECLSPEC void kerb_prepare (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS const u32 *checksum, PRIVATE_AS u32 *digest, const u32 make_k3)
 {
-  /**
-   * pads
-   */
-
-  u32 w0_t[4];
-  u32 w1_t[4];
-  u32 w2_t[4];
-  u32 w3_t[4];
-
-  w0_t[0] = w0[0];
-  w0_t[1] = w0[1];
-  w0_t[2] = w0[2];
-  w0_t[3] = w0[3];
-  w1_t[0] = w1[0];
-  w1_t[1] = w1[1];
-  w1_t[2] = w1[2];
-  w1_t[3] = w1[3];
-  w2_t[0] = 0;
-  w2_t[1] = 0;
-  w2_t[2] = 0;
-  w2_t[3] = 0;
-  w3_t[0] = 0;
-  w3_t[1] = 0;
-  w3_t[2] = 0;
-  w3_t[3] = 0;
-
   // K=MD4(Little_indian(UNICODE(pwd))
-
-  append_0x80_2x4 (w0_t, w1_t, pw_len);
-
-  make_utf16le (w1_t, w2_t, w3_t);
-  make_utf16le (w0_t, w0_t, w1_t);
-
-  w3_t[2] = pw_len * 8 * 2;
-  w3_t[3] = 0;
 
   digest[0] = MD4M_A;
   digest[1] = MD4M_B;
   digest[2] = MD4M_C;
   digest[3] = MD4M_D;
 
-  md4_transform (w0_t, w1_t, w2_t, w3_t, digest);
+  md4_transform (w0, w1, w2, w3, digest);
+
+  u32 w0_t[4];
+  u32 w1_t[4];
+  u32 w2_t[4];
+  u32 w3_t[4];
 
   // K1=MD5_HMAC(K,1); with 2 encoded as little indian on 4 bytes (02000000 in hexa);
 
@@ -402,12 +600,9 @@ DECLSPEC void kerb_prepare (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, 
 
   hmac_md5_run (w0_t, w1_t, w2_t, w3_t, ipad, opad, digest);
 
-  // K2 = K1;
+  // K2 = K1
 
-  K2[0] = digest[0];
-  K2[1] = digest[1];
-  K2[2] = digest[2];
-  K2[3] = digest[3];
+  if (make_k3 == 0) return;
 
   // K3=MD5_HMAC(K1,checksum);
 
@@ -467,17 +662,53 @@ DECLSPEC void m18200 (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, P
   checksum[2] = esalt_bufs[DIGESTS_OFFSET_HOST].checksum[2];
   checksum[3] = esalt_bufs[DIGESTS_OFFSET_HOST].checksum[3];
 
+  const u32 edata2_2 = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[2];
+  const u32 edata2_3 = esalt_bufs[DIGESTS_OFFSET_HOST].edata2[3];
+
   /**
    * loop
    */
 
-  u32 w0l = w0[0];
+  u32 md4_w0[4];
+
+  md4_w0[0] = w0[0];
+  md4_w0[1] = w0[1];
+  md4_w0[2] = w0[2];
+  md4_w0[3] = w0[3];
+
+  u32 md4_w1[4];
+
+  md4_w1[0] = w1[0];
+  md4_w1[1] = w1[1];
+  md4_w1[2] = w1[2];
+  md4_w1[3] = w1[3];
+
+  u32 md4_w2[4] = { 0 };
+  u32 md4_w3[4] = { 0 };
+
+  append_0x80_2x4 (md4_w0, md4_w1, pw_len);
+
+  make_utf16le_S (md4_w1, md4_w2, md4_w3);
+  make_utf16le_S (md4_w0, md4_w0, md4_w1);
+
+  md4_w3[2] = pw_len * 8 * 2;
+  md4_w3[3] = 0;
+
+  const u32 md4_w0l0 = md4_w0[0];
+  const u32 md4_w0l1 = md4_w0[1];
 
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos++)
   {
     const u32 w0r = bfs_buf[il_pos].i;
 
-    w0[0] = w0l | w0r;
+    u32 modifier[4] = { w0r, 0, 0, 0 };
+    u32 modifier_utf16[4];
+    u32 modifier_unused[4];
+
+    make_utf16le_S (modifier, modifier_utf16, modifier_unused);
+
+    md4_w0[0] = md4_w0l0 | modifier_utf16[0];
+    md4_w0[1] = md4_w0l1 | modifier_utf16[1];
 
     /**
      * kerberos
@@ -485,9 +716,7 @@ DECLSPEC void m18200 (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, P
 
     u32 digest[4];
 
-    u32 K2[4];
-
-    kerb_prepare (w0, w1, pw_len, checksum, digest, K2);
+    kerb_prepare (md4_w0, md4_w1, md4_w2, md4_w3, checksum, digest, 1);
 
     u32 tmp[4];
 
@@ -495,6 +724,14 @@ DECLSPEC void m18200 (LOCAL_AS u32 *S, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, P
     tmp[1] = digest[1];
     tmp[2] = digest[2];
     tmp[3] = digest[3];
+
+    rc4_init_128_virtual4 (S, tmp, lid);
+
+    if (asrep_early_check (S, edata2_2, edata2_3, lid) == 0) continue;
+
+    u32 K2[4];
+
+    kerb_prepare (md4_w0, md4_w1, md4_w2, md4_w3, checksum, K2, 0);
 
     if (decrypt_and_check (S, tmp, esalt_bufs[DIGESTS_OFFSET_HOST].edata2, esalt_bufs[DIGESTS_OFFSET_HOST].edata2_len, K2, checksum, lid) == 1)
     {
@@ -512,7 +749,7 @@ KERNEL_FQ KERNEL_FA void m18200_m04 (KERN_ATTR_ESALT (krb5asrep_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -563,7 +800,7 @@ KERNEL_FQ KERNEL_FA void m18200_m08 (KERN_ATTR_ESALT (krb5asrep_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -618,7 +855,7 @@ KERNEL_FQ KERNEL_FA void m18200_s04 (KERN_ATTR_ESALT (krb5asrep_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 
@@ -669,7 +906,7 @@ KERNEL_FQ KERNEL_FA void m18200_s08 (KERN_ATTR_ESALT (krb5asrep_t))
    * base
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
   const u64 lsz = get_local_size (0);
 

--- a/OpenCL/m18200_a3-pure.cl
+++ b/OpenCL/m18200_a3-pure.cl
@@ -26,7 +26,7 @@ typedef struct krb5asrep
 
 } krb5asrep_t;
 
-DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u64 lid)
+DECLSPEC int decrypt_and_check (LOCAL_AS u32 *S, PRIVATE_AS u32 *data, GLOBAL_AS const u32 *edata2, const u32 edata2_len, PRIVATE_AS const u32 *K2, PRIVATE_AS const u32 *checksum, const u32 lid)
 {
   rc4_init_128 (S, data, lid);
 
@@ -268,7 +268,7 @@ KERNEL_FQ KERNEL_FA void m18200_mxx (KERN_ATTR_VECTOR_ESALT (krb5asrep_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;
@@ -339,7 +339,7 @@ KERNEL_FQ KERNEL_FA void m18200_sxx (KERN_ATTR_VECTOR_ESALT (krb5asrep_t))
    * modifier
    */
 
-  const u64 lid = get_local_id (0);
+  const u32 lid = get_local_id (0);
   const u64 gid = get_global_id (0);
 
   if (gid >= GID_CNT) return;


### PR DESCRIPTION
Optimizes RC4 KSA, PRGA, and early-rejection paths for modes 9700, 9800, 10500, 13100, and 18200.

Shared helpers use compile-time specialization so each mode selects its validated addressing, unrolling, prefetching, and state-management variants while other RC4 consumers retain safe defaults.

## Performance

RTX 3090 at a fixed 1710 MHz, measured against current master with three interleaved A/B repetitions:

  Mode    Improvement
━━━━━━━━━━━━━━━━━━━━
  9700         +30.2%
────────────────────
  9800         +31.8%
────────────────────
 10500         +13.0%
────────────────────
 13100         +20.0%
────────────────────
 18200         +24.6%

## Validation

- All five modes pass startup/self-test on CUDA and NVIDIA OpenCL.
- Other RC4 consumers were compile and benchmark checked on both backends.
- No hash formats or module behavior are changed.
## Mode 9800 follow-up

The optimized single-hash a3 verifier now compares the first decrypted RC4 byte before generating the remaining three bytes. Most wrong candidates therefore return after one PRGA step, while survivors still generate the full word and perform the original exact 32-bit comparison.

On an RTX 3090 fixed at 1500 MHz, two interleaved A/B runs against the previous PR tip (`358c26027`) measured +0.411% and +0.384% (`8c3fd1dbf`), for a conservative incremental gain of +0.384%.

Correctness was checked with five exact a3 cracks on both CUDA and NVIDIA OpenCL, covering `$oldoffice$3` and `$oldoffice$4`, password lengths 1, 7, and 15, and the `$oldoffice$3` secondary-block form. Negative controls exhausted without false positives on both backends.
## Mode 9700 follow-up

Mode 9700 now uses `hc_bytealign_S` for cross-word byte alignment in its salt and repeated-digest blocks. This is value-identical to the explicit shifts and ORs while allowing each backend to select its native byte-alignment primitive.

On an RTX 3090 fixed at 1500 MHz, two interleaved A/B runs against the unchanged mode 9700 code in `358c26027` measured +3.869% and +3.952% (`e9481ed48`), for a conservative incremental gain of +3.869%.

All 42 substitutions passed differential checks against the original expressions and the generic, funnel-shift, and NVIDIA byte-permute implementations. Runtime validation passed on CUDA and NVIDIA OpenCL for Office v0/v1, optimized s04/s08, and both single- and multi-hash paths, including 7- and 15-character passwords.