### PR TITLE
Fix netbsd workflow and build warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ on:
   push:
     branches:
       - master
-      - fix_netbsd_workflow
     tags:
       - v*
     paths:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - master
+      - fix_netbsd_workflow
     tags:
       - v*
     paths:
@@ -157,7 +158,11 @@ jobs:
           envs: SHARED
           prepare: |
             export PATH="/usr/sbin:$PATH"
-            pkg_add git gcc14 gmake gsed python313 llvm libiconv clang
+            export PKG_PATH="https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All"
+            pkg_add pkgin
+            pkgin -y update
+            pkgin -y full-upgrade
+            pkgin -y install git gcc14 gmake gsed python313 llvm libiconv clang openmp
           run: |
             export PATH="/usr/pkg/gcc14/bin:$PATH"
             export TERM=xterm

--- a/src/affinity.c
+++ b/src/affinity.c
@@ -73,7 +73,7 @@ int set_cpu_affinity (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
   DWORD_PTR aff_mask = 0;
   const int cpu_id_max = 8 * sizeof (aff_mask);
   #elif defined (__NetBSD__)
-  cpuset_t * cpuset;
+  cpuset_t *cpuset = NULL;
   const int cpu_id_max = 8 * cpuset_size (cpuset);
   cpuset = cpuset_create ();
   if (cpuset == NULL)


### PR DESCRIPTION
Hi,

I've started splitting up the PCFG PR; this is the first one that fixes the error for the two NetBSD builds in the GitHub workflow, as well as a warning that appears during the hashcat build on NetBSD:

```
  src/affinity.c:77:43: warning: variable 'cpuset' is uninitialized when used here [-Wuninitialized]
     77 |   const int cpu_id_max = 8 * cpuset_size (cpuset);
        |                                           ^~~~~~
  src/affinity.c:76:20: note: initialize the variable 'cpuset' to silence this warning
     76 |   cpuset_t * cpuset;
        |                    ^
        |                     = NULL
  1 warning generated.
```

Thanks