### PR TITLE
update hashcat-toolchain docker to version 2.1

### DIFF
--- a/docker/hashcat_binaries.ubuntu
+++ b/docker/hashcat_binaries.ubuntu
@@ -5,7 +5,7 @@ FROM gm4tr1x/hashcat-toolchain:${HOST_ARCH}-${UBUNTU_VERSION} AS builder-toolcha
 
 LABEL org.opencontainers.image.authors="Gabriele 'matrix' Gristina <matrix@hashcat.net>" \
       org.opencontainers.image.title="Hashcat cross-build using hashcat-toolchain" \
-      org.opencontainers.image.version="2.0" \
+      org.opencontainers.image.version="2.1" \
       org.opencontainers.image.description="Docker image based on Ubuntu for cross-compiling Hashcat (Windows and Linux) and optionally scanning for potential vulnerabilities using clang-tidy and scan-build." \
       org.opencontainers.image.source="https://github.com/hashcat/hashcat/blob/master/docker/hashcat_binaries.ubuntu" \
       org.opencontainers.image.licenses="MIT"
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install apt-utils && ap
     dos2unix \
     git \
     libc6-dev \
+    libomp-dev \
     make \
     time \
     wget \
@@ -69,7 +70,7 @@ RUN echo "$WD/native/lib" > /etc/ld.so.conf.d/toolchain.conf && \
 
 # 7zip
 
-ARG SEVEN_ZIP_VERSION=25.01
+ARG SEVEN_ZIP_VERSION=26.02
 ENV SEVEN_ZIP_VERSION=${SEVEN_ZIP_VERSION}
 
 RUN cd $WD/src && git clone --depth 1 --branch ${SEVEN_ZIP_VERSION} https://github.com/ip7z/7zip.git && \


### PR DESCRIPTION
- add libomp-dev dep (will be used by pcfg)
- update 7z version to 26.02