### PR TITLE
update threads macros and types

### DIFF
--- a/include/thread.h
+++ b/include/thread.h
@@ -12,7 +12,11 @@
 #include <windows.h>
 #else
 #include <pthread.h>
+#if defined(__APPLE__)
+#include <dispatch/dispatch.h>
+#else
 #include <semaphore.h>
+#endif // __APPLE__
 #endif // _WIN
 
 #if defined (_WIN)
@@ -21,6 +25,8 @@
 #define hc_thread_wait(n,a)         for (int i = 0; i < n; i++) WaitForSingleObject ((a)[i], INFINITE)
 #define hc_thread_exit(t)           ExitThread (t)
 #define hc_thread_detach(t)         CloseHandle (t)
+#define hc_thread_self()            GetCurrentThreadId ()
+#define hc_thread_join(t)           WaitForSingleObject (t, INFINITE)
 
 #define hc_thread_mutex_init(m)     InitializeCriticalSection (&m)
 #define hc_thread_mutex_lock(m)     EnterCriticalSection      (&m)
@@ -34,6 +40,12 @@
 #define hc_thread_mutex_delete(m)   CloseHandle         (m)
 */
 
+#define hc_thread_cond_init(c)      InitializeConditionVariable (&c)
+#define hc_thread_cond_signal(c)    WakeConditionVariable       (&c)
+#define hc_thread_cond_broadcast(c) WakeAllConditionVariable    (&c)
+#define hc_thread_cond_wait(c,m)    SleepConditionVariableCS    (&c, &m, INFINITE)
+#define hc_thread_cond_delete(c)    (void)(c)
+
 #define hc_thread_sem_init(s)       s = CreateSemaphore (NULL, 0, INT_MAX, NULL)
 #define hc_thread_sem_post(s)       ReleaseSemaphore    (s, 1, NULL)
 #define hc_thread_sem_wait(s)       WaitForSingleObject (s, INFINITE)
@@ -45,16 +57,35 @@
 #define hc_thread_wait(n,a)         for (int i = 0; i < n; i++) pthread_join ((a)[i], NULL)
 #define hc_thread_exit(t)           pthread_exit (&t)
 #define hc_thread_detach(t)         pthread_detach (t)
+#define hc_thread_self()            pthread_self ()
+#define hc_thread_join(t)           pthread_join (t, NULL)
 
 #define hc_thread_mutex_init(m)     pthread_mutex_init     (&m, NULL)
 #define hc_thread_mutex_lock(m)     pthread_mutex_lock     (&m)
 #define hc_thread_mutex_unlock(m)   pthread_mutex_unlock   (&m)
 #define hc_thread_mutex_delete(m)   pthread_mutex_destroy  (&m)
 
-#define hc_thread_sem_init(s)       sem_init  (&s, 0, 0)
-#define hc_thread_sem_post(s)       sem_post  (&s)
-#define hc_thread_sem_wait(s)       sem_wait  (&s)
-#define hc_thread_sem_close(s)      sem_close (&s)
+#define hc_thread_cond_init(c)      pthread_cond_init      (&c, NULL)
+#define hc_thread_cond_signal(c)    pthread_cond_signal    (&c)
+#define hc_thread_cond_broadcast(c) pthread_cond_broadcast (&c)
+#define hc_thread_cond_wait(c,m)    pthread_cond_wait      (&c, &m)
+#define hc_thread_cond_delete(c)    pthread_cond_destroy   (&c)
+
+#if defined (__APPLE__)
+
+#define hc_thread_sem_init(s)       ((s) = dispatch_semaphore_create (0))
+#define hc_thread_sem_wait(s)       dispatch_semaphore_wait ((s), DISPATCH_TIME_FOREVER)
+#define hc_thread_sem_post(s)       dispatch_semaphore_signal ((s))
+#define hc_thread_sem_close(s)      dispatch_release ((s))
+
+#else
+
+#define hc_thread_sem_init(s)       sem_init    (&s, 0, 0)
+#define hc_thread_sem_post(s)       sem_post    (&s)
+#define hc_thread_sem_wait(s)       sem_wait    (&s)
+#define hc_thread_sem_close(s)      sem_destroy (&s)
+
+#endif // __APPLE__
 
 #endif
 

--- a/include/types.h
+++ b/include/types.h
@@ -73,18 +73,29 @@ typedef struct timespec   hc_timer_t;
 
 #if defined (_POSIX)
 #include <pthread.h>
+#if defined (__APPLE__)
+#include <dispatch/dispatch.h>
+#else
 #include <semaphore.h>
-#endif
+#endif // __APPLE__
+#endif // _POSIX
 
 #if defined (_WIN)
-typedef HANDLE           hc_thread_t;
-typedef CRITICAL_SECTION hc_thread_mutex_t;
-typedef HANDLE           hc_thread_semaphore_t;
+typedef HANDLE             hc_thread_t;
+typedef CRITICAL_SECTION   hc_thread_mutex_t;
+typedef CONDITION_VARIABLE hc_thread_cond_t;
+typedef HANDLE             hc_thread_semaphore_t;
 #else
-typedef pthread_t        hc_thread_t;
-typedef pthread_mutex_t  hc_thread_mutex_t;
-typedef sem_t            hc_thread_semaphore_t;
-#endif
+typedef pthread_t          hc_thread_t;
+typedef pthread_mutex_t    hc_thread_mutex_t;
+typedef pthread_cond_t     hc_thread_cond_t;
+
+#if defined (__APPLE__)
+typedef dispatch_semaphore_t hc_thread_semaphore_t;
+#else
+typedef sem_t                hc_thread_semaphore_t;
+#endif // __APPLE__
+#endif // _WIN
 
 // enums
 


### PR DESCRIPTION
- add hc_thread_self and hc_thread_join functions
- add hc_thread_cond_* support
- unnamed sem_init needs sem_destroy, not sem_close

- use Grand Central Dispatch on Apple instead of the POSIX sem_* functions (due to the deprecation warning)

```
src/pwpipe.c:99:3: warning: 'sem_init' is deprecated [-Wdeprecated-declarations]
   99 |   hc_thread_sem_init (pipe->sem_free);
      |   ^
include/thread.h:54:37: note: expanded from macro 'hc_thread_sem_init'
   54 | #define hc_thread_sem_init(s)       sem_init  (&s, 0, 0)
      |                                     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/sys/semaphore.h:55:42: note: 'sem_init' has been explicitly marked deprecated here
   55 | int sem_init(sem_t *, int, unsigned int) __deprecated;
      |                                          ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/sys/cdefs.h:214:40: note: expanded from macro '__deprecated'
  214 | #define __deprecated    __attribute__((__deprecated__))
      |                                        ^
src/pwpipe.c:100:3: warning: 'sem_init' is deprecated [-Wdeprecated-declarations]
  100 |   hc_thread_sem_init (pipe->sem_filled);
      |   ^
include/thread.h:54:37: note: expanded from macro 'hc_thread_sem_init'
   54 | #define hc_thread_sem_init(s)       sem_init  (&s, 0, 0)
      |                                     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/sys/semaphore.h:55:42: note: 'sem_init' has been explicitly marked deprecated here
   55 | int sem_init(sem_t *, int, unsigned int) __deprecated;
      |                                          ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/sys/cdefs.h:214:40: note: expanded from macro '__deprecated'
  214 | #define __deprecated    __attribute__((__deprecated__))
      |                                        ^
2 warnings generated.
```
