### PR TITLE
fix u32 overflow in hash/salt buffer pointer arithmetic

### DIFF
--- a/src/brain.c
+++ b/src/brain.c
@@ -70,7 +70,7 @@ u32 brain_compute_session (hashcat_ctx_t *hashcat_ctx)
     u32  digests_cnt = hashes->digests_cnt;
     u32 *digests_buf = (u32 *) hashes->digests_buf;
 
-    XXH64_update (state, digests_buf, digests_cnt * hashconfig->dgst_size);
+    XXH64_update (state, digests_buf, (u64) digests_cnt * hashconfig->dgst_size);
 
     // salt
 

--- a/src/hashes.c
+++ b/src/hashes.c
@@ -140,9 +140,9 @@ int hash_encode (const user_options_t *user_options, const hashconfig_t *hashcon
   char       *hook_salts_buf_ptr = (char *) hook_salts_buf;
   hashinfo_t *hash_info_ptr      = NULL;
 
-  digests_buf_ptr    += digest_cur * hashconfig->dgst_size;
-  esalts_buf_ptr     += digest_cur * hashconfig->esalt_size;
-  hook_salts_buf_ptr += digest_cur * hashconfig->hook_salt_size;
+  digests_buf_ptr    += (u64) digest_cur * hashconfig->dgst_size;
+  esalts_buf_ptr     += (u64) digest_cur * hashconfig->esalt_size;
+  hook_salts_buf_ptr += (u64) digest_cur * hashconfig->hook_salt_size;
 
   if (hash_info) hash_info_ptr = hash_info[digest_cur];
 
@@ -523,9 +523,9 @@ int check_hash (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pla
     char       *hook_salts_buf_ptr = (char *) hook_salts_buf;
     hashinfo_t *hash_info_ptr      = NULL;
 
-    digests_buf_ptr    += digest_cur * hashconfig->dgst_size;
-    esalts_buf_ptr     += digest_cur * hashconfig->esalt_size;
-    hook_salts_buf_ptr += digest_cur * hashconfig->hook_salt_size;
+    digests_buf_ptr    += (u64) digest_cur * hashconfig->dgst_size;
+    esalts_buf_ptr     += (u64) digest_cur * hashconfig->esalt_size;
+    hook_salts_buf_ptr += (u64) digest_cur * hashconfig->hook_salt_size;
 
     if (hash_info) hash_info_ptr = hash_info[digest_cur];
 
@@ -2050,7 +2050,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
     if (hashconfig->hook_salt_size > 0)
     {
-      char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + (salts_cnt * hashconfig->hook_salt_size);
+      char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + ((u64) salts_cnt * hashconfig->hook_salt_size);
 
       memcpy (hook_salts_buf_new_ptr, hashes_buf[0].hook_salt, hashconfig->hook_salt_size);
 
@@ -2102,7 +2102,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
         if (hashconfig->hook_salt_size > 0)
         {
-          char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + (salts_cnt * hashconfig->hook_salt_size);
+          char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + ((u64) salts_cnt * hashconfig->hook_salt_size);
 
           memcpy (hook_salts_buf_new_ptr, hashes_buf[hashes_pos].hook_salt, hashconfig->hook_salt_size);
 
@@ -2120,7 +2120,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
       if (hashconfig->hook_salt_size > 0)
       {
-        char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + (salts_cnt * hashconfig->hook_salt_size);
+        char *hook_salts_buf_new_ptr = ((char *) hook_salts_buf_new) + ((u64) salts_cnt * hashconfig->hook_salt_size);
 
         hashes_buf[hashes_pos].hook_salt = hook_salts_buf_new_ptr;
       }
@@ -2128,7 +2128,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
     salt_buf->digests_cnt++;
 
-    digests_buf_new_ptr = ((char *) digests_buf_new) + (hashes_pos * hashconfig->dgst_size);
+    digests_buf_new_ptr = ((char *) digests_buf_new) + ((u64) hashes_pos * hashconfig->dgst_size);
 
     memcpy (digests_buf_new_ptr, hashes_buf[hashes_pos].digest, hashconfig->dgst_size);
 
@@ -2136,7 +2136,7 @@ int hashes_init_stage2 (hashcat_ctx_t *hashcat_ctx)
 
     if (hashconfig->esalt_size > 0)
     {
-      char *esalts_buf_new_ptr = ((char *) esalts_buf_new) + (hashes_pos * hashconfig->esalt_size);
+      char *esalts_buf_new_ptr = ((char *) esalts_buf_new) + ((u64) hashes_pos * hashconfig->esalt_size);
 
       memcpy (esalts_buf_new_ptr, hashes_buf[hashes_pos].esalt, hashconfig->esalt_size);
 


### PR DESCRIPTION
digest/salt/esalt buffer offsets computed "count * size" in u32, which overflows past ~4 GB of hashes and yields a wrong pointer. Fixed by cast to u64.
