### PR TITLE
fix fgetl off-by-one

### DIFF
--- a/src/filehandling.c
+++ b/src/filehandling.c
@@ -1042,7 +1042,7 @@ size_t fgetl (HCFILE *fp, char *line_buf, const size_t line_sz)
   {
     if (c == '\n') break;
 
-    if (line_len == line_sz)
+    if (line_len == line_sz - 1)
     {
       line_truncated++;
     }


### PR DESCRIPTION
A line exactly as long as its destination buffer caused the terminating null byte to be written one position too far. Stop one byte earlier so it stays in bounds.

fix #4739