### PR TITLE
fix m34301 header overflow

### DIFF
--- a/src/modules/module_34301.c
+++ b/src/modules/module_34301.c
@@ -153,7 +153,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // 9. header
   token.len_min[9] = 400;
-  token.len_max[9] = 600;
+  token.len_max[9] = 512; // sizeof (keepass4->header) * 2
   token.sep[9]     = '*';
   token.attr[9]    = TOKEN_ATTR_VERIFY_LENGTH | TOKEN_ATTR_VERIFY_HEX;
 
@@ -249,6 +249,8 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   keepass4->header_len = token.len[9];
   if (keepass4->header_len % 2 != 0) return (PARSER_HASH_VALUE); // hex-value needs to be multiple of 2
   keepass4->header_len = keepass4->header_len / 2;
+
+  if (keepass4->header_len > sizeof (keepass4->header)) return (PARSER_SALT_LENGTH);
 
   const u8 *header_pos = token.buf[9];
   hex_decode ((const u8 *) header_pos, keepass4->header_len*2, (u8 *) keepass4->header);


### PR DESCRIPTION
Since there are no size limits for this format, a fixed-size buffer must reach its maximum limit and discard any excess data, rather than expanding. The previous limit of 600 hexadecimal digits exceeded the buffer's capacity on both the host and kernel sides. 256 bytes are sufficient to cover the typical header of approximately 207 bytes.

fix #4737