### PR TITLE
Fix wrong error label in hc_hipGetDeviceProperties and add context to HIP errors

### DIFF
--- a/src/ext_hip.c
+++ b/src/ext_hip.c
@@ -479,11 +479,11 @@ int hc_hipDeviceGetAttribute (void *hashcat_ctx, int *pi, hipDeviceAttribute_t a
 
     if (hip->hipGetErrorString (HIP_err, &pStr) == hipSuccess)
     {
-      event_log_error (hashcat_ctx, "hipDeviceGetAttribute(): %s", pStr);
+      event_log_error (hashcat_ctx, "hipDeviceGetAttribute(dev=%d, attrib=%d): %s", dev, attrib, pStr);
     }
     else
     {
-      event_log_error (hashcat_ctx, "hipDeviceGetAttribute(): %d", HIP_err);
+      event_log_error (hashcat_ctx, "hipDeviceGetAttribute(dev=%d, attrib=%d): %d", dev, attrib, HIP_err);
     }
 
     return -1;
@@ -1507,11 +1507,11 @@ int hc_hipGetDeviceProperties (void *hashcat_ctx, hipDeviceProp_t *prop, hipDevi
 
     if (hip->hipGetErrorString (HIP_err, &pStr) == hipSuccess)
     {
-      event_log_error (hashcat_ctx, "hipDeviceGetAttribute(): %s", pStr);
+      event_log_error (hashcat_ctx, "hipGetDeviceProperties(dev=%d): %s", dev, pStr);
     }
     else
     {
-      event_log_error (hashcat_ctx, "hipDeviceGetAttribute(): %d", HIP_err);
+      event_log_error (hashcat_ctx, "hipGetDeviceProperties(dev=%d): %d", dev, HIP_err);
     }
 
     return -1;


### PR DESCRIPTION
The error path of `hc_hipGetDeviceProperties()` reports its failures with the label `"hipDeviceGetAttribute()"`, which is a different function. This makes HIP device-property failures misleading and harder to diagnose, since the error message points at the wrong API call.

## Changes

- **Correct the error label** in `hc_hipGetDeviceProperties()` from `"hipDeviceGetAttribute()"` to `"hipGetDeviceProperties()"` to match the function that actually failed.
- **Add device id context** (`dev=%d`) to `hipGetDeviceProperties` error messages.
- **Add device and attribute context** (`dev=%d, attrib=%d`) to `hipDeviceGetAttribute` error messages, so a failing device or attribute can be identified without re-running with a debugger.

## Why

When a HIP device fails to initialize, the error message currently says `hipDeviceGetAttribute()` even if the failure was in `hipGetDeviceProperties()`. This sent me down the wrong path while debugging a HIP backend issue on a non-ROCm HIP implementation, where `hipGetDeviceProperties` was the call that actually returned an error.

## Scope

- 1 file changed (`src/ext_hip.c`), 4 insertions, 4 deletions
- No behavioral change, no new dependencies, no build flag changes
- Default build unaffected