### PR TITLE
secp256k1: fix zero-scalar OOB read and zero-input hang, add safegcd inverse; add opt-in FORCE_NO_INLINE

### DIFF
--- a/OpenCL/inc_ecc_secp256k1.cl
+++ b/OpenCL/inc_ecc_secp256k1.cl
@@ -795,10 +795,18 @@ DECLSPEC void sqrt_mod (PRIVATE_AS u32 *r)
 
 // (inverse (a, p) * a) % p == 1 (or think of a * a^-1 = a / a = 1)
 
-DECLSPEC void inv_mod (PRIVATE_AS u32 *a)
+DECLSPEC void inv_mod_binary_gcd (PRIVATE_AS u32 *a)
 {
-  // How often does this really happen? it should "almost" never happen (but would be safer)
-  // if ((a[0] | a[1] | a[2] | a[3] | a[4] | a[5] | a[6] | a[7]) == 0) return;
+  // Guard against a == 0 (the z-coordinate of the point at infinity, produced by
+  // point_add of P + (-P) or by feeding point_mul_xy a zero scalar).
+  // Without this the loop below never terminates: t0 = 0 is always even, so shifting
+  // keeps it 0 and the exit condition (t0 == p) is never reached. On a CPU OpenCL
+  // device (pocl) the work-item then spins forever and clFinish hangs; GPUs happen to
+  // mask it. Cheap, branch-predictable early-out (7 ORs + 1 compare).
+
+  const u32 a_is_zero = (a[0] | a[1] | a[2] | a[3] | a[4] | a[5] | a[6] | a[7]) == 0;
+
+  if (a_is_zero) return;
 
   u32 t0[8];
 
@@ -1026,6 +1034,291 @@ DECLSPEC void inv_mod (PRIVATE_AS u32 *a)
   a[5] = t2[5];
   a[6] = t2[6];
   a[7] = t2[7];
+}
+
+/*
+ * safegcd modular inverse (Bernstein-Yang "divsteps"), a faithful port of libsecp256k1's
+ * CONSTANT-TIME modinv32 (bitcoin-core/secp256k1, src/modinv32_impl.h, MIT). Drop-in alternative to
+ * inv_mod_binary_gcd() above with the SAME signature (u32 a[8] little-endian, value in [0, p),
+ * replaced by its inverse mod p). Self-contained: depends only on the field prime p (encoded below)
+ * and 32/64-bit integer math already used by mul_mod, no other helpers.
+ *
+ * Why this exists: inv_mod_binary_gcd() above is a binary extended GCD whose iteration count DEPENDS
+ * ON THE INPUT. Under SIMT every lane in a warp runs to the slowest lane's count (warp divergence).
+ * safegcd runs a FIXED 20*30 = 600 divsteps for every input, so a warp finishes in lock-step.
+ *
+ * Representation: 9 signed 30-bit limbs (value = sum v[i]*2^(30*i)). 30-bit limbs keep every
+ * intermediate product inside a 64-bit accumulator (safegcd_i64), avoiding the 128-bit math the
+ * 62-bit variant needs.
+ *
+ * Shift note: like the reference, this relies on ARITHMETIC (sign-extending) right shift of signed
+ * `int`/safegcd_i64. Every backend hashcat targets implements that; a device that does not would
+ * need -D USE_LEGACY_BINARY_GCD_INV_MOD.
+ */
+
+// Signed 64-bit accumulator. hashcat has no signed counterpart to u64, and plain `long` is not
+// portable here: under CUDA `long` follows the host ABI and is 32-bit on Windows (the same reason
+// inc_types.h spells ullong as `unsigned long long`), and this file is additionally compiled on the
+// host by src/emu_inc_ecc_secp256k1.c. So pick the width per backend, keyed off the same macros
+// inc_vendor.h selects: OpenCL C guarantees a 64-bit `long`, CUDA and HIP need `long long`, and the
+// native/host build has stdint.
+
+#if defined IS_OPENCL || defined IS_METAL
+typedef long safegcd_i64;
+#elif defined IS_CUDA || defined IS_HIP
+typedef signed long long safegcd_i64;
+#else
+typedef int64_t safegcd_i64;
+#endif
+
+#define SAFEGCD_M30 0x3fffffff
+// secp256k1 field prime p = 2^256 - 2^32 - 977 in signed-30 limbs, and -p^-1 mod 2^30 helper.
+#define SAFEGCD_P_INIT { -0x3d1, -4, 0, 0, 0, 0, 0, 0, 65536 }
+#define SAFEGCD_P_INV30 0x2ddacacfu
+
+// 30 divsteps: builds the 2x2 transition matrix t[u,v,q,r] and returns the new zeta.
+DECLSPEC int modinv32_divsteps_30 (int zeta, u32 f0, u32 g0, PRIVATE_AS int *t)
+{
+  u32 u = 1, v = 0, q = 0, r = 1;
+  u32 c1, c2, mask1, mask2, f = f0, g = g0, x, y, z;
+
+  for (int i = 0; i < 30; i++)
+  {
+    c1 = (u32) (zeta >> 31);     // all-ones iff zeta < 0
+    mask1 = c1;
+    c2 = g & 1;
+    mask2 = -c2;                 // all-ones iff g odd
+    x = (f ^ mask1) - mask1;     // conditionally negate f,u,v
+    y = (u ^ mask1) - mask1;
+    z = (v ^ mask1) - mask1;
+    g += x & mask2;
+    q += y & mask2;
+    r += z & mask2;
+    mask1 &= mask2;              // (zeta < 0) AND (g odd)
+    zeta = (int) ((u32) zeta ^ mask1) - 1;
+    f += g & mask1;
+    u += q & mask1;
+    v += r & mask1;
+    g >>= 1;
+    u <<= 1;
+    v <<= 1;
+  }
+  t[0] = (int) u;
+  t[1] = (int) v;
+  t[2] = (int) q;
+  t[3] = (int) r;
+  return zeta;
+}
+
+// d,e <- (t*[d,e]) / 2^30 mod p (Bezout coefficients).
+DECLSPEC void modinv32_update_de_30 (PRIVATE_AS int *d, PRIVATE_AS int *e, PRIVATE_AS const int *t)
+{
+  const int modulus[9] = SAFEGCD_P_INIT;
+  const int u = t[0], v = t[1], q = t[2], r = t[3];
+  int di, ei, md, me, sd, se;
+  safegcd_i64 cd, ce;
+
+  sd = d[8] >> 31;
+  se = e[8] >> 31;
+  md = (u & sd) + (v & se);
+  me = (q & sd) + (r & se);
+  di = d[0];
+  ei = e[0];
+  cd = (safegcd_i64) u * di + (safegcd_i64) v * ei;
+  ce = (safegcd_i64) q * di + (safegcd_i64) r * ei;
+  // choose md,me so the low 30 bits of t*[d,e]+p*[md,me] vanish
+  md -= (int) ((SAFEGCD_P_INV30 * (u32) cd + (u32) md) & SAFEGCD_M30);
+  me -= (int) ((SAFEGCD_P_INV30 * (u32) ce + (u32) me) & SAFEGCD_M30);
+  cd += (safegcd_i64) modulus[0] * md;
+  ce += (safegcd_i64) modulus[0] * me;
+  cd >>= 30;
+  ce >>= 30;
+  for (int i = 1; i < 9; i++)
+  {
+    di = d[i];
+    ei = e[i];
+    cd += (safegcd_i64) u * di + (safegcd_i64) v * ei;
+    ce += (safegcd_i64) q * di + (safegcd_i64) r * ei;
+    cd += (safegcd_i64) modulus[i] * md;
+    ce += (safegcd_i64) modulus[i] * me;
+    d[i - 1] = (int) cd & SAFEGCD_M30; cd >>= 30;
+    e[i - 1] = (int) ce & SAFEGCD_M30; ce >>= 30;
+  }
+  d[8] = (int) cd;
+  e[8] = (int) ce;
+}
+
+// f,g <- (t*[f,g]) / 2^30.
+DECLSPEC void modinv32_update_fg_30 (PRIVATE_AS int *f, PRIVATE_AS int *g, PRIVATE_AS const int *t)
+{
+  const int u = t[0], v = t[1], q = t[2], r = t[3];
+  int fi, gi;
+  safegcd_i64 cf, cg;
+
+  fi = f[0];
+  gi = g[0];
+  cf = (safegcd_i64) u * fi + (safegcd_i64) v * gi;
+  cg = (safegcd_i64) q * fi + (safegcd_i64) r * gi;
+  cf >>= 30;
+  cg >>= 30;
+  for (int i = 1; i < 9; i++)
+  {
+    fi = f[i];
+    gi = g[i];
+    cf += (safegcd_i64) u * fi + (safegcd_i64) v * gi;
+    cg += (safegcd_i64) q * fi + (safegcd_i64) r * gi;
+    f[i - 1] = (int) cf & SAFEGCD_M30; cf >>= 30;
+    g[i - 1] = (int) cg & SAFEGCD_M30; cg >>= 30;
+  }
+  f[8] = (int) cf;
+  g[8] = (int) cg;
+}
+
+// Bring r from (-2p, p) to [0, p), optionally negating first (sign < 0 => negate).
+DECLSPEC void modinv32_normalize_30 (PRIVATE_AS int *r, int sign)
+{
+  const int modulus[9] = SAFEGCD_P_INIT;
+  const int M30 = SAFEGCD_M30;
+  int r0 = r[0], r1 = r[1], r2 = r[2], r3 = r[3], r4 = r[4], r5 = r[5], r6 = r[6], r7 = r[7], r8 = r[8];
+  int cond_add, cond_negate;
+
+  cond_add = r8 >> 31;
+  r0 += modulus[0] & cond_add;
+  r1 += modulus[1] & cond_add;
+  r2 += modulus[2] & cond_add;
+  r3 += modulus[3] & cond_add;
+  r4 += modulus[4] & cond_add;
+  r5 += modulus[5] & cond_add;
+  r6 += modulus[6] & cond_add;
+  r7 += modulus[7] & cond_add;
+  r8 += modulus[8] & cond_add;
+  cond_negate = sign >> 31;
+  r0 = (r0 ^ cond_negate) - cond_negate;
+  r1 = (r1 ^ cond_negate) - cond_negate;
+  r2 = (r2 ^ cond_negate) - cond_negate;
+  r3 = (r3 ^ cond_negate) - cond_negate;
+  r4 = (r4 ^ cond_negate) - cond_negate;
+  r5 = (r5 ^ cond_negate) - cond_negate;
+  r6 = (r6 ^ cond_negate) - cond_negate;
+  r7 = (r7 ^ cond_negate) - cond_negate;
+  r8 = (r8 ^ cond_negate) - cond_negate;
+  r1 += r0 >> 30; r0 &= M30;
+  r2 += r1 >> 30; r1 &= M30;
+  r3 += r2 >> 30; r2 &= M30;
+  r4 += r3 >> 30; r3 &= M30;
+  r5 += r4 >> 30; r4 &= M30;
+  r6 += r5 >> 30; r5 &= M30;
+  r7 += r6 >> 30; r6 &= M30;
+  r8 += r7 >> 30; r7 &= M30;
+
+  cond_add = r8 >> 31;
+  r0 += modulus[0] & cond_add;
+  r1 += modulus[1] & cond_add;
+  r2 += modulus[2] & cond_add;
+  r3 += modulus[3] & cond_add;
+  r4 += modulus[4] & cond_add;
+  r5 += modulus[5] & cond_add;
+  r6 += modulus[6] & cond_add;
+  r7 += modulus[7] & cond_add;
+  r8 += modulus[8] & cond_add;
+  r1 += r0 >> 30; r0 &= M30;
+  r2 += r1 >> 30; r1 &= M30;
+  r3 += r2 >> 30; r2 &= M30;
+  r4 += r3 >> 30; r3 &= M30;
+  r5 += r4 >> 30; r4 &= M30;
+  r6 += r5 >> 30; r5 &= M30;
+  r7 += r6 >> 30; r6 &= M30;
+  r8 += r7 >> 30; r7 &= M30;
+
+  r[0] = r0; r[1] = r1; r[2] = r2; r[3] = r3; r[4] = r4;
+  r[5] = r5; r[6] = r6; r[7] = r7; r[8] = r8;
+}
+
+// u32[8] little-endian (value in [0, 2^256)) -> 9 signed-30 limbs in [0, 2^30).
+DECLSPEC void modinv32_from_u32x8 (PRIVATE_AS int *g, PRIVATE_AS const u32 *a)
+{
+  for (int i = 0; i < 9; i++)
+  {
+    const int bit = 30 * i;
+    const int word = bit >> 5;
+    const int off = bit & 31;
+    u64 chunk = ((u64) a[word]) >> off;
+    if (off > 0 && (word + 1) < 8) chunk |= ((u64) a[word + 1]) << (32 - off);
+    g[i] = (int) ((u32) chunk & SAFEGCD_M30);
+  }
+}
+
+// 9 signed-30 limbs in [0, 2^30) (value in [0, p)) -> u32[8] little-endian. Limbs occupy disjoint
+// 30-bit ranges, so a plain OR (no carry) reconstructs the 256-bit value.
+DECLSPEC void modinv32_to_u32x8 (PRIVATE_AS u32 *a, PRIVATE_AS const int *d)
+{
+  for (int i = 0; i < 8; i++) a[i] = 0;
+  for (int i = 0; i < 9; i++)
+  {
+    const u64 v = (u64) ((u32) d[i] & SAFEGCD_M30);
+    const int bit = 30 * i;
+    const int word = bit >> 5;
+    const int off = bit & 31;
+    const u64 shifted = v << off;
+    a[word] |= (u32) (shifted & 0xffffffffu);
+    if ((word + 1) < 8) a[word + 1] |= (u32) (shifted >> 32);
+  }
+}
+
+// Drop-in modular inverse: a (u32[8], in [0, p)) <- a^-1 mod p. Maps 0 to 0, as the binary GCD does.
+DECLSPEC void inv_mod_safegcd (PRIVATE_AS u32 *a)
+{
+  int d[9] = { 0 };
+  int e[9] = { 0 };
+  int f[9] = SAFEGCD_P_INIT;
+  int g[9];
+  int t[4];
+
+  e[0] = 1;
+  modinv32_from_u32x8 (g, a);
+
+  int zeta = -1;
+  for (int it = 0; it < 20; it++)
+  {
+    zeta = modinv32_divsteps_30 (zeta, (u32) f[0], (u32) g[0], t);
+    modinv32_update_de_30 (d, e, t);
+    modinv32_update_fg_30 (f, g, t);
+  }
+  // g has reached 0; f == +/-1 (== gcd); d holds +/- the inverse. Normalize using sign of f.
+  modinv32_normalize_30 (d, f[8]);
+  modinv32_to_u32x8 (a, d);
+}
+
+// Both implementations above compute the same thing; this picks which one the EC code uses.
+//
+// safegcd is the default because its iteration count is fixed, while the binary GCD's depends on
+// the input: under SIMT that makes every lane in a warp wait for the slowest one. Build with
+// -D USE_LEGACY_BINARY_GCD_INV_MOD to go back to the binary GCD, either to A/B the two or for a
+// device whose signed right shift is not arithmetic (safegcd assumes it is, the binary GCD does not).
+
+DECLSPEC void inv_mod (PRIVATE_AS u32 *a)
+{
+  #ifdef USE_LEGACY_BINARY_GCD_INV_MOD
+  inv_mod_binary_gcd (a);
+  #else
+  inv_mod_safegcd (a);
+  #endif
+}
+
+// Jacobian (x, y, z) -> affine (x, y), in place: x_affine = x / z^2, y_affine = y / z^3.
+// z is used as scratch and is destroyed.
+
+DECLSPEC void point_to_affine (PRIVATE_AS u32 *x, PRIVATE_AS u32 *y, PRIVATE_AS u32 *z)
+{
+  inv_mod (z);
+
+  u32 z2[8];
+
+  mul_mod (z2, z, z); // z^2
+  mul_mod (x, x, z2); // x / z^2
+
+  mul_mod (z, z2, z); // z^3
+  mul_mod (y, y, z);  // y / z^3
 }
 
 /*
@@ -1555,13 +1848,7 @@ DECLSPEC void point_get_coords (PRIVATE_AS secp256k1_t *r, PRIVATE_AS const u32 
 
   // to affine:
 
-  inv_mod (rz);
-
-  mul_mod (neg, rz, rz); // neg is temporary variable (z^2)
-  mul_mod (rx,  rx, neg);
-
-  mul_mod (rz, neg, rz);
-  mul_mod (ry, ry, rz);
+  point_to_affine (rx, ry, rz);
 
   r->xy[24] = rx[0];
   r->xy[25] = rx[1];
@@ -1620,13 +1907,7 @@ DECLSPEC void point_get_coords (PRIVATE_AS secp256k1_t *r, PRIVATE_AS const u32 
 
   // to affine:
 
-  inv_mod (rz);
-
-  mul_mod (neg, rz, rz);
-  mul_mod (rx,  rx, neg);
-
-  mul_mod (rz, neg, rz);
-  mul_mod (ry, ry, rz);
+  point_to_affine (rx, ry, rz);
 
   r->xy[48] = rx[0];
   r->xy[49] = rx[1];
@@ -1685,13 +1966,7 @@ DECLSPEC void point_get_coords (PRIVATE_AS secp256k1_t *r, PRIVATE_AS const u32 
 
   // to affine:
 
-  inv_mod (rz);
-
-  mul_mod (neg, rz, rz);
-  mul_mod (rx,  rx, neg);
-
-  mul_mod (rz, neg, rz);
-  mul_mod (ry, ry, rz);
+  point_to_affine (rx, ry, rz);
 
   r->xy[72] = rx[0];
   r->xy[73] = rx[1];
@@ -1858,7 +2133,13 @@ DECLSPEC void point_mul_xy (PRIVATE_AS u32 *x1, PRIVATE_AS u32 *y1, PRIVATE_AS c
 
   // first set:
 
-  const u32 multiplier = (naf[loop_start >> 3] >> ((loop_start & 7) << 2)) & 0x0f; // or use u8 ?
+  const u32 multiplier_raw = (naf[loop_start >> 3] >> ((loop_start & 7) << 2)) & 0x0f; // or use u8 ?
+
+  // Guard the first-window read against a zero digit (happens when the scalar k reduces to 0).
+  // Without this, (multiplier - 1) underflows and x_pos below indexes ~3.2e9 words past tmps->xy[]
+  // that is an out-of-bounds read (CPU OpenCL devices fault with SIGSEGV; GPUs read garbage).
+  // k == 0 is not a valid private key, so clamping to 1 (the base point G) just keeps it in bounds.
+  const u32 multiplier = (multiplier_raw == 0) ? 1 : multiplier_raw;
 
   const u32 odd = multiplier & 1;
 
@@ -1972,15 +2253,7 @@ DECLSPEC void point_mul_xy (PRIVATE_AS u32 *x1, PRIVATE_AS u32 *y1, PRIVATE_AS c
    *
    */
 
-  inv_mod (z1);
-
-  u32 z2[8];
-
-  mul_mod (z2, z1, z1); // z1^2
-  mul_mod (x1, x1, z2); // x1_affine
-
-  mul_mod (z1, z2, z1); // z1^3
-  mul_mod (y1, y1, z1); // y1_affine
+  point_to_affine (x1, y1, z1);
 
   // return values are already in x1 and y1
 }

--- a/OpenCL/inc_vendor.h
+++ b/OpenCL/inc_vendor.h
@@ -145,10 +145,31 @@ using namespace metal;
  * fast but pure kernels on rocm is a good example
  */
 
-#ifdef NO_INLINE
+#if defined NO_INLINE || defined FORCE_NO_INLINE
 #define HC_INLINE
 #else
 #define HC_INLINE inline static
+#endif
+
+/**
+ * NO_INLINE only drops the `inline static` hint. That is enough for some runtimes, but LLVM-based
+ * OpenCL back-ends (AMD's "LC" / comgr stack) still inline every DECLSPEC helper at -O3 and merge a
+ * kernel built from many large helpers into one huge function. Several LLVM back-end passes (greedy
+ * register allocation, SelectionDAG scheduling) scale ~super-linearly per function, so that single
+ * function can take minutes to compile. FORCE_NO_INLINE emits the hard noinline attribute, which
+ * partitions the kernel back into many small functions.
+ *
+ * This is deliberately a separate switch from NO_INLINE: the two are not interchangeable, and
+ * NO_INLINE already has a meaning that -m 33000 relies on. Out-of-line calls cost runtime
+ * throughput, so FORCE_NO_INLINE stays opt-in per module/device and must never become a global
+ * default. Note -cl-opt-disable is not an alternative: it fails to link the static/DECLSPEC helpers
+ * (`ld.lld: undefined hidden symbol`).
+ */
+
+#ifdef FORCE_NO_INLINE
+#define HC_NOINLINE __attribute__ ((noinline))
+#else
+#define HC_NOINLINE
 #endif
 
 // On a device DECLSPEC says how a function is compiled. On the host it says something else, because
@@ -159,15 +180,15 @@ using namespace metal;
 // so the macro is always in hand by the time this is read.
 
 #if defined IS_AMD && defined IS_GPU
-#define DECLSPEC HC_INLINE
+#define DECLSPEC HC_NOINLINE HC_INLINE
 #elif defined IS_CUDA
-#define DECLSPEC __device__
+#define DECLSPEC __device__ HC_NOINLINE
 #elif defined IS_HIP
-#define DECLSPEC __device__ HC_INLINE
+#define DECLSPEC __device__ HC_NOINLINE HC_INLINE
 #elif defined IS_NATIVE
 #define DECLSPEC HC_PLUGIN_API
 #else
-#define DECLSPEC
+#define DECLSPEC HC_NOINLINE
 #endif
 
 /**

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -150,6 +150,10 @@ See the section "The Core Library" in docs/hashcat-plugin-development-guide.md.
 - Status View: Attacks reading one source per round report their position again in Guess.Queue
 - Threads: Updated thread macros and types
 - Benchmark: Added a workaround for a CUDA benchmark memory leak caused by register spilling
+- secp256k1: inv_mod now uses a fixed-iteration safegcd inverse; -D USE_LEGACY_BINARY_GCD_INV_MOD restores the binary GCD
+- secp256k1: Factored the repeated Jacobian to affine conversion into point_to_affine
+- Kernels: Added HASHCAT_FORCE_NO_INLINE to build with -D FORCE_NO_INLINE for runtimes that inline the helpers into one slow-to-compile function
+- Backends: Environment on/off switches share one hc_env_flag helper
 
 ##
 ## Bugs
@@ -157,6 +161,8 @@ See the section "The Core Library" in docs/hashcat-plugin-development-guide.md.
 
 - Fixed combinator and hybrid attacks reporting a plaintext truncated to 256 characters, which did not match the cracked digest
 - Fixed a one byte buffer overflow in fgetl() when a line was as long as the caller's buffer
+- Fixed an out-of-bounds read in the secp256k1 point_mul_xy() when the scalar is zero
+- Fixed the secp256k1 inv_mod() looping forever on a zero input, which hangs clFinish on CPU devices
 - Fixed missing libclang dependencies for Rust bridges in Ubuntu 20.04 and Arch containers
 - Fixed the Windows Rust plugin failing to link in the Arch container because lld was missing
 - Fixed Windows Python plugins disappearing when the bundled Python version was not 3.12

--- a/include/shared.h
+++ b/include/shared.h
@@ -68,4 +68,7 @@ HC_API const char *stroptitype (const u32 opti_type);
 HC_PLUGIN_API u32 previous_power_of_two (const u32 x);
 HC_PLUGIN_API u32 next_power_of_two (const u32 x);
 
+// On/off environment switch, looked up once. Pass a static int initialised to -1 as the cache.
+bool hc_env_flag (const char *name, int *cache);
+
 #endif // HC_SHARED_H

--- a/src/backend.c
+++ b/src/backend.c
@@ -1308,13 +1308,9 @@ static u64    g_pipe_cands;
 
 static bool pipe_enabled (void)
 {
-  static int on = -1;
+  static int cache = -1;
 
-  if (on == -1) on = (getenv ("HASHCAT_PIPE") != NULL) ? 1 : 0;
-
-  const bool result = (on == 1) ? true : false;
-
-  return result;
+  return hc_env_flag ("HASHCAT_PIPE", &cache);
 }
 
 // How many launches between reports. HASHCAT_PIPE=1 keeps the fifty it always used, and any larger
@@ -14549,13 +14545,21 @@ void backend_session_context_reset (hashcat_ctx_t *hashcat_ctx)
 
 static bool memory_debug_enabled (void)
 {
-  static int on = -1;
+  static int cache = -1;
 
-  if (on == -1) on = (getenv ("HASHCAT_MEMORY") != NULL) ? 1 : 0;
+  return hc_env_flag ("HASHCAT_MEMORY", &cache);
+}
 
-  const bool result = (on == 1) ? true : false;
+// Set HASHCAT_FORCE_NO_INLINE to build the kernels with -D FORCE_NO_INLINE, which forces the
+// DECLSPEC helpers out-of-line (see OpenCL/inc_vendor.h). It exists for runtimes that need minutes
+// to compile a kernel whose helpers all get inlined into one huge function. It costs runtime
+// throughput, so it is off by default and is a knob the user turns rather than a built-in default.
 
-  return result;
+static bool force_no_inline_enabled (void)
+{
+  static int cache = -1;
+
+  return hc_env_flag ("HASHCAT_FORCE_NO_INLINE", &cache);
 }
 
 // How many active devices share one physical device.
@@ -15631,6 +15635,11 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
     char *build_options_buf = (char *) hcmalloc (build_options_sz);
 
     int build_options_len = snprintf(build_options_buf, build_options_sz, "-D KERNEL_STATIC ");
+
+    if (force_no_inline_enabled () == true)
+    {
+      build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-D FORCE_NO_INLINE ");
+    }
 
     #if defined (DEBUG) && (DEBUG >= 1)
     // only HIP and OpenCL have '-g'

--- a/src/pwpipe.c
+++ b/src/pwpipe.c
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "types.h"
+#include "shared.h"
 #include "wordlist.h"
 #include "pwpipe.h"
 
@@ -70,13 +71,9 @@ static HC_API_CALL void *pw_pipe_thread (void *p)
 
 static bool pw_pipe_sync (void)
 {
-  static int on = -1;
+  static int cache = -1;
 
-  if (on == -1) on = (getenv ("HASHCAT_PIPE_SYNC") != NULL) ? 1 : 0;
-
-  const bool result = (on == 1) ? true : false;
-
-  return result;
+  return hc_env_flag ("HASHCAT_PIPE_SYNC", &cache);
 }
 
 int pw_pipe_start (pw_pipe_t *pipe, hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pw_fill_t fill, void *state, const bool serial)

--- a/src/shared.c
+++ b/src/shared.c
@@ -617,3 +617,21 @@ u32 next_power_of_two (const u32 x)
 
   return r;
 }
+
+// Whether an on/off environment switch is set, looked up once.
+//
+// Several of these exist (HASHCAT_PIPE, HASHCAT_MEMORY, HASHCAT_PIPE_SYNC, ...) and each one used to
+// carry its own copy of the lookup and its own cache. The cache is what forced the duplication: one
+// static inside a shared function would be a single slot shared by every variable, so the slot stays
+// with the caller and only the logic moves here. Pass a static int initialised to -1.
+//
+// Presence is what counts, not the value, which is how these switches have always behaved.
+
+bool hc_env_flag (const char *name, int *cache)
+{
+  if (*cache == -1) *cache = (getenv (name) != NULL) ? 1 : 0;
+
+  const bool result = (*cache == 1) ? true : false;
+
+  return result;
+}


### PR DESCRIPTION
# secp256k1: fix two kernel bugs, add a fixed-iteration inverse, add an opt-in noinline switch

Four fixes and improvements to the secp256k1 kernel code (1–4), plus two changes that are not secp256k1-specific: an opt-in noinline switch (5) and the small helper it shares with three existing call sites (6). Each is described separately so any single part can be dropped.

---

## 1. Bug: out-of-bounds read in `point_mul_xy()` when the scalar is zero

`OpenCL/inc_ecc_secp256k1.cl`

```c
const u32 multiplier = (naf[loop_start >> 3] >> ((loop_start & 7) << 2)) & 0x0f;
const u32 odd        = multiplier & 1;
const u32 x_pos      = ((multiplier - 1 + odd) >> 1) * 24;
```

With `multiplier == 0`: `odd = 0`, `(0 - 1) >> 1 = 0x7FFFFFFF`, `* 24` puts `x_pos` about 3.2e9
words past `tmps->xy[]`, and the next 16 statements read from there. CPU OpenCL devices fault, GPUs
read whatever is there.

Reachable: `-m 28501/28502/28505/28506` and `-m 30901/30902/30905/30906` derive `prv_key` straight
from the candidate, so a wordlist entry encoding the key 0 with a valid base58 checksum reaches it.
For `-m 21700/21800` it is not realistically reachable.

Fixed by clamping a zero first-window digit to 1. `k == 0` is not a valid private key, so the value
does not matter, only that the index stays in bounds.

Reproduced with AddressSanitizer against the unpatched code (details under Verification).

## 2. Bug: `inv_mod()` never terminates on a zero input

`OpenCL/inc_ecc_secp256k1.cl`

The file already carried the check, commented out:

```c
// How often does this really happen? it should "almost" never happen (but would be safer)
// if ((a[0] | a[1] | ... | a[7]) == 0) return;
```

It is not almost-never, and the consequence is worse than a wrong result. `t0 = 0` is always even,
so the shift keeps it 0 and the exit condition `t0 == p` is never reached. On a CPU OpenCL device
the work-item spins forever and `clFinish` hangs; GPUs happen to mask it. `z == 0` is reachable
from `point_add` of P + (-P) and from a zero scalar. The guard is 7 ORs and a compare, uniform
across a warp.

## 3. `inv_mod()` now uses a fixed-iteration safegcd inverse

`OpenCL/inc_ecc_secp256k1.cl`, `OpenCL/inc_ecc_secp256k1.h`

The existing binary extended GCD has an **input-dependent** iteration count. Under SIMT every lane
in a warp runs to the slowest lane's count. `inv_mod_safegcd()` is a port of libsecp256k1's
`modinv32` (bitcoin-core/secp256k1, `src/modinv32_impl.h`, MIT) and runs a fixed 20 x 30 = 600
divsteps for every input, so a warp finishes in lock-step. Same result for every input.

The file is now structured as two implementations plus a selector:

```
inv_mod_binary_gcd()   the existing code, unchanged apart from the guard above
inv_mod_safegcd()      the port
inv_mod()              picks one
```

Build with `-D USE_LEGACY_BINARY_GCD_INV_MOD` to go back to the binary GCD, either to A/B them or
for a device whose signed right shift is not arithmetic (safegcd assumes it is; the binary GCD does
not).

Two notes for review:

* **`safegcd_i64`.** hashcat has no signed counterpart to `u64`, and plain `long` is not portable
  here: under CUDA it follows the host ABI and is 32-bit on Windows, which is exactly why
  `inc_types.h` spells `ullong` as `unsigned long long`. This file is additionally compiled on the
  host by `src/emu_inc_ecc_secp256k1.c`. The typedef therefore keys off the same backend macros
  `inc_vendor.h` selects.
* **Formatting.** The ported block keeps libsecp256k1's denser layout rather than hashcat house
  style, so it can be diffed against the upstream reference. Happy to reformat if preferred.

**No throughput measurement on hashcat's kernels is included.** The motivation is the divergence
argument plus measurements from a downstream project with a different kernel shape, which do not
transfer directly. safegcd also uses four 9-element `int` arrays; on register-tight kernels that
could cost occupancy. If you would rather have the code in but the default unchanged, inverting the
`#ifdef` in `inv_mod()` is a one-line change.

## 4. `point_to_affine()`

`OpenCL/inc_ecc_secp256k1.cl`

The Jacobian to affine conversion (`inv_mod` + three `mul_mod`) appeared four times verbatim: three
times in `point_get_coords()` and once at the tail of `point_mul_xy()`. Now one function, four call
sites, 28 lines fewer. Behavior identical; the only difference is that the three sites in
`point_get_coords()` no longer clobber `neg` as scratch, which they overwrote immediately anyway.

Not exported in the header, matching the file's existing split: the header declares what module
kernels consume, not the field and point primitives.

## 5. `FORCE_NO_INLINE` (opt-in, off by default)

`OpenCL/inc_vendor.h`, `src/backend.c`

`NO_INLINE` only drops the `inline static` hint. LLVM-based OpenCL back-ends still inline every
`DECLSPEC` helper at `-O3` and merge a kernel built from many large helpers into a single huge
function; greedy register allocation and SelectionDAG scheduling scale roughly super-linearly per
function, so compile time explodes. `-cl-opt-disable` is not an alternative — it fails to link the
`static`/`DECLSPEC` helpers with `ld.lld: undefined hidden symbol`.

`FORCE_NO_INLINE` emits the hard `noinline` attribute. It is deliberately **separate** from
`NO_INLINE`, which already has a meaning `-m 33000` relies on.

Off by default and byte-identical to today when off: `HC_NOINLINE` expands to nothing, so all four
`DECLSPEC` branches are unchanged. Turned on with `HASHCAT_FORCE_NO_INLINE`, following the existing
`HASHCAT_PIPE` / `HASHCAT_MEMORY` convention. Out-of-line calls cost runtime throughput, so this
must never become a default.

**Honest scope note:** the multi-minute AMD compile was measured on a downstream project's larger
kernel, not on hashcat's. I have no evidence hashcat's kernels hit it today. This adds the escape
hatch and documents the trap; it does not claim to fix an observed hashcat problem. Easy to drop —
it is confined to these two files.

## 6. `hc_env_flag()`

`src/shared.c`, `include/shared.h`, `src/backend.c`, `src/pwpipe.c`

Item 5 would have been a fourth copy of this:

```c
static int on = -1;
if (on == -1) on = (getenv ("NAME") != NULL) ? 1 : 0;
const bool result = (on == 1) ? true : false;
return result;
```

Extracted instead. The cache slot stays with the caller, because one static inside a shared function
would be a single slot shared by every variable. `pipe_enabled`, `memory_debug_enabled` and
`pw_pipe_sync` were converted; each drops from 7 lines to 3. `HASHCAT_SALT_INNER` was left alone —
it parses a value rather than testing presence and has an extra condition.

This is the one part that touches code unrelated to secp256k1. Split out on request.

---

## Verification

Built and run in Docker (Ubuntu 24.04, gcc, pocl 3.0 CPU device). Clean build, no new warnings under
`-W -Wall -Wextra`.

**Self-test plus a real crack against each module's own `ST_HASH`/`ST_PASS`, `-D 1` on pocl:**

| set | result |
|---|---|
| `-m 21700 21800 28501 28502 28505 28506 30901 30902 30905 30906` | all cracked |
| same 10, rebuilt with `-D USE_LEGACY_BINARY_GCD_INV_MOD` | all cracked, identical |
| `-m 28501 30901 21700` with `HASHCAT_FORCE_NO_INLINE=1` | all cracked |
| `-m 0 100 1000 1400 1700 3200 5500 13100 22000 33000` (regression, since `inc_vendor.h` is included everywhere) | all cracked |
| `-m 33000` with and without `HASHCAT_FORCE_NO_INLINE` | both cracked |

`FORCE_NO_INLINE` is confirmed to reach the compiler and not silently no-op: the kernel cache hash
changes from `m28501_a0-pure.6bd5126c` to `2de7abca`.

**Native harness over the kernel sources (host `IS_NATIVE` path), ASan + UBSan:**

```
sizeof(safegcd_i64) = 8
[1] safegcd vs binary GCD, 20000 random values: OK (0 failures)
[2] inv_mod_binary_gcd(0) terminates, result 0: OK
[3] inv_mod_safegcd(0)    terminates, result 0: OK
[4] point_mul_xy(k=0) returned without fault: OK
[5] point_mul_xy(k=1) == G: OK
```

[1] checks both inverses against each other **and** `a * a^-1 == 1 mod p`.

**Negative controls** — the same harness with each guard removed, to show the tests are not vacuous:

* without the `inv_mod` zero guard: hangs after [1], killed at 20 s
* without the `point_mul_xy` clamp:

```
ERROR: AddressSanitizer: SEGV on unknown address 0x79e760e00300
The signal is caused by a READ memory access.
    #0 point_mul_xy  OpenCL/inc_ecc_secp256k1.cl:2150
```

## Not verified

* **CUDA, HIP and Metal.** No toolkit available. The `signed long long` branch of `safegcd_i64` is
  the one that matters for Windows + CUDA and it has not been executed — only constructed to mirror
  `inc_types.h`'s own `ullong` handling. Worth a check on your side.
* **Throughput.** No before/after numbers on hashcat kernels, for either safegcd or the
  register-pressure question (see item 3).
* **AMD compile time**, the premise of item 5 (see the note there).
