### PR TITLE
Add -m 36800, OpenSSH Private Keys (bcrypt-pbkdf)

### DIFF
--- a/OpenCL/m37500-pure.cl
+++ b/OpenCL/m37500-pure.cl
@@ -1,0 +1,511 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#define NEW_SIMD_CODE
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sha512.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_blowfish.cl)
+#include M2S(INCLUDE_PATH/inc_cipher_aes.cl)
+#endif
+
+#if   VECT_SIZE == 1
+#define uint_to_hex_lower8(i) make_u32x (l_bin2asc[(i)])
+#endif
+
+// Must stay identical to the copy in src/modules/module_37500.c: esalt_bufs[]
+// strides by sizeof(), so a mismatch misreads every hash past the first. Only
+// the fields above data_buf are read here; the blob rides along so the host
+// encoder can reproduce its input line.
+typedef struct sshng_bcrypt
+{
+  u32 cipher;
+  u32 ct_offset;
+  u32 rounds;
+  u32 salt_buf[4];
+  u32 ct_buf[4];
+  u32 data_buf[8192];
+  int data_len;
+
+} sshng_bcrypt_t;
+
+typedef struct sshng_bcrypt_tmp
+{
+  u32 pass_hash[16];  // SHA-512 of the password, as 16 big-endian words
+  u32 dk[12];         // derived 48 bytes: 32 byte AES key + 16 byte IV
+
+} sshng_bcrypt_tmp_t;
+
+// "OxychromaticBlowfishSwatDynamite", read big-endian a word at a time.
+CONSTANT_VK u32 c_bcrypt_magic[8] =
+{
+  0x4f787963, 0x68726f6d, 0x61746963, 0x426c6f77,
+  0x66697368, 0x53776174, 0x44796e61, 0x6d697465
+};
+
+#define SSHNG_CIPHER_AES256_CBC 2
+#define SSHNG_CIPHER_AES256_CTR 6
+
+/**
+ * SHA-512 digest as 16 big-endian u32 words, which is the form
+ * Blowfish_stream2word consumes.
+ */
+DECLSPEC void sha512_digest_to_words (PRIVATE_AS const u64 *h, PRIVATE_AS u32 *w)
+{
+  for (int i = 0; i < 8; i++)
+  {
+    w[(i * 2) + 0] = (u32) (h[i] >> 32);
+    w[(i * 2) + 1] = (u32) (h[i] & 0xffffffff);
+  }
+}
+
+/**
+ * Blowfish_expand0state for a 64-byte (16 word) key.
+ *
+ * Written inline rather than via blowfish_set_key(): that helper re-initialises
+ * P and the S-boxes on entry, but expand0state has to mutate the state left by
+ * the previous call.
+ */
+DECLSPEC void bf_expand0state (PRIVATE_AS u32 *P, LOCAL_AS u32 *S0, LOCAL_AS u32 *S1, LOCAL_AS u32 *S2, LOCAL_AS u32 *S3, PRIVATE_AS const u32 *key)
+{
+  for (u32 i = 0; i < 18; i++)
+  {
+    P[i] ^= key[i % 16];
+  }
+
+  blowfish_encrypt (P, S0, S1, S2, S3);
+}
+
+/**
+ * Blowfish_expandstate with a 64-byte data stream.
+ *
+ * inc_cipher_blowfish's blowfish_set_key_salt() cannot be reused: it hardcodes
+ * a 4-word salt (salt_buf[(i & 2) + 0], and S-box loops referencing
+ * salt_buf[0..3] literally). bcrypt-pbkdf feeds a 64-byte sha2salt, so the data
+ * stream cycles over 16 words instead of 4.
+ */
+DECLSPEC void bf_expandstate (PRIVATE_AS u32 *P, LOCAL_AS u32 *S0, LOCAL_AS u32 *S1, LOCAL_AS u32 *S2, LOCAL_AS u32 *S3, PRIVATE_AS const u32 *data, PRIVATE_AS const u32 *key)
+{
+  for (u32 i = 0; i < 18; i++)
+  {
+    P[i] ^= key[i % 16];
+  }
+
+  u32 L0 = 0;
+  u32 R0 = 0;
+  u32 j  = 0;
+
+  for (u32 i = 0; i < 18; i += 2)
+  {
+    L0 ^= data[j & 15]; j++;
+    R0 ^= data[j & 15]; j++;
+
+    BF_ENCRYPT (L0, R0);
+
+    P[i + 0] = L0;
+    P[i + 1] = R0;
+  }
+
+  for (u32 i = 0; i < 256; i += 2)
+  {
+    L0 ^= data[j & 15]; j++;
+    R0 ^= data[j & 15]; j++;
+
+    BF_ENCRYPT (L0, R0);
+
+    SET_KEY32 (S0, i + 0, L0);
+    SET_KEY32 (S0, i + 1, R0);
+  }
+
+  for (u32 i = 0; i < 256; i += 2)
+  {
+    L0 ^= data[j & 15]; j++;
+    R0 ^= data[j & 15]; j++;
+
+    BF_ENCRYPT (L0, R0);
+
+    SET_KEY32 (S1, i + 0, L0);
+    SET_KEY32 (S1, i + 1, R0);
+  }
+
+  for (u32 i = 0; i < 256; i += 2)
+  {
+    L0 ^= data[j & 15]; j++;
+    R0 ^= data[j & 15]; j++;
+
+    BF_ENCRYPT (L0, R0);
+
+    SET_KEY32 (S2, i + 0, L0);
+    SET_KEY32 (S2, i + 1, R0);
+  }
+
+  for (u32 i = 0; i < 256; i += 2)
+  {
+    L0 ^= data[j & 15]; j++;
+    R0 ^= data[j & 15]; j++;
+
+    BF_ENCRYPT (L0, R0);
+
+    SET_KEY32 (S3, i + 0, L0);
+    SET_KEY32 (S3, i + 1, R0);
+  }
+}
+
+/**
+ * bcrypt_hash(sha2pass, sha2salt) -> 32 bytes, little-endian.
+ * This is where the entire cost of the KDF lives.
+ */
+DECLSPEC void bcrypt_hash (PRIVATE_AS const u32 *sha2pass, PRIVATE_AS const u32 *sha2salt, PRIVATE_AS u32 *out, LOCAL_AS u32 *S0, LOCAL_AS u32 *S1, LOCAL_AS u32 *S2, LOCAL_AS u32 *S3)
+{
+  u32 P[18];
+
+  // Blowfish_initstate
+
+  for (u32 i = 0; i < 18; i++)
+  {
+    P[i] = c_pbox[i];
+  }
+
+  for (u32 i = 0; i < 256; i++)
+  {
+    SET_KEY32 (S0, i, c_sbox0[i]);
+    SET_KEY32 (S1, i, c_sbox1[i]);
+    SET_KEY32 (S2, i, c_sbox2[i]);
+    SET_KEY32 (S3, i, c_sbox3[i]);
+  }
+
+  bf_expandstate (P, S0, S1, S2, S3, sha2salt, sha2pass);
+
+  for (u32 i = 0; i < 64; i++)
+  {
+    bf_expand0state (P, S0, S1, S2, S3, sha2salt);
+    bf_expand0state (P, S0, S1, S2, S3, sha2pass);
+  }
+
+  u32 cdata[8];
+
+  for (u32 i = 0; i < 8; i++)
+  {
+    cdata[i] = c_bcrypt_magic[i];
+  }
+
+  for (u32 i = 0; i < 64; i++)
+  {
+    for (u32 k = 0; k < 8; k += 2)
+    {
+      u32 L0 = cdata[k + 0];
+      u32 R0 = cdata[k + 1];
+
+      BF_ENCRYPT (L0, R0);
+
+      cdata[k + 0] = L0;
+      cdata[k + 1] = R0;
+    }
+  }
+
+  // output is little-endian
+
+  for (u32 i = 0; i < 8; i++)
+  {
+    out[i] = hc_swap32_S (cdata[i]);
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m37500_init (KERN_ATTR_TMPS_ESALT (sshng_bcrypt_tmp_t, sshng_bcrypt_t))
+{
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  sha512_ctx_t ctx;
+
+
+  sha512_init   (&ctx);
+  sha512_update_global_swap (&ctx, pws[gid].i, pws[gid].pw_len);
+  sha512_final  (&ctx);
+
+  u32 pass_hash[16];
+
+  sha512_digest_to_words (ctx.h, pass_hash);
+
+  for (u32 i = 0; i < 16; i++)
+  {
+    tmps[gid].pass_hash[i] = pass_hash[i];
+  }
+}
+
+KERNEL_FQ KERNEL_FA void m37500_loop (KERN_ATTR_TMPS_ESALT (sshng_bcrypt_tmp_t, sshng_bcrypt_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+
+  // On CUDA the S-boxes exceed the 48 KB static limit, so hashcat hands them
+  // in as dynamic shared memory and the static declaration is compiled out --
+  // same arrangement as m03200.
+  #ifdef DYNAMIC_LOCAL
+  // from host
+  #else
+  LOCAL_VK u32 S0_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S1_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S2_all[FIXED_LOCAL_SIZE][256];
+  LOCAL_VK u32 S3_all[FIXED_LOCAL_SIZE][256];
+  #endif
+
+  #ifdef BCRYPT_AVOID_BANK_CONFLICTS
+  LOCAL_AS u32 *S0 = S + (FIXED_LOCAL_SIZE * 256 * 0);
+  LOCAL_AS u32 *S1 = S + (FIXED_LOCAL_SIZE * 256 * 1);
+  LOCAL_AS u32 *S2 = S + (FIXED_LOCAL_SIZE * 256 * 2);
+  LOCAL_AS u32 *S3 = S + (FIXED_LOCAL_SIZE * 256 * 3);
+  #else
+  LOCAL_AS u32 *S0 = S0_all[lid];
+  LOCAL_AS u32 *S1 = S1_all[lid];
+  LOCAL_AS u32 *S2 = S2_all[lid];
+  LOCAL_AS u32 *S3 = S3_all[lid];
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  u32 sha2pass[16];
+
+  for (u32 i = 0; i < 16; i++)
+  {
+    sha2pass[i] = tmps[gid].pass_hash[i];
+  }
+
+  // salt_iter is 1 (the whole derivation runs in one invocation); the real
+  // round count lives in the esalt.
+  const u32 rounds = esalt_bufs[DIGESTS_OFFSET_HOST].rounds;
+
+
+  u32 salt_buf[4];
+
+  salt_buf[0] = esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf[0];
+  salt_buf[1] = esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf[1];
+  salt_buf[2] = esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf[2];
+  salt_buf[3] = esalt_bufs[DIGESTS_OFFSET_HOST].salt_buf[3];
+
+  // 48 bytes of output needs stride 2, i.e. two independent blocks.
+
+  u32 dk[12] = { 0 };
+
+  for (u32 count = 1; count <= 2; count++)
+  {
+    // sha2salt = SHA512 (salt || BE32 (count))
+
+    // sha512_update() reads 32 words regardless of len, so the buffer must be
+    // that big and zeroed -- a short array here feeds stack garbage into the
+    // digest.
+    u32 w[32] = { 0 };
+
+    w[0] = salt_buf[0];
+    w[1] = salt_buf[1];
+    w[2] = salt_buf[2];
+    w[3] = salt_buf[3];
+    w[4] = count;
+
+    sha512_ctx_t ctx;
+
+    sha512_init   (&ctx);
+    sha512_update (&ctx, w, 20);
+    sha512_final  (&ctx);
+
+    u32 sha2salt[16];
+
+    sha512_digest_to_words (ctx.h, sha2salt);
+
+    u32 out[8];
+    u32 tmp[8];
+
+    bcrypt_hash (sha2pass, sha2salt, tmp, S0, S1, S2, S3);
+
+    for (u32 i = 0; i < 8; i++)
+    {
+      out[i] = tmp[i];
+    }
+
+    for (u32 r = 1; r < rounds; r++)
+    {
+      // sha2salt = SHA512 (previous bcrypt_hash output)
+
+      u32 wt[32] = { 0 };
+
+      for (u32 i = 0; i < 8; i++)
+      {
+        wt[i] = tmp[i];
+      }
+
+      sha512_ctx_t ctx2;
+
+      sha512_init   (&ctx2);
+      sha512_update (&ctx2, wt, 32);
+      sha512_final  (&ctx2);
+
+      sha512_digest_to_words (ctx2.h, sha2salt);
+
+      bcrypt_hash (sha2pass, sha2salt, tmp, S0, S1, S2, S3);
+
+      for (u32 i = 0; i < 8; i++)
+      {
+        out[i] ^= tmp[i];
+      }
+    }
+
+    // key[i * stride + (count - 1)] = out[i], byte-wise, for i < 24.
+    //
+    // Done with explicit shifts rather than a u8* view: out[] holds
+    // big-endian-packed words, so on a little-endian device a byte pointer
+    // would walk each word backwards.
+
+    for (u32 i = 0; i < 24; i++)
+    {
+      const u32 dest = (i * 2) + (count - 1);
+
+      if (dest >= 48) continue;
+
+      const u32 b = (out[i / 4] >> (24 - (8 * (i % 4)))) & 0xff;
+
+      const u32 widx  = dest / 4;
+      const u32 shift = 24 - (8 * (dest % 4));
+
+      dk[widx] |= b << shift;
+    }
+  }
+
+  for (u32 i = 0; i < 12; i++)
+  {
+    tmps[gid].dk[i] = dk[i];
+  }
+
+}
+
+KERNEL_FQ KERNEL_FA void m37500_comp (KERN_ATTR_TMPS_ESALT (sshng_bcrypt_tmp_t, sshng_bcrypt_t))
+{
+  const u64 gid = get_global_id (0);
+  const u64 lid = get_local_id (0);
+  const u64 lsz = get_local_size (0);
+
+  /**
+   * aes shared
+   */
+
+  #ifdef REAL_SHM
+  LOCAL_VK u32 s_te0[256];
+  LOCAL_VK u32 s_te1[256];
+  LOCAL_VK u32 s_te2[256];
+  LOCAL_VK u32 s_te3[256];
+  LOCAL_VK u32 s_te4[256];
+
+  LOCAL_VK u32 s_td0[256];
+  LOCAL_VK u32 s_td1[256];
+  LOCAL_VK u32 s_td2[256];
+  LOCAL_VK u32 s_td3[256];
+  LOCAL_VK u32 s_td4[256];
+
+  for (u32 i = lid; i < 256; i += lsz)
+  {
+    s_te0[i] = te0[i];
+    s_te1[i] = te1[i];
+    s_te2[i] = te2[i];
+    s_te3[i] = te3[i];
+    s_te4[i] = te4[i];
+
+    s_td0[i] = td0[i];
+    s_td1[i] = td1[i];
+    s_td2[i] = td2[i];
+    s_td3[i] = td3[i];
+    s_td4[i] = td4[i];
+  }
+
+  SYNC_THREADS ();
+  #else
+  CONSTANT_AS u32a *s_te0 = te0;
+  CONSTANT_AS u32a *s_te1 = te1;
+  CONSTANT_AS u32a *s_te2 = te2;
+  CONSTANT_AS u32a *s_te3 = te3;
+  CONSTANT_AS u32a *s_te4 = te4;
+
+  CONSTANT_AS u32a *s_td0 = td0;
+  CONSTANT_AS u32a *s_td1 = td1;
+  CONSTANT_AS u32a *s_td2 = td2;
+  CONSTANT_AS u32a *s_td3 = td3;
+  CONSTANT_AS u32a *s_td4 = td4;
+  #endif
+
+  if (gid >= GID_CNT) return;
+
+  // The KDF wrote dk big-endian packed, which is the form AES wants: first 32
+  // bytes are the key, the following 16 are the IV.
+
+  u32 ukey[8];
+  u32 iv[4];
+
+  for (u32 i = 0; i < 8; i++)
+  {
+    ukey[i] = tmps[gid].dk[i];
+  }
+
+  for (u32 i = 0; i < 4; i++)
+  {
+    iv[i] = tmps[gid].dk[8 + i];
+  }
+
+  u32 ct[4];
+
+  for (u32 i = 0; i < 4; i++)
+  {
+    ct[i] = esalt_bufs[DIGESTS_OFFSET_HOST].ct_buf[i];
+  }
+
+  // Only the first plaintext block is needed: it holds the two check integers,
+  // which OpenSSH writes equal before encrypting.
+  //
+  // The uppercase AES256_* calls are the big-endian API -- each wrapper swaps
+  // and the lowercase callee swaps back, so a big-endian key/IV passes through
+  // unchanged. Mixing in the lowercase aes256_encrypt() would byte-reverse the
+  // IV, since that one swaps only once.
+
+  u32 pt[2];
+
+  u32 ks[60];
+
+  if (esalt_bufs[DIGESTS_OFFSET_HOST].cipher == SSHNG_CIPHER_AES256_CTR)
+  {
+    // CTR: the IV is counter block zero, and the first block needs no increment
+
+    AES256_set_encrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3);
+
+    u32 keystream[4];
+
+    AES256_encrypt (ks, iv, keystream, s_te0, s_te1, s_te2, s_te3, s_te4);
+
+    pt[0] = ct[0] ^ keystream[0];
+    pt[1] = ct[1] ^ keystream[1];
+  }
+  else
+  {
+    // CBC: P1 = D(K, C1) ^ IV
+
+    AES256_set_decrypt_key (ks, ukey, s_te0, s_te1, s_te2, s_te3, s_td0, s_td1, s_td2, s_td3);
+
+    u32 dec[4];
+
+    AES256_decrypt (ks, ct, dec, s_td0, s_td1, s_td2, s_td3, s_td4);
+
+    pt[0] = dec[0] ^ iv[0];
+    pt[1] = dec[1] ^ iv[1];
+  }
+
+  if (pt[0] == pt[1])
+  {
+    if (hc_atomic_inc (&hashes_shown[DIGESTS_OFFSET_HOST]) == 0)
+    {
+      mark_hash (plains_buf, d_return_buf, SALT_POS_HOST, DIGESTS_CNT, 0, DIGESTS_OFFSET_HOST + 0, gid, 0, 0, 0);
+    }
+  }
+}

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -45,6 +45,7 @@ Setting --brain-client-features on the command line overrules the decision in ei
 ## New Algorithms
 ##
 
+- Added hash-mode: OpenSSH Private Keys (bcrypt-pbkdf)
 - Added hash-mode: GPG (AES-OCB-128 (SHA-1($pass)))
 - Added hash-mode: KeePass AESKDF (KDBX v4)
 - Added hash-mode: Kerberos 5, etype 23, TGS-REP (NT)

--- a/src/modules/module_37500.c
+++ b/src/modules/module_37500.c
@@ -1,0 +1,396 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#include "common.h"
+#include "types.h"
+#include "modules.h"
+#include "bitops.h"
+#include "convert.h"
+#include "shared.h"
+#include "blowfish_common.c"
+
+static const u32   ATTACK_EXEC    = ATTACK_EXEC_OUTSIDE_KERNEL;
+static const u32   DGST_POS0      = 0;
+static const u32   DGST_POS1      = 1;
+static const u32   DGST_POS2      = 2;
+static const u32   DGST_POS3      = 3;
+static const u32   DGST_SIZE      = DGST_SIZE_4_4;
+static const u32   HASH_CATEGORY  = HASH_CATEGORY_PRIVATE_KEY;
+static const char *HASH_NAME      = "OpenSSH Private Keys (bcrypt-pbkdf)";
+static const u64   KERN_TYPE      = 37500;
+static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE
+                                  | OPTI_TYPE_SLOW_HASH_SIMD_LOOP;
+static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_DYNAMIC_SHARED;
+static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
+static const char *ST_PASS        = "hashcat";
+static const char *ST_HASH        = "$sshng$6$16$89b7dac5965613fa4f2faf9284983843$274$6f70656e7373682d6b65792d7631000000000a6165733235362d63747200000006626372797074000000180000001089b7dac5965613fa4f2faf92849838430000001000000001000000330000000b7373682d6564323535313900000020979ccdbbb3f2c8b04842e77fdd5475b21963e7ddad9a4d029d712322f5c930ee000000909e38aa2f92ae189f7e4f04ef62fcd869ceb572e5c047ea0e9dfbb4657c38a13506d580ff8709a8787810a53688e3b0c7b7af155422aed8089da87a63da0147d8c8e04a6d236e70f0c6be5fbeb0b620d7abe928b10169fd3e48c1b526d3ead3a28fa4385969aebea6621baada8821a20035be97e2fa42575f5e4246e174ac3c96b19e89623ff267a2629090da6f79f7e4$16$130";
+
+u32         module_attack_exec    (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ATTACK_EXEC;     }
+u32         module_dgst_pos0      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS0;       }
+u32         module_dgst_pos1      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS1;       }
+u32         module_dgst_pos2      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS2;       }
+u32         module_dgst_pos3      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_POS3;       }
+u32         module_dgst_size      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return DGST_SIZE;       }
+u32         module_hash_category  (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_CATEGORY;   }
+const char *module_hash_name      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return HASH_NAME;       }
+u64         module_kern_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return KERN_TYPE;       }
+u32         module_opti_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTI_TYPE;       }
+u64         module_opts_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return OPTS_TYPE;       }
+u32         module_salt_type      (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return SALT_TYPE;       }
+const char *module_st_hash        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_HASH;         }
+const char *module_st_pass        (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra) { return ST_PASS;         }
+
+
+// The kernel reads only cipher/ct_offset/rounds/salt_buf/ct_buf, but the whole
+// key blob is carried so module_hash_encode() can reproduce its input line --
+// same arrangement as the legacy PEM modules. Keep this layout identical to the
+// copy in OpenCL/m37500-pure.cl: esalt_bufs[] strides by sizeof(), so any
+// divergence silently misreads every hash past the first.
+typedef struct sshng_bcrypt
+{
+  u32 cipher;
+  u32 ct_offset;
+  u32 rounds;
+  u32 salt_buf[4];      // 16 byte bcrypt salt
+  u32 ct_buf[4];        // first encrypted block: the two check integers
+  u32 data_buf[8192];   // the openssh-key-v1 blob, up to SSHNG_DATA_MAX bytes
+  int data_len;
+
+} sshng_bcrypt_t;
+
+// Carried between kernels. A bcrypt_hash() cannot be split across invocations,
+// so the whole derivation runs inside one _loop and only the finished 48 bytes
+// need to survive it.
+typedef struct sshng_bcrypt_tmp
+{
+  u32 pass_hash[16];   // SHA-512 of the password, 64 bytes
+  u32 dk[12];          // derived 48 bytes: 32 byte AES key + 16 byte IV
+
+} sshng_bcrypt_tmp_t;
+
+static const char *SIGNATURE_SSHNG = "$sshng$";
+
+// Cipher ids as emitted by ssh2john for the openssh-key-v1 container.
+#define SSHNG_CIPHER_AES256_CBC 2
+#define SSHNG_CIPHER_AES256_CTR 6
+
+// bcrypt_pbkdf always uses a 16 byte salt (fixed in sshkey.c).
+#define SSHNG_SALT_LEN 16
+
+// key (32) + iv (16)
+#define SSHNG_DERIVE_LEN 48
+
+// sizeof (sshng_bcrypt_t.data_buf). An RSA-4096 key blob is around 3 KB, so
+// this leaves generous headroom; the tokenizer rejects anything longer.
+#define SSHNG_DATA_MAX 32768
+
+u64 module_esalt_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 esalt_size = (const u64) sizeof (sshng_bcrypt_t);
+
+  return esalt_size;
+}
+
+u64 module_tmp_size (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u64 tmp_size = (const u64) sizeof (sshng_bcrypt_tmp_t);
+
+  return tmp_size;
+}
+
+// One bcrypt_hash() per loop iteration. Each is 64 Blowfish key expansions, so
+// the autotuner is kept on a short leash the way -m 3200 is.
+u32 module_kernel_loops_min (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_min = 1;
+
+  return kernel_loops_min;
+}
+
+u32 module_kernel_loops_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
+{
+  const u32 kernel_loops_max = 1;
+
+  return kernel_loops_max;
+}
+
+int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED void *digest_buf, MAYBE_UNUSED salt_t *salt, MAYBE_UNUSED void *esalt_buf, MAYBE_UNUSED void *hook_salt_buf, MAYBE_UNUSED hashinfo_t *hash_info, const char *line_buf, MAYBE_UNUSED const int line_len)
+{
+  u32 *digest = (u32 *) digest_buf;
+
+  sshng_bcrypt_t *sshng = (sshng_bcrypt_t *) esalt_buf;
+
+  hc_token_t token;
+
+  // Uninitialised sep[]/len_min[]/len_max[] entries are read for every token
+  // index, so stack garbage in the ones we do not set makes the tokenizer
+  // search for a separator that is not there.
+  memset (&token, 0, sizeof (hc_token_t));
+
+  // $sshng$<cipher>$<saltlen>$<salt>$<datalen>$<data>$<rounds>$<ctoffset>
+  //
+  // Eight tokens. The legacy PEM form handled by -m 22911..22951 has six, so
+  // the count alone separates the two without ambiguity.
+
+  token.token_cnt  = 8;
+
+  token.signatures_cnt    = 1;
+  token.signatures_buf[0] = SIGNATURE_SSHNG;
+
+  token.len[0]     = 7;
+  token.attr[0]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_SIGNATURE;
+
+  token.sep[1]     = '$';
+  token.len_min[1] = 1;
+  token.len_max[1] = 1;
+  token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[2]     = '$';
+  token.len[2]     = 2;
+  token.attr[2]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[3]     = '$';
+  token.len[3]     = SSHNG_SALT_LEN * 2;
+  token.attr[3]    = TOKEN_ATTR_FIXED_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[4]     = '$';
+  token.len_min[4] = 1;
+  token.len_max[4] = 8;
+  token.attr[4]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  token.sep[5]     = '$';
+  token.len_min[5] = 64;
+  token.len_max[5] = 65536;
+  token.attr[5]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_HEX;
+
+  token.sep[6]     = '$';
+  token.len_min[6] = 1;
+  token.len_max[6] = 8;
+  token.attr[6]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  // last token runs to end of line: no trailing separator to match
+  token.len_min[7] = 1;
+  token.len_max[7] = 8;
+  token.attr[7]    = TOKEN_ATTR_VERIFY_LENGTH
+                   | TOKEN_ATTR_VERIFY_DIGIT;
+
+  const int rc_tokenizer = input_tokenizer ((const u8 *) line_buf, line_len, &token);
+
+  if (rc_tokenizer != PARSER_OK) return (rc_tokenizer);
+
+  // cipher
+
+  const int cipher = hc_strtoul ((const char *) token.buf[1], NULL, 10);
+
+  if ((cipher != SSHNG_CIPHER_AES256_CBC) && (cipher != SSHNG_CIPHER_AES256_CTR)) return (PARSER_CIPHER);
+
+  sshng->cipher = cipher;
+
+  // salt length is fixed by sshkey.c; reject anything else rather than
+  // silently deriving from the wrong number of bytes
+
+  const int salt_len_verify = hc_strtoul ((const char *) token.buf[2], NULL, 10);
+
+  if (salt_len_verify != SSHNG_SALT_LEN) return (PARSER_SALT_LENGTH);
+
+  // salt
+  //
+  // hex_to_u32() packs little-endian, but the kernel feeds salt_buf straight
+  // into sha512_update(), which reads its input big-endian packed. Swap here so
+  // the esalt holds the byte order the device wants.
+
+  const u8 *salt_pos = token.buf[3];
+
+  for (int i = 0, j = 0; i < SSHNG_SALT_LEN / 4; i += 1, j += 8)
+  {
+    sshng->salt_buf[i] = byte_swap_32 (hex_to_u32 (&salt_pos[j]));
+  }
+
+  // rounds -> salt_iter, so the autotuner sees the real cost
+
+  const u32 rounds = hc_strtoul ((const char *) token.buf[6], NULL, 10);
+
+  if (rounds == 0) return (PARSER_SALT_ITERATION);
+
+  // the whole derivation runs in one _loop invocation for now
+  salt->salt_iter = 1;
+
+  sshng->rounds = rounds;
+
+  // hashcat needs a salt_buf/salt_len for its own bookkeeping
+
+  memcpy (salt->salt_buf, sshng->salt_buf, SSHNG_SALT_LEN);
+
+  salt->salt_len = SSHNG_SALT_LEN;
+
+  // ciphertext offset within the blob
+
+  const u32 ct_offset = hc_strtoul ((const char *) token.buf[7], NULL, 10);
+
+  // the blob, kept whole so the encoder can reproduce the input line
+
+  if (token.len[5] > (SSHNG_DATA_MAX * 2)) return (PARSER_HASH_LENGTH);
+
+  sshng->data_len = hex_decode (token.buf[5], token.len[5], (u8 *) sshng->data_buf);
+
+  const int data_len = sshng->data_len;
+
+  // the declared length has to agree with the blob actually supplied
+
+  const int data_len_verify = hc_strtoul ((const char *) token.buf[4], NULL, 10);
+
+  if (data_len_verify != data_len) return (PARSER_HASH_LENGTH);
+
+  // The encrypted section must leave at least one AES block to verify against.
+
+  if ((ct_offset + 16) > (u32) data_len) return (PARSER_SALT_VALUE);
+
+  sshng->ct_offset = ct_offset;
+
+  // encrypted blob: only the first block is needed to compare the two check
+  // integers, so the rest is not copied to the device
+
+  // integers, so the rest is not copied to the device. Big-endian packed, to
+  // match the AES keystream it is XORed against in _comp.
+
+  const u8 *data_pos = token.buf[5] + (ct_offset * 2);
+
+  for (int i = 0, j = 0; i < 4; i += 1, j += 8)
+  {
+    sshng->ct_buf[i] = byte_swap_32 (hex_to_u32 (&data_pos[j]));
+  }
+
+  // fake digest: the encrypted check integers. Distinct per key, which is what
+  // hashcat needs for its hash table.
+
+  digest[0] = sshng->ct_buf[0];
+  digest[1] = sshng->ct_buf[1];
+  digest[2] = sshng->ct_buf[2];
+  digest[3] = sshng->ct_buf[3];
+
+  return (PARSER_OK);
+}
+
+int module_hash_encode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const void *digest_buf, MAYBE_UNUSED const salt_t *salt, MAYBE_UNUSED const void *esalt_buf, MAYBE_UNUSED const void *hook_salt_buf, MAYBE_UNUSED const hashinfo_t *hash_info, char *line_buf, MAYBE_UNUSED const int line_size)
+{
+  const sshng_bcrypt_t *sshng = (const sshng_bcrypt_t *) esalt_buf;
+
+  u8 *out_buf = (u8 *) line_buf;
+
+  u8 salt_hex[(SSHNG_SALT_LEN * 2) + 1] = { 0 };
+
+  // u32_to_hex packs little-endian, the inverse of hex_to_u32, so the
+  // big-endian words held in the esalt are swapped back before printing.
+
+  u32_to_hex (byte_swap_32 (sshng->salt_buf[0]), salt_hex +  0);
+  u32_to_hex (byte_swap_32 (sshng->salt_buf[1]), salt_hex +  8);
+  u32_to_hex (byte_swap_32 (sshng->salt_buf[2]), salt_hex + 16);
+  u32_to_hex (byte_swap_32 (sshng->salt_buf[3]), salt_hex + 24);
+
+  int out_len = snprintf ((char *) out_buf, line_size, "%s%u$%d$%s$%d$",
+    SIGNATURE_SSHNG,
+    sshng->cipher,
+    SSHNG_SALT_LEN,
+    salt_hex,
+    sshng->data_len);
+
+  out_len += hex_encode ((const u8 *) sshng->data_buf, sshng->data_len, out_buf + out_len);
+
+  out_len += snprintf ((char *) out_buf + out_len, line_size - out_len, "$%u$%u",
+    sshng->rounds,
+    sshng->ct_offset);
+
+  return out_len;
+}
+
+void module_init (module_ctx_t *module_ctx)
+{
+  module_ctx->module_context_size             = MODULE_CONTEXT_SIZE_CURRENT;
+  module_ctx->module_interface_version        = MODULE_INTERFACE_VERSION_CURRENT;
+
+  module_ctx->module_attack_exec              = module_attack_exec;
+  module_ctx->module_benchmark_esalt          = MODULE_DEFAULT;
+  module_ctx->module_benchmark_hook_salt      = MODULE_DEFAULT;
+  module_ctx->module_benchmark_mask           = MODULE_DEFAULT;
+  module_ctx->module_benchmark_charset        = MODULE_DEFAULT;
+  module_ctx->module_benchmark_salt           = MODULE_DEFAULT;
+  module_ctx->module_bridge_name              = MODULE_DEFAULT;
+  module_ctx->module_bridge_type              = MODULE_DEFAULT;
+  module_ctx->module_build_plain_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_deep_comp_kernel         = MODULE_DEFAULT;
+  module_ctx->module_deprecated_notice        = MODULE_DEFAULT;
+  module_ctx->module_dgst_pos0                = module_dgst_pos0;
+  module_ctx->module_dgst_pos1                = module_dgst_pos1;
+  module_ctx->module_dgst_pos2                = module_dgst_pos2;
+  module_ctx->module_dgst_pos3                = module_dgst_pos3;
+  module_ctx->module_dgst_size                = module_dgst_size;
+  module_ctx->module_esalt_size               = module_esalt_size;
+  module_ctx->module_extra_buffer_size        = MODULE_DEFAULT;
+  module_ctx->module_extra_tmp_size           = MODULE_DEFAULT;
+  module_ctx->module_extra_tuningdb_block     = MODULE_DEFAULT;
+  module_ctx->module_forced_outfile_format    = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_count        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_parse        = MODULE_DEFAULT;
+  module_ctx->module_hash_binary_save         = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_postprocess  = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_decode_zero_hash    = MODULE_DEFAULT;
+  module_ctx->module_hash_decode              = module_hash_decode;
+  module_ctx->module_hash_encode_status       = MODULE_DEFAULT;
+  module_ctx->module_hash_encode_potfile      = MODULE_DEFAULT;
+  module_ctx->module_hash_encode              = module_hash_encode;
+  module_ctx->module_hash_init_selftest       = MODULE_DEFAULT;
+  module_ctx->module_hash_mode                = MODULE_DEFAULT;
+  module_ctx->module_hash_category            = module_hash_category;
+  module_ctx->module_hash_name                = module_hash_name;
+  module_ctx->module_hashes_count_min         = MODULE_DEFAULT;
+  module_ctx->module_hashes_count_max         = MODULE_DEFAULT;
+  module_ctx->module_hlfmt_disable            = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_size    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_init    = MODULE_DEFAULT;
+  module_ctx->module_hook_extra_param_term    = MODULE_DEFAULT;
+  module_ctx->module_hook12                   = MODULE_DEFAULT;
+  module_ctx->module_hook23                   = MODULE_DEFAULT;
+  module_ctx->module_hook_salt_size           = MODULE_DEFAULT;
+  module_ctx->module_hook_size                = MODULE_DEFAULT;
+  module_ctx->module_jit_build_options        = blowfish_module_jit_build_options;
+  module_ctx->module_jit_cache_disable        = blowfish_module_jit_cache_disable;
+  module_ctx->module_kernel_accel_max         = MODULE_DEFAULT;
+  module_ctx->module_kernel_accel_min         = MODULE_DEFAULT;
+  module_ctx->module_kernel_loops_max         = module_kernel_loops_max;
+  module_ctx->module_kernel_loops_min         = module_kernel_loops_min;
+  module_ctx->module_kernel_threads_max       = MODULE_DEFAULT;
+  module_ctx->module_kernel_threads_min       = MODULE_DEFAULT;
+  module_ctx->module_kern_type                = module_kern_type;
+  module_ctx->module_kern_type_dynamic        = MODULE_DEFAULT;
+  module_ctx->module_opti_type                = module_opti_type;
+  module_ctx->module_opts_type                = module_opts_type;
+  module_ctx->module_outfile_check_disable    = MODULE_DEFAULT;
+  module_ctx->module_outfile_check_nocomp     = MODULE_DEFAULT;
+  module_ctx->module_potfile_custom_check     = MODULE_DEFAULT;
+  module_ctx->module_potfile_disable          = MODULE_DEFAULT;
+  module_ctx->module_potfile_keep_all_hashes  = MODULE_DEFAULT;
+  module_ctx->module_pwdump_column            = MODULE_DEFAULT;
+  module_ctx->module_pw_max                   = MODULE_DEFAULT;
+  module_ctx->module_pw_min                   = MODULE_DEFAULT;
+  module_ctx->module_salt_max                 = MODULE_DEFAULT;
+  module_ctx->module_salt_min                 = MODULE_DEFAULT;
+  module_ctx->module_salt_type                = module_salt_type;
+  module_ctx->module_separator                = MODULE_DEFAULT;
+  module_ctx->module_st_hash                  = module_st_hash;
+  module_ctx->module_st_pass                  = module_st_pass;
+  module_ctx->module_tmp_size                 = module_tmp_size;
+  module_ctx->module_unstable_warning         = MODULE_DEFAULT;
+  module_ctx->module_warmup_disable           = MODULE_DEFAULT;
+}

--- a/tools/test_modules/m37500.pm
+++ b/tools/test_modules/m37500.pm
@@ -1,0 +1,684 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+# OpenSSH private keys in the openssh-key-v1 container, keyed with bcrypt-pbkdf.
+#
+# There is no CPAN module for bcrypt_pbkdf, and it cannot be built out of
+# Crypt::Eksblowfish: eksblowfish runs ExpandKey(key) before ExpandKey(salt) in
+# its cost loop where bcrypt_pbkdf runs salt before key, and it fixes the salt
+# at 16 bytes where bcrypt_pbkdf feeds a 64 byte SHA-512. So Blowfish is
+# implemented here directly. The tables below are the standard ones, taken from
+# OpenCL/inc_cipher_blowfish.cl so the two cannot drift apart.
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (sha512);
+
+use Crypt::Rijndael;
+
+my @PBOX_INIT = (
+  0x243f6a88, 0x85a308d3, 0x13198a2e, 0x03707344, 0xa4093822, 0x299f31d0,
+  0x082efa98, 0xec4e6c89, 0x452821e6, 0x38d01377, 0xbe5466cf, 0x34e90c6c,
+  0xc0ac29b7, 0xc97c50dd, 0x3f84d5b5, 0xb5470917, 0x9216d5d9, 0x8979fb1b
+);
+
+my @SBOX0_INIT = (
+  0xd1310ba6, 0x98dfb5ac, 0x2ffd72db, 0xd01adfb7, 0xb8e1afed, 0x6a267e96,
+  0xba7c9045, 0xf12c7f99, 0x24a19947, 0xb3916cf7, 0x0801f2e2, 0x858efc16,
+  0x636920d8, 0x71574e69, 0xa458fea3, 0xf4933d7e, 0x0d95748f, 0x728eb658,
+  0x718bcd58, 0x82154aee, 0x7b54a41d, 0xc25a59b5, 0x9c30d539, 0x2af26013,
+  0xc5d1b023, 0x286085f0, 0xca417918, 0xb8db38ef, 0x8e79dcb0, 0x603a180e,
+  0x6c9e0e8b, 0xb01e8a3e, 0xd71577c1, 0xbd314b27, 0x78af2fda, 0x55605c60,
+  0xe65525f3, 0xaa55ab94, 0x57489862, 0x63e81440, 0x55ca396a, 0x2aab10b6,
+  0xb4cc5c34, 0x1141e8ce, 0xa15486af, 0x7c72e993, 0xb3ee1411, 0x636fbc2a,
+  0x2ba9c55d, 0x741831f6, 0xce5c3e16, 0x9b87931e, 0xafd6ba33, 0x6c24cf5c,
+  0x7a325381, 0x28958677, 0x3b8f4898, 0x6b4bb9af, 0xc4bfe81b, 0x66282193,
+  0x61d809cc, 0xfb21a991, 0x487cac60, 0x5dec8032, 0xef845d5d, 0xe98575b1,
+  0xdc262302, 0xeb651b88, 0x23893e81, 0xd396acc5, 0x0f6d6ff3, 0x83f44239,
+  0x2e0b4482, 0xa4842004, 0x69c8f04a, 0x9e1f9b5e, 0x21c66842, 0xf6e96c9a,
+  0x670c9c61, 0xabd388f0, 0x6a51a0d2, 0xd8542f68, 0x960fa728, 0xab5133a3,
+  0x6eef0b6c, 0x137a3be4, 0xba3bf050, 0x7efb2a98, 0xa1f1651d, 0x39af0176,
+  0x66ca593e, 0x82430e88, 0x8cee8619, 0x456f9fb4, 0x7d84a5c3, 0x3b8b5ebe,
+  0xe06f75d8, 0x85c12073, 0x401a449f, 0x56c16aa6, 0x4ed3aa62, 0x363f7706,
+  0x1bfedf72, 0x429b023d, 0x37d0d724, 0xd00a1248, 0xdb0fead3, 0x49f1c09b,
+  0x075372c9, 0x80991b7b, 0x25d479d8, 0xf6e8def7, 0xe3fe501a, 0xb6794c3b,
+  0x976ce0bd, 0x04c006ba, 0xc1a94fb6, 0x409f60c4, 0x5e5c9ec2, 0x196a2463,
+  0x68fb6faf, 0x3e6c53b5, 0x1339b2eb, 0x3b52ec6f, 0x6dfc511f, 0x9b30952c,
+  0xcc814544, 0xaf5ebd09, 0xbee3d004, 0xde334afd, 0x660f2807, 0x192e4bb3,
+  0xc0cba857, 0x45c8740f, 0xd20b5f39, 0xb9d3fbdb, 0x5579c0bd, 0x1a60320a,
+  0xd6a100c6, 0x402c7279, 0x679f25fe, 0xfb1fa3cc, 0x8ea5e9f8, 0xdb3222f8,
+  0x3c7516df, 0xfd616b15, 0x2f501ec8, 0xad0552ab, 0x323db5fa, 0xfd238760,
+  0x53317b48, 0x3e00df82, 0x9e5c57bb, 0xca6f8ca0, 0x1a87562e, 0xdf1769db,
+  0xd542a8f6, 0x287effc3, 0xac6732c6, 0x8c4f5573, 0x695b27b0, 0xbbca58c8,
+  0xe1ffa35d, 0xb8f011a0, 0x10fa3d98, 0xfd2183b8, 0x4afcb56c, 0x2dd1d35b,
+  0x9a53e479, 0xb6f84565, 0xd28e49bc, 0x4bfb9790, 0xe1ddf2da, 0xa4cb7e33,
+  0x62fb1341, 0xcee4c6e8, 0xef20cada, 0x36774c01, 0xd07e9efe, 0x2bf11fb4,
+  0x95dbda4d, 0xae909198, 0xeaad8e71, 0x6b93d5a0, 0xd08ed1d0, 0xafc725e0,
+  0x8e3c5b2f, 0x8e7594b7, 0x8ff6e2fb, 0xf2122b64, 0x8888b812, 0x900df01c,
+  0x4fad5ea0, 0x688fc31c, 0xd1cff191, 0xb3a8c1ad, 0x2f2f2218, 0xbe0e1777,
+  0xea752dfe, 0x8b021fa1, 0xe5a0cc0f, 0xb56f74e8, 0x18acf3d6, 0xce89e299,
+  0xb4a84fe0, 0xfd13e0b7, 0x7cc43b81, 0xd2ada8d9, 0x165fa266, 0x80957705,
+  0x93cc7314, 0x211a1477, 0xe6ad2065, 0x77b5fa86, 0xc75442f5, 0xfb9d35cf,
+  0xebcdaf0c, 0x7b3e89a0, 0xd6411bd3, 0xae1e7e49, 0x00250e2d, 0x2071b35e,
+  0x226800bb, 0x57b8e0af, 0x2464369b, 0xf009b91e, 0x5563911d, 0x59dfa6aa,
+  0x78c14389, 0xd95a537f, 0x207d5ba2, 0x02e5b9c5, 0x83260376, 0x6295cfa9,
+  0x11c81968, 0x4e734a41, 0xb3472dca, 0x7b14a94a, 0x1b510052, 0x9a532915,
+  0xd60f573f, 0xbc9bc6e4, 0x2b60a476, 0x81e67400, 0x08ba6fb5, 0x571be91f,
+  0xf296ec6b, 0x2a0dd915, 0xb6636521, 0xe7b9f9b6, 0xff34052e, 0xc5855664,
+  0x53b02d5d, 0xa99f8fa1, 0x08ba4799, 0x6e85076a
+);
+
+my @SBOX1_INIT = (
+  0x4b7a70e9, 0xb5b32944, 0xdb75092e, 0xc4192623, 0xad6ea6b0, 0x49a7df7d,
+  0x9cee60b8, 0x8fedb266, 0xecaa8c71, 0x699a17ff, 0x5664526c, 0xc2b19ee1,
+  0x193602a5, 0x75094c29, 0xa0591340, 0xe4183a3e, 0x3f54989a, 0x5b429d65,
+  0x6b8fe4d6, 0x99f73fd6, 0xa1d29c07, 0xefe830f5, 0x4d2d38e6, 0xf0255dc1,
+  0x4cdd2086, 0x8470eb26, 0x6382e9c6, 0x021ecc5e, 0x09686b3f, 0x3ebaefc9,
+  0x3c971814, 0x6b6a70a1, 0x687f3584, 0x52a0e286, 0xb79c5305, 0xaa500737,
+  0x3e07841c, 0x7fdeae5c, 0x8e7d44ec, 0x5716f2b8, 0xb03ada37, 0xf0500c0d,
+  0xf01c1f04, 0x0200b3ff, 0xae0cf51a, 0x3cb574b2, 0x25837a58, 0xdc0921bd,
+  0xd19113f9, 0x7ca92ff6, 0x94324773, 0x22f54701, 0x3ae5e581, 0x37c2dadc,
+  0xc8b57634, 0x9af3dda7, 0xa9446146, 0x0fd0030e, 0xecc8c73e, 0xa4751e41,
+  0xe238cd99, 0x3bea0e2f, 0x3280bba1, 0x183eb331, 0x4e548b38, 0x4f6db908,
+  0x6f420d03, 0xf60a04bf, 0x2cb81290, 0x24977c79, 0x5679b072, 0xbcaf89af,
+  0xde9a771f, 0xd9930810, 0xb38bae12, 0xdccf3f2e, 0x5512721f, 0x2e6b7124,
+  0x501adde6, 0x9f84cd87, 0x7a584718, 0x7408da17, 0xbc9f9abc, 0xe94b7d8c,
+  0xec7aec3a, 0xdb851dfa, 0x63094366, 0xc464c3d2, 0xef1c1847, 0x3215d908,
+  0xdd433b37, 0x24c2ba16, 0x12a14d43, 0x2a65c451, 0x50940002, 0x133ae4dd,
+  0x71dff89e, 0x10314e55, 0x81ac77d6, 0x5f11199b, 0x043556f1, 0xd7a3c76b,
+  0x3c11183b, 0x5924a509, 0xf28fe6ed, 0x97f1fbfa, 0x9ebabf2c, 0x1e153c6e,
+  0x86e34570, 0xeae96fb1, 0x860e5e0a, 0x5a3e2ab3, 0x771fe71c, 0x4e3d06fa,
+  0x2965dcb9, 0x99e71d0f, 0x803e89d6, 0x5266c825, 0x2e4cc978, 0x9c10b36a,
+  0xc6150eba, 0x94e2ea78, 0xa5fc3c53, 0x1e0a2df4, 0xf2f74ea7, 0x361d2b3d,
+  0x1939260f, 0x19c27960, 0x5223a708, 0xf71312b6, 0xebadfe6e, 0xeac31f66,
+  0xe3bc4595, 0xa67bc883, 0xb17f37d1, 0x018cff28, 0xc332ddef, 0xbe6c5aa5,
+  0x65582185, 0x68ab9802, 0xeecea50f, 0xdb2f953b, 0x2aef7dad, 0x5b6e2f84,
+  0x1521b628, 0x29076170, 0xecdd4775, 0x619f1510, 0x13cca830, 0xeb61bd96,
+  0x0334fe1e, 0xaa0363cf, 0xb5735c90, 0x4c70a239, 0xd59e9e0b, 0xcbaade14,
+  0xeecc86bc, 0x60622ca7, 0x9cab5cab, 0xb2f3846e, 0x648b1eaf, 0x19bdf0ca,
+  0xa02369b9, 0x655abb50, 0x40685a32, 0x3c2ab4b3, 0x319ee9d5, 0xc021b8f7,
+  0x9b540b19, 0x875fa099, 0x95f7997e, 0x623d7da8, 0xf837889a, 0x97e32d77,
+  0x11ed935f, 0x16681281, 0x0e358829, 0xc7e61fd6, 0x96dedfa1, 0x7858ba99,
+  0x57f584a5, 0x1b227263, 0x9b83c3ff, 0x1ac24696, 0xcdb30aeb, 0x532e3054,
+  0x8fd948e4, 0x6dbc3128, 0x58ebf2ef, 0x34c6ffea, 0xfe28ed61, 0xee7c3c73,
+  0x5d4a14d9, 0xe864b7e3, 0x42105d14, 0x203e13e0, 0x45eee2b6, 0xa3aaabea,
+  0xdb6c4f15, 0xfacb4fd0, 0xc742f442, 0xef6abbb5, 0x654f3b1d, 0x41cd2105,
+  0xd81e799e, 0x86854dc7, 0xe44b476a, 0x3d816250, 0xcf62a1f2, 0x5b8d2646,
+  0xfc8883a0, 0xc1c7b6a3, 0x7f1524c3, 0x69cb7492, 0x47848a0b, 0x5692b285,
+  0x095bbf00, 0xad19489d, 0x1462b174, 0x23820e00, 0x58428d2a, 0x0c55f5ea,
+  0x1dadf43e, 0x233f7061, 0x3372f092, 0x8d937e41, 0xd65fecf1, 0x6c223bdb,
+  0x7cde3759, 0xcbee7460, 0x4085f2a7, 0xce77326e, 0xa6078084, 0x19f8509e,
+  0xe8efd855, 0x61d99735, 0xa969a7aa, 0xc50c06c2, 0x5a04abfc, 0x800bcadc,
+  0x9e447a2e, 0xc3453484, 0xfdd56705, 0x0e1e9ec9, 0xdb73dbd3, 0x105588cd,
+  0x675fda79, 0xe3674340, 0xc5c43465, 0x713e38d8, 0x3d28f89e, 0xf16dff20,
+  0x153e21e7, 0x8fb03d4a, 0xe6e39f2b, 0xdb83adf7
+);
+
+my @SBOX2_INIT = (
+  0xe93d5a68, 0x948140f7, 0xf64c261c, 0x94692934, 0x411520f7, 0x7602d4f7,
+  0xbcf46b2e, 0xd4a20068, 0xd4082471, 0x3320f46a, 0x43b7d4b7, 0x500061af,
+  0x1e39f62e, 0x97244546, 0x14214f74, 0xbf8b8840, 0x4d95fc1d, 0x96b591af,
+  0x70f4ddd3, 0x66a02f45, 0xbfbc09ec, 0x03bd9785, 0x7fac6dd0, 0x31cb8504,
+  0x96eb27b3, 0x55fd3941, 0xda2547e6, 0xabca0a9a, 0x28507825, 0x530429f4,
+  0x0a2c86da, 0xe9b66dfb, 0x68dc1462, 0xd7486900, 0x680ec0a4, 0x27a18dee,
+  0x4f3ffea2, 0xe887ad8c, 0xb58ce006, 0x7af4d6b6, 0xaace1e7c, 0xd3375fec,
+  0xce78a399, 0x406b2a42, 0x20fe9e35, 0xd9f385b9, 0xee39d7ab, 0x3b124e8b,
+  0x1dc9faf7, 0x4b6d1856, 0x26a36631, 0xeae397b2, 0x3a6efa74, 0xdd5b4332,
+  0x6841e7f7, 0xca7820fb, 0xfb0af54e, 0xd8feb397, 0x454056ac, 0xba489527,
+  0x55533a3a, 0x20838d87, 0xfe6ba9b7, 0xd096954b, 0x55a867bc, 0xa1159a58,
+  0xcca92963, 0x99e1db33, 0xa62a4a56, 0x3f3125f9, 0x5ef47e1c, 0x9029317c,
+  0xfdf8e802, 0x04272f70, 0x80bb155c, 0x05282ce3, 0x95c11548, 0xe4c66d22,
+  0x48c1133f, 0xc70f86dc, 0x07f9c9ee, 0x41041f0f, 0x404779a4, 0x5d886e17,
+  0x325f51eb, 0xd59bc0d1, 0xf2bcc18f, 0x41113564, 0x257b7834, 0x602a9c60,
+  0xdff8e8a3, 0x1f636c1b, 0x0e12b4c2, 0x02e1329e, 0xaf664fd1, 0xcad18115,
+  0x6b2395e0, 0x333e92e1, 0x3b240b62, 0xeebeb922, 0x85b2a20e, 0xe6ba0d99,
+  0xde720c8c, 0x2da2f728, 0xd0127845, 0x95b794fd, 0x647d0862, 0xe7ccf5f0,
+  0x5449a36f, 0x877d48fa, 0xc39dfd27, 0xf33e8d1e, 0x0a476341, 0x992eff74,
+  0x3a6f6eab, 0xf4f8fd37, 0xa812dc60, 0xa1ebddf8, 0x991be14c, 0xdb6e6b0d,
+  0xc67b5510, 0x6d672c37, 0x2765d43b, 0xdcd0e804, 0xf1290dc7, 0xcc00ffa3,
+  0xb5390f92, 0x690fed0b, 0x667b9ffb, 0xcedb7d9c, 0xa091cf0b, 0xd9155ea3,
+  0xbb132f88, 0x515bad24, 0x7b9479bf, 0x763bd6eb, 0x37392eb3, 0xcc115979,
+  0x8026e297, 0xf42e312d, 0x6842ada7, 0xc66a2b3b, 0x12754ccc, 0x782ef11c,
+  0x6a124237, 0xb79251e7, 0x06a1bbe6, 0x4bfb6350, 0x1a6b1018, 0x11caedfa,
+  0x3d25bdd8, 0xe2e1c3c9, 0x44421659, 0x0a121386, 0xd90cec6e, 0xd5abea2a,
+  0x64af674e, 0xda86a85f, 0xbebfe988, 0x64e4c3fe, 0x9dbc8057, 0xf0f7c086,
+  0x60787bf8, 0x6003604d, 0xd1fd8346, 0xf6381fb0, 0x7745ae04, 0xd736fccc,
+  0x83426b33, 0xf01eab71, 0xb0804187, 0x3c005e5f, 0x77a057be, 0xbde8ae24,
+  0x55464299, 0xbf582e61, 0x4e58f48f, 0xf2ddfda2, 0xf474ef38, 0x8789bdc2,
+  0x5366f9c3, 0xc8b38e74, 0xb475f255, 0x46fcd9b9, 0x7aeb2661, 0x8b1ddf84,
+  0x846a0e79, 0x915f95e2, 0x466e598e, 0x20b45770, 0x8cd55591, 0xc902de4c,
+  0xb90bace1, 0xbb8205d0, 0x11a86248, 0x7574a99e, 0xb77f19b6, 0xe0a9dc09,
+  0x662d09a1, 0xc4324633, 0xe85a1f02, 0x09f0be8c, 0x4a99a025, 0x1d6efe10,
+  0x1ab93d1d, 0x0ba5a4df, 0xa186f20f, 0x2868f169, 0xdcb7da83, 0x573906fe,
+  0xa1e2ce9b, 0x4fcd7f52, 0x50115e01, 0xa70683fa, 0xa002b5c4, 0x0de6d027,
+  0x9af88c27, 0x773f8641, 0xc3604c06, 0x61a806b5, 0xf0177a28, 0xc0f586e0,
+  0x006058aa, 0x30dc7d62, 0x11e69ed7, 0x2338ea63, 0x53c2dd94, 0xc2c21634,
+  0xbbcbee56, 0x90bcb6de, 0xebfc7da1, 0xce591d76, 0x6f05e409, 0x4b7c0188,
+  0x39720a3d, 0x7c927c24, 0x86e3725f, 0x724d9db9, 0x1ac15bb4, 0xd39eb8fc,
+  0xed545578, 0x08fca5b5, 0xd83d7cd3, 0x4dad0fc4, 0x1e50ef5e, 0xb161e6f8,
+  0xa28514d9, 0x6c51133c, 0x6fd5c7e7, 0x56e14ec4, 0x362abfce, 0xddc6c837,
+  0xd79a3234, 0x92638212, 0x670efa8e, 0x406000e0
+);
+
+my @SBOX3_INIT = (
+  0x3a39ce37, 0xd3faf5cf, 0xabc27737, 0x5ac52d1b, 0x5cb0679e, 0x4fa33742,
+  0xd3822740, 0x99bc9bbe, 0xd5118e9d, 0xbf0f7315, 0xd62d1c7e, 0xc700c47b,
+  0xb78c1b6b, 0x21a19045, 0xb26eb1be, 0x6a366eb4, 0x5748ab2f, 0xbc946e79,
+  0xc6a376d2, 0x6549c2c8, 0x530ff8ee, 0x468dde7d, 0xd5730a1d, 0x4cd04dc6,
+  0x2939bbdb, 0xa9ba4650, 0xac9526e8, 0xbe5ee304, 0xa1fad5f0, 0x6a2d519a,
+  0x63ef8ce2, 0x9a86ee22, 0xc089c2b8, 0x43242ef6, 0xa51e03aa, 0x9cf2d0a4,
+  0x83c061ba, 0x9be96a4d, 0x8fe51550, 0xba645bd6, 0x2826a2f9, 0xa73a3ae1,
+  0x4ba99586, 0xef5562e9, 0xc72fefd3, 0xf752f7da, 0x3f046f69, 0x77fa0a59,
+  0x80e4a915, 0x87b08601, 0x9b09e6ad, 0x3b3ee593, 0xe990fd5a, 0x9e34d797,
+  0x2cf0b7d9, 0x022b8b51, 0x96d5ac3a, 0x017da67d, 0xd1cf3ed6, 0x7c7d2d28,
+  0x1f9f25cf, 0xadf2b89b, 0x5ad6b472, 0x5a88f54c, 0xe029ac71, 0xe019a5e6,
+  0x47b0acfd, 0xed93fa9b, 0xe8d3c48d, 0x283b57cc, 0xf8d56629, 0x79132e28,
+  0x785f0191, 0xed756055, 0xf7960e44, 0xe3d35e8c, 0x15056dd4, 0x88f46dba,
+  0x03a16125, 0x0564f0bd, 0xc3eb9e15, 0x3c9057a2, 0x97271aec, 0xa93a072a,
+  0x1b3f6d9b, 0x1e6321f5, 0xf59c66fb, 0x26dcf319, 0x7533d928, 0xb155fdf5,
+  0x03563482, 0x8aba3cbb, 0x28517711, 0xc20ad9f8, 0xabcc5167, 0xccad925f,
+  0x4de81751, 0x3830dc8e, 0x379d5862, 0x9320f991, 0xea7a90c2, 0xfb3e7bce,
+  0x5121ce64, 0x774fbe32, 0xa8b6e37e, 0xc3293d46, 0x48de5369, 0x6413e680,
+  0xa2ae0810, 0xdd6db224, 0x69852dfd, 0x09072166, 0xb39a460a, 0x6445c0dd,
+  0x586cdecf, 0x1c20c8ae, 0x5bbef7dd, 0x1b588d40, 0xccd2017f, 0x6bb4e3bb,
+  0xdda26a7e, 0x3a59ff45, 0x3e350a44, 0xbcb4cdd5, 0x72eacea8, 0xfa6484bb,
+  0x8d6612ae, 0xbf3c6f47, 0xd29be463, 0x542f5d9e, 0xaec2771b, 0xf64e6370,
+  0x740e0d8d, 0xe75b1357, 0xf8721671, 0xaf537d5d, 0x4040cb08, 0x4eb4e2cc,
+  0x34d2466a, 0x0115af84, 0xe1b00428, 0x95983a1d, 0x06b89fb4, 0xce6ea048,
+  0x6f3f3b82, 0x3520ab82, 0x011a1d4b, 0x277227f8, 0x611560b1, 0xe7933fdc,
+  0xbb3a792b, 0x344525bd, 0xa08839e1, 0x51ce794b, 0x2f32c9b7, 0xa01fbac9,
+  0xe01cc87e, 0xbcc7d1f6, 0xcf0111c3, 0xa1e8aac7, 0x1a908749, 0xd44fbd9a,
+  0xd0dadecb, 0xd50ada38, 0x0339c32a, 0xc6913667, 0x8df9317c, 0xe0b12b4f,
+  0xf79e59b7, 0x43f5bb3a, 0xf2d519ff, 0x27d9459c, 0xbf97222c, 0x15e6fc2a,
+  0x0f91fc71, 0x9b941525, 0xfae59361, 0xceb69ceb, 0xc2a86459, 0x12baa8d1,
+  0xb6c1075e, 0xe3056a0c, 0x10d25065, 0xcb03a442, 0xe0ec6e0e, 0x1698db3b,
+  0x4c98a0be, 0x3278e964, 0x9f1f9532, 0xe0d392df, 0xd3a0342b, 0x8971f21e,
+  0x1b0a7441, 0x4ba3348c, 0xc5be7120, 0xc37632d8, 0xdf359f8d, 0x9b992f2e,
+  0xe60b6f47, 0x0fe3f11d, 0xe54cda54, 0x1edad891, 0xce6279cf, 0xcd3e7e6f,
+  0x1618b166, 0xfd2c1d05, 0x848fd2c5, 0xf6fb2299, 0xf523f357, 0xa6327623,
+  0x93a83531, 0x56cccd02, 0xacf08162, 0x5a75ebb5, 0x6e163697, 0x88d273cc,
+  0xde966292, 0x81b949d0, 0x4c50901b, 0x71c65614, 0xe6c6c7bd, 0x327a140a,
+  0x45e1d006, 0xc3f27b9a, 0xc9aa53fd, 0x62a80f00, 0xbb25bfe2, 0x35bdd2f6,
+  0x71126905, 0xb2040222, 0xb6cbcf7c, 0xcd769c2b, 0x53113ec0, 0x1640e3d3,
+  0x38abbd60, 0x2547adf0, 0xba38209c, 0xf746ce76, 0x77afa1c5, 0x20756060,
+  0x85cbfe4e, 0x8ae88dd8, 0x7aaaf9b0, 0x4cf9aa7e, 0x1948c25c, 0x02fb8a8c,
+  0x01c36ae4, 0xd6ebe1f9, 0x90d4f869, 0xa65cdea0, 0x3f09252d, 0xc208e69f,
+  0xb74e6132, 0xce77e25b, 0x578fdfe3, 0x3ac372e6
+);
+
+use constant U32 => 0xffffffff;
+
+# One Blowfish round pair, operating on the caller's P array and S boxes.
+
+sub blowfish_encipher
+{
+  my ($st, $xl, $xr) = @_;
+
+  my $P = $st->{p};
+  my $S = $st->{s};
+
+  for (my $i = 0; $i < 16; $i++)
+  {
+    $xl ^= $P->[$i];
+    $xl &= U32;
+
+    my $f = $S->[0][($xl >> 24) & 0xff];
+    $f   += $S->[1][($xl >> 16) & 0xff];
+    $f   &= U32;
+    $f   ^= $S->[2][($xl >>  8) & 0xff];
+    $f   += $S->[3][ $xl        & 0xff];
+    $f   &= U32;
+
+    $xr ^= $f;
+
+    ($xl, $xr) = ($xr, $xl);
+  }
+
+  ($xl, $xr) = ($xr, $xl);
+
+  $xr ^= $P->[16];
+  $xl ^= $P->[17];
+
+  return ($xl & U32, $xr & U32);
+}
+
+sub blowfish_initstate
+{
+  return {
+    p => [@PBOX_INIT],
+    s => [[@SBOX0_INIT], [@SBOX1_INIT], [@SBOX2_INIT], [@SBOX3_INIT]],
+  };
+}
+
+# Blowfish_stream2word: consume 4 bytes big-endian, wrapping at the end of the
+# buffer. $pos is advanced in place.
+
+sub stream2word
+{
+  my ($data, $posref) = @_;
+
+  my $len = length ($data);
+  my $w   = 0;
+
+  for (my $i = 0; $i < 4; $i++)
+  {
+    $w = (($w << 8) | ord (substr ($data, $$posref, 1))) & U32;
+
+    $$posref = ($$posref + 1) % $len;
+  }
+
+  return $w;
+}
+
+sub blowfish_expandstate
+{
+  my ($st, $data, $key) = @_;
+
+  my $j = 0;
+
+  for (my $i = 0; $i < 18; $i++)
+  {
+    $st->{p}[$i] ^= stream2word ($key, \$j);
+  }
+
+  $j = 0;
+
+  my ($dl, $dr) = (0, 0);
+
+  for (my $i = 0; $i < 18; $i += 2)
+  {
+    $dl ^= stream2word ($data, \$j);
+    $dr ^= stream2word ($data, \$j);
+
+    ($dl, $dr) = blowfish_encipher ($st, $dl, $dr);
+
+    $st->{p}[$i]     = $dl;
+    $st->{p}[$i + 1] = $dr;
+  }
+
+  for (my $b = 0; $b < 4; $b++)
+  {
+    for (my $k = 0; $k < 256; $k += 2)
+    {
+      $dl ^= stream2word ($data, \$j);
+      $dr ^= stream2word ($data, \$j);
+
+      ($dl, $dr) = blowfish_encipher ($st, $dl, $dr);
+
+      $st->{s}[$b][$k]     = $dl;
+      $st->{s}[$b][$k + 1] = $dr;
+    }
+  }
+}
+
+sub blowfish_expand0state
+{
+  my ($st, $key) = @_;
+
+  my $j = 0;
+
+  for (my $i = 0; $i < 18; $i++)
+  {
+    $st->{p}[$i] ^= stream2word ($key, \$j);
+  }
+
+  my ($dl, $dr) = (0, 0);
+
+  for (my $i = 0; $i < 18; $i += 2)
+  {
+    ($dl, $dr) = blowfish_encipher ($st, $dl, $dr);
+
+    $st->{p}[$i]     = $dl;
+    $st->{p}[$i + 1] = $dr;
+  }
+
+  for (my $b = 0; $b < 4; $b++)
+  {
+    for (my $k = 0; $k < 256; $k += 2)
+    {
+      ($dl, $dr) = blowfish_encipher ($st, $dl, $dr);
+
+      $st->{s}[$b][$k]     = $dl;
+      $st->{s}[$b][$k + 1] = $dr;
+    }
+  }
+}
+
+# bcrypt_hash (sha2pass, sha2salt) -> 32 bytes, little-endian per word.
+
+sub bcrypt_hash
+{
+  my ($sha2pass, $sha2salt) = @_;
+
+  my $st = blowfish_initstate ();
+
+  blowfish_expandstate ($st, $sha2salt, $sha2pass);
+
+  for (my $i = 0; $i < 64; $i++)
+  {
+    blowfish_expand0state ($st, $sha2salt);
+    blowfish_expand0state ($st, $sha2pass);
+  }
+
+  my @cdata = unpack ("N8", "OxychromaticBlowfishSwatDynamite");
+
+  for (my $i = 0; $i < 64; $i++)
+  {
+    for (my $k = 0; $k < 8; $k += 2)
+    {
+      ($cdata[$k], $cdata[$k + 1]) = blowfish_encipher ($st, $cdata[$k], $cdata[$k + 1]);
+    }
+  }
+
+  return pack ("V8", @cdata);
+}
+
+sub bcrypt_pbkdf
+{
+  my ($pass, $salt, $rounds, $keylen) = @_;
+
+  my $sha2pass = sha512 ($pass);
+
+  my $stride = int (($keylen + 31) / 32);
+  my $amt    = int (($keylen + $stride - 1) / $stride);
+
+  my @key = (0) x $keylen;
+
+  my $left  = $keylen;
+  my $count = 1;
+
+  while ($left > 0)
+  {
+    my $sha2salt = sha512 ($salt . pack ("N", $count));
+
+    my $tmpout = bcrypt_hash ($sha2pass, $sha2salt);
+    my $out    = $tmpout;
+
+    for (my $i = 1; $i < $rounds; $i++)
+    {
+      $sha2salt = sha512 ($tmpout);
+
+      $tmpout = bcrypt_hash ($sha2pass, $sha2salt);
+
+      $out ^= $tmpout;
+    }
+
+    my $take = ($amt < $left) ? $amt : $left;
+
+    my $i = 0;
+
+    for ($i = 0; $i < $take; $i++)
+    {
+      my $dest = $i * $stride + ($count - 1);
+
+      last if ($dest >= $keylen);
+
+      $key[$dest] = ord (substr ($out, $i, 1));
+    }
+
+    $left -= $i;
+
+    $count++;
+  }
+
+  return pack ("C*", @key);
+}
+
+# --- AES ---------------------------------------------------------------------
+#
+# Crypt::Rijndael is used in ECB mode and the chaining is done here, so CTR and
+# CBC share one code path shape and neither depends on a padding convention.
+
+sub aes_ctr
+{
+  my ($key, $iv, $in) = @_;
+
+  my $c   = Crypt::Rijndael->new ($key, Crypt::Rijndael::MODE_ECB ());
+  my $ctr = $iv;
+  my $out = "";
+
+  for (my $i = 0; $i < length ($in); $i += 16)
+  {
+    my $ks    = $c->encrypt ($ctr);
+    my $block = substr ($in, $i, 16);
+
+    $out .= ($block ^ substr ($ks, 0, length ($block)));
+
+    # 128 bit big-endian increment
+
+    my @b = unpack ("C16", $ctr);
+
+    for (my $j = 15; $j >= 0; $j--)
+    {
+      $b[$j] = ($b[$j] + 1) & 0xff;
+
+      last if ($b[$j] != 0);
+    }
+
+    $ctr = pack ("C16", @b);
+  }
+
+  return $out;
+}
+
+sub aes_cbc_encrypt
+{
+  my ($key, $iv, $in) = @_;
+
+  my $c    = Crypt::Rijndael->new ($key, Crypt::Rijndael::MODE_ECB ());
+  my $prev = $iv;
+  my $out  = "";
+
+  for (my $i = 0; $i < length ($in); $i += 16)
+  {
+    my $blk = $c->encrypt (substr ($in, $i, 16) ^ $prev);
+
+    $out .= $blk;
+
+    $prev = $blk;
+  }
+
+  return $out;
+}
+
+sub aes_cbc_decrypt
+{
+  my ($key, $iv, $in) = @_;
+
+  my $c    = Crypt::Rijndael->new ($key, Crypt::Rijndael::MODE_ECB ());
+  my $prev = $iv;
+  my $out  = "";
+
+  for (my $i = 0; $i < length ($in); $i += 16)
+  {
+    my $blk = substr ($in, $i, 16);
+
+    $out .= ($c->decrypt ($blk) ^ $prev);
+
+    $prev = $blk;
+  }
+
+  return $out;
+}
+
+sub ssh_encrypt
+{
+  my ($cid, $key, $iv, $in) = @_;
+
+  return ($cid == 2) ? aes_cbc_encrypt ($key, $iv, $in) : aes_ctr ($key, $iv, $in);
+}
+
+sub ssh_decrypt
+{
+  my ($cid, $key, $iv, $in) = @_;
+
+  return ($cid == 2) ? aes_cbc_decrypt ($key, $iv, $in) : aes_ctr ($key, $iv, $in);
+}
+
+# --- openssh-key-v1 container ------------------------------------------------
+
+sub sshstr
+{
+  my $s = shift;
+
+  return pack ("N", length ($s)) . $s;
+}
+
+# The cleartext preamble, up to and including the length word of the encrypted
+# section. ct_offset is exactly its length.
+
+sub build_header
+{
+  my ($salt_bin, $rounds, $cid, $enc_len) = @_;
+
+  my $ciphername = ($cid == 2) ? "aes256-cbc" : "aes256-ctr";
+
+  # Fixed filler: nothing in this mode inspects the public key, and a constant
+  # keeps the generated hash reproducible for a given word/salt.
+
+  my $pub = "\x01" x 32;
+
+  my $header = "openssh-key-v1\x00"
+             . sshstr ($ciphername)
+             . sshstr ("bcrypt")
+             . sshstr (sshstr ($salt_bin) . pack ("N", $rounds))
+             . pack ("N", 1)
+             . sshstr (sshstr ("ssh-ed25519") . sshstr ($pub))
+             . pack ("N", $enc_len);
+
+  return $header;
+}
+
+sub default_plain
+{
+  # checkint1 == checkint2 is what marks a correct decryption
+
+  my $checkint = 0x01020304;
+
+  my $pub = "\x01" x 32;
+
+  my $plain = pack ("N", $checkint)
+            . pack ("N", $checkint)
+            . sshstr ("ssh-ed25519")
+            . sshstr ($pub)
+            . sshstr ($pub . $pub)
+            . sshstr ("hashcat");
+
+  # OpenSSH pads to the cipher block size with 1, 2, 3, ...
+
+  my $padlen = (16 - (length ($plain) % 16)) % 16;
+
+  for (my $i = 1; $i <= $padlen; $i++)
+  {
+    $plain .= chr ($i);
+  }
+
+  return $plain;
+}
+
+sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
+
+sub module_generate_hash
+{
+  my $word   = shift;
+  my $salt   = shift;
+  my $iter   = shift;
+  my $cid    = shift // 6;
+  my $blob   = shift;
+  my $ct_off = shift;
+
+  my $rounds = (defined ($iter) && length ($iter)) ? int ($iter) : 16;
+
+  my $salt_bin = pack ("H*", $salt);
+
+  my $dk = bcrypt_pbkdf ($word, $salt_bin, $rounds, 48);
+
+  my $key = substr ($dk, 0, 32);
+  my $iv  = substr ($dk, 32, 16);
+
+  my $plain;
+
+  if (defined ($blob))
+  {
+    # Verify path: recover the plaintext from the supplied blob. Reproducing the
+    # input line requires the original key material, so the decryption is only
+    # trusted when the two check integers agree -- otherwise fall through to the
+    # generated body, which yields a different line and so fails the comparison.
+
+    my $enc = substr ($blob, $ct_off);
+
+    $enc = substr ($enc, 0, length ($enc) & ~15);
+
+    my $dec = ssh_decrypt ($cid, $key, $iv, $enc);
+
+    my ($c1, $c2) = unpack ("NN", substr ($dec, 0, 8));
+
+    if ($c1 == $c2)
+    {
+      my $header = substr ($blob, 0, $ct_off);
+
+      my $out = $header . ssh_encrypt ($cid, $key, $iv, $dec);
+
+      return sprintf ('$sshng$%d$%d$%s$%d$%s$%d$%d',
+        $cid, length ($salt_bin), unpack ("H*", $salt_bin),
+        length ($out), unpack ("H*", $out), $rounds, $ct_off);
+    }
+  }
+
+  $plain = default_plain ();
+
+  my $enc    = ssh_encrypt ($cid, $key, $iv, $plain);
+  my $header = build_header ($salt_bin, $rounds, $cid, length ($enc));
+  my $out    = $header . $enc;
+
+  return sprintf ('$sshng$%d$%d$%s$%d$%s$%d$%d',
+    $cid, length ($salt_bin), unpack ("H*", $salt_bin),
+    length ($out), unpack ("H*", $out), $rounds, length ($header));
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = index ($line, ':');
+
+  return unless $idx >= 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless substr ($hash, 0, 7) eq '$sshng$';
+
+  my (undef, $signature, $cid, $salt_len, $salt, $data_len, $data, $rounds, $ct_off) = split '\$', $hash;
+
+  return unless defined $signature;
+  return unless defined $cid;
+  return unless defined $salt;
+  return unless defined $data;
+  return unless defined $rounds;
+  return unless defined $ct_off;
+
+  return unless ($signature eq 'sshng');
+
+  # eight tokens; the six token form is the legacy PEM layout of -m 22911..22951
+
+  return unless (($cid == 2) || ($cid == 6));
+
+  my $blob = pack ("H*", $data);
+
+  return unless (length ($blob) == $data_len);
+  return unless ($ct_off + 16 <= length ($blob));
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt, $rounds, $cid, $blob, $ct_off);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
### Motivation

`ssh-keygen` has written the `openssh-key-v1` container with bcrypt-pbkdf key derivation by default since OpenSSH 7.8 (2018). The existing `-m 22911..22951` handle only legacy PEM keys with the MD5-based KDF, so an SSH private key generated with default options today cannot be attacked with hashcat at all.

The gap is not a missing fast target — it is the opposite. The PEM formats hashcat implements run at ~2 GH/s on this card, while the format `ssh-keygen` actually produces has had no kernel. This adds one.

### Algorithm

Per OpenBSD `bcrypt_pbkdf.c`:

```
sha2pass = SHA512 (password)
for each 32 byte output block:
    sha2salt = SHA512 (salt || BE32 (block))
    out = bcrypt_hash (sha2pass, sha2salt)
    repeat rounds-1 times:
        sha2salt = SHA512 (previous bcrypt_hash output)
        out ^= bcrypt_hash (sha2pass, sha2salt)
    scatter out into the key at stride
```

Two properties of the KDF drive the plugin's shape:

- A `bcrypt_hash()` cannot be split across kernel invocations, so `kernel_loops` is pinned at 1 and the derivation runs inside `_loop`.
- 48 bytes of output (32 byte AES key + 16 byte IV) means `stride = 2`, so **two** independent blocks each run the full round loop. Real work is `2 x rounds x 129` Blowfish key expansions — twice what a naive reading of `bcrypt_pbkdf` suggests.

### Reuse, and one thing that could not be reused

`blowfish_encrypt()`, `c_pbox` and `c_sbox0..3` from `inc_cipher_blowfish.cl` are used unchanged.

`blowfish_set_key_salt()` could not be: it hardcodes a 4 word salt, indexing `salt_buf[(i & 2) + 0]` with S-box loops that reference `salt_buf[0..3]` literally. bcrypt-pbkdf feeds a 64 byte `sha2salt` that the data stream cycles over 16 words at a time. A 16-word `expandstate` is therefore written in `m37500-pure.cl`.

I kept it local to this kernel rather than generalising the shared helper, since changing `inc_cipher_blowfish.cl` would affect `-m 3200` and belongs in its own PR if it is wanted at all.

### Hash format

john's `$sshng$` encoding, so `ssh2john.py` works unmodified:

```
$sshng$<cipher>$16$<salt>$<datalen>$<data>$<rounds>$<ctoffset>
```

Eight tokens against six for the legacy PEM form, so the parsers stay separate rather than `-m 22921` growing a second layout. Cipher id `6` is aes256-ctr and `2` is aes256-cbc; both occur in practice and both are handled.

Verification decrypts the first ciphertext block and compares the two check integers OpenSSH writes equal before encrypting — the same criterion john and `-m 22921` use, at a 2^-32 false positive rate per guess. If a stricter check is preferred I can add a second stage parsing the decrypted key type string; say the word.

### Performance

RTX 4050 Laptop, CUDA 13.3:

```
Speed.#01........:      592 H/s (810.43ms) @ Accel:1 Loops:1 Thr:24 Vec:1
```

Scaling `-m 3200` (36,994 H/s at cost 5, 65 expansions) by the 4128 expansions this mode performs at the default 16 rounds predicts 583 H/s, so the measured figure lands within 1.5% of the cost model.

`Thr:24` is the same occupancy ceiling bcrypt hits: Blowfish needs 4 KB of S-boxes per work item, which caps residency per SM regardless of core count. This mode inherits that exactly, so `OPTS_TYPE_DYNAMIC_SHARED` is handled the way `-m 3200` handles it. The trade-off is inherent to the primitive — there is no arrangement that avoids the 4 KB.

For context, the same key on 16 CPU cores with john runs at 86.5 c/s, so this is roughly a 6.8x speedup. Real and worth having, but bcrypt-pbkdf does not collapse on a GPU and I would not want the mode to imply otherwise.

### Testing

Keys from `ssh-keygen` at `-a 8`, `16` and `64`, covering ed25519, RSA-2048 and ECDSA-256 across both ciphers:

- all recover; a wrong password recovers none
- every cracked line re-encodes byte identical to its input, so the potfile and `--show` round-trip
- self-test passes with the included example hash
- compiles with no warnings under `-W -Wall -std=gnu99`

The derived key was checked against an independent CPU implementation of `bcrypt_pbkdf` before the kernel was trusted, rather than inferring correctness from a successful crack.

### Test module

`tools/test_modules/m37500.pm` implements bcrypt_pbkdf in pure Perl. No CPAN module provides it, and `Crypt::Eksblowfish` cannot substitute: its cost loop runs `ExpandKey(key)` before `ExpandKey(salt)` where bcrypt_pbkdf runs salt before key, and it fixes the salt at 16 bytes where this needs 64. The Blowfish tables in it are generated from `OpenCL/inc_cipher_blowfish.cl` so the two cannot drift apart.

It was cross-checked against the kernel in both directions: hashcat cracks Perl-generated hashes for both ciphers, and the Perl module verifies every key the GPU cracked.

### Scope

One problem, one PR. I have a separate PR fixing an unrelated `-m 24420` parser bug; the two do not overlap. The mode number 37500 is unused on master — happy to renumber if you have a different slot in mind.
