### PR TITLE
Fix combinator attacks reporting a truncated, non-matching plaintext

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -131,6 +131,7 @@ Setting --brain-client-features on the command line overrules the decision in ei
 ## Bugs
 ##
 
+- Fixed combinator and hybrid attacks reporting a plaintext truncated to 256 characters, which did not match the cracked digest
 - Fixed a one byte buffer overflow in fgetl() when a line was as long as the caller's buffer
 - Fixed missing libclang dependencies for Rust bridges in Ubuntu 20.04 and Arch containers
 - Fixed the Windows Rust plugin failing to link in the Arch container because lld was missing

--- a/src/outfile.c
+++ b/src/outfile.c
@@ -348,9 +348,17 @@ int build_plain (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pl
 
   // pw_max is per pw_t element but in combinator we have two pw_t elements.
   // therefore we can support up to 64 in combinator in optimized mode (but limited by general hash limit 55)
-  // or full 512 in pure mode (but limited by hashcat buffer size limit 256).
+  // or the full 2 * PW_MAX in pure mode.
   // some algorithms do not support general default pw_max = 31,
   // therefore we need to use pw_max as a base and not hardcode it.
+  //
+  // The pure branch used to cap at 256 for "hashcat buffer size limit 256",
+  // which no longer holds: every consumer of plain_ptr is sized for the full
+  // combinator length. status.c uses u32[(64 * 2) + 2], which is exactly
+  // 2 * PW_MAX plus room for the terminator, and hashes.c uses HCBUFSIZ_TINY
+  // before handing off to HCBUFSIZ_LARGE writers. Capping below the real
+  // maximum silently reported a truncated password that does not hash to the
+  // digest it was reported against.
 
   if (plain_len > pw_max)
   {
@@ -362,7 +370,7 @@ int build_plain (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, pl
       }
       else
       {
-        pw_max = MIN ((pw_max * 2), 256);
+        pw_max = MIN ((pw_max * 2), PW_MAX * 2);
       }
     }
   }


### PR DESCRIPTION
Fixes #4042.

### Problem

In `-a 1`, `-a 6` and `-a 7` a candidate can be up to `2 * PW_MAX` = 512 bytes, but `build_plain()` capped the reported length at 256 for pure kernels.

The kernel still hashes and matches the *full* candidate, so hashcat reports the hash as cracked while printing a password that does not hash to it:

```
true plaintext    300 chars
reported          256 chars
target digest     4922604afa0ff3556101bf7dbb982ffc84640a33487f9ac5927153212b1da687
sha256(reported)  1446b46f33960b90f823418271db0fff6facabc39ff8704b4f067e35db504d0a   <- mismatch
```

This is worse than failing to crack. The output looks like a result, and only re-hashing it by hand reveals otherwise. It is also written to the potfile and outfile, so `--show` keeps repeating it.

Reproduction from #4042, still present on master (`37dfdc9`).

### Why the cap was there, and why it no longer applies

The 256 came with the comment *"limited by hashcat buffer size limit 256"*. That is no longer true — every consumer of `plain_ptr` is already sized for the full combinator length:

| Consumer | Buffer |
|---|---|
| `status.c` | `u32[(64 * 2) + 2]` = 520 bytes — exactly `2 * PW_MAX` plus room for the terminator |
| `hashes.c` | `HCBUFSIZ_TINY` (4096) |
| outfile / potfile writers | `HCBUFSIZ_LARGE` |
| loopback | writes straight to the file, no intermediate buffer |
| `build_debugdata` | returns early for non-straight modes, so `RP_PASSWORD_SIZE` is not reached |

The `status.c` buffer being `(64 * 2) + 2` rather than `64 + 2` looks deliberately sized for this case.

Worth noting for review: **`build_plain()` already wrote the full 512 bytes into that buffer before this change** and only shortened the length it *reported*. So the single new write introduced here is the terminator at index 512, seven bytes inside the smallest of those buffers. No new memory is touched on any other path.

The optimized-kernel branch is untouched and still caps at 55.

### Testing

`-m 1400`, verified by re-hashing the reported plaintext against the target rather than trusting the "Cracked" status:

| Case | Before | After |
|---|---|---|
| `-a 1`, 257 chars | truncated to 256, wrong | exact |
| `-a 1`, 300 chars | truncated to 256, wrong | exact |
| `-a 1`, 512 chars (max) | truncated to 256, wrong | exact |
| `-a 6`, 254 chars | ok | ok |
| `-a 7`, 254 chars | ok | ok |
| `-a 1 -O`, 50 chars | ok | ok (55 cap unchanged) |
| `-a 0` | ok | ok |

Potfile round-trips: after cracking a 512-character candidate, `--show` returns all 512 characters.

Also exercised the 520-byte `status.c` path at the 512 maximum with full status output, since that is the tightest buffer involved.

Compiles with no warnings under `-W -Wall -std=gnu99`.

### Scope

One problem. Unrelated to my other open PRs (#4766, #4767).
