### PR TITLE
Fix stdin feed blocking on short pipe writes

### DIFF
--- a/src/feeds/feed_stdin.c
+++ b/src/feeds/feed_stdin.c
@@ -63,6 +63,12 @@
 #include "thread.h"
 #include "feed.h"
 
+#include <errno.h>
+
+#if defined (_WIN)
+#include <io.h>
+#endif
+
 const int GENERIC_PLUGIN_VERSION = FEEDS_INTERFACE_VERSION_CURRENT;
 
 // A pipe carries text lines, so everything hashcat can do to a wordlist line applies here too. The
@@ -149,6 +155,7 @@ typedef struct stdin_global
   int filled_cnt;
 
   bool eof;      // the reader has seen the end of the input
+  bool read_error;
   bool stop;     // the session is over and the reader should wind up
 
   hc_thread_t reader;
@@ -199,6 +206,23 @@ static void stdin_error (generic_thread_ctx_t *thread_ctx, const char *msg)
   thread_ctx->error = true;
 
   snprintf (thread_ctx->error_msg, sizeof (thread_ctx->error_msg), "%s", msg);
+}
+
+static int stdin_read (char *buf, const size_t len)
+{
+  int rc_read;
+
+  do
+  {
+    #if defined (_WIN)
+    rc_read = _read (_fileno (stdin), buf, (unsigned int) len);
+    #else
+    rc_read = (int) read (fileno (stdin), buf, len);
+    #endif
+  }
+  while ((rc_read == -1) && (errno == EINTR));
+
+  return rc_read;
 }
 
 // The reader. It owns the descriptor and nothing else reads from it.
@@ -294,13 +318,14 @@ static HC_API_CALL void *stdin_reader (void *p)
       stdin_global->selects_returned++;
     }
 
+    // fread () can wait for the whole request on a pipe. read () returns what is available, so a producer
+    // that keeps the pipe open does not have to supply a full block before its complete lines are used.
 
-    const size_t rc_read = fread (buf + have, 1, STDIN_BLOCK_SIZE - have, stdin);
+    const int rc_read = stdin_read (buf + have, STDIN_BLOCK_SIZE - have);
 
+    if (rc_read > 0) have += (size_t) rc_read;
 
-    have += rc_read;
-
-    if (rc_read == 0)
+    if (rc_read <= 0)
     {
       // The end of the input. Anything held back is a last line with no line ending, and it is a
       // candidate like any other.
@@ -324,6 +349,8 @@ static HC_API_CALL void *stdin_reader (void *p)
         stdin_global->free_cnt++;
       }
 
+      if (rc_read == -1) stdin_global->read_error = true;
+
       stdin_global->eof = true;
 
       hc_thread_cond_broadcast (stdin_global->cond_filled);
@@ -333,8 +360,9 @@ static HC_API_CALL void *stdin_reader (void *p)
       break;
     }
 
-    // Publish the whole lines and keep the rest. A block with no line ending anywhere in it holds a
-    // line longer than a block, which is cut here rather than grown into.
+    // Publish the whole lines and keep the rest. A full block with no line ending anywhere in it holds
+    // a line longer than a block, which is cut here rather than grown into. A short read with no line
+    // ending is only an incomplete line and has to be carried into the next read.
 
     size_t whole = have;
 
@@ -342,7 +370,26 @@ static HC_API_CALL void *stdin_reader (void *p)
 
     if (whole == 0)
     {
-      whole = have;
+      if (have == STDIN_BLOCK_SIZE)
+      {
+        whole = have;
+      }
+      else
+      {
+        carry_len = have;
+
+        memcpy (carry, buf, carry_len);
+
+        hc_thread_mutex_lock (stdin_global->mux);
+
+        stdin_global->free_list[stdin_global->free_cnt] = blk;
+
+        stdin_global->free_cnt++;
+
+        hc_thread_mutex_unlock (stdin_global->mux);
+
+        continue;
+      }
     }
     else
     {
@@ -383,6 +430,7 @@ bool global_init (generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_
 
   stdin_global->hashcat_ctx      = hashcat_ctx;
   stdin_global->eof              = false;
+  stdin_global->read_error       = false;
   stdin_global->stop             = false;
   stdin_global->filled_head      = 0;
   stdin_global->filled_tail      = 0;
@@ -601,7 +649,11 @@ int thread_next (generic_global_ctx_t *global_ctx, generic_thread_ctx_t *thread_
 
   while (stdin_thread->off >= stdin_thread->len)
   {
-    if (stdin_block_next (stdin_global, stdin_thread) == false) return GENERIC_RC_EOF;
+    if (stdin_block_next (stdin_global, stdin_thread) == true) continue;
+
+    if (stdin_global->read_error == true) return GENERIC_RC_ERROR;
+
+    return GENERIC_RC_EOF;
   }
 
   const char *line = stdin_thread->buf + stdin_thread->off;


### PR DESCRIPTION
Fixes #4769.

### Problem

After `select()` reported that stdin was readable, the stdin feed called `fread()` with the entire remaining 1 MiB block as its request. On a pipe, `fread()` could continue waiting for that request to fill or for EOF, even when the producer had already flushed many complete newline-delimited candidates.

### Changes

- Read directly from the stdin descriptor so currently available pipe data is returned without waiting for the full block.
- Retry descriptor reads interrupted by `EINTR`.
- Carry a short newline-free read into the next read instead of treating it as an overlong line.
- Preserve the existing overlong-line behavior only when a newline-free block is actually full.

The Windows path uses `_read(_fileno(stdin), ...)`; POSIX uses `read(fileno(stdin), ...)`.

### Verification

- `make hashcat feeds IS_ARM=1 -j4` on macOS arm64 with `-W -Wall -Wextra`.
- End-to-end `hashcat --stdout -w 1 -M`: 1,000,000 bytes of complete candidates begin appearing while the producer keeps stdin open, and the final output matches byte-for-byte.
- Delayed and fragmented writes: incomplete `abc` produces nothing, adding `\n` immediately produces `abc\n`; the same test passes with an embedded NUL.
- 500 randomized binary records split across 1-47 byte writes matched the expected bytes.
- 10,000 weighted random binary records and 2.5 MiB arbitrary input matched both the length-based model and the wordlist feed.
- 300,000 unique records containing NUL and `0xff`, consumed by 16 threads: no missing, duplicate, or corrupted candidates.
- The concurrent test passed under AddressSanitizer/UndefinedBehaviorSanitizer and ThreadSanitizer.

### Throughput

Five million nine-byte candidates through the feed harness, three interleaved runs:

| Reader | Times (seconds) | Mean |
| --- | --- | --- |
| existing `fread()` | 2.40, 2.50, 2.49 | 2.46 |
| descriptor `read()` | 2.45, 2.46, 2.39 | 2.43 |

This did not show a measurable throughput regression.
