### PR TITLE
Fix yescrypt address space errors on Metal

### DIFF
--- a/OpenCL/inc_hash_yescrypt.cl
+++ b/OpenCL/inc_hash_yescrypt.cl
@@ -61,7 +61,7 @@ DECLSPEC void yescrypt_simd_unshuffle (PRIVATE_AS const u32 *src, PRIVATE_AS u32
 
 DECLSPEC u64 yescrypt_integerify (PRIVATE_AS const u32 *X, const u32 r)
 {
-  const u32 *last = &X[(2 * r - 1) * 16];
+  PRIVATE_AS const u32 *last = &X[(2 * r - 1) * 16];
 
   return ((u64) last[13] << 32) | last[0];
 }

--- a/OpenCL/m36100-pure.cl
+++ b/OpenCL/m36100-pure.cl
@@ -431,7 +431,17 @@ DECLSPEC void coop_blockmix_pwxform (XBUF_AS u32 *X, SBOX_AS u32 *sbox, PRIVATE_
 
   if (lid == 0)
   {
-    yescrypt_salsa20_2 (&X[(r1 - 1) * 16]);
+    const u32 off = (r1 - 1) * 16;
+
+    // yescrypt_salsa20_2 operates on private memory, while X can be local or global.
+
+    u32 salsa[16];
+
+    for (u32 i = 0; i < 16; i++) salsa[i] = X[off + i];
+
+    yescrypt_salsa20_2 (salsa);
+
+    for (u32 i = 0; i < 16; i++) X[off + i] = salsa[i];
   }
 
   SYNC_THREADS ();

--- a/OpenCL/m36200-pure.cl
+++ b/OpenCL/m36200-pure.cl
@@ -442,7 +442,17 @@ DECLSPEC void coop_blockmix_pwxform (XBUF_AS u32 *X, SBOX_AS u32 *sbox, PRIVATE_
 
   if (lid == 0)
   {
-    yescrypt_salsa20_2 (&X[(r1 - 1) * 16]);
+    const u32 off = (r1 - 1) * 16;
+
+    // yescrypt_salsa20_2 operates on private memory, while X can be local or global.
+
+    u32 salsa[16];
+
+    for (u32 i = 0; i < 16; i++) salsa[i] = X[off + i];
+
+    yescrypt_salsa20_2 (salsa);
+
+    for (u32 i = 0; i < 16; i++) X[off + i] = salsa[i];
   }
 
   SYNC_THREADS ();


### PR DESCRIPTION
Fixes #4764.

### Problem

The yescrypt cooperative kernels pass `X`, which is in local/threadgroup or global memory, directly to `yescrypt_salsa20_2()`, whose parameter is private memory. Apple Metal rejects that address-space conversion, both through the native Metal backend and Apple's OpenCL-to-Metal compiler.

The native Metal compiler also rejects an unqualified pointer derived from the private `X` parameter in `yescrypt_integerify()`.

Mode 36200 duplicates the same cooperative yescrypt path and has the same invalid call.

### Changes

- Explicitly qualify the derived pointer in `yescrypt_integerify()` as `PRIVATE_AS`.
- Copy the 16-word cooperative Salsa block from local/global `X` into a private array before calling `yescrypt_salsa20_2()`, then copy the result back.
- Apply the cooperative fix to both modes 36100 and 36200.

### Verification

Tested on Apple M3, macOS 26.3.1, with both Apple backends.

Before the change, mode 36100 failed on both backends with the errors reported in #4764:

- Native Metal: `pointer type must have explicit address space qualifier`
- Native Metal: cannot pass `threadgroup` pointer to the private Salsa parameter
- Apple OpenCL: passing `__local u32 *` to `__private u32 *` changes address space

After the change:

- `hashcat -m 36100 -b --backend-ignore-opencl`: 275 H/s, exit 0.
- `hashcat -m 36100 -b --backend-ignore-metal`: 223 H/s, exit 0.
- Mode 36100's `hashcat` known-answer vector cracked correctly on native Metal and Apple OpenCL.
- Mode 36200's `hashcat` known-answer vector cracked correctly on native Metal and Apple OpenCL.
- Temporarily forcing `COOP_X_GLOBAL` verified the alternate global-memory path for mode 36100 on both backends and mode 36200 on Metal; all recovered the expected password.
- Normal local/threadgroup placement was restored before committing.
- `make hashcat modules/module_36100.so modules/module_36200.so IS_ARM=1 -j4` completed without warnings from the changed files.
