### PR TITLE
Fix out-of-bounds read of the markov css buffers on device

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -15453,23 +15453,27 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
      * create input buffers on device : calculate size of fixed memory buffers
      */
 
-    // These two are indexed by password position. Two things bound how many positions can ever be
-    // read, and sizing by SP_PW_MAX respects neither.
+    // These two are indexed by password position, and only the mask-driven attacks create them at
+    // all, a few hundred lines below. A straight wordlist run allocates neither, so sizing them for
+    // that case reserved 64 MiB per device against something that is never made.
     //
-    // First, only the mask-driven attacks create these buffers at all, a few hundred lines below. A
-    // straight wordlist run allocates neither, so counting them reserved 64 MiB per device against
-    // something that is never made.
+    // The position count itself has to stay SP_PW_MAX. Bounding it by the mode's pw_max looks safe,
+    // because mask_ctx_update_loop skips a mask longer than pw_max, but that check runs before two
+    // steps that grow the position count past it:
     //
-    // Second, a mask longer than the mode's pw_max is skipped before it reaches a kernel, in
-    // mask_ctx_update_loop, so positions past pw_max are unreachable. A mode with a short pw_max
-    // caps it far below the 256 that was always reserved.
+    //   mp_css_utf16le_expand() / mp_css_utf16be_expand()   doubles css_cnt   (src/mpsp.c)
+    //   mp_css_append_salt()                                adds salt_len     (src/mpsp.c)
+    //
+    // Both bound themselves by 256 rather than by pw_max, and the host-side buffers they fill are
+    // SP_PW_MAX entries for exactly that reason. A 2 character mask against a UTF16LE mode with a
+    // 25 byte appended salt reaches position 28, whatever pw_max happens to be. hashconfig->pw_max
+    // is also reassigned per mask in mask_ctx_update_loop, long after these buffers are allocated,
+    // so it is not a fixed quantity to size against in the first place.
 
     const bool css_in_use = (user_options_extra->attack_kern != ATTACK_KERN_STRAIGHT) ? true : false;
 
-    const u64 css_pos_max = MIN ((u64) SP_PW_MAX, (u64) hashconfig->pw_max);
-
-    u64 size_root_css   = (css_in_use == true) ? css_pos_max *           sizeof (cs_t) : 4;
-    u64 size_markov_css = (css_in_use == true) ? css_pos_max * CHARSIZ * sizeof (cs_t) : 4;
+    u64 size_root_css   = (css_in_use == true) ? SP_PW_MAX *           sizeof (cs_t) : 4;
+    u64 size_markov_css = (css_in_use == true) ? SP_PW_MAX * CHARSIZ * sizeof (cs_t) : 4;
 
     device_param->size_root_css   = size_root_css;
     device_param->size_markov_css = size_markov_css;


### PR DESCRIPTION
# Out-of-bounds `__global__` read in the markov candidate generator

These crack on this PR but don't crack on current [master](https://github.com/hashcat/hashcat/commit/77e4ce181d5fcbba19932c31368aaf8448433c62):
```
# MD5  — md5(utf16le($pass).$salt), password "43"
./hashcat -m 30 -a 3 -O --potfile-disable \
  'f08ca4a9c2308460a540a14d302a17a6:2429302669753941929414132' '4?d'

# NTLM — md4(utf16le($pass)), password "hashcathashca42"
./hashcat -m 1000 -a 3 -O --potfile-disable \
  87f0077d7918f2f9c191185112d24576 'hashcathashca?d?d'

# SHA1 — sha1(utf16le($pass).$salt), password "hashcatpw42"
./hashcat -m 130 -a 3 -O --potfile-disable \
  'b629b3a761edde0da043a01406bb31999201a61a:12345678' 'hashcatpw?d?d'

# SHA1 — sha1($salt.utf16le($pass)), password "hashcathashca42"
./hashcat -m 140 -a 3 -O --potfile-disable \
  '01d9857c1ae438c9067bc2b6f4d0b87810b3ba34:12345678' 'hashcathashca?d?d'
```
sometimes I get `cuEventDestroy(): an illegal memory access was encountered` but no cracks.

_the bug is real, but I've vibe-coded the fix, the code is quite challenging for me to grasp_

----

`generate_pw()` reads past the end of `d_markov_css_buf` / `d_root_css_buf` on
device during any mask attack whose expanded position count exceeds the hash
mode's `pw_max`.

**The read is silent in a normal build: hashcat reports `Exhausted` and misses
passwords that are inside the given mask.** The out-of-bounds data steers
candidate generation, so the wrong candidates get produced and a hash that
should crack does not. Under `compute-sanitizer` the same read is caught,
which is how it was found.

Introduced by 7b9f3fbec ("Fix OpenCL C selection and virtual device memory
handling"), present in current master.

## Reproducing

NTLM, no salt involved, plain 15 character mask:

```
./hashcat -m 1000 -a 3 -O --force --self-test-disable --potfile-disable \
  b4b9b02e6f09a9bd760f388b67351e2b '?d?d?d?d?d?d?d?d?d?d?d?d?d?d?d'
```

Or the smallest one, which additionally demonstrates the missed crack because
its keyspace is searchable in a second:

```
./hashcat -m 30 -a 3 -O --force --self-test-disable --potfile-disable \
  'f08ca4a9c2308460a540a14d302a17a6:2429302669753941929414132' '4?d'
```

The password is `43`, it is inside the mask `4?d`, and it is correct:

```python
>>> hashlib.md5('43'.encode('utf-16le') + b'2429302669753941929414132').hexdigest()
'f08ca4a9c2308460a540a14d302a17a6'
```

Current master exits `Exhausted` without cracking it, 3 runs out of 3. With
the patch applied it cracks on all 3. No error is printed either way.

Under `compute-sanitizer --tool memcheck --show-backtrace device` the cause is
visible (the sanitizer traps the read, which additionally kills the CUDA
context and produces a cascade of `unspecified launch failure` on every
following CUDA API call):

```
========= Invalid __global__ read of size 4 bytes
=========     at generate_pw(unsigned int *, const cs_t *, const cs_t *, unsigned int,
                unsigned int, unsigned int, unsigned int, unsigned int,
                unsigned long long)+0xf90 in markov_le.cl:24
=========     by thread (0,0,0) in block (0,0,0)
=========     Access at 0x5042d3ccc is out of bounds
=========     and is 53453 bytes after the nearest allocation at 0x503c00000
                of size 7105536 bytes
=========         Device Frame: l_markov+0xa0 in markov_le.cl:125
```

Decoding the address against the allocation confirms it is a position index
overrun rather than a stray pointer:

| quantity | value |
|---|---|
| `sizeof (cs_t)` | 1028 bytes |
| allocation size | 7,105,536 = **27** positions × 256 × 1028 |
| faulting offset | 7,158,988 |
| `markov_css_buf` element | 6963 → `j = 27`, `key = 51` |
| valid `j` | 0 .. 26 |

The kernel indexed position 27 of a buffer holding 0..26.

## Cause

`backend.c` sizes the two device buffers by the mode's `pw_max`:

```c
const u64 css_pos_max = MIN ((u64) SP_PW_MAX, (u64) hashconfig->pw_max);

u64 size_root_css   = (css_in_use == true) ? css_pos_max *           sizeof (cs_t) : 4;
u64 size_markov_css = (css_in_use == true) ? css_pos_max * CHARSIZ * sizeof (cs_t) : 4;
```

The commit's reasoning is stated in the comment above it: *"a mask longer than
the mode's pw_max is skipped before it reaches a kernel, in
mask_ctx_update_loop, so positions past pw_max are unreachable."*

The skip does exist, in `mask_ctx_update_loop` (`src/mpsp.c`):

```c
if ((mask_ctx->css_cnt < mask_min) || (mask_ctx->css_cnt > mask_max))
{
  ...
  event_log_warning (hashcat_ctx, "Skipping mask '%s' because it is larger than the maximum password length.", mask_ctx->mask);
  ...
  return -1;
}
```

but it runs *before* two steps that grow `css_cnt` past `pw_max`, both a few
lines further down in the same function:

```c
if (hashconfig->opts_type & OPTS_TYPE_PT_UTF16LE)
{
  if (mp_css_utf16le_expand (hashcat_ctx) == -1) return -1;   // css_cnt *= 2
}
...
if (hashconfig->opti_type & OPTI_TYPE_SINGLE_HASH)
{
  if (hashconfig->opti_type & OPTI_TYPE_APPENDED_SALT)
  {
    if (mp_css_append_salt (hashcat_ctx, &hashes->salts_buf[0]) == -1) return -1;   // css_cnt += salt_len
  }
}
```

Neither bounds itself by `pw_max` — both bound by 256:

```c
static int mp_css_utf16le_expand (hashcat_ctx_t *hashcat_ctx)
{
  u32 css_cnt_utf16le = mask_ctx->css_cnt * 2;
  if (css_cnt_utf16le > 256) return -1;
  ...

static int mp_css_append_salt (hashcat_ctx_t *hashcat_ctx, salt_t *salt_buf)
{
  ...
  if ((mask_ctx->css_cnt + salt_len) > 256) return -1;
```

which is also why the host-side buffers these fill are `SP_PW_MAX` entries:

```c
mask_ctx->root_css_buf   = (cs_t *) hccalloc (SP_PW_MAX,           sizeof (cs_t));
mask_ctx->markov_css_buf = (cs_t *) hccalloc (SP_PW_MAX * CHARSIZ, sizeof (cs_t));
```

So the host fills up to 256 positions, the device copy is truncated to
`pw_max`, and the kernel walks whatever the host produced.

For the reproducer above:

```
mask '4?d'                         css_cnt =  2     (passes the <= pw_max check)
mp_css_utf16le_expand()            css_cnt =  4     (-m 30 is UTF16LE)
mp_css_append_salt(), 25 byte salt css_cnt = 29
```

`l_markov` walks positions 0..28; the device buffer holds 0..26; the first
read past the end is at position 27, exactly as the sanitizer reports.

There is a second, independent reason `pw_max` is not a safe quantity to size
against: `mask_ctx_update_loop` *reassigns* it per mask,

```c
hashconfig->pw_min = pw_min;
hashconfig->pw_max = pw_max;
```

long after `backend_session_begin()` has allocated the device buffers.

## Affected runs

The condition is `css_cnt` after expansion exceeding the `pw_max` the device
buffers were sized with. `pw_max` comes from `default_pw_max()`
(`src/interface.c:808`):

| kernel | `pw_max` | buffer positions |
|---|---|---|
| pure | `PW_MAX` = 256 | 256 — equals `SP_PW_MAX`, so `MIN()` is a no-op and the mode is **not affected** |
| `-O` | `PW_MAX_OLD` = 55 | 55 |
| `-O` + UTF16LE/BE | `PW_MAX_OLD / 2` = 27 | 27 |

UTF16 + `-O` is what gets hit, because the halving and the doubling work
against each other: `pw_max` is halved to 27 to express a *character* budget,
while `mp_css_utf16le_expand()` then doubles `css_cnt` into *byte* positions.
An appended salt adds to that but is **not required** — NTLM has no salt and
is affected.

The fault needs `css_cnt >= pw_max + 2`, not merely `> pw_max`: `generate_pw()`
computes the out-of-bounds pointer at the end of one iteration (line 38) and
only dereferences it at the top of the next (line 24), so overshooting by
exactly one position computes a bad pointer that is never read.

Verified boundaries, one mask position = 2 css positions under UTF16:

| mode | salt | `css_cnt` | first failing mask | verified |
|---|---|---|---|---|
| 1000 NTLM | none | `len*2` | **15** (css 30) | len 14 → css 28 clean, len 15 → OOB |
| 130 sha1(utf16le(pass).salt) | 8 | `len*2+8` | **11** (css 30) | len 10 → css 28 clean, len 11 → OOB |
| 30 md5(utf16le(pass).salt) | 25 | `len*2+25` | **2** (css 29) | len 1 → css 27 clean, len 2 → OOB |

A salt just lowers the mask length needed to reach the threshold. NTLM with a
15 character mask and `-O` is the widest-reaching case.

Controls behaving as the model predicts: `-m 0` and `-m 100` at mask length 50
are clean, since without UTF16 `css_cnt` equals the mask length and the mask
itself is already capped at `pw_max`.

Non-UTF16 `-O` modes (e.g. `-m 10`) were checked and settled: the OOB read
is physically reachable there too, but **no crackable password is missed**,
which is why the missed-crack impact is UTF16-specific.

For a non-UTF16 appended-salt mode, `css_cnt = mask_len + salt_len` is exactly
the candidate's byte length. Overflowing the buffer needs `css_cnt >= 57`
(`pw_max + 2`), while a candidate is only crackable if its length is
`<= pw_max = 55`. The two thresholds cannot both hold, so every candidate that
reaches the overflow region is already longer than the `-O` kernel can hash.
The read still happens while generating those over-length candidates — an
unpatched `-m 10 -O` run with `css_cnt` 59 reports `Status: Error` (3 of 3
runs), the patch turns it into a clean `Exhausted` — but nothing crackable is
lost.

UTF16 is worse precisely because that coincidence breaks: `pw_max` is halved
to 27 to count *characters*, while the css positions count *bytes*. A 15
character NTLM password (well under the 27 char limit, fully crackable) is 30
byte positions and overflows the 27 position buffer, so byte positions 28..54
hold valid, crackable password data that lives outside the markov buffer.
That is the configuration that silently drops real cracks; memcheck confirms
the read, and the functional test confirms the miss.

The practical impact is missed cracks, silently: the out-of-bounds data is
read into candidate generation, so hashcat produces the wrong candidates and
reports `Exhausted` for a password that is inside the mask. Nothing in the
output indicates anything went wrong. That makes it a correctness bug first
and a stability bug second — the read is only fatal when something is
watching for it (a sanitizer, or an unlucky unmapped page).

It is a read of adjacent device memory, and the value only influences which
candidates get generated, so there is no memory-corruption or code-execution
angle.

## Fix

Restore `SP_PW_MAX` for the position count.

The other half of 7b9f3fbec — `css_in_use`, skipping the allocation entirely
for `ATTACK_KERN_STRAIGHT` — is sound and is kept. That is where the saving
actually comes from: a straight wordlist run never creates these buffers, so
it no longer reserves 64 MiB per device for them. Mask attacks go back to
allocating what the host can actually fill.

A tighter bound than `SP_PW_MAX` would have to be `pw_max * 2 + salt_len`
evaluated after the expansions, and would still have to cope with `pw_max`
being reassigned per mask; given the buffers only exist for mask attacks at
all now, `SP_PW_MAX` seems the better trade.


## Verification

Built clean, and checked against the reproducer above:

| | cracks `43` | compute-sanitizer |
|---|---|---|
| master | no, `Exhausted`, 0 of 3 runs | `Invalid __global__ read`, context lost |
| patched | yes, 3 of 3 runs | `ERROR SUMMARY: 0 errors` |

## How this was found

See https://github.com/hashcat/hashcat/pull/4774

