### PR TITLE
bugfix: add fsanitize=address to linkerflags such that DEBUG=2 builds correctly

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -617,6 +617,10 @@ else
 CFLAGS                  += -DDEBUG -O0 -ggdb
 endif
 CFLAGS                  += -fsanitize=address -fno-omit-frame-pointer
+# ASan must reach the link too, otherwise every target that links the C++ deps
+# (deps/unrar) fails with undefined __asan_* references. CFLAGS alone is not
+# enough for the shared-library layout.
+LFLAGS                  += -fsanitize=address
 endif
 endif
 endif


### PR DESCRIPTION
# `make DEBUG=2` (AddressSanitizer) does not link

## Summary

`make DEBUG=2` is documented as the AddressSanitizer build, but it cannot
produce a binary in this tree. `-fsanitize=address` is added to `CFLAGS` only,
never to the link flags, so every target that links the C++ dependencies fails
with undefined ASan runtime references.

## Reproduction

```
git checkout cac3d6de9cf83d4bf40210ca4c74b5dda49c3a01 #current master
make clean
make DEBUG=2 -j$(nproc)
```

Fails at the first link that pulls in `deps/unrar`:

```
/usr/bin/ld: ./deps/unrar/hc_decompress_rar.cpp:19: undefined reference to `__asan_stack_free_10'
/usr/bin/ld: ./deps/unrar/hc_decompress_rar.cpp:58: undefined reference to `__asan_init'
/usr/bin/ld: ./deps/unrar/hc_decompress_rar.cpp:58: undefined reference to `__asan_version_mismatch_check_v8'
collect2: error: ld returned 1 exit status
make: *** [src/Makefile:1671: libhashcat.so.7] Error 1
```

## Root cause

`src/Makefile`, the `DEBUG=2` block (around line 604):

```make
ifeq ($(DEBUG),2)
ifneq ($(UNAME),Darwin)
CFLAGS                  += -DDEBUG -Og -ggdb
else
CFLAGS                  += -DDEBUG -O0 -ggdb
endif
CFLAGS                  += -fsanitize=address -fno-omit-frame-pointer
endif
```

`-fsanitize=address` is a flag the compiler driver needs at **both** compile and
link time: at compile time it instruments, at link time it pulls in
`libasan`. Here it only ever reaches `CFLAGS`.

Object files therefore carry references to `__asan_init` and friends, and
nothing on the link line supplies them.

This is specific to the shared-library layout introduced by "Build the core once
and link every plugin against it" — `libhashcat.so.7`, the 594 module `.so`
plugins and the feed plugins are all separate link steps, and none of them see
the sanitizer flag.

_completely vibe-coded whilst working on https://github.com/hashcat/hashcat/pull/4774_
