### PR TITLE
 `is_hexify()`: 4-byte out-of-bounds read below length 6

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -617,6 +617,10 @@ else
 CFLAGS                  += -DDEBUG -O0 -ggdb
 endif
 CFLAGS                  += -fsanitize=address -fno-omit-frame-pointer
+# ASan must reach the link too, otherwise every target that links the C++ deps
+# (deps/unrar) fails with undefined __asan_* references. CFLAGS alone is not
+# enough for the shared-library layout.
+LFLAGS                  += -fsanitize=address
 endif
 endif
 endif

--- a/src/convert.c
+++ b/src/convert.c
@@ -151,7 +151,12 @@ static bool matches_separator (const u8 *buf, const size_t len, const char separ
 
 bool is_hexify (const u8 *buf, const size_t len)
 {
-  //  if (len < 6) return false; // $HEX[] = 6
+  // "$HEX[]" is 6 bytes, and everything below reads as if at least that many
+  // are present: the u32 compare covers buf[0..3], then buf[4], buf[len - 1]
+  // and buf + 5 with a length of len - 6. Anything shorter reads out of bounds
+  // and underflows that last length.
+
+  if (len < 6) return false; // $HEX[] = 6
 
   // length of the hex string must be a multiple of 2
   // and the length of "$HEX[]" is 6 (also an even length)


### PR DESCRIPTION
`is_hexify()` reads a `u32` from `buf` after checking only that `len` is even.
For `len` of 0, 2 or 4 that is a 4-byte read past the end of the string.

The guard that would prevent it is present in the source — **commented out**:

```c
bool is_hexify (const u8 *buf, const size_t len)
{
  //  if (len < 6) return false; // $HEX[] = 6
```

**This is latent, not live.** It causes no wrong answer and no reachable crash
in hashcat as it stands today. It is worth fixing for a specific reason — the
commit that disabled the guard is the one that started moving hashcat toward
the memory layout that would make its absence matter. See
[Why fix it](#why-fix-it-if-nothing-breaks).

## Severity: what it does and does not cause

Being precise about this, because the function's *reach* invites overstating it.

**It cannot produce a wrong answer.** A short candidate can never be
misclassified as hexified and mangled by `exec_unhexify()`, because the checks
below length 6 are mutually unsatisfiable:

| `len` | `u32` compare requires | `buf[len - 1]` requires | verdict |
|---|---|---|---|
| 2 | `buf[1] == 'H'` | `buf[1] == ']'` | same byte, contradiction |
| 4 | `buf[3] == 'X'` | `buf[3] == ']'` | same byte, contradiction |

So `is_hexify()` always returns `false` for short input, which is the correct
answer. No cracking impact, no corrupted candidates.

**No reachable crash.** The `len - 6` underflow would be serious — a
`SIZE_MAX`-length walk through `is_valid_hex_string()` — but it needs
`len == 0`, which in turn needs `buf[0..3]` to spell `$HEX`, `buf[4] == '['`
and `buf[-1] == ']'`, three coincidences in memory the function does not own.
In `module_99999` it is foreclosed outright by `token.len_min[0] = 1`. Tried to
provoke it through a wordlist (`$HEX[4142]` followed by an empty line, so the
reused candidate buffer still holds `$HEX[`) — nothing.

**Not observable by any sanitizer in production.** Every live caller passes a
buffer far larger than the string, so the four bytes land in valid memory. A
plain `./hashcat -m 0 -a0 <hash> <wordlist>` under ASan reports nothing, even
with empty lines and 2-character words in the wordlist. Verified; it does not
fire.

What is left is a genuine 4-byte read of memory the function was not given,
on a code path that runs constantly.

## Affected code

`src/convert.c:152-170`:

```c
bool is_hexify (const u8 *buf, const size_t len)
{
  //  if (len < 6) return false; // $HEX[] = 6

  // length of the hex string must be a multiple of 2
  // and the length of "$HEX[]" is 6 (also an even length)
  // Therefore the overall length must be an even number:

  if ((len & 1) == 1) return false;

  u32 *ptr = (u32 *) buf;

  if (*ptr != 0x58454824) return false; // $HEX      <-- reads buf[0..3]

  if (buf[4]       != '[') return false;             // <-- reads buf[4]
  if (buf[len - 1] != ']') return false;             // <-- underflows at len 0

  if (is_valid_hex_string (buf + 5, len - 6) == false) return false;  // <-- len - 6 underflows
```

Every read below the parity check assumes at least 6 bytes. The parity check
catches odd lengths, so lengths **0, 2 and 4** fall through to the `u32` read.

## Why fix it, if nothing breaks

[`131a246d7` ](https://github.com/hashcat/hashcat/commit/131a246d7b14655ab2a02e854c4c556bb2d9d0ea) removed the guard **in the commit that added `pw_add_zerocopy()`**.

That is the whole argument. Zero-copy is precisely the direction that
eliminates the slack this read currently depends on: it hands the kernel the
caller's own buffer instead of copying into a roomy staging one. The safety of
`is_hexify()` today is an accident of its callers having padding to spare, and
the same commit began moving hashcat toward layouts where they will not.

Nothing in the function records that dependency. The one line that did is
commented out four lines above the read.

Secondary: it is undefined behaviour reading memory the function does not own,
in a function whose entire job is to validate untrusted input.

## History
[`131a246d7` ](https://github.com/hashcat/hashcat/commit/131a246d7b14655ab2a02e854c4c556bb2d9d0ea) (2025-08-30, "Add versioning check
in -a8 feeds / Add -j rule support for -a8 feeds / Add pw_add_zerocopy()").
That is a performance commit, and the `is_hexify()` hunk is one edit doing two
things:

```diff
-  if (len < 6) return false; // $HEX[] = 6
+  //  if (len < 6) return false; // $HEX[] = 6
...
-  if (buf[0]       != '$') return (false);
-  if (buf[1]       != 'H') return (false);
-  if (buf[2]       != 'E') return (false);
-  if (buf[3]       != 'X') return (false);
+  u32 *ptr = (u32 *) buf;
+
+  if (*ptr != 0x58454824) return false; // $HEX
```

Four byte-compares collapsed into one word-compare, and a length branch
dropped. Both are recognisable "make this hot function cheaper" moves, and the
guard was *commented out* rather than deleted, so this was a choice rather than
a slip.

**The two halves are individually defensible and jointly unsafe.** Note what
the old code did once the guard was gone:

```c
if (buf[0] != '$') return (false);   // reads one byte, then bails
```

It short-circuits. On an empty or two-byte candidate the byte-compare version
reads **one** byte past the end and stops, because a wordlist word essentially
never starts with `$`. The `u32` load reads **four**, unconditionally, on every
call — not short-circuiting is the entire point of it.

So the optimisation quadrupled the overread in the same hunk that disabled the
check which had been bounding it.

For sequencing: the `buf[len - 1]` and `len - 6` underflows at `len == 0`
predate this commit and were already latent behind the guard. What
[`131a246d7` ](https://github.com/hashcat/hashcat/commit/131a246d7b14655ab2a02e854c4c556bb2d9d0ea) added was making the entry read unconditional and removing the
thing that kept any of it in bounds.

`src/convert.c` has had **no commits since**, so this is the current state of
master rather than something transient.

## Reach

Reach is why the fix is cheap insurance, not why it is urgent — see
[Severity](#severity-what-it-does-and-does-not-cause). Nothing below is
currently failing.

| call site | gate | runs on |
|---|---|---|
| `src/wordlist.c:153` (`pw_transform_apply`) | `wordlist_autohex` | every candidate from every wordlist |
| `src/convert.c:214` (`need_hexify`) | — | every cracked plaintext, via `outfile.c:687`, `potfile.c:281`, `status.c:1086-1087` |
| `src/potfile.c:864` | `OPTS_TYPE_PT_ALWAYS_HEXIFY` | potfile entries for those modes |
| `src/modules/module_99999.c:84` | — | that module's parser |

(`src/wordlist.c:51`, inside `convert_from_hex()`, calls it too, but that
function currently has no callers — only a declaration in `wordlist.h`. The
live wordlist path is `pw_transform_apply()`.)

`wordlist_autohex` defaults to **enabled** (`WORDLIST_AUTOHEX = true`,
`include/types.h:896`; disabled only by `--wordlist-autohex-disable`), so the
wordlist path is the default path. The inputs that reach the overread are
ordinary rather than adversarial: an empty line, or any 2- or 4-character
candidate.

## Reproduction

There is no plain-hashcat command for this, and that is a property of the
callers rather than of the bug. `pw_transform_apply()` passes a candidate
buffer sized `buf_size`; `potfile.c:864` passes a fixed-size `pw_buf`. The
overread lands inside a valid allocation every time.

Give the function an exactly-sized allocation — which is what the guard it lost
was protecting against — and it reports immediately.

```c
// hexify_drv.c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include "types.h"
#include "convert.h"

int main (void)
{
  const char *cases[] = { "", "ab", "$H", "$HEX", "$HEX[]", "$HEX[4142]" };

  for (int i = 0; i < 6; i++)
  {
    const size_t len = strlen (cases[i]);

    // exact-size heap copy so an overread lands on a redzone
    u8 *p = (u8 *) malloc (len ? len : 1);
    memcpy (p, cases[i], len);

    printf ("  len=%2zu \"%s\" -> %d\n", len, cases[i], (int) is_hexify (p, len));
    free (p);
  }
  return 0;
}
```

```
gcc -std=gnu99 -DDEBUG -g -O1 -fsanitize=address -fno-omit-frame-pointer \
    -Iinclude/ -IOpenCL/ -Ideps/LZMA-SDK/C -Ideps/zlib -Ideps/zlib/contrib \
    -Ideps/OpenCL-Headers -Ideps/xxHash -Ideps/unrar \
    -DWITH_BRAIN -DWITH_HWMON hexify_drv.c src/convert.c -o hexdrv

ASAN_OPTIONS=detect_leaks=0 ./hexdrv
```

### Observed, unpatched

The **driver** aborts on the first case, the empty string. hashcat does not —
the abort is a consequence of the driver's exact-size `malloc`, which is the
point of the driver:

```
==2472401==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000000010
READ of size 4 at 0x502000000010 thread T0
    #0 0x5923aff651e1 in is_hexify src/convert.c:164
0x502000000011 is located 0 bytes to the right of 1-byte region [0x502000000010,0x502000000011)
```

### Observed, patched

All six classify correctly, no ASan report:

```
  len= 0 ""           -> 0
  len= 2 "ab"         -> 0
  len= 2 "$H"         -> 0
  len= 4 "$HEX"       -> 0
  len= 6 "$HEX[]"     -> 1
  len=10 "$HEX[4142]" -> 1
```

Note rows 2-4: the patched function returns the same answers the unpatched one
does. The guard changes *how* it gets there, not *what* it decides — which is
the other half of why this is latent.

## Fix

Restore the guard the author already wrote.

```c
  if (len < 6) return false; // $HEX[] = 6
```

The comment above it is expanded to record *why* six, so it does not get
commented out again: every read below assumes six bytes, and two of them
underflow `size_t` without it.

### On the cost

The objection to expect is speed, not correctness — this runs per candidate,
and[`131a246d7` ](https://github.com/hashcat/hashcat/commit/131a246d7b14655ab2a02e854c4c556bb2d9d0ea) dropped that branch on purpose. Worth answering directly:

`len` is already in a register (it is the function's own parameter, and the
parity check on the next line already uses it). One compare against an
immediate, and a branch that is essentially never taken — every real candidate
is at least six bytes, so the predictor gets it right every time. It sits in
front of a load, three compares and an `is_valid_hex_string()` scan over
`len - 6` bytes. It is not what makes this function expensive.

If even that is unwelcome, the `u32` load can be kept and made legal instead —
`memcpy` four bytes only once there are four to read — but restoring the
author's own guard is the smaller and more reviewable change, and it fixes the
two `size_t` underflows at `len == 0` at the same time, which a narrower fix to
the load alone would not.

## Verified

- unpatched, exact-size allocation, ASan: fires on `len` 0, 2 and 4
- unpatched, **plain hashcat** under ASan with empty lines and 2-character
  words in the wordlist: **silent** — the overread happens, nothing can see it
- patched, ASan: silent; `$HEX[]` and `$HEX[4142]` still detected (returns 1),
  so hexified-wordlist handling is unchanged
- patched, all six cases classify identically to unpatched

`test.sh` on the generic wordlist path, against a build with this and the other
patches applied:

```
./tools/test.sh -m 0
[ test_1786909352 ] > Init test for hash type 0.
[ test_1786909352 ] [ Type 0, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

## How it was found

The full-tree ASan parser sweep flagged `m99999`, whose parser is the only
*module* that calls `is_hexify()` directly. The module is a test/plaintext
module of no importance; the function it calls is not.

The finding only existed because the harness copies its input into an
exactly-sized allocation. Against hashcat's own buffers it is invisible, which
is both why it survived this long and why it is ranked as latent above.

---

_completely vibe-coded whilst working on #4774_
