### PR TITLE
Out-of-bounds `__local__` write in SAP CODVN F/G (modes 7800, 7801)

### DIFF
--- a/OpenCL/m07800_a0-optimized.cl
+++ b/OpenCL/m07800_a0-optimized.cl
@@ -256,6 +256,14 @@ KERNEL_FQ KERNEL_FA void m07800_m04 (KERN_ATTR_RULES ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -289,21 +297,20 @@ KERNEL_FQ KERNEL_FA void m07800_m04 (KERN_ATTR_RULES ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_M_SIMD (digest[3], digest[4], digest[2], digest[1]);
@@ -532,6 +539,14 @@ KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_RULES ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -565,21 +580,20 @@ KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_RULES ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_S_SIMD (digest[3], digest[4], digest[2], digest[1]);

--- a/OpenCL/m07800_a0-optimized.cl
+++ b/OpenCL/m07800_a0-optimized.cl
@@ -148,7 +148,19 @@ KERNEL_FQ KERNEL_FA void m07800_m04 (KERN_ATTR_RULES ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);
@@ -412,7 +424,19 @@ KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_RULES ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);

--- a/OpenCL/m07800_a1-optimized.cl
+++ b/OpenCL/m07800_a1-optimized.cl
@@ -366,6 +366,14 @@ KERNEL_FQ KERNEL_FA void m07800_m04 (KERN_ATTR_BASIC ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -399,21 +407,20 @@ KERNEL_FQ KERNEL_FA void m07800_m04 (KERN_ATTR_BASIC ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_M_SIMD (digest[3], digest[4], digest[2], digest[1]);
@@ -754,6 +761,14 @@ KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_BASIC ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -787,21 +802,20 @@ KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_BASIC ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_S_SIMD (digest[3], digest[4], digest[2], digest[1]);

--- a/OpenCL/m07800_a1-optimized.cl
+++ b/OpenCL/m07800_a1-optimized.cl
@@ -258,7 +258,19 @@ KERNEL_FQ KERNEL_FA void m07800_m04 (KERN_ATTR_BASIC ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);
@@ -634,7 +646,19 @@ KERNEL_FQ KERNEL_FA void m07800_s04 (KERN_ATTR_BASIC ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);

--- a/OpenCL/m07800_a3-optimized.cl
+++ b/OpenCL/m07800_a3-optimized.cl
@@ -223,6 +223,14 @@ DECLSPEC void m07800m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -256,21 +264,20 @@ DECLSPEC void m07800m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_M_SIMD (digest[3], digest[4], digest[2], digest[1]);
@@ -460,6 +467,14 @@ DECLSPEC void m07800s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -493,21 +508,20 @@ DECLSPEC void m07800s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_S_SIMD (digest[3], digest[4], digest[2], digest[1]);

--- a/OpenCL/m07800_a3-optimized.cl
+++ b/OpenCL/m07800_a3-optimized.cl
@@ -115,7 +115,19 @@ DECLSPEC void m07800m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
      * SAP
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = w0[0] | s0[0];
     final[ 1] = w0[1] | s0[1];
@@ -340,7 +352,19 @@ DECLSPEC void m07800s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
      * SAP
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = w0[0] | s0[0];
     final[ 1] = w0[1] | s0[1];

--- a/OpenCL/m07801_a0-optimized.cl
+++ b/OpenCL/m07801_a0-optimized.cl
@@ -256,6 +256,14 @@ KERNEL_FQ KERNEL_FA void m07801_m04 (KERN_ATTR_RULES ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -289,21 +297,20 @@ KERNEL_FQ KERNEL_FA void m07801_m04 (KERN_ATTR_RULES ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_M_SIMD (0, 0, digest[2] & 0xffff0000, digest[1]);
@@ -532,6 +539,14 @@ KERNEL_FQ KERNEL_FA void m07801_s04 (KERN_ATTR_RULES ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -565,21 +580,20 @@ KERNEL_FQ KERNEL_FA void m07801_s04 (KERN_ATTR_RULES ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_S_SIMD (0, 0, digest[2] & 0xffff0000, digest[1]);

--- a/OpenCL/m07801_a0-optimized.cl
+++ b/OpenCL/m07801_a0-optimized.cl
@@ -148,7 +148,19 @@ KERNEL_FQ KERNEL_FA void m07801_m04 (KERN_ATTR_RULES ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);
@@ -412,7 +424,19 @@ KERNEL_FQ KERNEL_FA void m07801_s04 (KERN_ATTR_RULES ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);

--- a/OpenCL/m07801_a1-optimized.cl
+++ b/OpenCL/m07801_a1-optimized.cl
@@ -258,7 +258,19 @@ KERNEL_FQ KERNEL_FA void m07801_m04 (KERN_ATTR_BASIC ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);
@@ -634,7 +646,19 @@ KERNEL_FQ KERNEL_FA void m07801_s04 (KERN_ATTR_BASIC ())
      * sha1
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = hc_swap32_S (w0[0] | s0[0]);
     final[ 1] = hc_swap32_S (w0[1] | s0[1]);

--- a/OpenCL/m07801_a1-optimized.cl
+++ b/OpenCL/m07801_a1-optimized.cl
@@ -366,6 +366,14 @@ KERNEL_FQ KERNEL_FA void m07801_m04 (KERN_ATTR_BASIC ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -399,21 +407,20 @@ KERNEL_FQ KERNEL_FA void m07801_m04 (KERN_ATTR_BASIC ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_M_SIMD (0, 0, digest[2] & 0xffff0000, digest[1]);
@@ -754,6 +761,14 @@ KERNEL_FQ KERNEL_FA void m07801_s04 (KERN_ATTR_BASIC ())
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -787,21 +802,20 @@ KERNEL_FQ KERNEL_FA void m07801_s04 (KERN_ATTR_BASIC ())
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_S_SIMD (0, 0, digest[2] & 0xffff0000, digest[1]);

--- a/OpenCL/m07801_a3-optimized.cl
+++ b/OpenCL/m07801_a3-optimized.cl
@@ -115,7 +115,19 @@ DECLSPEC void m07801m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
      * SAP
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = w0[0] | s0[0];
     final[ 1] = w0[1] | s0[1];
@@ -340,7 +352,19 @@ DECLSPEC void m07801s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
      * SAP
      */
 
-    u32 final[32];
+    // 32 was sized for pw_len alone. SETSHIFTEDINT() below packs three
+    // variable-length pieces into final[] back to back with no bounds check:
+    // the candidate (up to pw_max, 55 for -O), a SHA1-digest-derived "magic
+    // array" chunk (32 + up to 50 from ten mod-6 terms, so up to 82), and
+    // the salt (up to salt_max, 51 for -O). 55+82+51 = 188 bytes needs index
+    // 47 (and SETSHIFTEDINT also touches d+1), i.e. 49 u32 minimum -- 32
+    // overflows by design for realistic inputs, not just contrived ones.
+    // Sized here to the worst case with headroom; the sha1_transform calls
+    // a few lines down still only ever process the first two 64-byte blocks
+    // of it (final+0..32), which is a separate, not-yet-addressed question:
+    // whether that's a correctness gap for inputs long enough to need a
+    // third block is outside the scope of this memory-safety fix.
+    u32 final[64];
 
     final[ 0] = w0[0] | s0[0];
     final[ 1] = w0[1] | s0[1];

--- a/OpenCL/m07801_a3-optimized.cl
+++ b/OpenCL/m07801_a3-optimized.cl
@@ -223,6 +223,14 @@ DECLSPEC void m07801m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -256,21 +264,20 @@ DECLSPEC void m07801m (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_M_SIMD (0, 0, digest[2] & 0xffff0000, digest[1]);
@@ -460,6 +467,14 @@ DECLSPEC void m07801s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final[14] = 0;
     final[15] = 0;
 
+    // final[] can hold up to 4 SHA1 blocks (see the SETSHIFTEDINT fix); only
+    // the first block (final[0..15]) is set above, and SETSHIFTEDINT() below
+    // only ever writes as many bytes as are actually appended, so anything
+    // past the appended data and before the length word placed by the block
+    // loop further down would otherwise be uninitialized.
+
+    for (u32 j = 16; j < 64; j++) final[j] = 0;
+
     u32 final_len = pw_len;
 
     u32 i;
@@ -493,21 +508,20 @@ DECLSPEC void m07801s (PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w
     final_len += salt_len;
 
     // calculate
+    //
+    // final_len can reach up to 188 bytes (pw_max 55 + magic_max 82 +
+    // salt_max 51), needing up to 4 SHA1 blocks with padding -- this used to
+    // be hardcoded to at most 2 blocks, silently dropping anything past byte
+    // 119 into a wrong digest instead of a crash.
 
-    if (final_len >= 56)
+    const u32 n_blocks = ((final_len + 8) / 64) + 1;
+
+    final[(n_blocks * 16) - 2] = 0;
+    final[(n_blocks * 16) - 1] = final_len * 8;
+
+    for (u32 b = 0; b < n_blocks; b++)
     {
-      final[30] = 0;
-      final[31] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
-      sha1_transform (final + 16, final + 20, final + 24, final + 28, digest);
-    }
-    else
-    {
-      final[14] = 0;
-      final[15] = final_len * 8;
-
-      sha1_transform (final +  0, final +  4, final +  8, final + 12, digest);
+      sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
     }
 
     COMPARE_S_SIMD (0, 0, digest[2] & 0xffff0000, digest[1]);

--- a/src/Makefile
+++ b/src/Makefile
@@ -617,6 +617,10 @@ else
 CFLAGS                  += -DDEBUG -O0 -ggdb
 endif
 CFLAGS                  += -fsanitize=address -fno-omit-frame-pointer
+# ASan must reach the link too, otherwise every target that links the C++ deps
+# (deps/unrar) fails with undefined __asan_* references. CFLAGS alone is not
+# enough for the shared-library layout.
+LFLAGS                  += -fsanitize=address
 endif
 endif
 endif


### PR DESCRIPTION
`SETSHIFTEDINT()` writes past the end of a fixed 128-byte private buffer
(`final[32]`) while assembling the SAP "PASSCODE" hash input. The buffer
was sized for the password alone; three variable-length pieces actually get
packed into it, and their combined worst case is 188 bytes.

## Reproducing

**Plain hashcat will not show you this.** An out-of-bounds write into a
per-thread private array is absorbed silently by whatever sits next to it —
no fault, no message, normal exit. It needs NVIDIA's Compute Sanitizer, a
`DEBUG=1` build, and `--padding`:

```
make clean && make DEBUG=1 -j$(nproc)

tools/compute_sanitizer/run.py exec sap7800 -- \
  ./hashcat -m 7800 -a 3 -O --force --self-test-disable --potfile-disable \
  '517744718274$5842EE7D96F5D698AB24BB280C2D948D598457D9' \
  '1407874064678108687792639755548126173?d?d?d'
```

All three parts matter:

- **`compute-sanitizer`** — this is a *device*-side write. Nothing on the host
  can see it, so `./hashcat` on its own is not a repro at any optimisation
  level.
- **`--padding 128`** — memcheck only flags an access outside *every*
  allocation. An overshoot landing in whatever the CUDA allocator placed next
  door counts as "inside an allocation" and is not reported. `--padding` puts a
  tracked redzone after each allocation so the overshoot has somewhere to be
  caught. Without it this finding can vanish entirely.
- **`DEBUG=1`** — release builds pass no line info to NVRTC, so a finding
  resolves to a raw kernel name and instruction offset rather than
  `m07800_a3-optimized.cl:52`. The bug still fires; you just cannot see where.

```
========= Invalid __local__ write of size 4 bytes
=========     at SETSHIFTEDINT(unsigned int *, int, unsigned int)+0x49a0 in m07800_a3-optimized.cl:52
=========     by thread (21,0,0) in block (20,0,0)
=========     Access at 0xfffc20 is out of bounds
=========         Device Frame: m07800s(...)+0x4460 in m07800_a3-optimized.cl:466
=========         Device Frame: m07800_s16+0xd0 in m07800_a3-optimized.cl:808
```

Under the sanitizer hashcat's own exit status is `-1`: trapping the access
poisons the CUDA context, producing 18-19 cascading `unspecified launch
failure` errors on every subsequent CUDA API call in the same process. That
exit code is a consequence of the sanitizer catching the fault, not something
an unsanitized run reproduces.

Whether a given candidate overflows is also data-dependent: `lengthMagicArray`
is derived from a SHA1 digest computed inside the kernel (see
[Cause](#cause)), so it varies per candidate. The mask above is one that
overflows; an arbitrary long candidate is not guaranteed to.

`7801` ("SAP CODVN F/G (PASSCODE) from RFC_READ_TABLE") reproduces
identically -- it is a near-duplicate of 7800's kernel, differing only in
the final digest comparison.

## Cause

`OpenCL/m07800_a3-optimized.cl` (and the `_a0`/`_a1` variants, and the
`m07801` equivalents -- six files total, all containing the identical
pattern):

```c
DECLSPEC void SETSHIFTEDINT (PRIVATE_AS u32 *a, const int n, const u32 v)
{
  const int d = n / 4;
  ...
  a[d + 0] |= h32_from_64_S (tmp);
  a[d + 1]  = l32_from_64_S (tmp);   // line 52 -- the OOB write
}
```

called as `SETSHIFTEDINT (final, final_len + i, tmp)` against `u32
final[32]` (128 bytes), with `final_len` accumulating three pieces with no
bounds check anywhere in the accumulation:

1. **The candidate itself.** `u32 final_len = pw_len;` -- up to `pw_max`,
   which `module_07800.c`'s `module_pw_max()` sets to `hashconfig->pw_max`
   for `-O` builds: **55** (`PW_MAX_OLD`, this mode is not UTF16).

2. **A "magic array" chunk**, appended right after:
   ```c
   u32 lengthMagicArray = 0x20;
   lengthMagicArray += unpack_v8d_from_v32_S (digest[0]) % 6;
   ... // ten such terms, each 0-5
   for (i = 0; i < lengthMagicArray - 4; i += 4)
     SETSHIFTEDINT (final, final_len + i, tmp);
   ...
   final_len += lengthMagicArray;
   ```
   `lengthMagicArray` ranges **32-82** and is derived from a SHA1 digest
   computed earlier in the same kernel invocation -- it is data-dependent,
   not fixed, and not attacker-directly-controlled but not constant either.
   This is why a straight-attack test with an ordinary 55-character candidate
   did *not* reproduce it in my testing: that particular candidate's digest
   happened to land on a smaller `lengthMagicArray`. The fault is real for
   any candidate whose digest pushes `lengthMagicArray` high enough, not for
   every long candidate.

3. **The salt**, appended after that:
   ```c
   for (i = 0; i < salt_len + 1; i += 4) // +1 for the 0x80
     SETSHIFTEDINT (final, final_len + i, tmp);
   final_len += salt_len;
   ```
   `salt_max` for this mode (`SALT_TYPE_EMBEDDED`, no module override) comes
   from `default_salt_max()`: **51** (`SALT_MAX_OLD`) for `-O` builds.

Worst case: `55 + 82 + 51 = 188` bytes. `SETSHIFTEDINT`'s last write in that
chain touches index `d+1` where `d = 188/4 = 47`, i.e. index 48 -- `final`
only has 32.

## A second, separate issue found while tracing this (fixed in a separate commit)

Right after the three appends, the code decides how many SHA1 blocks to
process based on a hardcoded threshold:

```c
if (final_len >= 56)
{
  final[30] = 0;
  final[31] = final_len * 8;
  sha1_transform (final +  0, ...);
  sha1_transform (final + 16, ...);   // second block
}
else
{
  final[14] = 0;
  final[15] = final_len * 8;
  sha1_transform (final +  0, ...);   // one block only
}
```

`sha1_transform` is called **at most twice** -- the code assumes the
combined input never needs a third 64-byte block. Since the length word goes
at `final[30..31]` (bytes 120-127), the message must fit in bytes 0..119, so
any `final_len >= 120` has its excess silently dropped: a wrong digest, not a
crash. Growing `final[]` (this patch) fixes the crash but does not touch this:
`sha1_transform` is still called exactly twice, on `final+0..32`, regardless
of the buffer's new size.

**Minimal repro.** `final_len = pw_len + lengthMagicArray + salt_len`, and
`lengthMagicArray` is never below 32, so the cheapest way to cross 120 is to
hold `pw_len + salt_len` small and let `lengthMagicArray` roll high. This
pair was found by brute-forcing the oracle for a `lengthMagicArray >= 68`
digest (see "This is decidable" below for how):

```perl
require "./tools/test_modules/m07800.pm";
module_generate_hash(
  "8CoVb6N3lUF3QG8ysdlzJjoKjSxctgTNYX2t3Wtk",   # word, 40 bytes
  "HMOYpUkNdchu");                              # salt, 12 bytes
# => HMOYPUKNDCHU$CB9B7B9CB5E30115A83C9FB6F2D71580341E742D
```

`lengthMagicArray = 70` for this word/salt, so `final_len = 40 + 70 + 12 =
122` -- past the 120-byte cliff. `-a 3` with the word as a literal mask (no
`?` placeholders, generates that one candidate) feeds it straight to the
optimized kernel without any length-based rejection:

```
./hashcat -m 7800 -a 3 -O --force --potfile-disable --self-test-disable \
  'HMOYPUKNDCHU$CB9B7B9CB5E30115A83C9FB6F2D71580341E742D' \
  '8CoVb6N3lUF3QG8ysdlzJjoKjSxctgTNYX2t3Wtk'
```

```
Status...........: Exhausted
Kernel.Feature...: Optimized Kernel (password length 0-55 bytes)
Recovered........: 0/1 (0.00%) Digests (total), 0/1 (0.00%) Digests (new)
Rejected.........: 0/1 (0.00%)
```

`Rejected: 0/1` rules out a length cap silently eating the candidate --
this word/salt pair is genuinely fed to the kernel and genuinely not
cracked, even though the oracle above says it's the answer. See
"Verification (SHA1 truncation)" further down for the same test against
the patched build (`Status: Cracked`).


## Fix (OOB write)

Grow `final[]` from 32 to 64 `u32` (256 bytes) in all six files
(`m07800_a0/a1/a3-optimized.cl`, `m07801_a0/a1/a3-optimized.cl`) --
comfortable headroom over the 188-byte/49-element requirement, rounded to a
clean SHA1-block-aligned size. This only affects the size of a per-thread
private array; it does not change which bytes `sha1_transform` reads (still
`final+0..32`, per the SHA1-truncation issue below, fixed separately), so
normal-length passwords compute an identical digest before and after.

## Verification (OOB write)

```
./tools/test.sh -m 7800
[ test_1786913850 ] > Init test for hash type 7800.
[ test_1786913850 ] [ Type 7800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1786913850 ] [ Type 7800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped

./tools/test.sh -m 7801
[ test_1786913879 ] > Init test for hash type 7801.
[ test_1786913879 ] [ Type 7801, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1786913879 ] [ Type 7801, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

## Fix (SHA1 truncation)

Separate commit, applied on top of the OOB-write fix (it needs the
grown `final[64]` to have room for a 3rd/4th block).

Replace the hardcoded one-block/two-block branch with a general loop, in
both the `m` and `s` kernel variants of all six files:

```c
const u32 n_blocks = ((final_len + 8) / 64) + 1;

final[(n_blocks * 16) - 2] = 0;
final[(n_blocks * 16) - 1] = final_len * 8;

for (u32 b = 0; b < n_blocks; b++)
{
  sha1_transform (final + (b * 16) + 0, final + (b * 16) + 4, final + (b * 16) + 8, final + (b * 16) + 12, digest);
}
```

`n_blocks` reproduces the old thresholds exactly (`final_len` 0-55 -> 1,
56-119 -> 2) and extends correctly up to 4 blocks, which is what the
188-byte worst case needs.

While implementing this, found a second bug in the same code that the
original two-branch version also had: only `final[0..15]` (the first block)
was ever zero-initialised. `SETSHIFTEDINT()` only writes as many bytes as
are actually appended, so the padding gap between the end of the appended
data and the length word (e.g. `final[16..29]` in the old two-block case)
was never zeroed -- it held whatever was previously on that thread's stack.
Fixed by zeroing `final[16..63]` up front, before the appends. This means
the two-block case (`final_len` in `[56, 120)`, reachable by ordinary
passwords, not just the pathological ones that need a 3rd/4th block) may
have been producing wrong digests already, independent of the truncation
issue -- not verified either way, since a MemorySanitizer build to catch
uninitialized-read UB in `__local__`/private memory is a heavier setup than
was done for this bug (see `tools/asan/README.md`'s MSan section).

## Verification (SHA1 truncation)

Same word/salt pair as the repro above, before and after this patch, both
against a build with the OOB-write fix already applied (`-a 3 -O`, literal
mask, so the exact 40-byte candidate is fed to the optimized kernel with
nothing rejected):

| | command | result |
|---|---|---|
| before | `hashcat -m 7800 -a 3 -O ... 'HMOYPUKNDCHU$CB9B7B9CB5E30115A83C9FB6F2D71580341E742D' '8CoVb6N3lUF3QG8ysdlzJjoKjSxctgTNYX2t3Wtk'` | `Status: Exhausted`, `Rejected: 0/1` |
| after | same command | `Status: Cracked`, `Recovered: 1/1` |

Regression, same as above, re-run against the truncation-fix build:

```
./tools/test.sh -m 7800
[ Type 7800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ Type 7800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped

./tools/test.sh -m 7801
[ Type 7801, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ Type 7801, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

Also re-ran the original OOB-write repro (`-a 3 -O`, the 40-digit-mask
example from `## Reproducing`) against the truncation-fix build to confirm
short/normal passwords are unaffected: `Status: Cracked`, `Recovered: 1/1`.

---

_completely vibe-coded whilst working on #4774_
