### PR TITLE
Add NVIDIA GB10 tuning profile

### DIFF
--- a/tunings/Device_GB10.hctune
+++ b/tunings/Device_GB10.hctune
@@ -1,0 +1,11 @@
+#Device                                         Attack  Hash    Vector  Kernel  Kernel
+#Name                                           Mode    Type    Width   Accel   Loops
+
+##
+## NVIDIA GB10 (DGX Spark)
+##
+
+GB10                                            3       0       4       A       A
+GB10                                            3       1000    8       A       A
+GB10                                            3       5500    2       A       A
+GB10                                            3       5600    2       A       A


### PR DESCRIPTION
Add measured vector-width settings for NVIDIA GB10 (DGX Spark, compute capability 12.1).

| Mode | Vector | Before | After | Gain |
| --- | ---: | ---: | ---: | ---: |
| 0 MD5 | 4 | 51.779 GH/s | 53.050 GH/s | +2.45% |
| 1000 NTLM | 8 | 76.371 GH/s | 78.741 GH/s | +3.10% |
| 5500 NetNTLMv1 | 2 | 47.735 GH/s | 48.901 GH/s | +2.44% |
| 5600 NetNTLMv2 | 2 | 3.854 GH/s | 3.972 GH/s | +3.06% |

Results are three-run medians from master `758a517cf7a1275954d9a26c9b24890ed5457a85`, CUDA device 1 (`-d 1`), and optimized mask benchmarks. Profile results matched explicit vector overrides within 0.20%.

Modes 1100, 2100, and 22000 remain Vec1 because wider vectors did not improve speed.

Automated by MisterMal (Disclaimer, since I'm lazy to write PR messages, but I really tested it and its faster)


Tested on a MSI EdgeExpert 