### PR TITLE
Add tests for PKZIP modes (17200/17210/17220/17225/17230)

### DIFF
--- a/tools/test_modules/m17200.pm
+++ b/tools/test_modules/m17200.pm
@@ -1,0 +1,216 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+sub module_constraints { [[0, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+# PKZIP traditional PKWARE / ZipCrypto (mode 17200). Self-contained oracle:
+# the ZipCrypto key schedule is a byte-exact port of the kernel macros in
+# OpenCL/m172*-pure.cl (init keys 0x12345678/0x23456789/0x34567890,
+# update_key012 / update_key3, decrypt byte = ((key2 & 0xffff) | 3)).
+#
+# Each file is emitted as a "full data" (data_type_enum 2) block: a 12-byte
+# encryption header (whose last byte is (crc >> 24) & 0xff, the value hashcat
+# checks) followed by the ZipCrypto-encrypted file bytes -- stored for
+# compression_type 0, raw DEFLATE for compression_type 8. Generating by
+# *encrypting* the same way hashcat decrypts means a correct password
+# reproduces every header check and CRC32 by construction.
+#
+# Per-mode container shape (count + per-file compression types) is selected by
+# the mode number passed to the generator:
+#   17210 = 1 stored           17200 = 1 deflate
+#   17220 = N deflate          17225 = N mixed stored/deflate
+#   17230 = >=3 deflate (checksum-only mode; full-data blocks still validate)
+
+my $MODE = 17200;
+
+my $PY = <<'PYCODE';
+import sys, os, zlib, random
+
+def make_tab():
+    t = []
+    for i in range(256):
+        c = i
+        for _ in range(8):
+            c = (c >> 1) ^ (0xEDB88320 if (c & 1) else 0)
+        t.append(c & 0xffffffff)
+    return t
+TAB = make_tab()
+
+def c32(x, c):
+    return ((x >> 8) ^ TAB[(x ^ c) & 0xff]) & 0xffffffff
+
+class ZC:
+    def __init__(self, pw):
+        self.k = [0x12345678, 0x23456789, 0x34567890]
+        for b in pw:
+            self.upd(b)
+    def upd(self, c):
+        self.k[0] = c32(self.k[0], c)
+        self.k[1] = ((self.k[1] + (self.k[0] & 0xff)) * 0x08088405 + 1) & 0xffffffff
+        self.k[2] = c32(self.k[2], (self.k[1] >> 24) & 0xff)
+    def db(self):
+        t = (self.k[2] & 0xffff) | 3
+        return ((t * (t ^ 1)) >> 8) & 0xff
+    def enc(self, d):
+        o = bytearray()
+        for p in d:
+            o.append(p ^ self.db()); self.upd(p)
+        return bytes(o)
+    def dec(self, d):
+        o = bytearray()
+        for c in d:
+            p = (c ^ self.db()) & 0xff; self.upd(p); o.append(p)
+        return bytes(o)
+
+def make_block(pw, ctype):
+    content = os.urandom(random.randint(80, 320))
+    crc = zlib.crc32(content) & 0xffffffff
+    if ctype == 8:
+        co = zlib.compressobj(6, zlib.DEFLATED, -15)   # raw deflate
+        stream = co.compress(content) + co.flush()
+    else:
+        stream = content
+    hdr = bytearray(os.urandom(12))
+    hdr[10] = (crc >> 16) & 0xff
+    hdr[11] = (crc >> 24) & 0xff
+    enc = ZC(pw).enc(bytes(hdr) + stream)
+    dlen = len(enc)
+    csum = (crc >> 16) & 0xffff
+    # data_type_enum 2 block: 2*magic*clen*ulen*crc*off*aoff*ctype*dlen*csum_crc*csum_ts*data
+    # NOTE: hashcat's encoder prints crc/clen/ulen/off/aoff with %x (no zero pad),
+    # so match that exactly or the re-encoded hash won't round-trip (test.sh "not matched").
+    return "2*0*%x*%x*%x*0*%x*%d*%x*%04x*%04x*%s" % (
+        dlen, len(content), crc, dlen, ctype, dlen, csum, csum, enc.hex())
+
+def container(mode):
+    if mode == 17210:
+        return [0]
+    if mode == 17200:
+        return [8]
+    if mode == 17220:
+        return [8] * random.randint(2, 8)
+    if mode == 17225:
+        n = random.randint(3, 8)
+        cts = [random.choice([0, 8]) for _ in range(n)]
+        cts[0] = 0; cts[1] = 8          # guarantee a genuine mix
+        return cts
+    if mode == 17230:
+        return [8] * random.randint(3, 8)
+    return [8]
+
+def build(pw, mode):
+    cts = container(mode)
+    blocks = "*".join(make_block(pw, ct) for ct in cts)
+    return "$pkzip2$%d*1*%s*$/pkzip2$" % (len(cts), blocks)
+
+def parse(line):
+    core = line
+    if not core.startswith("$pkzip2$"):
+        raise ValueError("sig")
+    core = core[len("$pkzip2$"):]
+    if core.endswith("*$/pkzip2$"):
+        core = core[:-len("*$/pkzip2$")]
+    t = core.split("*")
+    n = int(t[0]); i = 2                 # skip count, checksum_size
+    files = []
+    for _ in range(n):
+        dtype = int(t[i]); i += 2        # dtype, magic
+        crc = 0
+        if dtype > 1:
+            crc = int(t[i + 2], 16); i += 5   # clen, ulen, crc, off, aoff
+        ctype = int(t[i]); i += 2        # ctype, dlen
+        i += 2                           # csum_crc, csum_ts (v2)
+        data = bytes.fromhex(t[i]); i += 1
+        files.append((ctype, crc, data))
+    return files
+
+def verify(pw, line):
+    try:
+        files = parse(line)
+    except Exception:
+        return False
+    for ctype, crc, enc in files:
+        dec = ZC(pw).dec(enc)
+        if dec[11] != ((crc >> 24) & 0xff):
+            return False
+        body = dec[12:]
+        if ctype == 8:
+            try:
+                body = zlib.decompressobj(-15).decompress(body)
+            except Exception:
+                return False
+        if (zlib.crc32(body) & 0xffffffff) != crc:
+            return False
+    return True
+
+action = sys.argv[1]
+pw     = bytes.fromhex(sys.argv[2])
+if action == "gen":
+    sys.stdout.write(build(pw, int(sys.argv[3])))
+else:
+    sys.stdout.write("1" if verify(pw, sys.argv[3]) else "0")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+  my $out = do
+  {
+    local $ENV{PYTHONUTF8} = 1;
+    open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+    local $/; my $r = <$fh>; close ($fh); $r;
+  };
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $word_hex = unpack ("H*", $word);
+
+  my $hash = _run ("gen", $word_hex, $MODE);
+
+  return unless defined $hash;
+
+  $hash =~ s/[\r\n]//g;
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = rindex ($line, ':');
+  return if $idx < 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+  my $word_hex    = unpack ("H*", $word_packed);
+
+  my $ok = _run ("verify", $word_hex, $hash);
+
+  return unless defined $ok;
+
+  $ok =~ s/[\r\n]//g;
+
+  return unless $ok eq "1";
+
+  return ($hash, $word);
+}
+
+1;

--- a/tools/test_modules/m17210.pm
+++ b/tools/test_modules/m17210.pm
@@ -1,0 +1,216 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+sub module_constraints { [[0, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+# PKZIP traditional PKWARE / ZipCrypto (mode 17210). Self-contained oracle:
+# the ZipCrypto key schedule is a byte-exact port of the kernel macros in
+# OpenCL/m172*-pure.cl (init keys 0x12345678/0x23456789/0x34567890,
+# update_key012 / update_key3, decrypt byte = ((key2 & 0xffff) | 3)).
+#
+# Each file is emitted as a "full data" (data_type_enum 2) block: a 12-byte
+# encryption header (whose last byte is (crc >> 24) & 0xff, the value hashcat
+# checks) followed by the ZipCrypto-encrypted file bytes -- stored for
+# compression_type 0, raw DEFLATE for compression_type 8. Generating by
+# *encrypting* the same way hashcat decrypts means a correct password
+# reproduces every header check and CRC32 by construction.
+#
+# Per-mode container shape (count + per-file compression types) is selected by
+# the mode number passed to the generator:
+#   17210 = 1 stored           17200 = 1 deflate
+#   17220 = N deflate          17225 = N mixed stored/deflate
+#   17230 = >=3 deflate (checksum-only mode; full-data blocks still validate)
+
+my $MODE = 17210;
+
+my $PY = <<'PYCODE';
+import sys, os, zlib, random
+
+def make_tab():
+    t = []
+    for i in range(256):
+        c = i
+        for _ in range(8):
+            c = (c >> 1) ^ (0xEDB88320 if (c & 1) else 0)
+        t.append(c & 0xffffffff)
+    return t
+TAB = make_tab()
+
+def c32(x, c):
+    return ((x >> 8) ^ TAB[(x ^ c) & 0xff]) & 0xffffffff
+
+class ZC:
+    def __init__(self, pw):
+        self.k = [0x12345678, 0x23456789, 0x34567890]
+        for b in pw:
+            self.upd(b)
+    def upd(self, c):
+        self.k[0] = c32(self.k[0], c)
+        self.k[1] = ((self.k[1] + (self.k[0] & 0xff)) * 0x08088405 + 1) & 0xffffffff
+        self.k[2] = c32(self.k[2], (self.k[1] >> 24) & 0xff)
+    def db(self):
+        t = (self.k[2] & 0xffff) | 3
+        return ((t * (t ^ 1)) >> 8) & 0xff
+    def enc(self, d):
+        o = bytearray()
+        for p in d:
+            o.append(p ^ self.db()); self.upd(p)
+        return bytes(o)
+    def dec(self, d):
+        o = bytearray()
+        for c in d:
+            p = (c ^ self.db()) & 0xff; self.upd(p); o.append(p)
+        return bytes(o)
+
+def make_block(pw, ctype):
+    content = os.urandom(random.randint(80, 320))
+    crc = zlib.crc32(content) & 0xffffffff
+    if ctype == 8:
+        co = zlib.compressobj(6, zlib.DEFLATED, -15)   # raw deflate
+        stream = co.compress(content) + co.flush()
+    else:
+        stream = content
+    hdr = bytearray(os.urandom(12))
+    hdr[10] = (crc >> 16) & 0xff
+    hdr[11] = (crc >> 24) & 0xff
+    enc = ZC(pw).enc(bytes(hdr) + stream)
+    dlen = len(enc)
+    csum = (crc >> 16) & 0xffff
+    # data_type_enum 2 block: 2*magic*clen*ulen*crc*off*aoff*ctype*dlen*csum_crc*csum_ts*data
+    # NOTE: hashcat's encoder prints crc/clen/ulen/off/aoff with %x (no zero pad),
+    # so match that exactly or the re-encoded hash won't round-trip (test.sh "not matched").
+    return "2*0*%x*%x*%x*0*%x*%d*%x*%04x*%04x*%s" % (
+        dlen, len(content), crc, dlen, ctype, dlen, csum, csum, enc.hex())
+
+def container(mode):
+    if mode == 17210:
+        return [0]
+    if mode == 17200:
+        return [8]
+    if mode == 17220:
+        return [8] * random.randint(2, 8)
+    if mode == 17225:
+        n = random.randint(3, 8)
+        cts = [random.choice([0, 8]) for _ in range(n)]
+        cts[0] = 0; cts[1] = 8          # guarantee a genuine mix
+        return cts
+    if mode == 17230:
+        return [8] * random.randint(3, 8)
+    return [8]
+
+def build(pw, mode):
+    cts = container(mode)
+    blocks = "*".join(make_block(pw, ct) for ct in cts)
+    return "$pkzip2$%d*1*%s*$/pkzip2$" % (len(cts), blocks)
+
+def parse(line):
+    core = line
+    if not core.startswith("$pkzip2$"):
+        raise ValueError("sig")
+    core = core[len("$pkzip2$"):]
+    if core.endswith("*$/pkzip2$"):
+        core = core[:-len("*$/pkzip2$")]
+    t = core.split("*")
+    n = int(t[0]); i = 2                 # skip count, checksum_size
+    files = []
+    for _ in range(n):
+        dtype = int(t[i]); i += 2        # dtype, magic
+        crc = 0
+        if dtype > 1:
+            crc = int(t[i + 2], 16); i += 5   # clen, ulen, crc, off, aoff
+        ctype = int(t[i]); i += 2        # ctype, dlen
+        i += 2                           # csum_crc, csum_ts (v2)
+        data = bytes.fromhex(t[i]); i += 1
+        files.append((ctype, crc, data))
+    return files
+
+def verify(pw, line):
+    try:
+        files = parse(line)
+    except Exception:
+        return False
+    for ctype, crc, enc in files:
+        dec = ZC(pw).dec(enc)
+        if dec[11] != ((crc >> 24) & 0xff):
+            return False
+        body = dec[12:]
+        if ctype == 8:
+            try:
+                body = zlib.decompressobj(-15).decompress(body)
+            except Exception:
+                return False
+        if (zlib.crc32(body) & 0xffffffff) != crc:
+            return False
+    return True
+
+action = sys.argv[1]
+pw     = bytes.fromhex(sys.argv[2])
+if action == "gen":
+    sys.stdout.write(build(pw, int(sys.argv[3])))
+else:
+    sys.stdout.write("1" if verify(pw, sys.argv[3]) else "0")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+  my $out = do
+  {
+    local $ENV{PYTHONUTF8} = 1;
+    open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+    local $/; my $r = <$fh>; close ($fh); $r;
+  };
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $word_hex = unpack ("H*", $word);
+
+  my $hash = _run ("gen", $word_hex, $MODE);
+
+  return unless defined $hash;
+
+  $hash =~ s/[\r\n]//g;
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = rindex ($line, ':');
+  return if $idx < 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+  my $word_hex    = unpack ("H*", $word_packed);
+
+  my $ok = _run ("verify", $word_hex, $hash);
+
+  return unless defined $ok;
+
+  $ok =~ s/[\r\n]//g;
+
+  return unless $ok eq "1";
+
+  return ($hash, $word);
+}
+
+1;

--- a/tools/test_modules/m17220.pm
+++ b/tools/test_modules/m17220.pm
@@ -1,0 +1,216 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+sub module_constraints { [[0, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+# PKZIP traditional PKWARE / ZipCrypto (mode 17220). Self-contained oracle:
+# the ZipCrypto key schedule is a byte-exact port of the kernel macros in
+# OpenCL/m172*-pure.cl (init keys 0x12345678/0x23456789/0x34567890,
+# update_key012 / update_key3, decrypt byte = ((key2 & 0xffff) | 3)).
+#
+# Each file is emitted as a "full data" (data_type_enum 2) block: a 12-byte
+# encryption header (whose last byte is (crc >> 24) & 0xff, the value hashcat
+# checks) followed by the ZipCrypto-encrypted file bytes -- stored for
+# compression_type 0, raw DEFLATE for compression_type 8. Generating by
+# *encrypting* the same way hashcat decrypts means a correct password
+# reproduces every header check and CRC32 by construction.
+#
+# Per-mode container shape (count + per-file compression types) is selected by
+# the mode number passed to the generator:
+#   17210 = 1 stored           17200 = 1 deflate
+#   17220 = N deflate          17225 = N mixed stored/deflate
+#   17230 = >=3 deflate (checksum-only mode; full-data blocks still validate)
+
+my $MODE = 17220;
+
+my $PY = <<'PYCODE';
+import sys, os, zlib, random
+
+def make_tab():
+    t = []
+    for i in range(256):
+        c = i
+        for _ in range(8):
+            c = (c >> 1) ^ (0xEDB88320 if (c & 1) else 0)
+        t.append(c & 0xffffffff)
+    return t
+TAB = make_tab()
+
+def c32(x, c):
+    return ((x >> 8) ^ TAB[(x ^ c) & 0xff]) & 0xffffffff
+
+class ZC:
+    def __init__(self, pw):
+        self.k = [0x12345678, 0x23456789, 0x34567890]
+        for b in pw:
+            self.upd(b)
+    def upd(self, c):
+        self.k[0] = c32(self.k[0], c)
+        self.k[1] = ((self.k[1] + (self.k[0] & 0xff)) * 0x08088405 + 1) & 0xffffffff
+        self.k[2] = c32(self.k[2], (self.k[1] >> 24) & 0xff)
+    def db(self):
+        t = (self.k[2] & 0xffff) | 3
+        return ((t * (t ^ 1)) >> 8) & 0xff
+    def enc(self, d):
+        o = bytearray()
+        for p in d:
+            o.append(p ^ self.db()); self.upd(p)
+        return bytes(o)
+    def dec(self, d):
+        o = bytearray()
+        for c in d:
+            p = (c ^ self.db()) & 0xff; self.upd(p); o.append(p)
+        return bytes(o)
+
+def make_block(pw, ctype):
+    content = os.urandom(random.randint(80, 320))
+    crc = zlib.crc32(content) & 0xffffffff
+    if ctype == 8:
+        co = zlib.compressobj(6, zlib.DEFLATED, -15)   # raw deflate
+        stream = co.compress(content) + co.flush()
+    else:
+        stream = content
+    hdr = bytearray(os.urandom(12))
+    hdr[10] = (crc >> 16) & 0xff
+    hdr[11] = (crc >> 24) & 0xff
+    enc = ZC(pw).enc(bytes(hdr) + stream)
+    dlen = len(enc)
+    csum = (crc >> 16) & 0xffff
+    # data_type_enum 2 block: 2*magic*clen*ulen*crc*off*aoff*ctype*dlen*csum_crc*csum_ts*data
+    # NOTE: hashcat's encoder prints crc/clen/ulen/off/aoff with %x (no zero pad),
+    # so match that exactly or the re-encoded hash won't round-trip (test.sh "not matched").
+    return "2*0*%x*%x*%x*0*%x*%d*%x*%04x*%04x*%s" % (
+        dlen, len(content), crc, dlen, ctype, dlen, csum, csum, enc.hex())
+
+def container(mode):
+    if mode == 17210:
+        return [0]
+    if mode == 17200:
+        return [8]
+    if mode == 17220:
+        return [8] * random.randint(2, 8)
+    if mode == 17225:
+        n = random.randint(3, 8)
+        cts = [random.choice([0, 8]) for _ in range(n)]
+        cts[0] = 0; cts[1] = 8          # guarantee a genuine mix
+        return cts
+    if mode == 17230:
+        return [8] * random.randint(3, 8)
+    return [8]
+
+def build(pw, mode):
+    cts = container(mode)
+    blocks = "*".join(make_block(pw, ct) for ct in cts)
+    return "$pkzip2$%d*1*%s*$/pkzip2$" % (len(cts), blocks)
+
+def parse(line):
+    core = line
+    if not core.startswith("$pkzip2$"):
+        raise ValueError("sig")
+    core = core[len("$pkzip2$"):]
+    if core.endswith("*$/pkzip2$"):
+        core = core[:-len("*$/pkzip2$")]
+    t = core.split("*")
+    n = int(t[0]); i = 2                 # skip count, checksum_size
+    files = []
+    for _ in range(n):
+        dtype = int(t[i]); i += 2        # dtype, magic
+        crc = 0
+        if dtype > 1:
+            crc = int(t[i + 2], 16); i += 5   # clen, ulen, crc, off, aoff
+        ctype = int(t[i]); i += 2        # ctype, dlen
+        i += 2                           # csum_crc, csum_ts (v2)
+        data = bytes.fromhex(t[i]); i += 1
+        files.append((ctype, crc, data))
+    return files
+
+def verify(pw, line):
+    try:
+        files = parse(line)
+    except Exception:
+        return False
+    for ctype, crc, enc in files:
+        dec = ZC(pw).dec(enc)
+        if dec[11] != ((crc >> 24) & 0xff):
+            return False
+        body = dec[12:]
+        if ctype == 8:
+            try:
+                body = zlib.decompressobj(-15).decompress(body)
+            except Exception:
+                return False
+        if (zlib.crc32(body) & 0xffffffff) != crc:
+            return False
+    return True
+
+action = sys.argv[1]
+pw     = bytes.fromhex(sys.argv[2])
+if action == "gen":
+    sys.stdout.write(build(pw, int(sys.argv[3])))
+else:
+    sys.stdout.write("1" if verify(pw, sys.argv[3]) else "0")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+  my $out = do
+  {
+    local $ENV{PYTHONUTF8} = 1;
+    open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+    local $/; my $r = <$fh>; close ($fh); $r;
+  };
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $word_hex = unpack ("H*", $word);
+
+  my $hash = _run ("gen", $word_hex, $MODE);
+
+  return unless defined $hash;
+
+  $hash =~ s/[\r\n]//g;
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = rindex ($line, ':');
+  return if $idx < 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+  my $word_hex    = unpack ("H*", $word_packed);
+
+  my $ok = _run ("verify", $word_hex, $hash);
+
+  return unless defined $ok;
+
+  $ok =~ s/[\r\n]//g;
+
+  return unless $ok eq "1";
+
+  return ($hash, $word);
+}
+
+1;

--- a/tools/test_modules/m17225.pm
+++ b/tools/test_modules/m17225.pm
@@ -1,0 +1,216 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+sub module_constraints { [[0, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+# PKZIP traditional PKWARE / ZipCrypto (mode 17225). Self-contained oracle:
+# the ZipCrypto key schedule is a byte-exact port of the kernel macros in
+# OpenCL/m172*-pure.cl (init keys 0x12345678/0x23456789/0x34567890,
+# update_key012 / update_key3, decrypt byte = ((key2 & 0xffff) | 3)).
+#
+# Each file is emitted as a "full data" (data_type_enum 2) block: a 12-byte
+# encryption header (whose last byte is (crc >> 24) & 0xff, the value hashcat
+# checks) followed by the ZipCrypto-encrypted file bytes -- stored for
+# compression_type 0, raw DEFLATE for compression_type 8. Generating by
+# *encrypting* the same way hashcat decrypts means a correct password
+# reproduces every header check and CRC32 by construction.
+#
+# Per-mode container shape (count + per-file compression types) is selected by
+# the mode number passed to the generator:
+#   17210 = 1 stored           17200 = 1 deflate
+#   17220 = N deflate          17225 = N mixed stored/deflate
+#   17230 = >=3 deflate (checksum-only mode; full-data blocks still validate)
+
+my $MODE = 17225;
+
+my $PY = <<'PYCODE';
+import sys, os, zlib, random
+
+def make_tab():
+    t = []
+    for i in range(256):
+        c = i
+        for _ in range(8):
+            c = (c >> 1) ^ (0xEDB88320 if (c & 1) else 0)
+        t.append(c & 0xffffffff)
+    return t
+TAB = make_tab()
+
+def c32(x, c):
+    return ((x >> 8) ^ TAB[(x ^ c) & 0xff]) & 0xffffffff
+
+class ZC:
+    def __init__(self, pw):
+        self.k = [0x12345678, 0x23456789, 0x34567890]
+        for b in pw:
+            self.upd(b)
+    def upd(self, c):
+        self.k[0] = c32(self.k[0], c)
+        self.k[1] = ((self.k[1] + (self.k[0] & 0xff)) * 0x08088405 + 1) & 0xffffffff
+        self.k[2] = c32(self.k[2], (self.k[1] >> 24) & 0xff)
+    def db(self):
+        t = (self.k[2] & 0xffff) | 3
+        return ((t * (t ^ 1)) >> 8) & 0xff
+    def enc(self, d):
+        o = bytearray()
+        for p in d:
+            o.append(p ^ self.db()); self.upd(p)
+        return bytes(o)
+    def dec(self, d):
+        o = bytearray()
+        for c in d:
+            p = (c ^ self.db()) & 0xff; self.upd(p); o.append(p)
+        return bytes(o)
+
+def make_block(pw, ctype):
+    content = os.urandom(random.randint(80, 320))
+    crc = zlib.crc32(content) & 0xffffffff
+    if ctype == 8:
+        co = zlib.compressobj(6, zlib.DEFLATED, -15)   # raw deflate
+        stream = co.compress(content) + co.flush()
+    else:
+        stream = content
+    hdr = bytearray(os.urandom(12))
+    hdr[10] = (crc >> 16) & 0xff
+    hdr[11] = (crc >> 24) & 0xff
+    enc = ZC(pw).enc(bytes(hdr) + stream)
+    dlen = len(enc)
+    csum = (crc >> 16) & 0xffff
+    # data_type_enum 2 block: 2*magic*clen*ulen*crc*off*aoff*ctype*dlen*csum_crc*csum_ts*data
+    # NOTE: hashcat's encoder prints crc/clen/ulen/off/aoff with %x (no zero pad),
+    # so match that exactly or the re-encoded hash won't round-trip (test.sh "not matched").
+    return "2*0*%x*%x*%x*0*%x*%d*%x*%04x*%04x*%s" % (
+        dlen, len(content), crc, dlen, ctype, dlen, csum, csum, enc.hex())
+
+def container(mode):
+    if mode == 17210:
+        return [0]
+    if mode == 17200:
+        return [8]
+    if mode == 17220:
+        return [8] * random.randint(2, 8)
+    if mode == 17225:
+        n = random.randint(3, 8)
+        cts = [random.choice([0, 8]) for _ in range(n)]
+        cts[0] = 0; cts[1] = 8          # guarantee a genuine mix
+        return cts
+    if mode == 17230:
+        return [8] * random.randint(3, 8)
+    return [8]
+
+def build(pw, mode):
+    cts = container(mode)
+    blocks = "*".join(make_block(pw, ct) for ct in cts)
+    return "$pkzip2$%d*1*%s*$/pkzip2$" % (len(cts), blocks)
+
+def parse(line):
+    core = line
+    if not core.startswith("$pkzip2$"):
+        raise ValueError("sig")
+    core = core[len("$pkzip2$"):]
+    if core.endswith("*$/pkzip2$"):
+        core = core[:-len("*$/pkzip2$")]
+    t = core.split("*")
+    n = int(t[0]); i = 2                 # skip count, checksum_size
+    files = []
+    for _ in range(n):
+        dtype = int(t[i]); i += 2        # dtype, magic
+        crc = 0
+        if dtype > 1:
+            crc = int(t[i + 2], 16); i += 5   # clen, ulen, crc, off, aoff
+        ctype = int(t[i]); i += 2        # ctype, dlen
+        i += 2                           # csum_crc, csum_ts (v2)
+        data = bytes.fromhex(t[i]); i += 1
+        files.append((ctype, crc, data))
+    return files
+
+def verify(pw, line):
+    try:
+        files = parse(line)
+    except Exception:
+        return False
+    for ctype, crc, enc in files:
+        dec = ZC(pw).dec(enc)
+        if dec[11] != ((crc >> 24) & 0xff):
+            return False
+        body = dec[12:]
+        if ctype == 8:
+            try:
+                body = zlib.decompressobj(-15).decompress(body)
+            except Exception:
+                return False
+        if (zlib.crc32(body) & 0xffffffff) != crc:
+            return False
+    return True
+
+action = sys.argv[1]
+pw     = bytes.fromhex(sys.argv[2])
+if action == "gen":
+    sys.stdout.write(build(pw, int(sys.argv[3])))
+else:
+    sys.stdout.write("1" if verify(pw, sys.argv[3]) else "0")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+  my $out = do
+  {
+    local $ENV{PYTHONUTF8} = 1;
+    open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+    local $/; my $r = <$fh>; close ($fh); $r;
+  };
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $word_hex = unpack ("H*", $word);
+
+  my $hash = _run ("gen", $word_hex, $MODE);
+
+  return unless defined $hash;
+
+  $hash =~ s/[\r\n]//g;
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = rindex ($line, ':');
+  return if $idx < 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+  my $word_hex    = unpack ("H*", $word_packed);
+
+  my $ok = _run ("verify", $word_hex, $hash);
+
+  return unless defined $ok;
+
+  $ok =~ s/[\r\n]//g;
+
+  return unless $ok eq "1";
+
+  return ($hash, $word);
+}
+
+1;

--- a/tools/test_modules/m17230.pm
+++ b/tools/test_modules/m17230.pm
@@ -1,0 +1,216 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+sub module_constraints { [[0, 64], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
+
+# PKZIP traditional PKWARE / ZipCrypto (mode 17230). Self-contained oracle:
+# the ZipCrypto key schedule is a byte-exact port of the kernel macros in
+# OpenCL/m172*-pure.cl (init keys 0x12345678/0x23456789/0x34567890,
+# update_key012 / update_key3, decrypt byte = ((key2 & 0xffff) | 3)).
+#
+# Each file is emitted as a "full data" (data_type_enum 2) block: a 12-byte
+# encryption header (whose last byte is (crc >> 24) & 0xff, the value hashcat
+# checks) followed by the ZipCrypto-encrypted file bytes -- stored for
+# compression_type 0, raw DEFLATE for compression_type 8. Generating by
+# *encrypting* the same way hashcat decrypts means a correct password
+# reproduces every header check and CRC32 by construction.
+#
+# Per-mode container shape (count + per-file compression types) is selected by
+# the mode number passed to the generator:
+#   17210 = 1 stored           17200 = 1 deflate
+#   17220 = N deflate          17225 = N mixed stored/deflate
+#   17230 = >=3 deflate (checksum-only mode; full-data blocks still validate)
+
+my $MODE = 17230;
+
+my $PY = <<'PYCODE';
+import sys, os, zlib, random
+
+def make_tab():
+    t = []
+    for i in range(256):
+        c = i
+        for _ in range(8):
+            c = (c >> 1) ^ (0xEDB88320 if (c & 1) else 0)
+        t.append(c & 0xffffffff)
+    return t
+TAB = make_tab()
+
+def c32(x, c):
+    return ((x >> 8) ^ TAB[(x ^ c) & 0xff]) & 0xffffffff
+
+class ZC:
+    def __init__(self, pw):
+        self.k = [0x12345678, 0x23456789, 0x34567890]
+        for b in pw:
+            self.upd(b)
+    def upd(self, c):
+        self.k[0] = c32(self.k[0], c)
+        self.k[1] = ((self.k[1] + (self.k[0] & 0xff)) * 0x08088405 + 1) & 0xffffffff
+        self.k[2] = c32(self.k[2], (self.k[1] >> 24) & 0xff)
+    def db(self):
+        t = (self.k[2] & 0xffff) | 3
+        return ((t * (t ^ 1)) >> 8) & 0xff
+    def enc(self, d):
+        o = bytearray()
+        for p in d:
+            o.append(p ^ self.db()); self.upd(p)
+        return bytes(o)
+    def dec(self, d):
+        o = bytearray()
+        for c in d:
+            p = (c ^ self.db()) & 0xff; self.upd(p); o.append(p)
+        return bytes(o)
+
+def make_block(pw, ctype):
+    content = os.urandom(random.randint(80, 320))
+    crc = zlib.crc32(content) & 0xffffffff
+    if ctype == 8:
+        co = zlib.compressobj(6, zlib.DEFLATED, -15)   # raw deflate
+        stream = co.compress(content) + co.flush()
+    else:
+        stream = content
+    hdr = bytearray(os.urandom(12))
+    hdr[10] = (crc >> 16) & 0xff
+    hdr[11] = (crc >> 24) & 0xff
+    enc = ZC(pw).enc(bytes(hdr) + stream)
+    dlen = len(enc)
+    csum = (crc >> 16) & 0xffff
+    # data_type_enum 2 block: 2*magic*clen*ulen*crc*off*aoff*ctype*dlen*csum_crc*csum_ts*data
+    # NOTE: hashcat's encoder prints crc/clen/ulen/off/aoff with %x (no zero pad),
+    # so match that exactly or the re-encoded hash won't round-trip (test.sh "not matched").
+    return "2*0*%x*%x*%x*0*%x*%d*%x*%04x*%04x*%s" % (
+        dlen, len(content), crc, dlen, ctype, dlen, csum, csum, enc.hex())
+
+def container(mode):
+    if mode == 17210:
+        return [0]
+    if mode == 17200:
+        return [8]
+    if mode == 17220:
+        return [8] * random.randint(2, 8)
+    if mode == 17225:
+        n = random.randint(3, 8)
+        cts = [random.choice([0, 8]) for _ in range(n)]
+        cts[0] = 0; cts[1] = 8          # guarantee a genuine mix
+        return cts
+    if mode == 17230:
+        return [8] * random.randint(3, 8)
+    return [8]
+
+def build(pw, mode):
+    cts = container(mode)
+    blocks = "*".join(make_block(pw, ct) for ct in cts)
+    return "$pkzip2$%d*1*%s*$/pkzip2$" % (len(cts), blocks)
+
+def parse(line):
+    core = line
+    if not core.startswith("$pkzip2$"):
+        raise ValueError("sig")
+    core = core[len("$pkzip2$"):]
+    if core.endswith("*$/pkzip2$"):
+        core = core[:-len("*$/pkzip2$")]
+    t = core.split("*")
+    n = int(t[0]); i = 2                 # skip count, checksum_size
+    files = []
+    for _ in range(n):
+        dtype = int(t[i]); i += 2        # dtype, magic
+        crc = 0
+        if dtype > 1:
+            crc = int(t[i + 2], 16); i += 5   # clen, ulen, crc, off, aoff
+        ctype = int(t[i]); i += 2        # ctype, dlen
+        i += 2                           # csum_crc, csum_ts (v2)
+        data = bytes.fromhex(t[i]); i += 1
+        files.append((ctype, crc, data))
+    return files
+
+def verify(pw, line):
+    try:
+        files = parse(line)
+    except Exception:
+        return False
+    for ctype, crc, enc in files:
+        dec = ZC(pw).dec(enc)
+        if dec[11] != ((crc >> 24) & 0xff):
+            return False
+        body = dec[12:]
+        if ctype == 8:
+            try:
+                body = zlib.decompressobj(-15).decompress(body)
+            except Exception:
+                return False
+        if (zlib.crc32(body) & 0xffffffff) != crc:
+            return False
+    return True
+
+action = sys.argv[1]
+pw     = bytes.fromhex(sys.argv[2])
+if action == "gen":
+    sys.stdout.write(build(pw, int(sys.argv[3])))
+else:
+    sys.stdout.write("1" if verify(pw, sys.argv[3]) else "0")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+  my $out = do
+  {
+    local $ENV{PYTHONUTF8} = 1;
+    open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+    local $/; my $r = <$fh>; close ($fh); $r;
+  };
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $word_hex = unpack ("H*", $word);
+
+  my $hash = _run ("gen", $word_hex, $MODE);
+
+  return unless defined $hash;
+
+  $hash =~ s/[\r\n]//g;
+
+  return $hash;
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my $idx = rindex ($line, ':');
+  return if $idx < 0;
+
+  my $hash = substr ($line, 0, $idx);
+  my $word = substr ($line, $idx + 1);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my $word_packed = pack_if_HEX_notation ($word);
+  my $word_hex    = unpack ("H*", $word_packed);
+
+  my $ok = _run ("verify", $word_hex, $hash);
+
+  return unless defined $ok;
+
+  $ok =~ s/[\r\n]//g;
+
+  return unless $ok eq "1";
+
+  return ($hash, $word);
+}
+
+1;

--- a/tools/test_pkzip.sh
+++ b/tools/test_pkzip.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# PKZIP real-container validator.
+#
+# Cross-checks hashcat's traditional-PKZIP modes (17200/17210/17220/17225/17230)
+# against GENUINE archives produced by InfoZip's `zip`, extracted with John's
+# `zip2john`. This is the ground-truth complement to the self-contained test.pl
+# oracles in tools/test_modules/m172*.pm: those prove hashcat agrees with our
+# own ZipCrypto, this proves it agrees with a real-world ZIP toolchain.
+#
+# Dependencies (override via env):
+#   ZIP       - InfoZip `zip`      (default: zip on PATH)
+#   ZIP2JOHN  - John's zip2john    (default: /home/user/john/run/zip2john)
+#   HASHCAT   - hashcat binary     (default: ./hashcat)
+#
+# Usage: tools/pkzip_realzip_validate.sh [password]
+#
+set -u
+
+ZIP="${ZIP:-zip}"
+ZIP2JOHN="${ZIP2JOHN:-/home/user/john/run/zip2john}"
+HASHCAT="${HASHCAT:-./hashcat}"
+PW="${1:-hashcat}"
+
+for t in "$ZIP" "$ZIP2JOHN" "$HASHCAT"; do
+  command -v "$t" >/dev/null 2>&1 || [ -x "$t" ] || { echo "missing tool: $t"; exit 2; }
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+FILES="$WORK/files"; mkdir -p "$FILES"
+
+# a few compressible text files + one incompressible blob (forces a stored entry)
+for i in 1 2 3 4; do
+  python3 - "$FILES/t$i.txt" "$i" <<'PY'
+import sys
+open(sys.argv[1], "w").write(("pattern %s the quick brown fox " % sys.argv[2]) * 400)
+PY
+done
+head -c 64 /dev/urandom > "$FILES/rand.bin"
+
+echo "$PW" > "$WORK/pw.txt"
+
+extract() { "$ZIP2JOHN" ${2:-} "$1" 2>/dev/null | sed -E 's/^[^:]*://' | grep -oE '^\$pkzip2?\$[^:]+' | head -1; }
+
+# build the container matrix: label -> hashcat mode -> zip invocation [-> zip2john flag]
+declare -a ROWS=(
+  "stored-single|17210|-0 -e|"
+  "deflate-single|17200|-9 -e|"
+  "deflate-multi|17220|-9 -e|MULTI"
+  "mixed-multi|17225|-e|MIXED"
+  "checksum-only|17230|-9 -e|CKSUM"
+)
+
+pass=0; fail=0
+printf "%-16s %-7s %-9s %s\n" "container" "mode" "files" "result"
+printf -- "----------------------------------------------------\n"
+
+for row in "${ROWS[@]}"; do
+  IFS='|' read -r label mode zflags special <<<"$row"
+  zf="$WORK/$label.zip"; rm -f "$zf"
+
+  case "$special" in
+    MULTI) inputs=("$FILES/t1.txt" "$FILES/t2.txt" "$FILES/t3.txt") ;;
+    MIXED) inputs=("$FILES/t1.txt" "$FILES/rand.bin" "$FILES/t2.txt") ;;
+    CKSUM) inputs=("$FILES/t1.txt" "$FILES/t2.txt" "$FILES/t3.txt" "$FILES/t4.txt") ;;
+    *)     inputs=("$FILES/t1.txt") ;;
+  esac
+
+  "$ZIP" $zflags -P "$PW" "$zf" "${inputs[@]}" >/dev/null 2>&1
+
+  j2jflag=""
+  [ "$special" = "CKSUM" ] && j2jflag="-c"
+  hash="$(extract "$zf" "$j2jflag")"
+
+  nfiles="${#inputs[@]}"
+  if [ -z "$hash" ]; then
+    printf "%-16s %-7s %-9s %s\n" "$label" "$mode" "$nfiles" "NO-HASH"; fail=$((fail+1)); continue
+  fi
+  echo "$hash" > "$WORK/h.txt"
+
+  find kernels -name "*$mode*" -delete 2>/dev/null
+  rm -f "$WORK/o.txt"
+  # </dev/null: hashcat's interactive keypress thread reads the terminal; run
+  # from a script with no controlling tty that read raises SIGTTIN and the
+  # process is suspended (state T) until timeout kills it. Feed it EOF instead.
+  timeout 180 "$HASHCAT" -m "$mode" -a 0 --self-test-disable --potfile-disable \
+      -d 1 --quiet -o "$WORK/o.txt" "$WORK/h.txt" "$WORK/pw.txt" </dev/null >/dev/null 2>&1
+
+  if [ -s "$WORK/o.txt" ]; then
+    printf "%-16s %-7s %-9s %s\n" "$label" "$mode" "$nfiles" "CRACKED"; pass=$((pass+1))
+  else
+    printf "%-16s %-7s %-9s %s\n" "$label" "$mode" "$nfiles" "FAILED (investigate)"; fail=$((fail+1))
+  fi
+done
+
+printf -- "----------------------------------------------------\n"
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Add vibe-coded `test.pl`s verification modules for the five traditional PKWARE / ZipCrypto modes.
Plus a real-container validator that cross-checks them against genuine ZIP archives.
Should help with regression/correctness-testing.

Didn't find any bugs :)

### `tools/test_modules/m172{00,10,20,25,30}.pm`

Each is a byte-exact port of the ZipCrypto key schedule from
`OpenCL/m172*-pure.cl` (init keys `0x12345678/0x23456789/0x34567890`,
`update_key012` / `update_key3`, decrypt byte `((key2 & 0xffff) | 3)`).

The generator produces each entry as a **"full data" block** (data_type_enum 2):
a 12-byte ZipCrypto encryption header whose last byte is `(crc >> 24) & 0xff`
— the value hashcat checks — followed by the encrypted file bytes (raw DEFLATE
for compression_type 8, stored for type 0). Because the oracle *encrypts* the
same way the kernel *decrypts*, a correct password reproduces every header check
and CRC32 by construction, so `module_verify_hash` is exact rather than
probabilistic.

Container shape is selected by mode number:

| mode  | shape                                   |
|-------|-----------------------------------------|
| 17210 | 1 stored file                           |
| 17200 | 1 deflate file                          |
| 17220 | N deflate files                         |
| 17225 | N mixed stored/deflate files            |
| 17230 | ≥3 deflate files (checksum-only variant)|

```
./tools/test.sh -m17210-17230
[ test_1787173568 ] > Init test for hash type 17210.
[ test_1787173568 ] [ Type 17210, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787173568 ] [ Type 17210, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787173568 ] > Init test for hash type 17220.
[ test_1787173568 ] [ Type 17220, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787173568 ] [ Type 17220, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787173568 ] > Init test for hash type 17225.
[ test_1787173568 ] [ Type 17225, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787173568 ] [ Type 17225, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787173568 ] > Init test for hash type 17230.
[ test_1787173568 ] [ Type 17230, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787173568 ] [ Type 17230, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

### `tools/test_pkzip.sh`

Ground-truth complement to the oracles. Builds a matrix of **real** archives
with InfoZip `zip` (`-0`/`-9`, single/multi/mixed/checksum, including an
incompressible blob to force a stored entry), extracts them with John's
`zip2john`, and confirms hashcat cracks each with the known password. Where the
oracles prove hashcat agrees with our own ZipCrypto, this proves it agrees with
a real-world ZIP toolchain end to end.

Tool paths are env-overridable (`ZIP`, `ZIP2JOHN`, `HASHCAT`); the script prints
a per-container pass/fail table and exits non-zero on any failure.

This is an example of what I meant in https://github.com/hashcat/hashcat/pull/4782#issuecomment-5346725233 2. i.e. this could be folded into `test.sh -g`

```
./tools/test_pkzip.sh hashcat123
container        mode    files     result
----------------------------------------------------
stored-single    17210   1         CRACKED
deflate-single   17200   1         CRACKED
deflate-multi    17220   3         CRACKED
mixed-multi      17225   3         CRACKED
checksum-only    17230   4         CRACKED
----------------------------------------------------
passed: 5   failed: 0
```

---


_completely vibe-coded whilst working on #4774_
