### PR TITLE
Add test for Python Werkzeug modes (30000 MD5, 30120 SHA256)

### DIFF
--- a/tools/test_modules/m30000.pm
+++ b/tools/test_modules/m30000.pm
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::HMAC_MD5 qw (hmac_md5_hex);
+
+sub module_constraints { [[0, 256], [0, 256], [0, 31], [0, 51], [0, 82]] }
+
+# Python Werkzeug legacy password hash, method "md5":
+#   werkzeug.security.generate_password_hash(pw, method="md5", salt_length=N)
+# produces  md5$<salt>$<digest>  where digest = HMAC-MD5(key=salt, msg=password).
+# (Werkzeug uses the salt as the HMAC key; removed from werkzeug >= 2.3.)
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $digest = hmac_md5_hex ($word, $salt);   # (data, key) -> HMAC-MD5(key = salt)
+
+  return sprintf ("md5\$%s\$%s", $salt, $digest);
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line, 2);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @parts = split (/\$/, $hash);
+
+  return unless scalar @parts == 3;
+  return unless $parts[0] eq "md5";
+
+  my $salt = $parts[1];
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt);
+
+  return ($new_hash, $word);
+}
+
+1;

--- a/tools/test_modules/m30120.pm
+++ b/tools/test_modules/m30120.pm
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+
+##
+## Author......: See docs/credits.txt
+## License.....: MIT
+##
+
+use strict;
+use warnings;
+
+use Digest::SHA qw (hmac_sha256_hex);
+
+sub module_constraints { [[0, 256], [0, 256], [0, 31], [0, 51], [0, 82]] }
+
+# Python Werkzeug legacy password hash, method "sha256":
+#   werkzeug.security.generate_password_hash(pw, method="sha256", salt_length=N)
+# produces  sha256$<salt>$<digest>  where digest = HMAC-SHA256(key=salt, msg=password).
+# (Werkzeug uses the salt as the HMAC key; removed from werkzeug >= 2.3.)
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $digest = hmac_sha256_hex ($word, $salt);   # (data, key) -> HMAC-SHA256(key = salt)
+
+  return sprintf ("sha256\$%s\$%s", $salt, $digest);
+}
+
+sub module_verify_hash
+{
+  my $line = shift;
+
+  my ($hash, $word) = split (':', $line, 2);
+
+  return unless defined $hash;
+  return unless defined $word;
+
+  my @parts = split (/\$/, $hash);
+
+  return unless scalar @parts == 3;
+  return unless $parts[0] eq "sha256";
+
+  my $salt = $parts[1];
+
+  my $word_packed = pack_if_HEX_notation ($word);
+
+  my $new_hash = module_generate_hash ($word_packed, $salt);
+
+  return ($new_hash, $word);
+}
+
+1;


### PR DESCRIPTION
_similar to https://github.com/hashcat/hashcat/pull/4783_

Add vibe-coded `test.pl` verification modules for the two legacy Python Werkzeug
password-hash modes.
Should help with regression/correctness-testing.

Didn't find any bugs :)

## The oracles: `tools/test_modules/m30000.pm`, `m30120.pm`

Each is a direct port of what `werkzeug.security.generate_password_hash` did for
these legacy methods:

```
generate_password_hash(pw, method="md5",    salt_length=N)  ->  md5$<salt>$<digest>
generate_password_hash(pw, method="sha256", salt_length=N)  ->  sha256$<salt>$<digest>
```

The quirk this pins down: Werkzeug uses the **salt as the HMAC key** and the
**password as the message** — `digest = HMAC(key=salt, msg=password)` — not the
other way round. So the oracle just calls `hmac_md5_hex($word, $salt)` /
`hmac_sha256_hex($word, $salt)` (Perl's `(data, key)` argument order) and formats
`method$salt$digest`. Because it computes the digest the same way the kernel
does, a correct password reproduces the stored hash exactly, so
`module_verify_hash` is exact rather than probabilistic.

(These `method="md5"`/`"sha256"` forms were removed from Werkzeug >= 2.3, which
is why an oracle is worth having — you can't `pip install` a current Werkzeug and
get them back.)

| mode  | digest                                  |
|-------|-----------------------------------------|
| 30000 | HMAC-MD5    (key = salt)                |
| 30120 | HMAC-SHA256 (key = salt)                |

Salt/word length ranges follow each module's `module_constraints`.

```
./tools/test.sh -m30000-30120
[ test_1787174098 ] > Init test for hash type 30000.
[ test_1787174098 ] [ Type 30000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787174098 ] [ Type 30000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787174098 ] > Init test for hash type 30120.
[ test_1787174098 ] [ Type 30120, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787174098 ] [ Type 30120, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```

---


_completely vibe-coded whilst working on #4774_
