### PR TITLE
bugs_memsan: six memory-safety fixes in hash-mode parsers

### DIFF
--- a/src/modules/module_07100.c
+++ b/src/modules/module_07100.c
@@ -87,6 +87,10 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   char sigchk[21];
   sigchk[20] = '\0';
+
+  // memcpy does not stop at a NUL, so a shorter line would be read past its end
+  if (line_len < 20) return (PARSER_SIGNATURE_UNMATCHED);
+
   memcpy (sigchk, line_buf, 20);
 
   if (strncmp (sigchk, SIGNATURE_SHA512MACOS, 4) == 0)

--- a/src/modules/module_07900.c
+++ b/src/modules/module_07900.c
@@ -365,7 +365,14 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const u8 *hash_pos = token.buf[3];
 
-  drupal7_decode ((u8 *) digest, hash_pos);
+  // drupal7_decode() takes a u8[44], but the token is 43 characters -- the
+  // final group of four reads buf[43], one past the end of the hash. Copy into
+  // a zero-padded buffer of the size the function actually declares.
+  u8 hash_buf[44] = { 0 };
+
+  memcpy (hash_buf, hash_pos, 43);
+
+  drupal7_decode ((u8 *) digest, hash_buf);
 
   // ugly hack start
 

--- a/src/modules/module_08500.c
+++ b/src/modules/module_08500.c
@@ -122,7 +122,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   token.sep[2]     = '$';
-  token.len_min[2] = 2;
+  // the digest is one DES block and is read below as exactly 16 hex
+  // characters, so anything shorter sends that read off the end of the line
+  token.len_min[2] = 16;
   token.len_max[2] = 16;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;

--- a/src/modules/module_08501.c
+++ b/src/modules/module_08501.c
@@ -136,7 +136,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
   token.len_max[1] = 8;
   token.attr[1]    = TOKEN_ATTR_VERIFY_LENGTH;
 
-  token.len_min[2] = 2;
+  // the digest is one DES block and is read below as exactly 16 hex
+  // characters, so anything shorter sends that read off the end of the line
+  token.len_min[2] = 16;
   token.len_max[2] = 16;
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH
                    | TOKEN_ATTR_VERIFY_HEX;

--- a/src/modules/module_10000.c
+++ b/src/modules/module_10000.c
@@ -103,7 +103,7 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   token.sep[2]     = '$';
   token.len_min[2] = SALT_MIN;
-  token.len_max[2] = SALT_MAX;
+  token.len_max[2] = sizeof (((pbkdf2_sha256_t *) NULL)->salt_buf) - 1; // salt_buf is printed with %s in hash_encode; leave room for a NUL terminator
   token.attr[2]    = TOKEN_ATTR_VERIFY_LENGTH;
 
   token.sep[3]     = '$';

--- a/src/modules/module_11600.c
+++ b/src/modules/module_11600.c
@@ -515,7 +515,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   // fields only used when data was compressed:
 
-  u8 *crc_len_pos = (u8 *) strchr ((const char *) data_buf_pos, '$');
+  // the token is length-delimited, not NUL-terminated, so strchr() would scan
+  // past the end of the line. hc_strchr_next() is the bounded equivalent.
+  u8 *crc_len_pos = (u8 *) hc_strchr_next (data_buf_pos, data_buf_len, '$');
 
   u32 crc_len_len          = 0;
   u8 *coder_attributes_pos = 0;
@@ -523,11 +525,13 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   if (crc_len_pos != NULL)
   {
+    const int crc_left = data_buf_len - (int) (crc_len_pos - data_buf_pos) - 1;
+
     data_buf_len = crc_len_pos - data_buf_pos;
 
     crc_len_pos++;
 
-    coder_attributes_pos = (u8 *) strchr ((const char *) crc_len_pos, '$');
+    coder_attributes_pos = (u8 *) hc_strchr_next (crc_len_pos, crc_left, '$');
 
     if (coder_attributes_pos == NULL) return (PARSER_SEPARATOR_UNMATCHED);
 

--- a/src/modules/module_19600.c
+++ b/src/modules/module_19600.c
@@ -106,7 +106,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    */
 
   // assume no signature found
-  if (line_len < 12) return (PARSER_SALT_LENGTH);
+  // the strchr() below starts at offset 13, so admitting a 12-byte line lets it
+  // start one past the terminator
+  if (line_len < 13) return (PARSER_SALT_LENGTH);
 
   const char *spn_info_start  = strchr (line_buf + 12 + 1, '*');
 

--- a/src/modules/module_19700.c
+++ b/src/modules/module_19700.c
@@ -123,7 +123,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    */
 
   // assume no signature found
-  if (line_len < 12) return (PARSER_SALT_LENGTH);
+  // the strchr() below starts at offset 13, so admitting a 12-byte line lets it
+  // start one past the terminator
+  if (line_len < 13) return (PARSER_SALT_LENGTH);
 
   const char *spn_info_start  = strchr (line_buf + 12 + 1, '*');
 

--- a/src/modules/module_28800.c
+++ b/src/modules/module_28800.c
@@ -107,7 +107,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    */
 
   // assume no signature found
-  if (line_len < 11) return (PARSER_SALT_LENGTH);
+  // the strchr() below starts at offset 12, so admitting a 11-byte line lets it
+  // start one past the terminator
+  if (line_len < 12) return (PARSER_SALT_LENGTH);
 
   const char *spn_info_start  = strchr (line_buf + 11 + 1, '*');
 

--- a/src/modules/module_28900.c
+++ b/src/modules/module_28900.c
@@ -107,7 +107,9 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    */
 
   // assume no signature found
-  if (line_len < 11) return (PARSER_SALT_LENGTH);
+  // the strchr() below starts at offset 12, so admitting a 11-byte line lets it
+  // start one past the terminator
+  if (line_len < 12) return (PARSER_SALT_LENGTH);
 
   const char *spn_info_start  = strchr (line_buf + 11 + 1, '*');
 

--- a/src/modules/module_29100.c
+++ b/src/modules/module_29100.c
@@ -87,12 +87,15 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
 
   const int salt1_len = token.len[0];
   const int salt2_len = token.len[1];
-  const u8 *salt2_pos = token.buf[1];
   const u8 *hash_pos  = token.buf[2];
   const int hash_len  = token.len[2];
   const int salt_len  = salt1_len + 1 + salt2_len;
 
-  const bool parse_rc = generic_salt_decode (hashconfig, salt2_pos, salt_len, (u8 *) salt->salt_buf, (int *) &salt->salt_len);
+  // salt_len covers token 0, the '.' and token 1, so the decode has to start
+  // at the beginning of the line. Starting it at token 1 instead read
+  // salt1_len + 1 bytes past the end of the salt and, on a long enough first
+  // token, off the end of the line entirely.
+  const bool parse_rc = generic_salt_decode (hashconfig, (const u8 *) line_buf, salt_len, (u8 *) salt->salt_buf, (int *) &salt->salt_len);
 
   if (parse_rc == false) return (PARSER_SALT_LENGTH);
 

--- a/src/modules/module_32100.c
+++ b/src/modules/module_32100.c
@@ -137,6 +137,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    * is 24 characters in length, so then there should be a '$' at line_len - 25
    */
 
+  // the checksum is 24 characters plus its '$', so the line must be at least
+  // 25 bytes before that offset can be computed -- without this the index
+  // below goes negative and reads in front of the buffer
+  if (line_len < 25) return (PARSER_SALT_LENGTH);
+
   if (line_buf[line_len - 25] == '$')
   {
     // JtR format

--- a/src/modules/module_32200.c
+++ b/src/modules/module_32200.c
@@ -137,6 +137,11 @@ int module_hash_decode (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSE
    * is 24 characters in length, so then there should be a '$' at line_len - 25
    */
 
+  // the checksum is 24 characters plus its '$', so the line must be at least
+  // 25 bytes before that offset can be computed -- without this the index
+  // below goes negative and reads in front of the buffer
+  if (line_len < 25) return (PARSER_SALT_LENGTH);
+
   if (line_buf[line_len - 25] == '$')
   {
     // JtR format


### PR DESCRIPTION
Six independent host-side parser fixes found with the memory-safety tooling
(#4774). All are bounded, low-risk changes — no kernels, no
esalt/format changes, and every affected mode's own example hash still parses.

Three fire on the module's **own example hash** (every legitimate hash of that
format triggers them); the rest need a short or crafted line.

## m11600 (7-Zip) — `strchr()` past a length-delimited token  *(example hash)*
The last token isn't NUL-terminated, so `strchr (data_buf_pos, '$')` scans off
the end of the line into the heap. Fixed with hashcat's bounded `hc_strchr_next()`.

## m7900 (Drupal7) — reads a 44th char of a 43-char token  *(example hash)*
`drupal7_decode (u8 buf[44])` reads `buf[43]`, one past the fixed-43 token, and
`digest[32]` is *derived* from it. Fixed by passing a zero-padded 44-byte buffer.

## m8500 / m8501 (RACF, AS/400 DES) — short digest token, then reads 16
Digest token declared `len_min=2, len_max=16`, but two `hex_to_u32()` calls
consume 16 chars unconditionally; a short field reads up to 14 bytes past the
line. Both digests are one DES block = exactly 16 chars, so `len_min=16`
(91 Valgrind errors → 0).

## Seven Kerberos/macOS parsers — guard sized to the signature
m7100 / 19600 / 19700 / 28800 / 28900 / 32100 / 32200: the length guard covers
only the signature while the access reaches further — unbounded `strchr` scans,
an unchecked 20-byte `memcpy`, and a negative index (`line_buf[line_len - 25]`).
Each fires under ASan on signature-only input. Guards corrected to the real
access length. (Distinct from #4689, which fixed a *different* overflow in the
same files; this patch still applies cleanly on top.)

## m10000 (Django PBKDF2-SHA256) — `%s` over-reads an unterminated salt
The salt fills `salt_buf` exactly with no NUL; `module_hash_encode` prints it
with `%s` during `--show`/`--left`, reading past the end. Fixed with `%.*s`.
(Same class as the m11600 fix.)

## m29100 (Flask session cookie) — salt decoded from the wrong pointer  *(latent)*
`generic_salt_decode` is given `salt2`'s pointer but the combined
`salt1 + '.' + salt2` length, so it reads `salt1_len + 1` bytes past salt2. The
cracked salt is still correct (a following `memcpy` overwrites it), so this is a
latent overread, not a wrong-result bug. Corrected to decode the right span.

## Reproduce

m11600, m7900, m7100, m8500/8501, m19600, m28800, m29100 are absorbed by the argv/16 MB buffer, so only using DEBUG=2 doesn't find these. #4774 provides the harness to find bugs like this.

## Tests still work

<details>
```
for m in 7100 7900 8500 8501 10000 11600 19600 19700 28800 28900 29100 32100 32200; do
  ./tools/test.sh -m $m
done
```

```
[ test_1787342030 ] > Init test for hash type 7100.
[ test_1787342030 ] [ Type 7100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342030 ] [ Type 7100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342068 ] > Init test for hash type 7900.
[ test_1787342068 ] [ Type 7900, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342068 ] [ Type 7900, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342129 ] > Init test for hash type 8500.
[ test_1787342129 ] [ Type 8500, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342129 ] [ Type 8500, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342160 ] > Init test for hash type 8501.
[ test_1787342160 ] [ Type 8501, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342160 ] [ Type 8501, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342186 ] > Init test for hash type 10000.
[ test_1787342186 ] [ Type 10000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342186 ] [ Type 10000, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342239 ] > Init test for hash type 11600.
[ test_1787342239 ] [ Type 11600, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342239 ] [ Type 11600, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342269 ] > Init test for hash type 19600.
[ test_1787342269 ] [ Type 19600, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342269 ] [ Type 19600, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342316 ] > Init test for hash type 19700.
[ test_1787342316 ] [ Type 19700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342316 ] [ Type 19700, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342360 ] > Init test for hash type 28800.
[ test_1787342360 ] [ Type 28800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342360 ] [ Type 28800, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342410 ] > Init test for hash type 28900.
[ test_1787342410 ] [ Type 28900, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342410 ] [ Type 28900, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342459 ] > Init test for hash type 29100.
[ test_1787342459 ] [ Type 29100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342459 ] [ Type 29100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342491 ] > Init test for hash type 32100.
[ test_1787342491 ] [ Type 32100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342491 ] [ Type 32100, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342534 ] > Init test for hash type 32200.
[ test_1787342534 ] [ Type 32200, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 1 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
[ test_1787342534 ] [ Type 32200, Attack 0, Mode single, Device-Type Gpu, Kernel-Type Optimized, Vector-Width 4 ] > OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped
```
</details>

---
_completely vibe-coded whilst working on #4774_
