### PR TITLE
PKZIP segfaults on PoCL: so keep tinfl_decompress() out of line so the kernels build

### DIFF
--- a/OpenCL/inc_vendor.h
+++ b/OpenCL/inc_vendor.h
@@ -184,6 +184,18 @@ using namespace metal;
 #define HC_NOINLINE
 #endif
 
+/**
+ * HC_NOINLINE_ALWAYS is the same hard noinline attribute, but always on, and it is not the switch
+ * above. FORCE_NO_INLINE is global and opt-in: the user turns it on for a whole run when a runtime
+ * is too slow to build anything. HC_NOINLINE_ALWAYS is a property of one function, it travels with
+ * that function's definition, and it is for the few helpers that are so large that inlining them
+ * cannot pay off anywhere: the caller gets a copy of thousands of instructions to save one call.
+ *
+ * Use it sparingly, and only where the body is big enough that the call is free by comparison.
+ */
+
+#define HC_NOINLINE_ALWAYS __attribute__ ((noinline))
+
 // On a device DECLSPEC says how a function is compiled. On the host it says something else, because
 // the host build of these files is compiled into the core and a plugin calls the result: every one
 // of these functions is a host side hash, cipher or helper entry point, so DECLSPEC is where they

--- a/OpenCL/inc_zip_inflate.cl
+++ b/OpenCL/inc_zip_inflate.cl
@@ -498,7 +498,25 @@ DECLSPEC void zlib_memcpy_g (PRIVATE_AS void *dest, MAYBE_GLOBAL const void *src
   }
 }
 
-DECLSPEC tinfl_status tinfl_decompress (PRIVATE_AS tinfl_decompressor *r, MAYBE_GLOBAL const mz_uint8 *pIn_buf_next, PRIVATE_AS size_t *pIn_buf_size, PRIVATE_AS mz_uint8 *pOut_buf_start, PRIVATE_AS mz_uint8 *pOut_buf_next, PRIVATE_AS size_t *pOut_buf_size, const mz_uint32 decomp_flags, mz_streamp pStream)
+// tinfl_decompress() stays out of line, everywhere, on purpose.
+//
+// This is miniz's decompressor written as one coroutine: a single function that holds the whole
+// inflate state machine, a few hundred basic blocks of it. Inlining it saves one call and costs the
+// caller a copy of all of that, so there is no device on which it is a win.
+//
+// It is also what makes the three PKZIP modes that decompress fail to build at all on PoCL. Once
+// DECLSPEC gained its `static`, the helpers became internal and the runtime is free to inline them,
+// so hc_inflate() -> mz_inflate() -> tinfl_decompress() collapses into the kernel body. Building
+// that kernel sends a PoCL function pass into a recursion that does not terminate: hashcat dies
+// with SIGSEGV inside clGetProgramInfo(), before a single candidate is hashed. The stack is not
+// simply too small: raising the limit 16x only makes the recursion 16x deeper, from 14,119 frames
+// at 8 MB to 226,668 at 128 MB. Measured on PoCL 5.0 with LLVM 16.
+//
+// Keeping this one function out of line is enough for all three to build and crack again. 17210 and
+// 17230 never touch inflate and were never affected, and 21800 inflates from a slow hash's _comp
+// kernel, which is small to begin with.
+
+DECLSPEC HC_NOINLINE_ALWAYS tinfl_status tinfl_decompress (PRIVATE_AS tinfl_decompressor *r, MAYBE_GLOBAL const mz_uint8 *pIn_buf_next, PRIVATE_AS size_t *pIn_buf_size, PRIVATE_AS mz_uint8 *pOut_buf_start, PRIVATE_AS mz_uint8 *pOut_buf_next, PRIVATE_AS size_t *pOut_buf_size, const mz_uint32 decomp_flags, mz_streamp pStream)
 {
 
     const int s_length_base[31] = { 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0 };


### PR DESCRIPTION
17200, 17220 and 17225 segfault before they hash anything, on their own example hash, on PoCL 5.0 with LLVM 16. The fault is a stack exhaustion inside a PoCL function pass reached from clGetProgramInfo(), so it is a kernel build failure, not a wrong result: `hashcat -b -m 17200` dies the same way. 17210 and 17230, the two PKZIP modes that never inflate, are fine.

Since DECLSPEC gained its `static`, the DECLSPEC helpers are internal and the runtime inlines them, so hc_inflate() -> mz_inflate() -> tinfl_decompress() collapses into the kernel body. tinfl_decompress() is miniz's whole inflate state machine written as one coroutine, and that is what tips the pass over. The recursion does not terminate, so a bigger stack does not help: raising the limit 16x only makes it 16x deeper, from 14,119 frames at 8 MB to 226,668 at 128 MB.

Marking that one function noinline is enough. It is not a workaround aimed at PoCL: inlining a function that size can never pay off, since the caller trades a copy of a few hundred basic blocks for one saved call. The new HC_NOINLINE_ALWAYS is deliberately separate from FORCE_NO_INLINE, which stays a global opt-in switch the user turns on for a whole run.

After the change all three build, benchmark and crack, and tools/test.sh passes them at vector widths 1 and 4 in attack modes 0, 1, 3 and 6, single and multi.

----

```
m=17200
./hashcat -m $m --hash-info --machine-readable | tail -n +3 \
  | sed -n 's/.*"example_hash": "\(.*\)", "example_pass".*/\1/p' > st.hash
echo hashcat > st.pw
./hashcat -m $m -a 0 -D 1 --force --potfile-disable --self-test-disable st.hash st.pw >/dev/null 2>&1
echo "m$m rc=$?"
```

on master cf04e413e4f2b3127e13794dd61b4fdb40f9ead5 `m17200 rc=139` with this patch `m17200 rc=0`

