### PR TITLE
bug m17040: copy 8 IV bytes into the 8 byte CFB register, not 16

### DIFF
--- a/OpenCL/m17040-pure.cl
+++ b/OpenCL/m17040-pure.cl
@@ -115,7 +115,8 @@ DECLSPEC void cast128_decrypt_cfb (GLOBAL_AS const u32 *encrypted_data, int data
   PRIVATE_AS u8 *iv8 = (PRIVATE_AS u8*)iv;
 
   // set IV
-  for (int j = 0; j < 16; j++)
+  // CAST5 has an 8 byte block, and essiv is 8 bytes wide.
+  for (int j = 0; j < 8; j++)
   {
     essiv[j] = iv8[j];
   }


### PR DESCRIPTION
`cast128_decrypt_cfb()` in `OpenCL/m17040-pure.cl` fills an 8 byte CFB register with
a loop that runs 16 times. On PoCL 6.0 / LLVM 18, which is what Ubuntu 26.04 ships,
that overflow makes the IV read back as zero and GPG CAST5 keys stop cracking.
hashcat's own self-test vector has an all zero IV, so it keeps passing and nothing
looks wrong until a real key fails.

## Reproduction

Ubuntu 26.04, PoCL 6.0+debian, LLVM 18.1.8. `rm -rf kernels/` before each run.

```
./hashcat -m 17040 -a 3 -D 1 --force --potfile-disable '$gpg$*1*668*4096*76fafd9c009629f34f5de389e4ca78893c7f43e64c246effe017b5e83b0838dbb322f9474309b2e9b12849b4c068a9c7ad557d84aa57da969da0260e2bcc89b83a4ff882940bd27e33461a9027b963a382a111fa1e30d8a179af72196575d25b537b400437000855daada6ad36f2e848311dd42c14924af667b257dc29c5324aa041bcbc37717890c8fc9292c81d837385bfa64a7a1396d577f43f3be75c516aa5cdad5fcaa3cdef30d3f1f15e1b216894beb77478ab9f9280a6e616e3f6573c811e4b867a4f18c6ae33e1a9e6efe3589be50138e02c84cc4552fec0fa31b9f37e358cecee451db517681d7dae1bf5b7761f1ce9b77bd1382c25c0e51c638c8934bd624a0f4b790e28e8a97901f60a83e37ccda9a74299871c455981e8fae3391629d6a5bae8824b197e5bfadcb6066e8117c8b4894ae0aa3a5c24512cef81039ded94a01f9c726e577d42cc26b446e1f3b3342d7deef32bd7c8b118d3f6cdd119b305a7f1e01164ad315e908c372a21bcbfa66e459b21827c6767afea0a6e53876b477371d561b6e4c6b8048c51c30395722d1292767cbbff8155f69a4034fb3673bcbe9f8c31f097a1e5a03fb44ca893e6c0414fbae8fb07f3e2c4e04c8621c5e6b2459b915f02d77c82abd89b1f38bd8aa8c1f20f57324cad495797cd24ceccef3096f2ee2c3203d61e25b7015c52f0f0bda71bf434a3c0866041cf18b3ef986d17249b1bbf83640702c7d8c103e6d9d70c56b1052bf4dde8b9c3fec4f579c2e5658bef91bba93cc1871cd06eccca9a862313221d9f4b5bda22d415e802971102abf0d0ab7d48cec5be9110c57e2783397a06302d5489ae0769ccdb76dc101c03feb3f702fdc96f7e29bcb5db5bb785d0a39d359fa13514dbd81a4e52f9b2025273895920084107ee63ef80be1b2c1c5318b05181a27610b16f2b*1*254*2*3*8*622411228d3da4aa*0*3dc43acac7b97e2e' 'Passw0rd!'

before: Recovered 0/1, Status Exhausted, rc=1
after:  Recovered 1/1, Status Cracked,   rc=0
```

On Ubuntu 24.04, PoCL 5.0 and LLVM 16.0.6, the same command cracks either way, which
is why this has gone unnoticed.

A machine to reproduce it on, if you do not have 26.04 to hand:

```
podman run --rm -it -v "$PWD:/hc" ubuntu:26.04 bash -c '
  apt-get update -qq && apt-get install -y -qq pocl-opencl-icd ocl-icd-libopencl1 libstdc++6
  cd /hc && rm -rf kernels/ && bash'
```

hashcat itself can be built on the host; the container only needs the OpenCL runtime.

## Cause

```c
u8 essiv[8];
...
// set IV
for (int j = 0; j < 16; j++)
{
  essiv[j] = iv8[j];
}
```

CAST5 has an 8 byte block, and `essiv` is 8 bytes wide. The loop writes 16, so the
last 8 bytes land past the end of the local. The source, `u32 iv[4]`, is 16 bytes, so
only the destination overflows.

LLVM 16 leaves enough slack around that local for the write to go unnoticed. LLVM 18
does not, and the register reads back as zero. That produces the signature this bug
actually has: a key whose IV is all zero still cracks, any other key does not.

The self-test vector is one of the all zero ones:

    ST_HASH = ...*1*254*2*3*8*0000000000000000*0*a11df265e4e54bee

so `Finished self-test` prints, `-b -m 17040` benchmarks at 763 kH/s, and the mode is
broken anyway.

The fix is one character, `j < 16` to `j < 8`.

## Blast radius

One function in one kernel. The four sibling GPG modes keep the register as
`u32 essiv[4]` and copy four words into it, which is correct:

| mode | cipher | register | copy |
|---|---|---|---|
| 17010 | AES | `u32 essiv[4]` | 4 words |
| 17020 | AES | `u32 essiv[4]` | 4 words |
| 17030 | AES | `u32 essiv[4]` | 4 words |
| 17040 | CAST5 | `u8 essiv[8]` | **16 bytes** |
| 17050 | AES | `u32 essiv[4]` | 4 words |

## How the failure was isolated

Only 17040 fails, and only on 26.04. Three keys per mode, generated by the
`tools/test_modules` oracles:

| | 17010 | 17020 | 17030 | 17040 |
|---|---|---|---|---|
| 26.04, PoCL 6.0 / LLVM 18 | 3/3 | 3/3 | 3/3 | **0/3** |
| 24.04, PoCL 5.0 / LLVM 16 | 3/3 | 3/3 | 3/3 | 3/3 |

Backend vector widths 1, 2, 4 and 8 all fail on 26.04, so it is not a vectorisation
effect. Sweeping ciphertext length against the IV is what named the cause:

| ciphertext | IV | 26.04 | 24.04 |
|---|---|---|---|
| 220 to 1308 bytes | all zero | cracks | cracks |
| 220 to 1308 bytes | random | **fails** | cracks |

(Ciphertexts of 120 bytes and under fail on both, consistently, for an unrelated
reason: `check_decoded_data()` wants more data than that. Real keys are far larger.)

## Verification

* 26.04: 15 generated CAST5 keys go from 0/15 to 15/15. The self-test vector still
  passes.
* 24.04: the same 15 keys stay at 15/15.
* 24.04: `./tools/test.sh -m <m> -a 0 -t single -D 1 -f` for 17010, 17020, 17030,
  17040 and 17050 reports `OK : 0/8 not found` at vector widths 1 and 4.
