### PR TITLE
feeds: add feed_xz and feed_lz4 — seekable xz and lz4 wordlists (follow-up to #4801)

### DIFF
--- a/src/feeds/feed_lz4.c
+++ b/src/feeds/feed_lz4.c
@@ -1,0 +1,395 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+// A generic (attack-mode 8) feed that reads an lz4-compressed wordlist and seeks inside it, like
+// feed_zstd / feed_xz. The lz4 frame format has no native index, but its blocks are independent by
+// default (`-BI`), so this feed walks the frame once to record each block's file offset, decodes the
+// blocks in parallel to record the line each opens on (cached), and reaches word N by decoding only
+// its block with LZ4_decompress_safe. lz4's strength is decode speed; its ratio is weak, so this is
+// the "fast" complement to the zstd/xz feeds.
+//
+//   lz4 -9 -BI -B7 wordlist wordlist.lz4     # once, with the stock lz4 tool (block-independent)
+//   hashcat -a 8 -m 0 hash.txt feeds/feed_lz4.so wordlist.lz4 -r rules/best64.rule
+//
+// A block-dependent frame (`-BD`) is not seekable and is rejected. Seek granularity is the block max
+// size (up to 4 MiB with -B7).
+
+#define XXH_INLINE_ALL
+#include "xxhash.h"
+
+#include "common.h"
+#include "types.h"
+#include "memory.h"
+#include "shared.h"
+#include "path.h"
+#include "folder.h"
+#include "memchr.h"
+#include "feed.h"
+
+#include <lz4.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <stdarg.h>
+#include <inttypes.h>
+
+const int GENERIC_PLUGIN_VERSION = FEEDS_INTERFACE_VERSION_CURRENT;
+
+const int GENERIC_PLUGIN_OPTIONS = GENERIC_PLUGIN_OPTIONS_AUTOHEX
+                                 | GENERIC_PLUGIN_OPTIONS_ICONV
+                                 | GENERIC_PLUGIN_OPTIONS_RULES;
+
+#define LFIDX_CACHE_MAGIC  0x315844494C465831ULL
+#define LFIDX_CACHE_VER    1ULL
+#define LFIDX_SAMPLE       65536
+#define LZ4_FRAME_MAGIC    0x184D2204u
+
+typedef struct { u64 comp_off, first_line, uncomp_size, line_off; } lf_frame_t;
+
+typedef struct
+{
+  char   *path;
+
+  u64    *comp_off;    // [nblocks + 1]; block k on-disk size = comp_off[k+1] - comp_off[k]
+  u64    *first_line;  // [nblocks]
+  u64    *uncomp_size; // [nblocks] (actual, from the build decode; informational)
+  u64    *line_off;    // [nblocks]
+
+  u64     nblocks;
+  u64     total_lines;
+  u64     filesize;
+
+  size_t  bms;         // block max size (decode buffer capacity)
+  size_t  max_comp;
+  int     b_csum;      // per-block checksum present
+
+  u64     build_threads;
+} lf_global_t;
+
+typedef struct
+{
+  int             fd;
+  unsigned char  *cbuf;
+  unsigned char  *dbuf;
+  size_t          dlen, doff;
+  u64             block;
+  u64             line;
+  unsigned char  *carry;
+  size_t          carry_cap;
+} lf_thread_t;
+
+static void error_set (generic_global_ctx_t *g, const char *fmt, ...)
+{ g->error = true; va_list ap; va_start (ap, fmt); vsnprintf (g->error_msg, sizeof (g->error_msg), fmt, ap); va_end (ap); }
+static void thread_error_set (generic_thread_ctx_t *t, const char *fmt, ...)
+{ t->error = true; va_list ap; va_start (ap, fmt); vsnprintf (t->error_msg, sizeof (t->error_msg), fmt, ap); va_end (ap); }
+
+static u32 rd32 (const unsigned char *p) { return (u32) p[0] | ((u32) p[1] << 8) | ((u32) p[2] << 16) | ((u32) p[3] << 24); }
+
+static u64 file_ident (const char *path, u64 *filesize)
+{
+  struct stat st; if (stat (path, &st) != 0) return 0; *filesize = (u64) st.st_size;
+  FILE *fp = fopen (path, "rb"); if (fp == NULL) return 0;
+  XXH64_state_t *s = XXH64_createState (); XXH64_reset (s, 0);
+  XXH64_update (s, &st.st_size, sizeof (st.st_size));
+  u8 *b = (u8 *) hcmalloc (LFIDX_SAMPLE);
+  size_t n1 = fread (b, 1, LFIDX_SAMPLE, fp); XXH64_update (s, b, n1);
+  if ((u64) st.st_size > LFIDX_SAMPLE) { fseeko (fp, (off_t) st.st_size - LFIDX_SAMPLE, SEEK_SET); size_t n2 = fread (b, 1, LFIDX_SAMPLE, fp); XXH64_update (s, b, n2); }
+  hcfree (b); fclose (fp); u64 h = XXH64_digest (s); XXH64_freeState (s); return h;
+}
+
+static char *cache_path (generic_global_ctx_t *global_ctx, const u64 ident)
+{
+  char *dir = NULL;
+  if (global_ctx->seekdb_dir != NULL) dir = hcstrdup (global_ctx->seekdb_dir);
+  else { hc_asprintf (&dir, "%s/seekdbs", global_ctx->cache_dir); hc_mkdir (dir, 0700); }
+  char *path = NULL; hc_asprintf (&path, "%s/%016" PRIx64 ".lfidx", dir, ident); hcfree (dir); return path;
+}
+
+static u64 block_of_line (const lf_global_t *g, const u64 offset)
+{
+  u64 lo = 0, hi = g->nblocks - 1, k = 0;
+  while (lo <= hi) { u64 m = lo + (hi - lo) / 2; if (g->first_line[m] <= offset) { k = m; lo = m + 1; } else { if (m == 0) break; hi = m - 1; } }
+  return k;
+}
+
+// decode one lz4 block: cbuf points at the 4-byte block-size prefix
+static bool decode_block (const lf_global_t *g, const unsigned char *cbuf, size_t csize, unsigned char *dbuf, size_t *dlen)
+{
+  if (csize < 4) return false;
+  const u32 bs = rd32 (cbuf); const u32 ds = bs & 0x7fffffffu;
+  if ((size_t) ds + 4 > csize) return false;
+  if (bs & 0x80000000u) { if (ds > g->bms) return false; memcpy (dbuf, cbuf + 4, ds); *dlen = ds; return true; }
+  const int got = LZ4_decompress_safe ((const char *) (cbuf + 4), (char *) dbuf, (int) ds, (int) g->bms);
+  if (got < 0) return false;
+  *dlen = (size_t) got; return true;
+}
+
+// walk the frame header + block list -> comp_off[], nblocks, bms, b_csum
+static bool lz4_read_index (lf_global_t *g)
+{
+  int fd = open (g->path, O_RDONLY); if (fd == -1) return false;
+  struct stat st; if (fstat (fd, &st) != 0) { close (fd); return false; }
+  g->filesize = (u64) st.st_size; if (g->filesize < 11) { close (fd); return false; }
+
+  unsigned char h[19];
+  if (pread (fd, h, sizeof (h), 0) != (ssize_t) sizeof (h)) { close (fd); return false; }
+  if (rd32 (h) != LZ4_FRAME_MAGIC) { close (fd); return false; }
+  const u8 FLG = h[4], BD = h[5];
+  const int b_indep = (FLG >> 5) & 1, b_csum = (FLG >> 4) & 1, c_size = (FLG >> 3) & 1, dictid = FLG & 1;
+  const int bid = (BD >> 4) & 7;
+  if (bid < 4 || bid > 7) { close (fd); return false; }
+  if (!b_indep) { close (fd); return false; }              // block-dependent: not seekable
+  g->bms    = (size_t) 1 << (2 * bid + 8);
+  g->b_csum = b_csum;
+  size_t off = 6 + (c_size ? 8 : 0) + (dictid ? 4 : 0) + 1; // + header checksum
+
+  // walk blocks
+  u64 *comp_off = NULL; u64 nblocks = 0, cap = 0;
+  unsigned char sz[4];
+  bool ok = true;
+  for (;;)
+  {
+    if (off + 4 > g->filesize) { ok = false; break; }
+    if (pread (fd, sz, 4, (off_t) off) != 4) { ok = false; break; }
+    const u32 bs = rd32 (sz);
+    if (bs == 0) break;                                    // endmark
+    const u32 ds = bs & 0x7fffffffu;
+    if (nblocks == cap) { u64 o = cap; cap = cap ? cap * 2 : 256; comp_off = (u64 *) hcrealloc (comp_off, o * sizeof (u64), (cap - o) * sizeof (u64)); }
+    comp_off[nblocks++] = off;
+    off += 4 + ds + (b_csum ? 4 : 0);
+    if (off > g->filesize) { ok = false; break; }
+  }
+  close (fd);
+
+  if (!ok || nblocks == 0) { hcfree (comp_off); return false; }
+
+  comp_off = (u64 *) hcrealloc (comp_off, cap * sizeof (u64), sizeof (u64));
+  comp_off[nblocks] = off;   // endmark offset = end of last block
+  g->comp_off = comp_off; g->nblocks = nblocks;
+
+  for (u64 k = 0; k < nblocks; k++) { size_t c = (size_t) (comp_off[k + 1] - comp_off[k]); if (c > g->max_comp) g->max_comp = c; }
+  return true;
+}
+
+typedef struct { lf_global_t *g; u64 *nl; uint8_t *last_nl; int64_t *first_nl; u64 *usz; u64 next; int error; } lf_build_ctx_t;
+
+static void *lf_build_worker (void *arg)
+{
+  lf_build_ctx_t *b = (lf_build_ctx_t *) arg; lf_global_t *g = b->g;
+  unsigned char *cbuf = (unsigned char *) malloc (g->max_comp);
+  unsigned char *dbuf = (unsigned char *) malloc (g->bms);
+  int fd = open (g->path, O_RDONLY);
+  if (cbuf == NULL || dbuf == NULL || fd == -1) { b->error = 1; free (cbuf); free (dbuf); if (fd != -1) close (fd); return NULL; }
+  for (;;)
+  {
+    if (b->error) break;
+    u64 k = __atomic_fetch_add (&b->next, 1, __ATOMIC_RELAXED);
+    if (k >= g->nblocks) break;
+    size_t csize = (size_t) (g->comp_off[k + 1] - g->comp_off[k]);
+    if (pread (fd, cbuf, csize, (off_t) g->comp_off[k]) != (ssize_t) csize) { b->error = 1; break; }
+    size_t dlen = 0;
+    if (decode_block (g, cbuf, csize, dbuf, &dlen) == false) { b->error = 1; break; }
+    u64 nl = 0; int64_t first = -1;
+    for (size_t o = 0; o < dlen; o++) if (dbuf[o] == '\n') { nl++; if (first < 0) first = (int64_t) o; }
+    b->nl[k] = nl; b->last_nl[k] = (dlen > 0 && dbuf[dlen - 1] == '\n') ? 1 : 0; b->first_nl[k] = first; b->usz[k] = dlen;
+  }
+  free (cbuf); free (dbuf); close (fd); return NULL;
+}
+
+static void index_finish (lf_global_t *g, const u64 *nl, const uint8_t *last_nl, const int64_t *first_nl, const u64 *usz)
+{
+  g->first_line  = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+  g->line_off    = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+  g->uncomp_size = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+  u64 prefix = 0;
+  for (u64 k = 0; k < g->nblocks; k++)
+  {
+    g->uncomp_size[k] = usz[k];
+    if (k == 0) { g->first_line[0] = 0; g->line_off[0] = 0; }
+    else { g->first_line[k] = 1 + prefix - last_nl[k - 1]; g->line_off[k] = last_nl[k - 1] ? 0 : ((first_nl[k] < 0) ? usz[k] : (u64) (first_nl[k] + 1)); }
+    prefix += nl[k];
+  }
+  g->total_lines = prefix + (last_nl[g->nblocks - 1] ? 0 : 1);
+}
+
+static bool index_build (lf_global_t *g)
+{
+  const long ncpu = sysconf (_SC_NPROCESSORS_ONLN);
+  u64 nthreads = g->build_threads ? g->build_threads : ((ncpu > 0) ? (u64) ncpu : 1);
+  const u64 by_mem = ((u64) 8 * 1024 * 1024 * 1024) / g->bms;
+  if (by_mem < 1) nthreads = 1; else if (nthreads > by_mem) nthreads = by_mem;
+  if (nthreads > g->nblocks) nthreads = g->nblocks;
+  if (nthreads < 1) nthreads = 1;
+
+  lf_build_ctx_t b; b.g = g; b.next = 0; b.error = 0;
+  b.nl       = (u64 *)     hcmalloc (g->nblocks * sizeof (u64));
+  b.last_nl  = (uint8_t *) hcmalloc (g->nblocks * sizeof (uint8_t));
+  b.first_nl = (int64_t *) hcmalloc (g->nblocks * sizeof (int64_t));
+  b.usz      = (u64 *)     hcmalloc (g->nblocks * sizeof (u64));
+
+  pthread_t *t = (pthread_t *) hcmalloc (nthreads * sizeof (pthread_t)); u64 sp = 0;
+  for (u64 i = 0; i < nthreads; i++) { if (pthread_create (&t[i], NULL, lf_build_worker, &b) != 0) break; sp++; }
+  if (sp == 0) lf_build_worker (&b);
+  for (u64 i = 0; i < sp; i++) pthread_join (t[i], NULL);
+  hcfree (t);
+
+  bool ok = (b.error == 0);
+  if (ok) index_finish (g, b.nl, b.last_nl, b.first_nl, b.usz);
+  hcfree (b.nl); hcfree (b.last_nl); hcfree (b.first_nl); hcfree (b.usz);
+  return ok;
+}
+
+static bool index_from_cache (lf_global_t *g, const char *cpath, const u64 ident)
+{
+  FILE *fx = fopen (cpath, "rb"); if (fx == NULL) return false;
+  u64 hdr[6];
+  if (fread (hdr, sizeof (hdr), 1, fx) != 1 || hdr[0] != LFIDX_CACHE_MAGIC || hdr[1] != LFIDX_CACHE_VER
+   || hdr[2] != g->nblocks || hdr[4] != g->filesize || hdr[5] != ident) { fclose (fx); return false; }
+  lf_frame_t *e = (lf_frame_t *) hcmalloc (g->nblocks * sizeof (lf_frame_t));
+  bool ok = (fread (e, sizeof (lf_frame_t), g->nblocks, fx) == g->nblocks);
+  fclose (fx);
+  if (ok)
+  {
+    g->first_line = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+    g->line_off   = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+    g->total_lines = hdr[3];
+    for (u64 i = 0; i < g->nblocks; i++) { g->first_line[i] = e[i].first_line; g->line_off[i] = e[i].line_off; }
+  }
+  hcfree (e); return ok;
+}
+
+static void index_save_cache (const lf_global_t *g, const char *cpath, const u64 ident)
+{
+  char *tmp = NULL; hc_asprintf (&tmp, "%s.tmp.%d", cpath, (int) getpid ());
+  FILE *fx = fopen (tmp, "wb"); if (fx == NULL) { hcfree (tmp); return; }
+  u64 hdr[6] = { LFIDX_CACHE_MAGIC, LFIDX_CACHE_VER, g->nblocks, g->total_lines, g->filesize, ident };
+  bool ok = (fwrite (hdr, sizeof (hdr), 1, fx) == 1);
+  for (u64 i = 0; ok && i < g->nblocks; i++) { lf_frame_t e = { g->comp_off[i], g->first_line[i], g->uncomp_size[i], g->line_off[i] }; ok = (fwrite (&e, sizeof (e), 1, fx) == 1); }
+  fclose (fx);
+  if (ok) rename (tmp, cpath); else unlink (tmp);
+  hcfree (tmp);
+}
+
+static bool load_block (generic_thread_ctx_t *tc, lf_global_t *g, lf_thread_t *t, const u64 k)
+{
+  size_t csize = (size_t) (g->comp_off[k + 1] - g->comp_off[k]);
+  if (pread (t->fd, t->cbuf, csize, (off_t) g->comp_off[k]) != (ssize_t) csize) { thread_error_set (tc, "%s: short read of block %" PRIu64, g->path, k); return false; }
+  size_t dlen = 0;
+  if (decode_block (g, t->cbuf, csize, t->dbuf, &dlen) == false) { thread_error_set (tc, "%s: block %" PRIu64 " decode failed", g->path, k); return false; }
+  t->dlen = dlen; t->doff = 0; t->block = k; return true;
+}
+
+static void carry_reserve (lf_thread_t *t, const size_t need)
+{
+  if (need <= t->carry_cap) return;
+  size_t old = t->carry_cap, cap = old ? old : 4096; while (cap < need) cap *= 2;
+  t->carry = (unsigned char *) hcrealloc (t->carry, old, cap - old); t->carry_cap = cap;
+}
+
+bool global_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  lf_global_t *g = (lf_global_t *) hccalloc (1, sizeof (lf_global_t));
+  global_ctx->gbldata = g;
+
+  u64 p_threads = 0;
+  const feed_param_t params[] = { { "threads", FEED_PARAM_TYPE_U64, &p_threads, 0, 4096, "cores for the parallel index build (0 = all)" }, { NULL, 0, NULL, 0, 0, NULL } };
+  char perr[256];
+  if (feed_param_parse (global_ctx->workc, global_ctx->workv, params, perr, sizeof (perr)) == false) { error_set (global_ctx, "%s", perr); return false; }
+  g->build_threads = p_threads;
+
+  const char *src = NULL;
+  for (int i = 1; i < global_ctx->workc; i++) if (feed_param_is_setting (global_ctx->workv[i]) == false) { src = global_ctx->workv[i]; break; }
+  if (src == NULL) { error_set (global_ctx, "usage: feed_lz4.so <wordlist.lz4> [threads=<n>]  (block-independent: lz4 -BI)"); return false; }
+  g->path = hcstrdup (src);
+
+  u64 ident = file_ident (g->path, &g->filesize);
+  if (ident == 0) { error_set (global_ctx, "%s: cannot open", g->path); return false; }
+
+  if (lz4_read_index (g) == false) { error_set (global_ctx, "%s: not a block-independent lz4 frame (use lz4 -BI)", g->path); return false; }
+
+  char *cpath = cache_path (global_ctx, ident);
+  if (index_from_cache (g, cpath, ident) == false)
+  {
+    if (index_build (g) == false) { hcfree (cpath); error_set (global_ctx, "%s: block decode failed during index build", g->path); return false; }
+    index_save_cache (g, cpath, ident);
+  }
+  hcfree (cpath);
+
+  global_ctx->source_ident = (g->filesize * 1000003ULL) ^ (g->total_lines * 2654435761ULL) ^ g->nblocks;
+  snprintf (global_ctx->guess_base, sizeof (global_ctx->guess_base), "%s", g->path);
+  if (g->nblocks < 2) feed_say (hashcat_ctx, "feed_lz4: %s is a single block, so --skip decodes from the start. Recompress smaller blocks: lz4 -BI -B7", g->path);
+  return true;
+}
+
+void global_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  lf_global_t *g = global_ctx->gbldata; if (g == NULL) return;
+  hcfree (g->comp_off); hcfree (g->first_line); hcfree (g->uncomp_size); hcfree (g->line_off); hcfree (g->path); hcfree (g); global_ctx->gbldata = NULL;
+}
+
+u64 global_keyspace (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{ lf_global_t *g = global_ctx->gbldata; return g->total_lines; }
+
+bool thread_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
+{
+  lf_global_t *g = global_ctx->gbldata;
+  lf_thread_t *t = (lf_thread_t *) hccalloc (1, sizeof (lf_thread_t));
+  t->fd = open (g->path, O_RDONLY);
+  if (t->fd == -1) { thread_error_set (thread_ctx, "%s: %s", g->path, strerror (errno)); hcfree (t); return false; }
+  t->cbuf = (unsigned char *) hcmalloc (g->max_comp); t->dbuf = (unsigned char *) hcmalloc (g->bms);
+  t->block = (u64) -1; t->line = 0; thread_ctx->thrdata = t; return true;
+}
+
+void thread_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
+{
+  lf_thread_t *t = thread_ctx->thrdata; if (t == NULL) return;
+  if (t->fd != -1) close (t->fd);
+  hcfree (t->cbuf); hcfree (t->dbuf); hcfree (t->carry); hcfree (t); thread_ctx->thrdata = NULL;
+}
+
+int thread_next (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, u8 *out_buf, const int out_size)
+{
+  lf_global_t *g = global_ctx->gbldata; lf_thread_t *t = thread_ctx->thrdata;
+  if (t->block == (u64) -1) { if (load_block (thread_ctx, g, t, 0) == false) return GENERIC_RC_ERROR; t->doff = g->line_off[0]; t->line = 0; }
+  while (t->doff >= t->dlen) { u64 nx = t->block + 1; if (nx >= g->nblocks) return GENERIC_RC_EOF; if (load_block (thread_ctx, g, t, nx) == false) return GENERIC_RC_ERROR; }
+
+  const size_t remaining = t->dlen - t->doff; size_t word_len = 0;
+  const size_t step = hc_line_next (t->dbuf + t->doff, remaining, &word_len);
+  if (step < remaining) { const size_t cl = MIN (word_len, (size_t) out_size); memcpy (out_buf, t->dbuf + t->doff, cl); t->doff += step + 1; t->line++; return (int) word_len; }
+
+  const bool last = (t->block + 1 >= g->nblocks);
+  if (last) { const size_t cl = MIN (word_len, (size_t) out_size); memcpy (out_buf, t->dbuf + t->doff, cl); t->doff = t->dlen; t->line++; return (int) word_len; }
+
+  size_t clen = remaining; carry_reserve (t, clen); memcpy (t->carry, t->dbuf + t->doff, clen); t->doff = t->dlen;
+  for (;;)
+  {
+    if (load_block (thread_ctx, g, t, t->block + 1) == false) return GENERIC_RC_ERROR;
+    const size_t nl = hc_memchr_get () (t->dbuf, '\n', t->dlen);
+    if (nl < t->dlen) { carry_reserve (t, clen + nl); memcpy (t->carry + clen, t->dbuf, nl); clen += nl; t->doff = nl + 1; break; }
+    carry_reserve (t, clen + t->dlen); memcpy (t->carry + clen, t->dbuf, t->dlen); clen += t->dlen; t->doff = t->dlen;
+    if (t->block + 1 >= g->nblocks) break;
+  }
+  while (clen > 0 && t->carry[clen - 1] == '\r') clen--;
+  const size_t cl = MIN (clen, (size_t) out_size); memcpy (out_buf, t->carry, cl); t->line++; return (int) clen;
+}
+
+bool thread_seek (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, const u64 offset)
+{
+  lf_global_t *g = global_ctx->gbldata; lf_thread_t *t = thread_ctx->thrdata;
+  if (offset >= g->total_lines) { thread_error_set (thread_ctx, "seek target past EOF: %" PRIu64, offset); return false; }
+  const u64 k = block_of_line (g, offset);
+  if (load_block (thread_ctx, g, t, k) == false) return false;
+  t->doff = g->line_off[k];
+  u64 skip = offset - g->first_line[k]; hc_memchr_t mc = hc_memchr_get ();
+  while (skip)
+  {
+    const size_t nl = mc (t->dbuf + t->doff, '\n', t->dlen - t->doff);
+    if (t->doff + nl < t->dlen) { t->doff += nl + 1; skip--; }
+    else { if (t->block + 1 >= g->nblocks) break; if (load_block (thread_ctx, g, t, t->block + 1) == false) return false; }
+  }
+  t->line = offset; return true;
+}

--- a/src/feeds/feed_lz4.mk
+++ b/src/feeds/feed_lz4.mk
@@ -1,0 +1,2 @@
+feeds/feed_lz4.so:  LFLAGS_NATIVE += -llz4
+feeds/feed_lz4.dll: LFLAGS_NATIVE += -llz4

--- a/src/feeds/feed_xz.c
+++ b/src/feeds/feed_xz.c
@@ -1,0 +1,443 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+// A generic (attack-mode 8) feed that reads an xz-compressed wordlist and seeks inside it, the same
+// way feed_zstd does for zstd. The one difference is where the frame boundaries come from: an .xz
+// stream carries a native block Index (compressed and uncompressed offset per block) in its footer,
+// so there is nothing to reframe -- the standard `xz --block-size=16MiB -T0 wordlist` produces a
+// multi-block, seekable file directly. This feed reads that index, records the line each block opens
+// on (one parallel decode pass, cached), and reaches word N by decoding only its block.
+//
+//   xz --block-size=16MiB -T0 -k wordlist          # once, with the stock xz tool
+//   hashcat -a 8 -m 0 hash.txt feeds/feed_xz.so wordlist.xz -r rules/best64.rule
+//
+// A single-block .xz (xz's default) still works but is one block, so a seek decodes from the start;
+// use --block-size for O(1) skip. Multi-stream .xz (manually concatenated) is not handled yet.
+
+#define XXH_INLINE_ALL
+#include "xxhash.h"
+
+#include "common.h"
+#include "types.h"
+#include "memory.h"
+#include "shared.h"
+#include "path.h"
+#include "folder.h"
+#include "memchr.h"
+#include "feed.h"
+
+#include <lzma.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <stdarg.h>
+#include <inttypes.h>
+
+const int GENERIC_PLUGIN_VERSION = FEEDS_INTERFACE_VERSION_CURRENT;
+
+const int GENERIC_PLUGIN_OPTIONS = GENERIC_PLUGIN_OPTIONS_AUTOHEX
+                                 | GENERIC_PLUGIN_OPTIONS_ICONV
+                                 | GENERIC_PLUGIN_OPTIONS_RULES;
+
+#define XFIDX_CACHE_MAGIC  0x315844495A465831ULL // "1XFZIDX1"-ish; distinct from feed_zstd's
+#define XFIDX_CACHE_VER    1ULL
+#define XFIDX_SAMPLE       65536
+
+typedef struct { u64 comp_off, first_line, uncomp_size, line_off; } xf_frame_t;
+
+typedef struct
+{
+  char        *path;
+
+  u64         *comp_off;    // [nblocks + 1], comp_off[nblocks] = filesize
+  u64         *total_size;  // [nblocks] compressed block size incl header+padding
+  u64         *first_line;  // [nblocks]
+  u64         *uncomp_size; // [nblocks]
+  u64         *line_off;    // [nblocks]
+
+  u64          nblocks;
+  u64          total_lines;
+  u64          filesize;
+
+  size_t       max_comp;
+  size_t       max_uncomp;
+
+  u64          build_threads;
+  lzma_check   check;       // stream check type, needed to decode a block
+
+} xf_global_t;
+
+typedef struct
+{
+  int             fd;
+  unsigned char  *cbuf;
+  unsigned char  *dbuf;
+  size_t          dlen, doff;
+  u64             block;    // (u64) -1 when none loaded
+  u64             line;
+  unsigned char  *carry;
+  size_t          carry_cap;
+} xf_thread_t;
+
+static void error_set (generic_global_ctx_t *g, const char *fmt, ...)
+{
+  g->error = true; va_list ap; va_start (ap, fmt);
+  vsnprintf (g->error_msg, sizeof (g->error_msg), fmt, ap); va_end (ap);
+}
+static void thread_error_set (generic_thread_ctx_t *t, const char *fmt, ...)
+{
+  t->error = true; va_list ap; va_start (ap, fmt);
+  vsnprintf (t->error_msg, sizeof (t->error_msg), fmt, ap); va_end (ap);
+}
+
+// ---- file identity + cache dir (same convention as the plaintext seekdb / feed_zstd) ----
+
+static u64 file_ident (const char *path, u64 *filesize)
+{
+  struct stat st; if (stat (path, &st) != 0) return 0;
+  *filesize = (u64) st.st_size;
+  FILE *fp = fopen (path, "rb"); if (fp == NULL) return 0;
+  XXH64_state_t *s = XXH64_createState (); XXH64_reset (s, 0);
+  XXH64_update (s, &st.st_size, sizeof (st.st_size));
+  u8 *b = (u8 *) hcmalloc (XFIDX_SAMPLE);
+  size_t n1 = fread (b, 1, XFIDX_SAMPLE, fp); XXH64_update (s, b, n1);
+  if ((u64) st.st_size > XFIDX_SAMPLE) { fseeko (fp, (off_t) st.st_size - XFIDX_SAMPLE, SEEK_SET); size_t n2 = fread (b, 1, XFIDX_SAMPLE, fp); XXH64_update (s, b, n2); }
+  hcfree (b); fclose (fp);
+  u64 h = XXH64_digest (s); XXH64_freeState (s); return h;
+}
+
+static char *cache_path (generic_global_ctx_t *global_ctx, const u64 ident)
+{
+  char *dir = NULL;
+  if (global_ctx->seekdb_dir != NULL) dir = hcstrdup (global_ctx->seekdb_dir);
+  else { hc_asprintf (&dir, "%s/seekdbs", global_ctx->cache_dir); hc_mkdir (dir, 0700); }
+  char *path = NULL; hc_asprintf (&path, "%s/%016" PRIx64 ".xfidx", dir, ident); hcfree (dir); return path;
+}
+
+static u64 block_of_line (const xf_global_t *g, const u64 offset)
+{
+  u64 lo = 0, hi = g->nblocks - 1, k = 0;
+  while (lo <= hi) { u64 m = lo + (hi - lo) / 2; if (g->first_line[m] <= offset) { k = m; lo = m + 1; } else { if (m == 0) break; hi = m - 1; } }
+  return k;
+}
+
+// decode one xz block (its compressed bytes are already in cbuf) into dbuf
+static bool decode_block (const xf_global_t *g, const unsigned char *cbuf, size_t csize, unsigned char *dbuf, size_t dsize)
+{
+  lzma_block blk; memset (&blk, 0, sizeof (blk));
+  lzma_filter filt[LZMA_FILTERS_MAX + 1];
+  blk.filters = filt; blk.check = g->check; blk.version = 0;
+  blk.header_size = lzma_block_header_size_decode (cbuf[0]);
+  if (lzma_block_header_decode (&blk, NULL, cbuf) != LZMA_OK) return false;
+
+  lzma_stream s = LZMA_STREAM_INIT;
+  if (lzma_block_decoder (&s, &blk) != LZMA_OK) { for (int i = 0; filt[i].id != LZMA_VLI_UNKNOWN; i++) free (filt[i].options); return false; }
+  s.next_in = cbuf + blk.header_size; s.avail_in = csize - blk.header_size;
+  s.next_out = dbuf; s.avail_out = dsize;
+  lzma_ret r = lzma_code (&s, LZMA_FINISH);
+  size_t got = dsize - s.avail_out;
+  lzma_end (&s);
+  for (int i = 0; filt[i].id != LZMA_VLI_UNKNOWN; i++) free (filt[i].options);
+  return (r == LZMA_STREAM_END || r == LZMA_OK) && got == dsize;
+}
+
+// ---- read the native xz block index: fills comp_off/total_size/uncomp_size/nblocks + check ----
+
+static bool xz_read_index (xf_global_t *g)
+{
+  int fd = open (g->path, O_RDONLY); if (fd == -1) return false;
+  struct stat st; if (fstat (fd, &st) != 0) { close (fd); return false; }
+  g->filesize = (u64) st.st_size;
+  if (g->filesize < 24) { close (fd); return false; }
+
+  unsigned char hdr[12], ftr[12];
+  if (pread (fd, hdr, 12, 0) != 12) { close (fd); return false; }
+  if (pread (fd, ftr, 12, (off_t) g->filesize - 12) != 12) { close (fd); return false; }
+
+  lzma_stream_flags sh, sf;
+  if (lzma_stream_header_decode (&sh, hdr) != LZMA_OK) { close (fd); return false; }
+  if (lzma_stream_footer_decode (&sf, ftr) != LZMA_OK) { close (fd); return false; }
+  g->check = sh.check;
+
+  const size_t idx_size = (size_t) sf.backward_size;
+  const off_t  idx_off  = (off_t) g->filesize - 12 - (off_t) idx_size;
+  if (idx_off < 12) { close (fd); return false; }
+
+  unsigned char *ibuf = (unsigned char *) hcmalloc (idx_size);
+  if (pread (fd, ibuf, idx_size, idx_off) != (ssize_t) idx_size) { hcfree (ibuf); close (fd); return false; }
+  close (fd);
+
+  uint64_t memlimit = UINT64_MAX; size_t inpos = 0; lzma_index *idx = NULL;
+  lzma_ret r = lzma_index_buffer_decode (&idx, &memlimit, NULL, ibuf, &inpos, idx_size);
+  hcfree (ibuf);
+  if (r != LZMA_OK) { if (idx) lzma_index_end (idx, NULL); return false; }
+
+  // single-stream only: the index must cover the whole file
+  if (lzma_index_stream_size (idx) != g->filesize)
+  {
+    // more than one stream present; not handled yet
+    lzma_index_end (idx, NULL); return false;
+  }
+
+  const u64 n = (u64) lzma_index_block_count (idx);
+  if (n == 0) { lzma_index_end (idx, NULL); return false; }
+
+  g->nblocks     = n;
+  g->comp_off    = (u64 *) hcmalloc ((n + 1) * sizeof (u64));
+  g->total_size  = (u64 *) hcmalloc (n * sizeof (u64));
+  g->uncomp_size = (u64 *) hcmalloc (n * sizeof (u64));
+
+  lzma_index_iter it; lzma_index_iter_init (&it, idx);
+  u64 k = 0;
+  while (!lzma_index_iter_next (&it, LZMA_INDEX_ITER_BLOCK) && k < n)
+  {
+    g->comp_off[k]    = (u64) it.block.compressed_file_offset;
+    g->total_size[k]  = (u64) it.block.total_size;
+    g->uncomp_size[k] = (u64) it.block.uncompressed_size;
+    if (g->uncomp_size[k] > g->max_uncomp) g->max_uncomp = (size_t) g->uncomp_size[k];
+    if (g->total_size[k] > g->max_comp)    g->max_comp   = (size_t) g->total_size[k];
+    k++;
+  }
+  g->comp_off[n] = g->filesize;
+  lzma_index_end (idx, NULL);
+  return k == n;
+}
+
+// ---- parallel line-count over the blocks -> first_line[] / line_off[] ----
+
+typedef struct
+{
+  xf_global_t   *g;
+  u64           *nl; uint8_t *last_nl; int64_t *first_nl;
+  u64            next; int error;
+} xf_build_ctx_t;
+
+static void *xf_build_worker (void *arg)
+{
+  xf_build_ctx_t *b = (xf_build_ctx_t *) arg; xf_global_t *g = b->g;
+  unsigned char *cbuf = (unsigned char *) malloc (g->max_comp);
+  unsigned char *dbuf = (unsigned char *) malloc (g->max_uncomp ? g->max_uncomp : 1);
+  int fd = open (g->path, O_RDONLY);
+  if (cbuf == NULL || dbuf == NULL || fd == -1) { b->error = 1; free (cbuf); free (dbuf); if (fd!=-1) close (fd); return NULL; }
+
+  for (;;)
+  {
+    if (b->error) break;
+    u64 k = __atomic_fetch_add (&b->next, 1, __ATOMIC_RELAXED);
+    if (k >= g->nblocks) break;
+    size_t csize = (size_t) g->total_size[k], dsize = (size_t) g->uncomp_size[k];
+    if (pread (fd, cbuf, csize, (off_t) g->comp_off[k]) != (ssize_t) csize) { b->error = 1; break; }
+    if (decode_block (g, cbuf, csize, dbuf, dsize) == false) { b->error = 1; break; }
+    u64 nl = 0; int64_t first = -1;
+    for (size_t o = 0; o < dsize; o++) if (dbuf[o] == '\n') { nl++; if (first < 0) first = (int64_t) o; }
+    b->nl[k] = nl; b->last_nl[k] = (dsize > 0 && dbuf[dsize - 1] == '\n') ? 1 : 0; b->first_nl[k] = first;
+  }
+  free (cbuf); free (dbuf); close (fd); return NULL;
+}
+
+static void index_finish (xf_global_t *g, const u64 *nl, const uint8_t *last_nl, const int64_t *first_nl)
+{
+  g->first_line = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+  g->line_off   = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+  u64 prefix = 0;
+  for (u64 k = 0; k < g->nblocks; k++)
+  {
+    if (k == 0) { g->first_line[0] = 0; g->line_off[0] = 0; }
+    else
+    {
+      g->first_line[k] = 1 + prefix - last_nl[k - 1];
+      g->line_off[k]   = last_nl[k - 1] ? 0 : ((first_nl[k] < 0) ? g->uncomp_size[k] : (u64) (first_nl[k] + 1));
+    }
+    prefix += nl[k];
+  }
+  g->total_lines = prefix + (last_nl[g->nblocks - 1] ? 0 : 1);
+}
+
+static bool index_build (xf_global_t *g)
+{
+  const long ncpu = sysconf (_SC_NPROCESSORS_ONLN);
+  u64 nthreads = g->build_threads ? g->build_threads : ((ncpu > 0) ? (u64) ncpu : 1);
+  const u64 by_mem = ((u64) 8 * 1024 * 1024 * 1024) / (g->max_uncomp ? g->max_uncomp : 1);
+  if (by_mem < 1) nthreads = 1; else if (nthreads > by_mem) nthreads = by_mem;
+  if (nthreads > g->nblocks) nthreads = g->nblocks;
+  if (nthreads < 1) nthreads = 1;
+
+  xf_build_ctx_t b; b.g = g; b.next = 0; b.error = 0;
+  b.nl       = (u64 *)     hcmalloc (g->nblocks * sizeof (u64));
+  b.last_nl  = (uint8_t *) hcmalloc (g->nblocks * sizeof (uint8_t));
+  b.first_nl = (int64_t *) hcmalloc (g->nblocks * sizeof (int64_t));
+
+  pthread_t *t = (pthread_t *) hcmalloc (nthreads * sizeof (pthread_t)); u64 sp = 0;
+  for (u64 i = 0; i < nthreads; i++) { if (pthread_create (&t[i], NULL, xf_build_worker, &b) != 0) break; sp++; }
+  if (sp == 0) xf_build_worker (&b);
+  for (u64 i = 0; i < sp; i++) pthread_join (t[i], NULL);
+  hcfree (t);
+
+  bool ok = (b.error == 0);
+  if (ok) index_finish (g, b.nl, b.last_nl, b.first_nl);
+  hcfree (b.nl); hcfree (b.last_nl); hcfree (b.first_nl);
+  return ok;
+}
+
+// ---- cache (block -> first_line/line_off), same shape as feed_zstd's .zfidx ----
+
+static bool index_from_cache (xf_global_t *g, const char *cpath, const u64 ident)
+{
+  FILE *fx = fopen (cpath, "rb"); if (fx == NULL) return false;
+  u64 hdr[6];
+  if (fread (hdr, sizeof (hdr), 1, fx) != 1 || hdr[0] != XFIDX_CACHE_MAGIC || hdr[1] != XFIDX_CACHE_VER
+   || hdr[2] != g->nblocks || hdr[4] != g->filesize || hdr[5] != ident) { fclose (fx); return false; }
+  xf_frame_t *e = (xf_frame_t *) hcmalloc (g->nblocks * sizeof (xf_frame_t));
+  bool ok = (fread (e, sizeof (xf_frame_t), g->nblocks, fx) == g->nblocks);
+  fclose (fx);
+  if (ok)
+  {
+    g->first_line = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+    g->line_off   = (u64 *) hcmalloc (g->nblocks * sizeof (u64));
+    g->total_lines = hdr[3];
+    for (u64 i = 0; i < g->nblocks; i++) { g->first_line[i] = e[i].first_line; g->line_off[i] = e[i].line_off; }
+  }
+  hcfree (e); return ok;
+}
+
+static void index_save_cache (const xf_global_t *g, const char *cpath, const u64 ident)
+{
+  char *tmp = NULL; hc_asprintf (&tmp, "%s.tmp.%d", cpath, (int) getpid ());
+  FILE *fx = fopen (tmp, "wb"); if (fx == NULL) { hcfree (tmp); return; }
+  u64 hdr[6] = { XFIDX_CACHE_MAGIC, XFIDX_CACHE_VER, g->nblocks, g->total_lines, g->filesize, ident };
+  bool ok = (fwrite (hdr, sizeof (hdr), 1, fx) == 1);
+  for (u64 i = 0; ok && i < g->nblocks; i++)
+  { xf_frame_t e = { g->comp_off[i], g->first_line[i], g->uncomp_size[i], g->line_off[i] }; ok = (fwrite (&e, sizeof (e), 1, fx) == 1); }
+  fclose (fx);
+  if (ok) rename (tmp, cpath); else unlink (tmp);
+  hcfree (tmp);
+}
+
+static bool load_block (generic_thread_ctx_t *tc, xf_global_t *g, xf_thread_t *t, const u64 k)
+{
+  size_t csize = (size_t) g->total_size[k], dsize = (size_t) g->uncomp_size[k];
+  if (pread (t->fd, t->cbuf, csize, (off_t) g->comp_off[k]) != (ssize_t) csize) { thread_error_set (tc, "%s: short read of block %" PRIu64, g->path, k); return false; }
+  if (decode_block (g, t->cbuf, csize, t->dbuf, dsize) == false) { thread_error_set (tc, "%s: block %" PRIu64 " decode failed", g->path, k); return false; }
+  t->dlen = dsize; t->doff = 0; t->block = k; return true;
+}
+
+static void carry_reserve (xf_thread_t *t, const size_t need)
+{
+  if (need <= t->carry_cap) return;
+  size_t old = t->carry_cap, cap = old ? old : 4096; while (cap < need) cap *= 2;
+  t->carry = (unsigned char *) hcrealloc (t->carry, old, cap - old); t->carry_cap = cap;
+}
+
+bool global_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  xf_global_t *g = (xf_global_t *) hccalloc (1, sizeof (xf_global_t));
+  global_ctx->gbldata = g;
+
+  u64 p_threads = 0;
+  const feed_param_t params[] = {
+    { "threads", FEED_PARAM_TYPE_U64, &p_threads, 0, 4096, "cores for the parallel index build (0 = all)" },
+    { NULL, 0, NULL, 0, 0, NULL },
+  };
+  char perr[256];
+  if (feed_param_parse (global_ctx->workc, global_ctx->workv, params, perr, sizeof (perr)) == false) { error_set (global_ctx, "%s", perr); return false; }
+  g->build_threads = p_threads;
+
+  const char *src = NULL;
+  for (int i = 1; i < global_ctx->workc; i++) if (feed_param_is_setting (global_ctx->workv[i]) == false) { src = global_ctx->workv[i]; break; }
+  if (src == NULL) { error_set (global_ctx, "usage: feed_xz.so <wordlist.xz> [threads=<n>]  (make it multi-block: xz --block-size=16MiB -T0)"); return false; }
+  g->path = hcstrdup (src);
+
+  u64 ident = file_ident (g->path, &g->filesize);
+  if (ident == 0) { error_set (global_ctx, "%s: cannot open", g->path); return false; }
+
+  if (xz_read_index (g) == false) { error_set (global_ctx, "%s: not a single-stream xz file (or unreadable index)", g->path); return false; }
+
+  char *cpath = cache_path (global_ctx, ident);
+  if (index_from_cache (g, cpath, ident) == false)
+  {
+    if (index_build (g) == false) { hcfree (cpath); error_set (global_ctx, "%s: block decode failed during index build", g->path); return false; }
+    index_save_cache (g, cpath, ident);
+  }
+  hcfree (cpath);
+
+  global_ctx->source_ident = (g->filesize * 1000003ULL) ^ (g->total_lines * 2654435761ULL) ^ g->nblocks;
+  snprintf (global_ctx->guess_base, sizeof (global_ctx->guess_base), "%s", g->path);
+  if (g->nblocks < 2) feed_say (hashcat_ctx, "feed_xz: %s is a single block, so --skip decodes from the start. Recompress with: xz --block-size=16MiB -T0", g->path);
+  return true;
+}
+
+void global_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  xf_global_t *g = global_ctx->gbldata; if (g == NULL) return;
+  hcfree (g->comp_off); hcfree (g->total_size); hcfree (g->first_line); hcfree (g->uncomp_size); hcfree (g->line_off);
+  hcfree (g->path); hcfree (g); global_ctx->gbldata = NULL;
+}
+
+u64 global_keyspace (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  xf_global_t *g = global_ctx->gbldata; return g->total_lines;
+}
+
+bool thread_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
+{
+  xf_global_t *g = global_ctx->gbldata;
+  xf_thread_t *t = (xf_thread_t *) hccalloc (1, sizeof (xf_thread_t));
+  t->fd = open (g->path, O_RDONLY);
+  if (t->fd == -1) { thread_error_set (thread_ctx, "%s: %s", g->path, strerror (errno)); hcfree (t); return false; }
+  t->cbuf = (unsigned char *) hcmalloc (g->max_comp); t->dbuf = (unsigned char *) hcmalloc (g->max_uncomp);
+  t->block = (u64) -1; t->line = 0; thread_ctx->thrdata = t; return true;
+}
+
+void thread_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
+{
+  xf_thread_t *t = thread_ctx->thrdata; if (t == NULL) return;
+  if (t->fd != -1) close (t->fd);
+  hcfree (t->cbuf); hcfree (t->dbuf); hcfree (t->carry); hcfree (t); thread_ctx->thrdata = NULL;
+}
+
+int thread_next (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, u8 *out_buf, const int out_size)
+{
+  xf_global_t *g = global_ctx->gbldata; xf_thread_t *t = thread_ctx->thrdata;
+  if (t->block == (u64) -1) { if (load_block (thread_ctx, g, t, 0) == false) return GENERIC_RC_ERROR; t->doff = g->line_off[0]; t->line = 0; }
+  while (t->doff >= t->dlen) { u64 nx = t->block + 1; if (nx >= g->nblocks) return GENERIC_RC_EOF; if (load_block (thread_ctx, g, t, nx) == false) return GENERIC_RC_ERROR; }
+
+  const size_t remaining = t->dlen - t->doff; size_t word_len = 0;
+  const size_t step = hc_line_next (t->dbuf + t->doff, remaining, &word_len);
+  if (step < remaining) { const size_t cl = MIN (word_len, (size_t) out_size); memcpy (out_buf, t->dbuf + t->doff, cl); t->doff += step + 1; t->line++; return (int) word_len; }
+
+  const bool last = (t->block + 1 >= g->nblocks);
+  if (last) { const size_t cl = MIN (word_len, (size_t) out_size); memcpy (out_buf, t->dbuf + t->doff, cl); t->doff = t->dlen; t->line++; return (int) word_len; }
+
+  size_t clen = remaining; carry_reserve (t, clen); memcpy (t->carry, t->dbuf + t->doff, clen); t->doff = t->dlen;
+  for (;;)
+  {
+    if (load_block (thread_ctx, g, t, t->block + 1) == false) return GENERIC_RC_ERROR;
+    const size_t nl = hc_memchr_get () (t->dbuf, '\n', t->dlen);
+    if (nl < t->dlen) { carry_reserve (t, clen + nl); memcpy (t->carry + clen, t->dbuf, nl); clen += nl; t->doff = nl + 1; break; }
+    carry_reserve (t, clen + t->dlen); memcpy (t->carry + clen, t->dbuf, t->dlen); clen += t->dlen; t->doff = t->dlen;
+    if (t->block + 1 >= g->nblocks) break;
+  }
+  while (clen > 0 && t->carry[clen - 1] == '\r') clen--;
+  const size_t cl = MIN (clen, (size_t) out_size); memcpy (out_buf, t->carry, cl); t->line++; return (int) clen;
+}
+
+bool thread_seek (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, const u64 offset)
+{
+  xf_global_t *g = global_ctx->gbldata; xf_thread_t *t = thread_ctx->thrdata;
+  if (offset >= g->total_lines) { thread_error_set (thread_ctx, "seek target past EOF: %" PRIu64, offset); return false; }
+  const u64 k = block_of_line (g, offset);
+  if (load_block (thread_ctx, g, t, k) == false) return false;
+  t->doff = g->line_off[k];
+  u64 skip = offset - g->first_line[k]; hc_memchr_t mc = hc_memchr_get ();
+  while (skip)
+  {
+    const size_t nl = mc (t->dbuf + t->doff, '\n', t->dlen - t->doff);
+    if (t->doff + nl < t->dlen) { t->doff += nl + 1; skip--; }
+    else { if (t->block + 1 >= g->nblocks) break; if (load_block (thread_ctx, g, t, t->block + 1) == false) return false; }
+  }
+  t->line = offset; return true;
+}

--- a/src/feeds/feed_xz.mk
+++ b/src/feeds/feed_xz.mk
@@ -1,0 +1,2 @@
+feeds/feed_xz.so:  LFLAGS_NATIVE += -llzma
+feeds/feed_xz.dll: LFLAGS_NATIVE += -llzma

--- a/src/feeds/feed_zstd.c
+++ b/src/feeds/feed_zstd.c
@@ -3,22 +3,33 @@
  * License.....: MIT
  */
 
-// A generic (attack-mode 8) feed that reads a SEEKABLE zstd wordlist: a file of independent,
-// line-aligned zstd frames plus a sidecar index (<path>.idx) mapping each frame to its compressed
-// offset and the line number it starts at. Because every frame decodes on its own, reaching word N
-// decompresses exactly one frame rather than the whole file, so --skip stays O(1) and the wordlist
-// stays compressed. This is the seekdb idea (a checkpoint -> position map) applied to frames instead
-// of raw byte offsets.
+// A generic (attack-mode 8) feed that reads a zstd-compressed wordlist and seeks within it without
+// decompressing the whole file. A zstd stream is a sequence of independently decodable frames, so a
+// small index -- frame k starts at compressed offset X and at line L -- turns "reach word N" into
+// "decode the one frame that holds it". That is the seekdb idea (a checkpoint -> position map) moved
+// from raw byte offsets, which need a plaintext file, onto frame offsets, which do not. The stock
+// mmap wordlist feed cannot seek a compressed file at all.
 //
-// The .zsf / .zsf.idx pair is produced offline by the `zsf` tool (hashcat-seekable repo). A plain
-// single-frame .zst also works, but is one frame, i.e. seeking still decodes from the start.
+// The index is built on first use by one streaming pass over the file and then cached, named by a
+// hash of the file the same way the plaintext seek database is, so a second run and every other
+// machine sharing the file (see --seekdb-path) reuse it. A sidecar written by the `zsf` tool
+// (<path>.idx) is used directly when present.
 //
-//   hashcat -a 8 -m 0 hash.txt feeds/feed_zstd.so wordlist.zsf -r rules/best64.rule
+// A file compressed as a single frame still works but is one frame, so a seek decodes from the
+// start: to get fast --skip the wordlist must be compressed in frames (the `zsf` tool, or zstd's
+// seekable format). Lines that cross a frame boundary are handled, so any multi-frame zstd works.
+//
+//   hashcat -a 8 -m 0 hash.txt feeds/feed_zstd.so wordlist.zst -r rules/best64.rule
+
+#define XXH_INLINE_ALL
+#include "xxhash.h"
 
 #include "common.h"
 #include "types.h"
 #include "memory.h"
 #include "shared.h"
+#include "path.h"
+#include "folder.h"
 #include "memchr.h"
 #include "feed.h"
 
@@ -35,32 +46,41 @@ const int GENERIC_PLUGIN_OPTIONS = GENERIC_PLUGIN_OPTIONS_AUTOHEX
                                  | GENERIC_PLUGIN_OPTIONS_ICONV
                                  | GENERIC_PLUGIN_OPTIONS_RULES;
 
-// index sidecar format, identical to prototype/zsf.c
-#define ZSF_IDX_MAGIC 0x315A53464B434821ULL
+#define ZFIDX_CACHE_MAGIC  0x315844495A465A46ULL // cache file this feed writes
+#define ZFIDX_CACHE_VER    1ULL
+#define ZSF_SIDECAR_MAGIC  0x315A53464B434821ULL // sidecar written by prototype/zsf.c
 
+#define ZFIDX_SAMPLE       65536
+#define BUILD_OUTBUF       (4 * 1024 * 1024)
+
+// One frame: where it starts in the compressed file, the line number of the first line that begins
+// inside it, how many bytes it decodes to, and where in those bytes that first line begins (nonzero
+// only when the frame opens in the middle of a line carried over from the frame before).
 typedef struct
 {
   u64 comp_off;
   u64 first_line;
   u64 uncomp_size;
-} zsf_entry_t;
+  u64 line_off;
+} zf_frame_t;
 
 typedef struct
 {
-  char   *path;
+  char       *path;
 
-  u64    *comp_off;    // [nframes + 1], comp_off[nframes] = filesize
-  u64    *first_line;  // [nframes]
-  u64    *uncomp_size; // [nframes]
+  u64        *comp_off;    // [nframes + 1], comp_off[nframes] = filesize
+  u64        *first_line;  // [nframes]
+  u64        *uncomp_size; // [nframes]
+  u64        *line_off;    // [nframes]
 
-  u64     nframes;
-  u64     total_lines;
-  u64     filesize;
+  u64         nframes;
+  u64         total_lines;
+  u64         filesize;
 
-  size_t  max_comp;    // largest compressed frame, sizes the thread read buffer
-  size_t  max_uncomp;  // largest decompressed frame, sizes the thread frame buffer
+  size_t      max_comp;    // largest compressed frame  -> thread read buffer
+  size_t      max_uncomp;  // largest decompressed frame -> thread frame buffer
 
-} zsf_global_t;
+} zf_global_t;
 
 typedef struct
 {
@@ -75,7 +95,10 @@ typedef struct
   u64             frame;  // frame currently in dbuf, or (u64) -1 when none is loaded
   u64             line;   // global line number of the next candidate
 
-} zsf_thread_t;
+  unsigned char  *carry;  // a line that spans frames is assembled here
+  size_t          carry_cap;
+
+} zf_thread_t;
 
 static void error_set (generic_global_ctx_t *global_ctx, const char *fmt, ...)
 {
@@ -97,27 +120,328 @@ static void thread_error_set (generic_thread_ctx_t *thread_ctx, const char *fmt,
   va_end (ap);
 }
 
-// Hand out the word that starts here and say where the next one starts. Same contract as the
-// wordlist feed: write at most out_size bytes but report the real length, so hashcat rejects an
-// over-long word rather than being handed a truncated candidate that is not in the list.
+// ----------------------------------------------------------------------------------------------
+// file identity, mirrored on the plaintext seek database: the size plus a sample of each end, so a
+// file that changed under the same path builds a fresh index rather than trusting a stale one.
+// ----------------------------------------------------------------------------------------------
 
-static size_t process_word (const u8 *buf, const size_t max_len, u8 *out_buf, const size_t out_size, size_t *out_len)
+static u64 file_ident (const char *path, u64 *filesize)
 {
-  size_t word_len = 0;
+  struct stat st;
 
-  const size_t step = hc_line_next (buf, max_len, &word_len);
+  if (stat (path, &st) != 0) return 0;
 
-  const size_t copy_len = MIN (word_len, out_size);
+  *filesize = (u64) st.st_size;
 
-  memcpy ((char *) out_buf, buf, copy_len);
+  FILE *fp = fopen (path, "rb");
 
-  *out_len = word_len;
+  if (fp == NULL) return 0;
 
-  return step;
+  XXH64_state_t *state = XXH64_createState ();
+  XXH64_reset (state, 0);
+  XXH64_update (state, &st.st_size, sizeof (st.st_size));
+
+  u8 *buf = (u8 *) hcmalloc (ZFIDX_SAMPLE);
+
+  const size_t n1 = fread (buf, 1, ZFIDX_SAMPLE, fp);
+  XXH64_update (state, buf, n1);
+
+  if ((u64) st.st_size > ZFIDX_SAMPLE)
+  {
+    fseeko (fp, (off_t) st.st_size - ZFIDX_SAMPLE, SEEK_SET);
+    const size_t n2 = fread (buf, 1, ZFIDX_SAMPLE, fp);
+    XXH64_update (state, buf, n2);
+  }
+
+  hcfree (buf);
+  fclose (fp);
+
+  const u64 h = XXH64_digest (state);
+  XXH64_freeState (state);
+
+  return h;
 }
 
+static char *cache_path (generic_global_ctx_t *global_ctx, const u64 ident)
+{
+  char *dir = NULL;
+
+  if (global_ctx->seekdb_dir != NULL)
+  {
+    dir = hcstrdup (global_ctx->seekdb_dir);
+  }
+  else
+  {
+    hc_asprintf (&dir, "%s/seekdbs", global_ctx->cache_dir);
+    hc_mkdir (dir, 0700);
+  }
+
+  char *path = NULL;
+  hc_asprintf (&path, "%s/%016" PRIx64 ".zfidx", dir, ident);
+  hcfree (dir);
+
+  return path;
+}
+
+// ----------------------------------------------------------------------------------------------
+// populate the in-memory index from a flat frame array
+// ----------------------------------------------------------------------------------------------
+
+static void index_adopt (zf_global_t *g, zf_frame_t *frames, const u64 nframes, const u64 total_lines)
+{
+  g->nframes     = nframes;
+  g->total_lines = total_lines;
+
+  g->comp_off    = (u64 *) hcmalloc ((nframes + 1) * sizeof (u64));
+  g->first_line  = (u64 *) hcmalloc (nframes * sizeof (u64));
+  g->uncomp_size = (u64 *) hcmalloc (nframes * sizeof (u64));
+  g->line_off    = (u64 *) hcmalloc (nframes * sizeof (u64));
+
+  for (u64 i = 0; i < nframes; i++)
+  {
+    g->comp_off[i]    = frames[i].comp_off;
+    g->first_line[i]  = frames[i].first_line;
+    g->uncomp_size[i] = frames[i].uncomp_size;
+    g->line_off[i]    = frames[i].line_off;
+
+    if (frames[i].uncomp_size > g->max_uncomp) g->max_uncomp = (size_t) frames[i].uncomp_size;
+  }
+
+  g->comp_off[nframes] = g->filesize;
+
+  for (u64 i = 0; i < nframes; i++)
+  {
+    const size_t csize = (size_t) (g->comp_off[i + 1] - g->comp_off[i]);
+    if (csize > g->max_comp) g->max_comp = csize;
+  }
+}
+
+// ----------------------------------------------------------------------------------------------
+// index sources: the zsf sidecar, the cache, or a fresh scan
+// ----------------------------------------------------------------------------------------------
+
+// prototype/zsf.c sidecar: header {magic, level, chunk, nframes, total_lines} then
+// {comp_off, first_line, uncomp_size} per frame. Its frames are line-aligned, so line_off is 0.
+static bool index_from_sidecar (zf_global_t *g, const char *path)
+{
+  char idxpath[4352];
+  snprintf (idxpath, sizeof (idxpath), "%s.idx", path);
+
+  FILE *fx = fopen (idxpath, "rb");
+  if (fx == NULL) return false;
+
+  u64 hdr[5];
+  if (fread (hdr, sizeof (hdr), 1, fx) != 1 || hdr[0] != ZSF_SIDECAR_MAGIC)
+  {
+    fclose (fx);
+    return false;
+  }
+
+  const u64 nframes = hdr[3];
+  const u64 total   = hdr[4];
+
+  if (nframes == 0) { fclose (fx); return false; }
+
+  zf_frame_t *frames = (zf_frame_t *) hcmalloc (nframes * sizeof (zf_frame_t));
+
+  bool ok = true;
+
+  for (u64 i = 0; i < nframes; i++)
+  {
+    u64 e[3];
+    if (fread (e, sizeof (e), 1, fx) != 1) { ok = false; break; }
+    frames[i].comp_off    = e[0];
+    frames[i].first_line  = e[1];
+    frames[i].uncomp_size = e[2];
+    frames[i].line_off    = 0;
+  }
+
+  fclose (fx);
+
+  if (ok) index_adopt (g, frames, nframes, total);
+
+  hcfree (frames);
+
+  return ok;
+}
+
+static bool index_from_cache (zf_global_t *g, const char *cpath, const u64 ident)
+{
+  FILE *fx = fopen (cpath, "rb");
+  if (fx == NULL) return false;
+
+  u64 hdr[6];
+  if (fread (hdr, sizeof (hdr), 1, fx) != 1
+   || hdr[0] != ZFIDX_CACHE_MAGIC
+   || hdr[1] != ZFIDX_CACHE_VER
+   || hdr[4] != g->filesize
+   || hdr[5] != ident)
+  {
+    fclose (fx);
+    return false;
+  }
+
+  const u64 nframes = hdr[2];
+  const u64 total   = hdr[3];
+
+  if (nframes == 0) { fclose (fx); return false; }
+
+  zf_frame_t *frames = (zf_frame_t *) hcmalloc (nframes * sizeof (zf_frame_t));
+
+  const bool ok = (fread (frames, sizeof (zf_frame_t), nframes, fx) == nframes);
+
+  fclose (fx);
+
+  if (ok) index_adopt (g, frames, nframes, total);
+
+  hcfree (frames);
+
+  return ok;
+}
+
+static void index_save_cache (const zf_global_t *g, const char *cpath, const u64 ident)
+{
+  // A failed write is not fatal: the run uses the index it just built in memory, and the next run
+  // rebuilds. Write to a temp beside the target and rename, so a reader never sees a half file.
+
+  char *tmp = NULL;
+  hc_asprintf (&tmp, "%s.tmp.%d", cpath, (int) getpid ());
+
+  FILE *fx = fopen (tmp, "wb");
+  if (fx == NULL) { hcfree (tmp); return; }
+
+  u64 hdr[6] = { ZFIDX_CACHE_MAGIC, ZFIDX_CACHE_VER, g->nframes, g->total_lines, g->filesize, ident };
+
+  bool ok = (fwrite (hdr, sizeof (hdr), 1, fx) == 1);
+
+  for (u64 i = 0; ok && i < g->nframes; i++)
+  {
+    zf_frame_t e = { g->comp_off[i], g->first_line[i], g->uncomp_size[i], g->line_off[i] };
+    ok = (fwrite (&e, sizeof (e), 1, fx) == 1);
+  }
+
+  fclose (fx);
+
+  if (ok) rename (tmp, cpath);
+  else    unlink (tmp);
+
+  hcfree (tmp);
+}
+
+// One streaming pass: decode the whole file, and at each frame boundary record where the frame
+// started and the line it opened on. Bounded memory (one input and one output block), decode only.
+static bool index_build (zf_global_t *g, const char *path)
+{
+  int fd = open (path, O_RDONLY);
+  if (fd == -1) return false;
+
+  ZSTD_DStream *ds = ZSTD_createDStream ();
+  if (ds == NULL) { close (fd); return false; }
+
+  ZSTD_bounds const wb = ZSTD_dParam_getBounds (ZSTD_d_windowLogMax);
+  if (!ZSTD_isError (wb.error)) ZSTD_DCtx_setParameter (ds, ZSTD_d_windowLogMax, wb.upperBound);
+
+  const size_t incap = ZSTD_DStreamInSize ();
+  unsigned char *inbuf  = (unsigned char *) hcmalloc (incap);
+  unsigned char *outbuf = (unsigned char *) hcmalloc (BUILD_OUTBUF);
+
+  zf_frame_t *frames = NULL;
+  u64 nframes = 0, aframes = 0;
+
+  u64 comp_base   = 0;      // file offset of the current inbuf
+  u64 line_count  = 0;      // line-starts seen
+  bool prev_nl    = true;   // the file begins a line
+  bool ok         = true;
+  bool have_frame = false;
+
+  zf_frame_t cur = { 0, 0, 0, (u64) -1 };  // line_off = -1 means "no line has started in this frame yet"
+
+  for (;;)
+  {
+    ssize_t rd = read (fd, inbuf, incap);
+    if (rd < 0) { ok = false; break; }
+    if (rd == 0) break; // EOF
+
+    ZSTD_inBuffer ib = { inbuf, (size_t) rd, 0 };
+
+    while (ib.pos < ib.size)
+    {
+      ZSTD_outBuffer ob = { outbuf, BUILD_OUTBUF, 0 };
+
+      const size_t ret = ZSTD_decompressStream (ds, &ob, &ib);
+      if (ZSTD_isError (ret)) { ok = false; break; }
+
+      const u64 base = cur.uncomp_size; // frame bytes before this output block
+
+      for (size_t o = 0; o < ob.pos; o++)
+      {
+        if (prev_nl)
+        {
+          if (cur.line_off == (u64) -1) cur.line_off = base + o;
+          line_count++;
+        }
+        prev_nl = (outbuf[o] == '\n');
+      }
+
+      cur.uncomp_size += ob.pos;
+      have_frame = true;
+
+      if (ret == 0)
+      {
+        // frame complete; if it never opened a line, leave line_off as 0 so seek code is simple
+        if (cur.line_off == (u64) -1) cur.line_off = 0;
+
+        if (nframes == aframes)
+        {
+          const u64 olda = aframes;
+          aframes = aframes ? aframes * 2 : 256;
+          frames = (zf_frame_t *) hcrealloc (frames, olda * sizeof (zf_frame_t), (aframes - olda) * sizeof (zf_frame_t));
+        }
+        frames[nframes++] = cur;
+
+        // next frame starts where this one ended
+        cur.comp_off    = comp_base + ib.pos;
+        cur.first_line  = line_count;
+        cur.uncomp_size = 0;
+        cur.line_off    = (u64) -1;
+        have_frame      = false;
+      }
+    }
+
+    if (ok == false) break;
+
+    comp_base += (u64) rd;
+  }
+
+  // a trailing partial frame (truncated stream) is still usable up to where it decoded
+  if (ok && have_frame && cur.uncomp_size > 0)
+  {
+    if (cur.line_off == (u64) -1) cur.line_off = 0;
+    if (nframes == aframes)
+    {
+      const u64 olda = aframes;
+      aframes = aframes ? aframes * 2 : 1;
+      frames = (zf_frame_t *) hcrealloc (frames, olda * sizeof (zf_frame_t), (aframes - olda) * sizeof (zf_frame_t));
+    }
+    frames[nframes++] = cur;
+  }
+
+  hcfree (inbuf);
+  hcfree (outbuf);
+  ZSTD_freeDStream (ds);
+  close (fd);
+
+  if (ok && nframes > 0) index_adopt (g, frames, nframes, line_count);
+
+  hcfree (frames);
+
+  return ok && nframes > 0;
+}
+
+// ----------------------------------------------------------------------------------------------
+
 // largest frame with first_line <= offset
-static u64 frame_of_line (const zsf_global_t *g, const u64 offset)
+static u64 frame_of_line (const zf_global_t *g, const u64 offset)
 {
   u64 lo = 0;
   u64 hi = g->nframes - 1;
@@ -127,31 +451,19 @@ static u64 frame_of_line (const zsf_global_t *g, const u64 offset)
   {
     const u64 mid = lo + (hi - lo) / 2;
 
-    if (g->first_line[mid] <= offset)
-    {
-      k = mid;
-      lo = mid + 1;
-    }
-    else
-    {
-      if (mid == 0) break;
-      hi = mid - 1;
-    }
+    if (g->first_line[mid] <= offset) { k = mid; lo = mid + 1; }
+    else { if (mid == 0) break; hi = mid - 1; }
   }
 
   return k;
 }
 
-// read and decompress frame k into the thread's dbuf
-static bool load_frame (generic_thread_ctx_t *thread_ctx, zsf_global_t *g, zsf_thread_t *t, const u64 k)
+static bool load_frame (generic_thread_ctx_t *thread_ctx, zf_global_t *g, zf_thread_t *t, const u64 k)
 {
-  const u64 comp_start = g->comp_off[k];
-  const u64 comp_end   = g->comp_off[k + 1];
-  const size_t csize   = (size_t) (comp_end - comp_start);
-  const size_t dsize   = (size_t) g->uncomp_size[k];
+  const size_t csize = (size_t) (g->comp_off[k + 1] - g->comp_off[k]);
+  const size_t dsize = (size_t) g->uncomp_size[k];
 
-  ssize_t rd = pread (t->fd, t->cbuf, csize, (off_t) comp_start);
-
+  ssize_t rd = pread (t->fd, t->cbuf, csize, (off_t) g->comp_off[k]);
   if (rd < 0 || (size_t) rd != csize)
   {
     thread_error_set (thread_ctx, "%s: short read of frame %" PRIu64, g->path, k);
@@ -159,7 +471,6 @@ static bool load_frame (generic_thread_ctx_t *thread_ctx, zsf_global_t *g, zsf_t
   }
 
   const size_t ds = ZSTD_decompress (t->dbuf, dsize, t->cbuf, csize);
-
   if (ZSTD_isError (ds) || ds != dsize)
   {
     thread_error_set (thread_ctx, "%s: frame %" PRIu64 " decode failed", g->path, k);
@@ -173,118 +484,85 @@ static bool load_frame (generic_thread_ctx_t *thread_ctx, zsf_global_t *g, zsf_t
   return true;
 }
 
+static void carry_reserve (zf_thread_t *t, const size_t need)
+{
+  if (need <= t->carry_cap) return;
+
+  const size_t oldcap = t->carry_cap;
+  size_t cap = oldcap ? oldcap : 4096;
+  while (cap < need) cap *= 2;
+
+  t->carry = (unsigned char *) hcrealloc (t->carry, oldcap, cap - oldcap);
+  t->carry_cap = cap;
+}
+
 bool global_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 {
-  zsf_global_t *g = (zsf_global_t *) hccalloc (1, sizeof (zsf_global_t));
+  zf_global_t *g = (zf_global_t *) hccalloc (1, sizeof (zf_global_t));
 
   global_ctx->gbldata = g;
 
   if (global_ctx->workc < 2)
   {
-    error_set (global_ctx, "usage: feed_zstd.so <wordlist.zsf> (built by the zsf tool)");
+    error_set (global_ctx, "usage: feed_zstd.so <wordlist.zst> (multi-frame for fast --skip)");
     return false;
   }
 
   g->path = hcstrdup (global_ctx->workv[1]);
 
-  // file size (end offset of the last frame)
+  u64 ident = file_ident (g->path, &g->filesize);
 
-  struct stat st;
-
-  if (stat (g->path, &st) != 0)
+  if (ident == 0)
   {
-    error_set (global_ctx, "%s: cannot stat", g->path);
+    error_set (global_ctx, "%s: cannot open", g->path);
     return false;
   }
 
-  g->filesize = (u64) st.st_size;
+  // 1) a zsf sidecar sits next to the file and is already the index
+  // 2) a cached index for this exact file
+  // 3) build it now, one streaming pass, and cache it
 
-  // read the sidecar index: <path>.idx
-
-  char idxpath[4352];
-  snprintf (idxpath, sizeof (idxpath), "%s.idx", g->path);
-
-  FILE *fx = fopen (idxpath, "rb");
-
-  if (fx == NULL)
+  if (index_from_sidecar (g, g->path) == false)
   {
-    error_set (global_ctx, "%s: missing seek index (build it with: zsf build <in> %s)", idxpath, g->path);
-    return false;
+    char *cpath = cache_path (global_ctx, ident);
+
+    if (index_from_cache (g, cpath, ident) == false)
+    {
+      if (index_build (g, g->path) == false)
+      {
+        hcfree (cpath);
+        error_set (global_ctx, "%s: not a valid zstd stream", g->path);
+        return false;
+      }
+
+      index_save_cache (g, cpath, ident);
+    }
+
+    hcfree (cpath);
   }
 
-  u64 hdr[5];
-
-  if (fread (hdr, sizeof (hdr), 1, fx) != 1 || hdr[0] != ZSF_IDX_MAGIC)
-  {
-    fclose (fx);
-    error_set (global_ctx, "%s: not a valid zsf index", idxpath);
-    return false;
-  }
-
-  g->nframes     = hdr[3];
-  g->total_lines = hdr[4];
-
-  if (g->nframes == 0)
-  {
-    fclose (fx);
-    error_set (global_ctx, "%s: empty index", idxpath);
-    return false;
-  }
-
-  zsf_entry_t *ent = (zsf_entry_t *) hcmalloc (g->nframes * sizeof (zsf_entry_t));
-
-  if (fread (ent, sizeof (zsf_entry_t), g->nframes, fx) != g->nframes)
-  {
-    hcfree (ent);
-    fclose (fx);
-    error_set (global_ctx, "%s: truncated index", idxpath);
-    return false;
-  }
-
-  fclose (fx);
-
-  g->comp_off    = (u64 *) hcmalloc ((g->nframes + 1) * sizeof (u64));
-  g->first_line  = (u64 *) hcmalloc (g->nframes * sizeof (u64));
-  g->uncomp_size = (u64 *) hcmalloc (g->nframes * sizeof (u64));
-
-  for (u64 i = 0; i < g->nframes; i++)
-  {
-    g->comp_off[i]    = ent[i].comp_off;
-    g->first_line[i]  = ent[i].first_line;
-    g->uncomp_size[i] = ent[i].uncomp_size;
-
-    if (ent[i].uncomp_size > g->max_uncomp) g->max_uncomp = (size_t) ent[i].uncomp_size;
-  }
-
-  g->comp_off[g->nframes] = g->filesize;
-
-  for (u64 i = 0; i < g->nframes; i++)
-  {
-    const size_t csize = (size_t) (g->comp_off[i + 1] - g->comp_off[i]);
-    if (csize > g->max_comp) g->max_comp = csize;
-  }
-
-  hcfree (ent);
-
-  // brain / restore identity: two files with the same size and line count over the same frames are
-  // the same attack.
-
-  global_ctx->source_ident = (g->filesize * 1000003ULL) ^ (g->total_lines * 2654435761ULL) ^ g->nframes;
+  global_ctx->source_ident = (g->filesize * 1000003ULL) ^ (g->total_lines * 2654435761ULL) ^ ident;
 
   snprintf (global_ctx->guess_base, sizeof (global_ctx->guess_base), "%s", g->path);
+
+  if (g->nframes < 2)
+  {
+    feed_say (hashcat_ctx, "feed_zstd: %s is a single frame, so --skip decodes from the start. Recompress in frames (e.g. the zsf tool) for O(1) skip.", g->path);
+  }
 
   return true;
 }
 
 void global_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 {
-  zsf_global_t *g = global_ctx->gbldata;
+  zf_global_t *g = global_ctx->gbldata;
 
   if (g == NULL) return;
 
   hcfree (g->comp_off);
   hcfree (g->first_line);
   hcfree (g->uncomp_size);
+  hcfree (g->line_off);
   hcfree (g->path);
   hcfree (g);
 
@@ -293,19 +571,18 @@ void global_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED ge
 
 u64 global_keyspace (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 {
-  zsf_global_t *g = global_ctx->gbldata;
+  zf_global_t *g = global_ctx->gbldata;
 
   return g->total_lines;
 }
 
 bool thread_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
 {
-  zsf_global_t *g = global_ctx->gbldata;
+  zf_global_t *g = global_ctx->gbldata;
 
-  zsf_thread_t *t = (zsf_thread_t *) hccalloc (1, sizeof (zsf_thread_t));
+  zf_thread_t *t = (zf_thread_t *) hccalloc (1, sizeof (zf_thread_t));
 
   t->fd = open (g->path, O_RDONLY);
-
   if (t->fd == -1)
   {
     thread_error_set (thread_ctx, "%s: %s", g->path, strerror (errno));
@@ -325,13 +602,14 @@ bool thread_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED ge
 
 void thread_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
 {
-  zsf_thread_t *t = thread_ctx->thrdata;
+  zf_thread_t *t = thread_ctx->thrdata;
 
   if (t == NULL) return;
 
   if (t->fd != -1) close (t->fd);
   hcfree (t->cbuf);
   hcfree (t->dbuf);
+  hcfree (t->carry);
   hcfree (t);
 
   thread_ctx->thrdata = NULL;
@@ -339,44 +617,92 @@ void thread_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED ge
 
 int thread_next (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, u8 *out_buf, const int out_size)
 {
-  zsf_global_t *g = global_ctx->gbldata;
-  zsf_thread_t *t = thread_ctx->thrdata;
-
-  // hashcat normally seeks before the first candidate; if it did not, start at frame 0
+  zf_global_t *g = global_ctx->gbldata;
+  zf_thread_t *t = thread_ctx->thrdata;
 
   if (t->frame == (u64) -1)
   {
     if (load_frame (thread_ctx, g, t, 0) == false) return GENERIC_RC_ERROR;
+    t->doff = g->line_off[0];
     t->line = 0;
   }
-
-  // advance across empty tails / frame boundaries
 
   while (t->doff >= t->dlen)
   {
     const u64 next = t->frame + 1;
-
     if (next >= g->nframes) return GENERIC_RC_EOF;
-
     if (load_frame (thread_ctx, g, t, next) == false) return GENERIC_RC_ERROR;
   }
 
   const size_t remaining = t->dlen - t->doff;
 
   size_t word_len = 0;
+  const size_t step = hc_line_next (t->dbuf + t->doff, remaining, &word_len);
 
-  const size_t step = process_word (t->dbuf + t->doff, remaining, out_buf, out_size, &word_len);
+  if (step < remaining)
+  {
+    // whole line inside this frame
+    const size_t copy_len = MIN (word_len, (size_t) out_size);
+    memcpy (out_buf, t->dbuf + t->doff, copy_len);
+    t->doff += step + 1;
+    t->line++;
+    return (int) word_len;
+  }
 
-  t->doff += (step < remaining) ? (step + 1) : remaining;
+  // no newline to the end of the frame
+  const bool last_frame = (t->frame + 1 >= g->nframes);
+
+  if (last_frame)
+  {
+    const size_t copy_len = MIN (word_len, (size_t) out_size);
+    memcpy (out_buf, t->dbuf + t->doff, copy_len);
+    t->doff = t->dlen;
+    t->line++;
+    return (int) word_len;
+  }
+
+  // the line spans into the next frame(s): assemble it in the carry buffer
+  size_t clen = remaining;
+  carry_reserve (t, clen);
+  memcpy (t->carry, t->dbuf + t->doff, clen);
+  t->doff = t->dlen;
+
+  for (;;)
+  {
+    if (load_frame (thread_ctx, g, t, t->frame + 1) == false) return GENERIC_RC_ERROR;
+
+    const size_t nl = hc_memchr_get () (t->dbuf, '\n', t->dlen);
+
+    if (nl < t->dlen)
+    {
+      carry_reserve (t, clen + nl);
+      memcpy (t->carry + clen, t->dbuf, nl);
+      clen += nl;
+      t->doff = nl + 1;
+      break;
+    }
+
+    carry_reserve (t, clen + t->dlen);
+    memcpy (t->carry + clen, t->dbuf, t->dlen);
+    clen += t->dlen;
+    t->doff = t->dlen;
+
+    if (t->frame + 1 >= g->nframes) break; // line ends at EOF
+  }
+
+  while (clen > 0 && t->carry[clen - 1] == '\r') clen--;
+
+  const size_t copy_len = MIN (clen, (size_t) out_size);
+  memcpy (out_buf, t->carry, copy_len);
   t->line++;
 
-  return (int) word_len;
+  return (int) clen;
 }
 
 bool thread_seek (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, const u64 offset)
 {
-  zsf_global_t *g = global_ctx->gbldata;
-  zsf_thread_t *t = thread_ctx->thrdata;
+  zf_global_t *g = global_ctx->gbldata;
+  zf_thread_t *t = thread_ctx->thrdata;
 
   if (offset >= g->total_lines)
   {
@@ -388,18 +714,28 @@ bool thread_seek (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED ge
 
   if (load_frame (thread_ctx, g, t, k) == false) return false;
 
-  // walk forward to the exact line inside the one decoded frame
+  t->doff = g->line_off[k];
 
+  // walk forward to the exact line; a line that spans frames is followed across the boundary
   u64 skip = offset - g->first_line[k];
 
-  while (skip && t->doff < t->dlen)
+  hc_memchr_t memchr_fn = hc_memchr_get ();
+
+  while (skip)
   {
-    const u8 *nl = (const u8 *) memchr (t->dbuf + t->doff, '\n', t->dlen - t->doff);
+    const size_t nl = memchr_fn (t->dbuf + t->doff, '\n', t->dlen - t->doff);
 
-    if (nl == NULL) break;
-
-    t->doff = (size_t) (nl - t->dbuf) + 1;
-    skip--;
+    if (t->doff + nl < t->dlen)
+    {
+      t->doff += nl + 1;
+      skip--;
+    }
+    else
+    {
+      if (t->frame + 1 >= g->nframes) break;
+      if (load_frame (thread_ctx, g, t, t->frame + 1) == false) return false;
+      // no decrement: this line's newline is in the next frame
+    }
   }
 
   t->line = offset;

--- a/src/feeds/feed_zstd.c
+++ b/src/feeds/feed_zstd.c
@@ -1,0 +1,408 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+// A generic (attack-mode 8) feed that reads a SEEKABLE zstd wordlist: a file of independent,
+// line-aligned zstd frames plus a sidecar index (<path>.idx) mapping each frame to its compressed
+// offset and the line number it starts at. Because every frame decodes on its own, reaching word N
+// decompresses exactly one frame rather than the whole file, so --skip stays O(1) and the wordlist
+// stays compressed. This is the seekdb idea (a checkpoint -> position map) applied to frames instead
+// of raw byte offsets.
+//
+// The .zsf / .zsf.idx pair is produced offline by the `zsf` tool (hashcat-seekable repo). A plain
+// single-frame .zst also works, but is one frame, i.e. seeking still decodes from the start.
+//
+//   hashcat -a 8 -m 0 hash.txt feeds/feed_zstd.so wordlist.zsf -r rules/best64.rule
+
+#include "common.h"
+#include "types.h"
+#include "memory.h"
+#include "shared.h"
+#include "memchr.h"
+#include "feed.h"
+
+#include <zstd.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <stdarg.h>
+#include <inttypes.h>
+
+const int GENERIC_PLUGIN_VERSION = FEEDS_INTERFACE_VERSION_CURRENT;
+
+const int GENERIC_PLUGIN_OPTIONS = GENERIC_PLUGIN_OPTIONS_AUTOHEX
+                                 | GENERIC_PLUGIN_OPTIONS_ICONV
+                                 | GENERIC_PLUGIN_OPTIONS_RULES;
+
+// index sidecar format, identical to prototype/zsf.c
+#define ZSF_IDX_MAGIC 0x315A53464B434821ULL
+
+typedef struct
+{
+  u64 comp_off;
+  u64 first_line;
+  u64 uncomp_size;
+} zsf_entry_t;
+
+typedef struct
+{
+  char   *path;
+
+  u64    *comp_off;    // [nframes + 1], comp_off[nframes] = filesize
+  u64    *first_line;  // [nframes]
+  u64    *uncomp_size; // [nframes]
+
+  u64     nframes;
+  u64     total_lines;
+  u64     filesize;
+
+  size_t  max_comp;    // largest compressed frame, sizes the thread read buffer
+  size_t  max_uncomp;  // largest decompressed frame, sizes the thread frame buffer
+
+} zsf_global_t;
+
+typedef struct
+{
+  int             fd;
+
+  unsigned char  *cbuf;   // one compressed frame
+  unsigned char  *dbuf;   // one decompressed frame
+
+  size_t          dlen;   // valid bytes in dbuf
+  size_t          doff;   // read cursor in dbuf
+
+  u64             frame;  // frame currently in dbuf, or (u64) -1 when none is loaded
+  u64             line;   // global line number of the next candidate
+
+} zsf_thread_t;
+
+static void error_set (generic_global_ctx_t *global_ctx, const char *fmt, ...)
+{
+  global_ctx->error = true;
+
+  va_list ap;
+  va_start (ap, fmt);
+  vsnprintf (global_ctx->error_msg, sizeof (global_ctx->error_msg), fmt, ap);
+  va_end (ap);
+}
+
+static void thread_error_set (generic_thread_ctx_t *thread_ctx, const char *fmt, ...)
+{
+  thread_ctx->error = true;
+
+  va_list ap;
+  va_start (ap, fmt);
+  vsnprintf (thread_ctx->error_msg, sizeof (thread_ctx->error_msg), fmt, ap);
+  va_end (ap);
+}
+
+// Hand out the word that starts here and say where the next one starts. Same contract as the
+// wordlist feed: write at most out_size bytes but report the real length, so hashcat rejects an
+// over-long word rather than being handed a truncated candidate that is not in the list.
+
+static size_t process_word (const u8 *buf, const size_t max_len, u8 *out_buf, const size_t out_size, size_t *out_len)
+{
+  size_t word_len = 0;
+
+  const size_t step = hc_line_next (buf, max_len, &word_len);
+
+  const size_t copy_len = MIN (word_len, out_size);
+
+  memcpy ((char *) out_buf, buf, copy_len);
+
+  *out_len = word_len;
+
+  return step;
+}
+
+// largest frame with first_line <= offset
+static u64 frame_of_line (const zsf_global_t *g, const u64 offset)
+{
+  u64 lo = 0;
+  u64 hi = g->nframes - 1;
+  u64 k  = 0;
+
+  while (lo <= hi)
+  {
+    const u64 mid = lo + (hi - lo) / 2;
+
+    if (g->first_line[mid] <= offset)
+    {
+      k = mid;
+      lo = mid + 1;
+    }
+    else
+    {
+      if (mid == 0) break;
+      hi = mid - 1;
+    }
+  }
+
+  return k;
+}
+
+// read and decompress frame k into the thread's dbuf
+static bool load_frame (generic_thread_ctx_t *thread_ctx, zsf_global_t *g, zsf_thread_t *t, const u64 k)
+{
+  const u64 comp_start = g->comp_off[k];
+  const u64 comp_end   = g->comp_off[k + 1];
+  const size_t csize   = (size_t) (comp_end - comp_start);
+  const size_t dsize   = (size_t) g->uncomp_size[k];
+
+  ssize_t rd = pread (t->fd, t->cbuf, csize, (off_t) comp_start);
+
+  if (rd < 0 || (size_t) rd != csize)
+  {
+    thread_error_set (thread_ctx, "%s: short read of frame %" PRIu64, g->path, k);
+    return false;
+  }
+
+  const size_t ds = ZSTD_decompress (t->dbuf, dsize, t->cbuf, csize);
+
+  if (ZSTD_isError (ds) || ds != dsize)
+  {
+    thread_error_set (thread_ctx, "%s: frame %" PRIu64 " decode failed", g->path, k);
+    return false;
+  }
+
+  t->dlen  = ds;
+  t->doff  = 0;
+  t->frame = k;
+
+  return true;
+}
+
+bool global_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  zsf_global_t *g = (zsf_global_t *) hccalloc (1, sizeof (zsf_global_t));
+
+  global_ctx->gbldata = g;
+
+  if (global_ctx->workc < 2)
+  {
+    error_set (global_ctx, "usage: feed_zstd.so <wordlist.zsf> (built by the zsf tool)");
+    return false;
+  }
+
+  g->path = hcstrdup (global_ctx->workv[1]);
+
+  // file size (end offset of the last frame)
+
+  struct stat st;
+
+  if (stat (g->path, &st) != 0)
+  {
+    error_set (global_ctx, "%s: cannot stat", g->path);
+    return false;
+  }
+
+  g->filesize = (u64) st.st_size;
+
+  // read the sidecar index: <path>.idx
+
+  char idxpath[4352];
+  snprintf (idxpath, sizeof (idxpath), "%s.idx", g->path);
+
+  FILE *fx = fopen (idxpath, "rb");
+
+  if (fx == NULL)
+  {
+    error_set (global_ctx, "%s: missing seek index (build it with: zsf build <in> %s)", idxpath, g->path);
+    return false;
+  }
+
+  u64 hdr[5];
+
+  if (fread (hdr, sizeof (hdr), 1, fx) != 1 || hdr[0] != ZSF_IDX_MAGIC)
+  {
+    fclose (fx);
+    error_set (global_ctx, "%s: not a valid zsf index", idxpath);
+    return false;
+  }
+
+  g->nframes     = hdr[3];
+  g->total_lines = hdr[4];
+
+  if (g->nframes == 0)
+  {
+    fclose (fx);
+    error_set (global_ctx, "%s: empty index", idxpath);
+    return false;
+  }
+
+  zsf_entry_t *ent = (zsf_entry_t *) hcmalloc (g->nframes * sizeof (zsf_entry_t));
+
+  if (fread (ent, sizeof (zsf_entry_t), g->nframes, fx) != g->nframes)
+  {
+    hcfree (ent);
+    fclose (fx);
+    error_set (global_ctx, "%s: truncated index", idxpath);
+    return false;
+  }
+
+  fclose (fx);
+
+  g->comp_off    = (u64 *) hcmalloc ((g->nframes + 1) * sizeof (u64));
+  g->first_line  = (u64 *) hcmalloc (g->nframes * sizeof (u64));
+  g->uncomp_size = (u64 *) hcmalloc (g->nframes * sizeof (u64));
+
+  for (u64 i = 0; i < g->nframes; i++)
+  {
+    g->comp_off[i]    = ent[i].comp_off;
+    g->first_line[i]  = ent[i].first_line;
+    g->uncomp_size[i] = ent[i].uncomp_size;
+
+    if (ent[i].uncomp_size > g->max_uncomp) g->max_uncomp = (size_t) ent[i].uncomp_size;
+  }
+
+  g->comp_off[g->nframes] = g->filesize;
+
+  for (u64 i = 0; i < g->nframes; i++)
+  {
+    const size_t csize = (size_t) (g->comp_off[i + 1] - g->comp_off[i]);
+    if (csize > g->max_comp) g->max_comp = csize;
+  }
+
+  hcfree (ent);
+
+  // brain / restore identity: two files with the same size and line count over the same frames are
+  // the same attack.
+
+  global_ctx->source_ident = (g->filesize * 1000003ULL) ^ (g->total_lines * 2654435761ULL) ^ g->nframes;
+
+  snprintf (global_ctx->guess_base, sizeof (global_ctx->guess_base), "%s", g->path);
+
+  return true;
+}
+
+void global_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  zsf_global_t *g = global_ctx->gbldata;
+
+  if (g == NULL) return;
+
+  hcfree (g->comp_off);
+  hcfree (g->first_line);
+  hcfree (g->uncomp_size);
+  hcfree (g->path);
+  hcfree (g);
+
+  global_ctx->gbldata = NULL;
+}
+
+u64 global_keyspace (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
+{
+  zsf_global_t *g = global_ctx->gbldata;
+
+  return g->total_lines;
+}
+
+bool thread_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
+{
+  zsf_global_t *g = global_ctx->gbldata;
+
+  zsf_thread_t *t = (zsf_thread_t *) hccalloc (1, sizeof (zsf_thread_t));
+
+  t->fd = open (g->path, O_RDONLY);
+
+  if (t->fd == -1)
+  {
+    thread_error_set (thread_ctx, "%s: %s", g->path, strerror (errno));
+    hcfree (t);
+    return false;
+  }
+
+  t->cbuf  = (unsigned char *) hcmalloc (g->max_comp);
+  t->dbuf  = (unsigned char *) hcmalloc (g->max_uncomp);
+  t->frame = (u64) -1;
+  t->line  = 0;
+
+  thread_ctx->thrdata = t;
+
+  return true;
+}
+
+void thread_term (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx)
+{
+  zsf_thread_t *t = thread_ctx->thrdata;
+
+  if (t == NULL) return;
+
+  if (t->fd != -1) close (t->fd);
+  hcfree (t->cbuf);
+  hcfree (t->dbuf);
+  hcfree (t);
+
+  thread_ctx->thrdata = NULL;
+}
+
+int thread_next (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, u8 *out_buf, const int out_size)
+{
+  zsf_global_t *g = global_ctx->gbldata;
+  zsf_thread_t *t = thread_ctx->thrdata;
+
+  // hashcat normally seeks before the first candidate; if it did not, start at frame 0
+
+  if (t->frame == (u64) -1)
+  {
+    if (load_frame (thread_ctx, g, t, 0) == false) return GENERIC_RC_ERROR;
+    t->line = 0;
+  }
+
+  // advance across empty tails / frame boundaries
+
+  while (t->doff >= t->dlen)
+  {
+    const u64 next = t->frame + 1;
+
+    if (next >= g->nframes) return GENERIC_RC_EOF;
+
+    if (load_frame (thread_ctx, g, t, next) == false) return GENERIC_RC_ERROR;
+  }
+
+  const size_t remaining = t->dlen - t->doff;
+
+  size_t word_len = 0;
+
+  const size_t step = process_word (t->dbuf + t->doff, remaining, out_buf, out_size, &word_len);
+
+  t->doff += (step < remaining) ? (step + 1) : remaining;
+  t->line++;
+
+  return (int) word_len;
+}
+
+bool thread_seek (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t *thread_ctx, const u64 offset)
+{
+  zsf_global_t *g = global_ctx->gbldata;
+  zsf_thread_t *t = thread_ctx->thrdata;
+
+  if (offset >= g->total_lines)
+  {
+    thread_error_set (thread_ctx, "seek target past EOF: %" PRIu64, offset);
+    return false;
+  }
+
+  const u64 k = frame_of_line (g, offset);
+
+  if (load_frame (thread_ctx, g, t, k) == false) return false;
+
+  // walk forward to the exact line inside the one decoded frame
+
+  u64 skip = offset - g->first_line[k];
+
+  while (skip && t->doff < t->dlen)
+  {
+    const u8 *nl = (const u8 *) memchr (t->dbuf + t->doff, '\n', t->dlen - t->doff);
+
+    if (nl == NULL) break;
+
+    t->doff = (size_t) (nl - t->dbuf) + 1;
+    skip--;
+  }
+
+  t->line = offset;
+
+  return true;
+}

--- a/src/feeds/feed_zstd.c
+++ b/src/feeds/feed_zstd.c
@@ -82,6 +82,8 @@ typedef struct
   size_t      max_comp;    // largest compressed frame  -> thread read buffer
   size_t      max_uncomp;  // largest decompressed frame -> thread frame buffer
 
+  u64         build_threads; // cap for the parallel index build / reframe (0 = auto = all cores)
+
 } zf_global_t;
 
 typedef struct
@@ -164,7 +166,7 @@ static u64 file_ident (const char *path, u64 *filesize)
   return h;
 }
 
-static char *cache_path (generic_global_ctx_t *global_ctx, const u64 ident)
+static char *zf_seekdb_dir (generic_global_ctx_t *global_ctx)
 {
   char *dir = NULL;
 
@@ -178,7 +180,14 @@ static char *cache_path (generic_global_ctx_t *global_ctx, const u64 ident)
     hc_mkdir (dir, 0700);
   }
 
+  return dir;
+}
+
+static char *cache_path (generic_global_ctx_t *global_ctx, const u64 ident)
+{
+  char *dir  = zf_seekdb_dir (global_ctx);
   char *path = NULL;
+
   hc_asprintf (&path, "%s/%016" PRIx64 ".zfidx", dir, ident);
   hcfree (dir);
 
@@ -565,7 +574,7 @@ static bool index_build_parallel (zf_global_t *g, const char *path)
   // 2) decode + line-scan every frame in parallel, bounded so threads * largest_frame stays modest
 
   const long ncpu = sysconf (_SC_NPROCESSORS_ONLN);
-  u64 nthreads = (ncpu > 0) ? (u64) ncpu : 1;
+  u64 nthreads = (g->build_threads > 0) ? g->build_threads : ((ncpu > 0) ? (u64) ncpu : 1);
   const u64 by_mem = ((u64) 8 * 1024 * 1024 * 1024) / max_ucs;
   if (by_mem < 1) nthreads = 1; else if (nthreads > by_mem) nthreads = by_mem;
   if (nthreads > nframes) nthreads = nframes;
@@ -704,19 +713,189 @@ static void carry_reserve (zf_thread_t *t, const size_t need)
   t->carry_cap = cap;
 }
 
+// ---- on-the-fly reframing (the zsf tool, embedded) ----
+// Decompress any zstd file and re-emit it as independent, line-aligned frames of ~frame_bytes each,
+// so a single-frame .zst becomes seekable without an offline step. The slow part (compressing each
+// frame) runs in parallel; the decode that cuts frames on line boundaries is serial but fast. Output
+// is a standard multi-frame .zst that the normal index path then indexes.
+
+typedef struct { unsigned char *plain; size_t plen; unsigned char *comp; size_t clen; int level; int err; } rf_job_t;
+typedef struct { rf_job_t *jobs; u64 njobs; u64 next; } rf_pool_t;
+
+static void *rf_worker (void *arg)
+{
+  rf_pool_t *p = (rf_pool_t *) arg;
+  for (;;)
+  {
+    const u64 i = __atomic_fetch_add (&p->next, 1, __ATOMIC_RELAXED);
+    if (i >= p->njobs) break;
+    rf_job_t *j = &p->jobs[i];
+    const size_t bound = ZSTD_compressBound (j->plen);
+    j->comp = (unsigned char *) malloc (bound);
+    if (j->comp == NULL) { j->err = 1; continue; }
+    const size_t c = ZSTD_compress (j->comp, bound, j->plain, j->plen, j->level);
+    if (ZSTD_isError (c)) { j->err = 1; continue; }
+    j->clen = c;
+  }
+  return NULL;
+}
+
+static bool rf_flush (FILE *out, rf_job_t *jobs, u64 njobs, u64 nthreads)
+{
+  if (njobs == 0) return true;
+
+  rf_pool_t p = { jobs, njobs, 0 };
+  u64 nt = nthreads ? nthreads : 1; if (nt > njobs) nt = njobs;
+
+  pthread_t *t = (pthread_t *) hcmalloc (nt * sizeof (pthread_t));
+  u64 spawned = 0;
+  for (u64 i = 0; i < nt; i++) { if (pthread_create (&t[i], NULL, rf_worker, &p) != 0) break; spawned++; }
+  if (spawned == 0) rf_worker (&p);
+  for (u64 i = 0; i < spawned; i++) pthread_join (t[i], NULL);
+  hcfree (t);
+
+  bool ok = true;
+  for (u64 i = 0; i < njobs; i++)
+  {
+    if (jobs[i].err) ok = false;
+    else if (fwrite (jobs[i].comp, 1, jobs[i].clen, out) != jobs[i].clen) ok = false;
+    free (jobs[i].comp); jobs[i].comp = NULL;
+    free (jobs[i].plain); jobs[i].plain = NULL;
+  }
+  return ok;
+}
+
+static bool reframe (const char *inpath, const char *outpath, size_t frame_bytes, int level, u64 nthreads)
+{
+  int fd = open (inpath, O_RDONLY);
+  if (fd == -1) return false;
+
+  ZSTD_DStream *ds = ZSTD_createDStream ();
+  if (ds == NULL) { close (fd); return false; }
+  ZSTD_bounds const wb = ZSTD_dParam_getBounds (ZSTD_d_windowLogMax);
+  if (!ZSTD_isError (wb.error)) ZSTD_DCtx_setParameter (ds, ZSTD_d_windowLogMax, wb.upperBound);
+
+  FILE *out = fopen (outpath, "wb");
+  if (out == NULL) { ZSTD_freeDStream (ds); close (fd); return false; }
+
+  const size_t incap = ZSTD_DStreamInSize ();
+  unsigned char *inbuf  = (unsigned char *) hcmalloc (incap);
+  unsigned char *outbuf = (unsigned char *) hcmalloc (BUILD_OUTBUF);
+
+  size_t cap = frame_bytes + BUILD_OUTBUF + 1;
+  unsigned char *line = (unsigned char *) hcmalloc (cap);
+  size_t head = 0, len = 0;
+
+  const u64 BATCH = (nthreads ? nthreads : 1) * 4;
+  rf_job_t *batch = (rf_job_t *) hcmalloc (BATCH * sizeof (rf_job_t));
+  u64 bn = 0;
+
+  hc_memchr_t mc = hc_memchr_get ();
+  bool ok = true;
+
+  #define RF_EMIT(P,L) do {                                                                    \
+    unsigned char *cpy = (unsigned char *) malloc (L);                                         \
+    if (cpy == NULL) { ok = false; break; }                                                    \
+    memcpy (cpy, (P), (L));                                                                     \
+    batch[bn].plain = cpy; batch[bn].plen = (L); batch[bn].comp = NULL; batch[bn].clen = 0;    \
+    batch[bn].level = level; batch[bn].err = 0; bn++;                                           \
+    if (bn == BATCH) { if (rf_flush (out, batch, bn, nthreads) == false) ok = false; bn = 0; } \
+  } while (0)
+
+  for (;;)
+  {
+    ssize_t rd = read (fd, inbuf, incap);
+    if (rd < 0) { ok = false; break; }
+    if (rd == 0) break;
+
+    ZSTD_inBuffer ib = { inbuf, (size_t) rd, 0 };
+    while (ib.pos < ib.size && ok)
+    {
+      ZSTD_outBuffer ob = { outbuf, BUILD_OUTBUF, 0 };
+      const size_t r = ZSTD_decompressStream (ds, &ob, &ib);
+      if (ZSTD_isError (r)) { ok = false; break; }
+
+      if (head > 0 && len + ob.pos > cap) { memmove (line, line + head, len - head); len -= head; head = 0; }
+      if (len + ob.pos > cap) { size_t nc = cap; while (nc < len + ob.pos) nc *= 2; line = (unsigned char *) hcrealloc (line, cap, nc - cap); cap = nc; }
+      memcpy (line + len, outbuf, ob.pos);
+      len += ob.pos;
+
+      while (ok && (len - head) >= frame_bytes)
+      {
+        const unsigned char *base = line + head;
+        const size_t avail = len - head;
+        const size_t nl = mc (base + frame_bytes - 1, '\n', avail - (frame_bytes - 1));
+        if ((frame_bytes - 1 + nl) >= avail) break; // no newline yet, need more input
+        const size_t cut = (frame_bytes - 1) + nl + 1;
+        RF_EMIT (base, cut);
+        head += cut;
+      }
+      if (head == len) { head = 0; len = 0; }
+    }
+    if (!ok) break;
+  }
+
+  if (ok && (len - head) > 0) RF_EMIT (line + head, len - head);
+  if (ok && bn > 0) { if (rf_flush (out, batch, bn, nthreads) == false) ok = false; bn = 0; }
+
+  #undef RF_EMIT
+
+  for (u64 i = 0; i < bn; i++) { free (batch[i].plain); free (batch[i].comp); }
+
+  hcfree (batch); hcfree (line); hcfree (inbuf); hcfree (outbuf);
+  ZSTD_freeDStream (ds);
+  fclose (out);
+  close (fd);
+
+  if (!ok) unlink (outpath);
+  return ok;
+}
+
 bool global_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_ctx_t **thread_ctx, MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx)
 {
   zf_global_t *g = (zf_global_t *) hccalloc (1, sizeof (zf_global_t));
 
   global_ctx->gbldata = g;
 
-  if (global_ctx->workc < 2)
+  // feed settings, given attack-mode-8 style as key=value among the arguments:
+  //   -a 8 feeds/feed_zstd.so wordlist.zst frame=16 level=19 threads=8
+
+  u64 p_frame = 0, p_level = 19, p_threads = 0;
+
+  const feed_param_t params[] =
   {
-    error_set (global_ctx, "usage: feed_zstd.so <wordlist.zst> (multi-frame for fast --skip)");
+    { "frame",   FEED_PARAM_TYPE_U64, &p_frame,   0, 1024, "reframe into this frame size in MiB (0 = use the file's own frames)" },
+    { "level",   FEED_PARAM_TYPE_U64, &p_level,   1, 22,   "zstd level used when reframing (default 19)" },
+    { "threads", FEED_PARAM_TYPE_U64, &p_threads, 0, 4096, "cores for the parallel build/reframe (0 = all)" },
+    { NULL, 0, NULL, 0, 0, NULL },
+  };
+
+  char perr[256];
+
+  if (feed_param_parse (global_ctx->workc, global_ctx->workv, params, perr, sizeof (perr)) == false)
+  {
+    error_set (global_ctx, "%s", perr);
     return false;
   }
 
-  g->path = hcstrdup (global_ctx->workv[1]);
+  g->build_threads = p_threads;
+
+  // the source is the first argument that is not a key=value setting
+
+  const char *src = NULL;
+
+  for (int i = 1; i < global_ctx->workc; i++)
+  {
+    if (feed_param_is_setting (global_ctx->workv[i]) == false) { src = global_ctx->workv[i]; break; }
+  }
+
+  if (src == NULL)
+  {
+    error_set (global_ctx, "usage: feed_zstd.so <wordlist.zst> [frame=<MiB>] [level=<n>] [threads=<n>]");
+    return false;
+  }
+
+  g->path = hcstrdup (src);
 
   u64 ident = file_ident (g->path, &g->filesize);
 
@@ -724,6 +903,37 @@ bool global_init (MAYBE_UNUSED generic_global_ctx_t *global_ctx, MAYBE_UNUSED ge
   {
     error_set (global_ctx, "%s: cannot open", g->path);
     return false;
+  }
+
+  // optional: reframe on the fly into a cached multi-frame file, then operate on that copy
+
+  if (p_frame > 0)
+  {
+    char *dir    = zf_seekdb_dir (global_ctx);
+    char *framed = NULL;
+    hc_asprintf (&framed, "%s/%016" PRIx64 "-f%" PRIu64 "l%" PRIu64 ".zst", dir, ident, p_frame, p_level);
+    hcfree (dir);
+
+    struct stat fst;
+
+    if (stat (framed, &fst) != 0)
+    {
+      feed_say (hashcat_ctx, "feed_zstd: reframing %s into %" PRIu64 " MiB frames (level %" PRIu64 ") ...", g->path, p_frame, p_level);
+
+      const u64 nt = p_threads ? p_threads : ((sysconf (_SC_NPROCESSORS_ONLN) > 0) ? (u64) sysconf (_SC_NPROCESSORS_ONLN) : 1);
+
+      if (reframe (g->path, framed, (size_t) p_frame * 1024 * 1024, (int) p_level, nt) == false)
+      {
+        hcfree (framed);
+        error_set (global_ctx, "%s: reframe failed", g->path);
+        return false;
+      }
+    }
+
+    hcfree (g->path);
+    g->path = framed;
+
+    ident = file_ident (g->path, &g->filesize);
   }
 
   // 1) a zsf sidecar sits next to the file and is already the index

--- a/src/feeds/feed_zstd.c
+++ b/src/feeds/feed_zstd.c
@@ -37,6 +37,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <inttypes.h>
 
@@ -330,7 +332,8 @@ static void index_save_cache (const zf_global_t *g, const char *cpath, const u64
 
 // One streaming pass: decode the whole file, and at each frame boundary record where the frame
 // started and the line it opened on. Bounded memory (one input and one output block), decode only.
-static bool index_build (zf_global_t *g, const char *path)
+// The fallback: correct for anything (unknown content sizes, skippable frames), just single-threaded.
+static bool index_build_serial (zf_global_t *g, const char *path)
 {
   int fd = open (path, O_RDONLY);
   if (fd == -1) return false;
@@ -436,6 +439,211 @@ static bool index_build (zf_global_t *g, const char *path)
   hcfree (frames);
 
   return ok && nframes > 0;
+}
+
+// When every frame carries its content size in its header (one-shot compressed frames -- what the
+// zsf tool and per-chunk `zstd -c` produce), the whole frame layout is known from the headers alone,
+// so each frame can be decoded and line-scanned independently. That turns the first-run count from
+// one serial decode of the entire file into an embarrassingly parallel decode across frames.
+
+typedef struct
+{
+  const unsigned char *map;
+  const u64 *comp_off;     // [nframes + 1]
+  const u64 *uncomp_size;  // [nframes]
+  u64        nframes;
+
+  u64       *nl;           // out: newline count per frame
+  uint8_t   *last_nl;      // out: 1 if the frame's last byte is '\n'
+  int64_t   *first_nl;     // out: offset of first '\n' in the frame, or -1
+  size_t     bufcap;       // per-thread decode buffer (>= largest frame)
+
+  u64        next;         // atomic frame dispenser
+  int        error;
+} zf_build_ctx_t;
+
+static void *zf_build_worker (void *arg)
+{
+  zf_build_ctx_t *b = (zf_build_ctx_t *) arg;
+
+  unsigned char *out = (unsigned char *) malloc (b->bufcap);
+  if (out == NULL) { b->error = 1; return NULL; }
+
+  for (;;)
+  {
+    if (b->error) break;
+
+    const u64 k = __atomic_fetch_add (&b->next, 1, __ATOMIC_RELAXED);
+    if (k >= b->nframes) break;
+
+    const size_t csize = (size_t) (b->comp_off[k + 1] - b->comp_off[k]);
+    const size_t dsize = (size_t) b->uncomp_size[k];
+
+    const size_t ds = ZSTD_decompress (out, b->bufcap, b->map + b->comp_off[k], csize);
+    if (ZSTD_isError (ds) || ds != dsize) { b->error = 1; break; }
+
+    u64 nl = 0;
+    int64_t first = -1;
+
+    for (size_t o = 0; o < ds; o++)
+    {
+      if (out[o] == '\n') { nl++; if (first < 0) first = (int64_t) o; }
+    }
+
+    b->nl[k]       = nl;
+    b->last_nl[k]  = (ds > 0 && out[ds - 1] == '\n') ? 1 : 0;
+    b->first_nl[k] = first;
+  }
+
+  free (out);
+  return NULL;
+}
+
+static bool index_build_parallel (zf_global_t *g, const char *path)
+{
+  int fd = open (path, O_RDONLY);
+  if (fd == -1) return false;
+
+  struct stat st;
+  if (fstat (fd, &st) != 0) { close (fd); return false; }
+
+  const size_t fsz = (size_t) st.st_size;
+  if (fsz == 0) { close (fd); return false; }
+
+  unsigned char *map = (unsigned char *) mmap (NULL, fsz, PROT_READ, MAP_PRIVATE, fd, 0);
+  close (fd);
+  if (map == MAP_FAILED) return false;
+
+  // 1) walk frame headers only (no decode); bail to serial on anything unusual
+  //    (unknown content size, a skippable frame, a truncated tail)
+
+  u64 *comp_off = NULL, *ucs = NULL;
+  u64 nframes = 0, acap = 0;
+  size_t off = 0;
+  bool ok = true;
+
+  while (off < fsz)
+  {
+    const size_t fcs = ZSTD_findFrameCompressedSize (map + off, fsz - off);
+    if (ZSTD_isError (fcs)) { ok = false; break; }
+
+    u32 magic;
+    memcpy (&magic, map + off, sizeof (magic));
+    if ((magic & 0xFFFFFFF0u) == 0x184D2A50u) { ok = false; break; } // skippable frame
+
+    const unsigned long long content = ZSTD_getFrameContentSize (map + off, fcs);
+    if (content == ZSTD_CONTENTSIZE_UNKNOWN || content == ZSTD_CONTENTSIZE_ERROR) { ok = false; break; }
+
+    if (nframes == acap)
+    {
+      const u64 olda = acap;
+      acap = acap ? acap * 2 : 256;
+      comp_off = (u64 *) hcrealloc (comp_off, olda * sizeof (u64), (acap - olda) * sizeof (u64));
+      ucs      = (u64 *) hcrealloc (ucs,      olda * sizeof (u64), (acap - olda) * sizeof (u64));
+    }
+
+    comp_off[nframes] = off;
+    ucs[nframes]      = (u64) content;
+    nframes++;
+    off += fcs;
+  }
+
+  if (ok == false || off != fsz || nframes == 0)
+  {
+    munmap (map, fsz);
+    hcfree (comp_off);
+    hcfree (ucs);
+    return false;
+  }
+
+  comp_off = (u64 *) hcrealloc (comp_off, acap * sizeof (u64), sizeof (u64)); // room for the sentinel
+  comp_off[nframes] = fsz;
+
+  size_t max_ucs = 1;
+  for (u64 i = 0; i < nframes; i++) if (ucs[i] > max_ucs) max_ucs = (size_t) ucs[i];
+
+  // 2) decode + line-scan every frame in parallel, bounded so threads * largest_frame stays modest
+
+  const long ncpu = sysconf (_SC_NPROCESSORS_ONLN);
+  u64 nthreads = (ncpu > 0) ? (u64) ncpu : 1;
+  const u64 by_mem = ((u64) 8 * 1024 * 1024 * 1024) / max_ucs;
+  if (by_mem < 1) nthreads = 1; else if (nthreads > by_mem) nthreads = by_mem;
+  if (nthreads > nframes) nthreads = nframes;
+  if (nthreads < 1) nthreads = 1;
+
+  zf_build_ctx_t b;
+  b.map = map; b.comp_off = comp_off; b.uncomp_size = ucs; b.nframes = nframes;
+  b.nl       = (u64 *)     hcmalloc (nframes * sizeof (u64));
+  b.last_nl  = (uint8_t *) hcmalloc (nframes * sizeof (uint8_t));
+  b.first_nl = (int64_t *) hcmalloc (nframes * sizeof (int64_t));
+  b.bufcap   = max_ucs;
+  b.next     = 0;
+  b.error    = 0;
+
+  pthread_t *tids = (pthread_t *) hcmalloc (nthreads * sizeof (pthread_t));
+  u64 spawned = 0;
+  for (u64 i = 0; i < nthreads; i++)
+  {
+    if (pthread_create (&tids[i], NULL, zf_build_worker, &b) != 0) break;
+    spawned++;
+  }
+  if (spawned == 0) zf_build_worker (&b);
+  for (u64 i = 0; i < spawned; i++) pthread_join (tids[i], NULL);
+  hcfree (tids);
+
+  bool bad = (b.error != 0);
+
+  // 3) combine per-frame summaries: line-starts before frame k = 1 + (newlines in frames < k)
+  //    - (frame k-1 ended on '\n'); line_off[k] skips a leading carried-over partial line.
+
+  zf_frame_t *frames = NULL;
+  u64 total_lines = 0;
+
+  if (bad == false)
+  {
+    frames = (zf_frame_t *) hcmalloc (nframes * sizeof (zf_frame_t));
+    u64 prefix_nl = 0;
+
+    for (u64 k = 0; k < nframes; k++)
+    {
+      frames[k].comp_off    = comp_off[k];
+      frames[k].uncomp_size = ucs[k];
+
+      if (k == 0)
+      {
+        frames[k].first_line = 0;
+        frames[k].line_off   = 0;
+      }
+      else
+      {
+        frames[k].first_line = 1 + prefix_nl - b.last_nl[k - 1];
+        frames[k].line_off   = b.last_nl[k - 1] ? 0 : ((b.first_nl[k] < 0) ? ucs[k] : (u64) (b.first_nl[k] + 1));
+      }
+
+      prefix_nl += b.nl[k];
+    }
+
+    total_lines = prefix_nl + (b.last_nl[nframes - 1] ? 0 : 1);
+  }
+
+  munmap (map, fsz);
+  hcfree (b.nl); hcfree (b.last_nl); hcfree (b.first_nl);
+  hcfree (comp_off); hcfree (ucs);
+
+  if (bad) { hcfree (frames); return false; }
+
+  index_adopt (g, frames, nframes, total_lines);
+  hcfree (frames);
+
+  return true;
+}
+
+// parallel when the frame layout is header-derivable, else the always-correct serial pass
+static bool index_build (zf_global_t *g, const char *path)
+{
+  if (index_build_parallel (g, path)) return true;
+
+  return index_build_serial (g, path);
 }
 
 // ----------------------------------------------------------------------------------------------

--- a/src/feeds/feed_zstd.mk
+++ b/src/feeds/feed_zstd.mk
@@ -1,0 +1,2 @@
+feeds/feed_zstd.so:  LFLAGS_NATIVE += -lzstd
+feeds/feed_zstd.dll: LFLAGS_NATIVE += -lzstd

--- a/src/generic.c
+++ b/src/generic.c
@@ -11,6 +11,7 @@
 #include "shared.h"
 #include "path.h"
 #include "folder.h"
+#include "filehandling.h"
 #include "rp.h"
 #include "mpsp.h"
 #include "feed_ctx.h"
@@ -420,6 +421,29 @@ static void generic_instance_destroy (hashcat_ctx_t *hashcat_ctx, generic_ctx_t 
 // all address those arguments by position, so moving every index by one to make room for a plugin
 // name changes what all of them see.
 
+// A base wordlist that is a single zstd stream is handed to the shipped zstd feed, which decompresses
+// and seeks inside it; anything else goes to the plain wordlist feed. Detected by magic so a .zst under
+// any name is classified by content and a plaintext file never is. Only the base source is auto-routed;
+// amplifiers (-a 1/6/7) stay on the wordlist feed.
+static const char *generic_base_feed (const char *path)
+{
+  if (path == NULL) return "wordlist";
+
+  HCFILE fp;
+
+  if (hc_fopen_raw (&fp, path, "rb") == false) return "wordlist";
+
+  u8 m[4] = { 0 };
+
+  const size_t n = hc_fread (m, 1, sizeof (m), &fp);
+
+  hc_fclose (&fp);
+
+  if (n == 4 && m[0] == 0x28 && m[1] == 0xb5 && m[2] == 0x2f && m[3] == 0xfd) return "zstd";
+
+  return "wordlist";
+}
+
 static int generic_instance_open (hashcat_ctx_t *hashcat_ctx, const generic_role_t role, const int from, const int to)
 {
   generic_ctx_t        *generic_ctx        = &hashcat_ctx->generic_ctx[role];
@@ -428,7 +452,9 @@ static int generic_instance_open (hashcat_ctx_t *hashcat_ctx, const generic_role
   generic_ctx->workc = (to - from) + 1;
   generic_ctx->workv = (char **) hcmalloc ((size_t) generic_ctx->workc * sizeof (char *));
 
-  generic_ctx->workv[0] = "wordlist";
+  generic_ctx->workv[0] = (char *) (((role == GENERIC_ROLE_BASE) && ((to - from) == 1))
+                                    ? generic_base_feed (user_options_extra->hc_workv[from])
+                                    : "wordlist");
 
   for (int i = from; i < to; i++)
   {
@@ -467,7 +493,7 @@ int generic_ctx_base_round (hashcat_ctx_t *hashcat_ctx, const char *path)
   // -a 9 splitting its own hash file has no file to name per round. Its rounds are the words one account
   // name becomes, so the source is which of those words this round is trying.
 
-  generic_ctx->workv[0] = (user_options_extra->association_autosplit == true) ? "association" : "wordlist";
+  generic_ctx->workv[0] = (char *) ((user_options_extra->association_autosplit == true) ? "association" : generic_base_feed (path));
   generic_ctx->workv[1] = (char *) path;
 
   generic_ctx->workv_owned = true;

--- a/src/generic.c
+++ b/src/generic.c
@@ -433,13 +433,14 @@ static const char *generic_base_feed (const char *path)
 
   if (hc_fopen_raw (&fp, path, "rb") == false) return "wordlist";
 
-  u8 m[4] = { 0 };
+  u8 m[6] = { 0 };
 
   const size_t n = hc_fread (m, 1, sizeof (m), &fp);
 
   hc_fclose (&fp);
 
-  if (n == 4 && m[0] == 0x28 && m[1] == 0xb5 && m[2] == 0x2f && m[3] == 0xfd) return "zstd";
+  if (n >= 4 && m[0] == 0x28 && m[1] == 0xb5 && m[2] == 0x2f && m[3] == 0xfd) return "zstd";
+  if (n >= 6 && m[0] == 0xfd && m[1] == 0x37 && m[2] == 0x7a && m[3] == 0x58 && m[4] == 0x5a && m[5] == 0x00) return "xz";
 
   return "wordlist";
 }

--- a/src/generic.c
+++ b/src/generic.c
@@ -441,6 +441,7 @@ static const char *generic_base_feed (const char *path)
 
   if (n >= 4 && m[0] == 0x28 && m[1] == 0xb5 && m[2] == 0x2f && m[3] == 0xfd) return "zstd";
   if (n >= 6 && m[0] == 0xfd && m[1] == 0x37 && m[2] == 0x7a && m[3] == 0x58 && m[4] == 0x5a && m[5] == 0x00) return "xz";
+  if (n >= 4 && m[0] == 0x04 && m[1] == 0x22 && m[2] == 0x4d && m[3] == 0x18) return "lz4";
 
   return "wordlist";
 }

--- a/tools/zsf.c
+++ b/tools/zsf.c
@@ -1,0 +1,357 @@
+// zsf — seekable-zstd wordlist tool (companion to the feed_zstd generic attack-mode-8 feed).
+//
+// Frames a wordlist into independent, line-aligned zstd frames plus a sidecar index
+// (<out>.idx: per frame -> compressed offset, first line, uncompressed size). feed_zstd reads that
+// index (or rebuilds it) and reaches word N by decoding only the one frame that holds it. The
+// compressed file is a standard multi-frame .zst (any zstd tool reads it); the .idx is a small side
+// file.
+//
+// Standalone; not wired into the hashcat build. Compile with:
+//   cc -O2 -std=gnu11 tools/zsf.c -lzstd -lpthread -o zsf
+//
+//   zsf build   [opts] <in.txt> <out.zst>    frame a PLAINTEXT wordlist
+//   zsf reframe [opts] <in.zst> <out.zst>    re-frame an existing zstd wordlist (streaming, no temp)
+//   zsf skip           <in.zst> <N> [count]  print `count` words from word N (0-based), one frame
+//   zsf info           <in.zst>              show frame / line counts
+//
+// opts:  -f/--frame <MiB> (16)   -l/--level <1..22> (19)   -t/--threads <n> (all cores)   -h/--help
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <pthread.h>
+#include <getopt.h>
+#include <errno.h>
+#include <zstd.h>
+
+#define IDX_MAGIC 0x315A53464B434821ULL   // matches feed_zstd's sidecar reader
+
+static void die (const char *m) { fprintf (stderr, "zsf: %s\n", m); exit (1); }
+
+// ---------------------------------------------------------------- input source (plaintext or zstd)
+
+typedef struct
+{
+  int            is_zstd;
+  FILE          *fp;      // plaintext
+  int            fd;      // zstd raw
+  ZSTD_DStream  *ds;
+  unsigned char *inbuf;
+  size_t         incap, inlen, inpos;
+  int            ineof, err;
+} src_t;
+
+static int src_open (src_t *s, const char *path, int is_zstd)
+{
+  memset (s, 0, sizeof (*s));
+  s->is_zstd = is_zstd;
+
+  if (!is_zstd)
+  {
+    s->fp = fopen (path, "rb");
+    return s->fp ? 0 : -1;
+  }
+
+  s->fd = open (path, O_RDONLY);
+  if (s->fd == -1) return -1;
+  s->ds = ZSTD_createDStream ();
+  if (!s->ds) { close (s->fd); return -1; }
+  ZSTD_bounds b = ZSTD_dParam_getBounds (ZSTD_d_windowLogMax);
+  if (!ZSTD_isError (b.error)) ZSTD_DCtx_setParameter (s->ds, ZSTD_d_windowLogMax, b.upperBound);
+  s->incap = ZSTD_DStreamInSize ();
+  s->inbuf = malloc (s->incap);
+  if (!s->inbuf) { ZSTD_freeDStream (s->ds); close (s->fd); return -1; }
+  return 0;
+}
+
+// fill up to cap decoded bytes; return count, 0 at EOF
+static size_t src_read (src_t *s, unsigned char *out, size_t cap)
+{
+  if (!s->is_zstd) return fread (out, 1, cap, s->fp);
+
+  ZSTD_outBuffer ob = { out, cap, 0 };
+  while (ob.pos == 0)
+  {
+    if (s->inpos == s->inlen)
+    {
+      if (s->ineof) break;
+      ssize_t r = read (s->fd, s->inbuf, s->incap);
+      if (r < 0) { s->err = 1; break; }
+      if (r == 0) { s->ineof = 1; break; }
+      s->inlen = (size_t) r; s->inpos = 0;
+    }
+    ZSTD_inBuffer ib = { s->inbuf, s->inlen, s->inpos };
+    size_t rc = ZSTD_decompressStream (s->ds, &ob, &ib);
+    s->inpos = ib.pos;
+    if (ZSTD_isError (rc)) { s->err = 1; break; }
+  }
+  return ob.pos;
+}
+
+static void src_close (src_t *s)
+{
+  if (s->is_zstd) { if (s->ds) ZSTD_freeDStream (s->ds); free (s->inbuf); if (s->fd != -1) close (s->fd); }
+  else if (s->fp) fclose (s->fp);
+}
+
+// ---------------------------------------------------------------- parallel per-frame compression
+
+typedef struct { unsigned char *plain; size_t plen; unsigned char *comp; size_t clen; uint64_t nl; int level; int err; } job_t;
+typedef struct { job_t *j; size_t n, next; } pool_t;
+
+static void *cworker (void *arg)
+{
+  pool_t *p = (pool_t *) arg;
+  for (;;)
+  {
+    size_t i = __atomic_fetch_add (&p->next, 1, __ATOMIC_RELAXED);
+    if (i >= p->n) break;
+    job_t *j = &p->j[i];
+    size_t bound = ZSTD_compressBound (j->plen);
+    j->comp = malloc (bound);
+    if (!j->comp) { j->err = 1; continue; }
+    size_t c = ZSTD_compress (j->comp, bound, j->plain, j->plen, j->level);
+    if (ZSTD_isError (c)) { j->err = 1; continue; }
+    j->clen = c;
+    uint64_t nl = 0;
+    for (size_t o = 0; o < j->plen; o++) if (j->plain[o] == '\n') nl++;
+    j->nl = nl;
+  }
+  return NULL;
+}
+
+// ---------------------------------------------------------------- frame + write (build & reframe)
+
+typedef struct { uint64_t comp_off, first_line, uncomp_size; } ent_t;
+
+static int frame_and_write (src_t *s, const char *outpath, size_t frame_bytes, int level, long threads)
+{
+  FILE *out = fopen (outpath, "wb");
+  if (!out) return -1;
+
+  char idxpath[8192];
+  snprintf (idxpath, sizeof idxpath, "%s.idx", outpath);
+  FILE *fx = fopen (idxpath, "wb");
+  if (!fx) { fclose (out); return -1; }
+
+  long ncpu = sysconf (_SC_NPROCESSORS_ONLN);
+  size_t nthreads = threads > 0 ? (size_t) threads : (ncpu > 0 ? (size_t) ncpu : 1);
+  size_t BATCH = nthreads * 4;
+
+  job_t  *batch = calloc (BATCH, sizeof (job_t));
+  ent_t  *ents  = NULL; size_t nents = 0, cents = 0;
+  uint64_t comp_off = 0, first_line = 0, total_lines = 0;
+
+  size_t cap = frame_bytes + 4 * 1024 * 1024 + 1;
+  unsigned char *line = malloc (cap);
+  size_t head = 0, len = 0;
+  unsigned char *rd = malloc (4 * 1024 * 1024);
+  size_t bn = 0;
+  int ok = 1, last_nl = 1;
+
+  // flush the current batch: compress in parallel, write in order, record index
+  #define FLUSH() do {                                                                          \
+    if (bn) {                                                                                    \
+      pool_t p = { batch, bn, 0 };                                                               \
+      size_t nt = nthreads > bn ? bn : nthreads;                                                 \
+      pthread_t *t = malloc (nt * sizeof (pthread_t)); size_t sp = 0;                            \
+      for (size_t i = 0; i < nt; i++) { if (pthread_create (&t[i], NULL, cworker, &p)) break; sp++; } \
+      if (!sp) cworker (&p);                                                                     \
+      for (size_t i = 0; i < sp; i++) pthread_join (t[i], NULL);                                 \
+      free (t);                                                                                  \
+      for (size_t i = 0; i < bn; i++) {                                                          \
+        if (batch[i].err) ok = 0;                                                                \
+        else if (fwrite (batch[i].comp, 1, batch[i].clen, out) != batch[i].clen) ok = 0;         \
+        if (nents == cents) { cents = cents ? cents * 2 : 1024; ents = realloc (ents, cents * sizeof (ent_t)); } \
+        ents[nents].comp_off = comp_off; ents[nents].first_line = first_line;                    \
+        ents[nents].uncomp_size = batch[i].plen; nents++;                                        \
+        comp_off += batch[i].clen; first_line += batch[i].nl; total_lines += batch[i].nl;        \
+        free (batch[i].comp); free (batch[i].plain); batch[i].comp = batch[i].plain = NULL;      \
+      }                                                                                          \
+      bn = 0;                                                                                    \
+    }                                                                                            \
+  } while (0)
+
+  #define EMIT(P,L) do {                                                                         \
+    unsigned char *c = malloc (L); if (!c) { ok = 0; break; }                                    \
+    memcpy (c, (P), (L)); if ((L) > 0) last_nl = ((P)[(L)-1] == '\n');                            \
+    batch[bn].plain = c; batch[bn].plen = (L); batch[bn].comp = NULL; batch[bn].level = level; batch[bn].err = 0; bn++; \
+    if (bn == BATCH) FLUSH ();                                                                    \
+  } while (0)
+
+  while (ok)
+  {
+    size_t n = src_read (s, rd, 4 * 1024 * 1024);
+    if (s->err) { ok = 0; break; }
+    if (n == 0) break;
+
+    if (head > 0 && len + n > cap) { memmove (line, line + head, len - head); len -= head; head = 0; }
+    while (len + n > cap) { cap *= 2; line = realloc (line, cap); }
+    memcpy (line + len, rd, n); len += n;
+
+    while (ok && (len - head) >= frame_bytes)
+    {
+      unsigned char *base = line + head;
+      size_t avail = len - head;
+      unsigned char *nl = memchr (base + frame_bytes - 1, '\n', avail - (frame_bytes - 1));
+      if (!nl) break;                     // no newline yet; need more input
+      size_t cut = (size_t) (nl - base) + 1;
+      EMIT (base, cut);
+      head += cut;
+    }
+    if (head == len) { head = len = 0; }
+  }
+
+  if (ok && (len - head) > 0) EMIT (line + head, len - head);
+  FLUSH ();
+
+  #undef EMIT
+  #undef FLUSH
+
+  // a final line with no trailing newline is still a line (matches feed_zstd's count)
+  if (nents > 0 && last_nl == 0) total_lines++;
+
+  // sidecar: header {magic, level, frame_bytes, nframes, total_lines} then entries
+  uint64_t hdr[5] = { IDX_MAGIC, (uint64_t) level, (uint64_t) frame_bytes, nents, total_lines };
+  if (fwrite (hdr, sizeof hdr, 1, fx) != 1) ok = 0;
+  if (fwrite (ents, sizeof (ent_t), nents, fx) != nents) ok = 0;
+
+  fclose (fx); fclose (out);
+  free (batch); free (ents); free (line); free (rd);
+
+  if (!ok) { unlink (outpath); unlink (idxpath); return -1; }
+
+  fprintf (stderr, "zsf: %s: %" PRIu64 " lines, %zu frames, %" PRIu64 " B compressed, index %zu B\n",
+           outpath, total_lines, nents, comp_off, (size_t) (sizeof hdr + nents * sizeof (ent_t)));
+  return 0;
+}
+
+// ---------------------------------------------------------------- skip / info (read the sidecar)
+
+static ent_t *load_idx (const char *path, uint64_t *nframes, uint64_t *total, uint64_t *frame_bytes, uint64_t *filesize)
+{
+  struct stat st; if (stat (path, &st) != 0) die ("cannot stat input"); *filesize = (uint64_t) st.st_size;
+  char ip[8192]; snprintf (ip, sizeof ip, "%s.idx", path);
+  FILE *fx = fopen (ip, "rb"); if (!fx) die ("missing <in>.idx (run: zsf build/reframe ...)");
+  uint64_t h[5]; if (fread (h, sizeof h, 1, fx) != 1 || h[0] != IDX_MAGIC) die ("bad index");
+  *frame_bytes = h[2]; *nframes = h[3]; *total = h[4];
+  ent_t *e = malloc (*nframes * sizeof (ent_t));
+  if (fread (e, sizeof (ent_t), *nframes, fx) != *nframes) die ("truncated index");
+  fclose (fx); return e;
+}
+
+static int cmd_skip (const char *path, uint64_t N, uint64_t count)
+{
+  uint64_t nframes, total, fb, fsz; ent_t *idx = load_idx (path, &nframes, &total, &fb, &fsz);
+  if (N >= total) { fprintf (stderr, "zsf: N=%" PRIu64 " >= %" PRIu64 " lines\n", N, total); return 1; }
+
+  uint64_t lo = 0, hi = nframes - 1, k = 0;
+  while (lo <= hi) { uint64_t m = lo + (hi - lo) / 2; if (idx[m].first_line <= N) { k = m; lo = m + 1; } else { if (!m) break; hi = m - 1; } }
+
+  uint64_t cstart = idx[k].comp_off, cend = (k + 1 < nframes) ? idx[k + 1].comp_off : fsz;
+  size_t csize = cend - cstart;
+  unsigned char *cbuf = malloc (csize), *dbuf = malloc (idx[k].uncomp_size);
+  int fd = open (path, O_RDONLY); if (fd == -1) die ("open");
+  if (pread (fd, cbuf, csize, (off_t) cstart) != (ssize_t) csize) die ("read frame");
+  close (fd);
+  size_t ds = ZSTD_decompress (dbuf, idx[k].uncomp_size, cbuf, csize);
+  if (ZSTD_isError (ds)) die ("decompress");
+
+  uint64_t skip = N - idx[k].first_line; unsigned char *p = dbuf, *end = dbuf + ds;
+  while (skip && p < end) { unsigned char *nl = memchr (p, '\n', end - p); if (!nl) break; p = nl + 1; skip--; }
+  for (uint64_t c = 0; c < count && p < end; c++) { unsigned char *nl = memchr (p, '\n', end - p); size_t l = nl ? (size_t) (nl - p) + 1 : (size_t) (end - p); fwrite (p, 1, l, stdout); if (!nl) break; p = nl + 1; }
+  fprintf (stderr, "zsf: word %" PRIu64 " -> frame %" PRIu64 "/%" PRIu64 ", decoded %" PRIu64 " B (1 frame)\n", N, k, nframes, idx[k].uncomp_size);
+  free (cbuf); free (dbuf); free (idx); return 0;
+}
+
+static int cmd_info (const char *path)
+{
+  uint64_t nframes, total, fb, fsz; ent_t *idx = load_idx (path, &nframes, &total, &fb, &fsz);
+  uint64_t maxu = 0; for (uint64_t i = 0; i < nframes; i++) if (idx[i].uncomp_size > maxu) maxu = idx[i].uncomp_size;
+  printf ("file            : %s\n", path);
+  printf ("compressed size : %" PRIu64 " B\n", fsz);
+  printf ("frames          : %" PRIu64 " (target %.1f MiB each)\n", nframes, (double) fb / (1024*1024));
+  printf ("lines           : %" PRIu64 "\n", total);
+  printf ("largest frame   : %.2f MiB uncompressed (seek decodes <= this)\n", (double) maxu / (1024*1024));
+  free (idx); return 0;
+}
+
+// ---------------------------------------------------------------- CLI
+
+static void usage (FILE *o)
+{
+  fprintf (o,
+    "zsf — seekable-zstd wordlist tool\n\n"
+    "usage:\n"
+    "  zsf build   [opts] <in.txt> <out.zst>    frame a plaintext wordlist\n"
+    "  zsf reframe [opts] <in.zst> <out.zst>    re-frame an existing zstd wordlist (streaming)\n"
+    "  zsf skip           <in.zst> <N> [count]  print `count` words from word N (0-based)\n"
+    "  zsf info           <in.zst>              show frame / line counts\n\n"
+    "opts (build, reframe):\n"
+    "  -f, --frame <MiB>    frame size, the seek granularity (default 16)\n"
+    "  -l, --level <1..22>  zstd level (default 19)\n"
+    "  -t, --threads <n>    worker threads (default: all cores)\n"
+    "  -h, --help           this help\n\n"
+    "the output is a standard multi-frame .zst (any zstd tool reads it) plus <out>.zst.idx.\n"
+    "to replace a single-frame file in place:  zsf reframe old.zst new.zst && mv new.zst old.zst\n");
+}
+
+int main (int argc, char **argv)
+{
+  if (argc < 2) { usage (stderr); return 2; }
+  const char *cmd = argv[1];
+
+  size_t frame_mib = 16; int level = 19; long threads = 0;
+  static struct option lo[] = {
+    { "frame", required_argument, 0, 'f' }, { "level", required_argument, 0, 'l' },
+    { "threads", required_argument, 0, 't' }, { "help", no_argument, 0, 'h' }, { 0, 0, 0, 0 } };
+
+  optind = 2;
+  int c;
+  while ((c = getopt_long (argc, argv, "f:l:t:h", lo, NULL)) != -1)
+  {
+    if (c == 'f') frame_mib = strtoull (optarg, NULL, 10);
+    else if (c == 'l') level = atoi (optarg);
+    else if (c == 't') threads = atol (optarg);
+    else if (c == 'h') { usage (stdout); return 0; }
+    else { usage (stderr); return 2; }
+  }
+  char **pos = argv + optind; int npos = argc - optind;
+
+  if (frame_mib < 1) frame_mib = 1;
+  if (level < 1) level = 1;
+  if (level > 22) level = 22;
+  size_t frame_bytes = frame_mib * 1024 * 1024;
+
+  if (!strcmp (cmd, "build") || !strcmp (cmd, "reframe"))
+  {
+    if (npos < 2) { usage (stderr); return 2; }
+    src_t s;
+    if (src_open (&s, pos[0], !strcmp (cmd, "reframe")) != 0) die ("cannot open input");
+    int rc = frame_and_write (&s, pos[1], frame_bytes, level, threads);
+    src_close (&s);
+    return rc == 0 ? 0 : 1;
+  }
+  if (!strcmp (cmd, "skip"))
+  {
+    if (npos < 2) { usage (stderr); return 2; }
+    uint64_t N = strtoull (pos[1], NULL, 10);
+    uint64_t count = (npos >= 3) ? strtoull (pos[2], NULL, 10) : 1;
+    return cmd_skip (pos[0], N, count);
+  }
+  if (!strcmp (cmd, "info"))
+  {
+    if (npos < 1) { usage (stderr); return 2; }
+    return cmd_info (pos[0]);
+  }
+  if (!strcmp (cmd, "-h") || !strcmp (cmd, "--help")) { usage (stdout); return 0; }
+
+  usage (stderr);
+  return 2;
+}


### PR DESCRIPTION
# feeds: add feed_xz and feed_lz4 — seekable xz and lz4 wordlists

Follow-up to #4801 (feed_zstd). Adds the two sibling feeds that flank zstd on the ratio/speed curve, using the same seekable design, and extends the `-a 0` magic router to `.xz` and `.lz4`.

> **Stacked on #4801.** This branch sits on top of #4801's branch (it reuses the `generic.c` base-wordlist magic router that #4801 introduces), so the diff currently shows #4801's six commits too. **Only the two top commits are new here** — please review those; once #4801 merges, this reduces to just:
> - `d2c24b6` feeds: add feed_xz — seekable xz wordlists; route .xz under -a 0
> - `edcf907` feeds: add feed_lz4 — seekable lz4 wordlists; route .lz4 under -a 0

## Why

feed_zstd made compressed wordlists seekable for `-a 0`/`-a 8`. zstd is the balanced choice, but two common codecs sit on either side of it and are worth offering:

- **xz** — best ratio (≈6.6× vs zstd 5.2× on our data), i.e. the smallest dictionaries;
- **lz4** — fastest decode (≈1150 MB/s vs zstd ≈460–650), i.e. the least host CPU when feeding fast hashes.

Both are already seekable in principle, so the feed is a small variation on feed_zstd.

## Design (shared with feed_zstd)

Each feed indexes the file's blocks/frames as `{compressed_offset, first_line, uncompressed_size, line_off}`, decodes only the block that holds word N, reassembles lines that cross a block boundary, builds the index in parallel on first use and caches it under the seekdb dir (revalidated by size + content hash), and takes a `threads=` setting. The difference is only where block boundaries come from and how one block is decoded:

- **feed_xz** (`liblzma`): an `.xz` stream carries a **native block Index** in its footer, so there is nothing to reframe — the stock `xz --block-size=16MiB -T0 wordlist` produces a multi-block seekable file directly. The feed reads the index (`lzma_stream_footer_decode` + `lzma_index_buffer_decode` + `lzma_index_iter`) and decodes a block with `lzma_block_decoder`. Single-block `.xz` still works (decodes from the start). Multi-stream `.xz` (manually concatenated) is not handled yet. Links the system `liblzma` via `feed_xz.mk`.
- **feed_lz4** (`liblz4`): the lz4 frame format has no native index, but its blocks are **independent by default** (`-BI`). The feed walks the frame once (reading each block's 4-byte size prefix) to record block offsets, and decodes a block with `LZ4_decompress_safe`. A block-dependent frame (`-BD`) is rejected. Seek granularity is the block max size (up to 4 MiB, `-B7`). Links the system `liblz4` via `feed_lz4.mk`.

`generic.c`: the `-a 0` base-wordlist magic check (added in #4801 for `.zst`) is extended to also route `.xz → feed_xz` and `.lz4 → feed_lz4`. Plaintext and amplifiers are untouched.

## Usage

```sh
# xz: the stock tool makes it seekable; no framing helper needed
xz --block-size=16MiB -T0 -k wordlist
hashcat -a 0 -m 0 hash.txt wordlist.xz -r rules/best64.rule

# lz4: block-independent (the default)
lz4 -9 -BI -B7 wordlist wordlist.lz4
hashcat -a 0 -m 0 hash.txt wordlist.lz4 -r rules/best64.rule

# or invoke a feed explicitly
hashcat -a 8 -m 0 hash.txt feeds/feed_xz.so wordlist.xz threads=8
```

## Verified (measured, on GPU, `-m 0`)

Both, on a 5,000,000-line list with the target at line 4,000,000:

- **feed_xz** — 47-block `.xz`: keyspace 5,000,000; every candidate emitted exactly once (sorted-equal to plaintext); `-a 0` auto-route cracks the target; `-s 3999999 -l 1` cracks (exact seek across blocks) while `-s 4000000` misses; single-block `.xz` keyspace correct; `.xfidx` cache written.
- **feed_lz4** — block-independent `.lz4` (~750 × 64 KiB blocks): keyspace 5,000,000; every candidate once; `-a 0` auto-route cracks; `-s 3999999 -l 1` cracks / `-s 4000000` misses; block-dependent `-BD` rejected; `.lfidx` cache written.

All outputs stay standard files (`unxz` / `lz4 -d` reconstruct them); the index is an external side file.

## Follow-ups

- Vendor `liblzma`/`liblz4` under `deps/` for the Windows/macOS plugin cross-builds (same open item as libzstd in #4801).
- feed_xz: handle multi-stream `.xz` (combine per-stream indexes with `lzma_index_cat`).
- The three feeds share a lot of structure (index/cache/straddle/seek); a future refactor could factor a common "framed seekable feed" core with per-codec hooks.

Codec choice, in one line: **zstd** balanced (default), **xz** for max compression, **lz4** for max feed speed.
