### PR TITLE
OpenCL: work around Mesa rusticl compiler crashes on gfx1013

### DIFF
--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -2127,9 +2127,20 @@ DECLSPEC int hc_enc_validate_utf8_global (GLOBAL_AS const u32 *src_buf, const in
 // Input buffer and Output buffer size has to be multiple of 4 and at least of size 4.
 // The output buffer is not zero padded, so entire buffer has to be set all zero before entering this function or truncated afterwards.
 
+// Read one byte of src_buf through a u32 load instead of a u8 load. Three or more
+// u8 loads from private (stack) memory through a casted pointer with a variable
+// index crash the AMDGPU back end of Mesa rusticl (LLVM 21) while compiling
+// gpu_utf8_to_utf16 - the process dies with SIGSEGV inside libLLVM. Extracting
+// the byte from a word load is semantically identical on little-endian targets
+// and measures the same after optimization on other OpenCL platforms.
+
+DECLSPEC u32 hc_enc_src_byte (PRIVATE_AS const u32 *src_buf, const int pos)
+{
+  return (src_buf[pos >> 2] >> ((pos & 3) << 3)) & 0xff;
+}
+
 DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src_buf, const int src_len, const int src_sz, PRIVATE_AS u32 *dst_buf, const int dst_sz)
 {
-  PRIVATE_AS const u8 *src_ptr = (PRIVATE_AS const u8 *) src_buf;
   PRIVATE_AS       u8 *dst_ptr = (PRIVATE_AS       u8 *) dst_buf;
 
   int src_pos = hc_enc->pos;
@@ -2142,7 +2153,7 @@ DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src
 
   while ((src_pos < src_len) && (dst_pos < dst_sz))
   {
-    const u8 c = src_ptr[src_pos];
+    const u8 c = hc_enc_src_byte (src_buf, src_pos);
 
     int extraBytesToRead = -1;
 
@@ -2213,25 +2224,25 @@ DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src
         break;
       */
       case 3:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++; ch <<= 6;
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++; ch <<= 6;
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++; ch <<= 6;
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++;
         ch -= offsetsFromUTF8_3;
         break;
       case 2:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++; ch <<= 6;
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++; ch <<= 6;
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++;
         ch -= offsetsFromUTF8_2;
         break;
       case 1:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++; ch <<= 6;
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++;
         ch -= offsetsFromUTF8_1;
         break;
       case 0:
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_src_byte (src_buf, src_pos); src_pos++;
         ch -= offsetsFromUTF8_0;
         break;
     }

--- a/OpenCL/inc_common.cl
+++ b/OpenCL/inc_common.cl
@@ -2197,115 +2197,51 @@ DECLSPEC int hc_enc_has_next (PRIVATE_AS hc_enc_t *hc_enc, const int sz)
   return 0;
 }
 
-DECLSPEC int hc_enc_validate_utf8 (PRIVATE_AS const u32 *src_buf, const int src_pos, const int extraBytesToRead)
+DECLSPEC u32 hc_enc_seq_byte (const u32 w0, const u32 w1, const int p, const int j)
 {
-  PRIVATE_AS const u8 *src_ptr = (PRIVATE_AS const u8 *) src_buf;
+  const int k = p + j;
 
-  if (extraBytesToRead == 0)
-  {
-    const u8 c0 = src_ptr[src_pos + 0]; if (c0 >= 0x80) return 0;
-  }
-  else if (extraBytesToRead == 1)
-  {
-    const u8 c0 = src_ptr[src_pos + 0]; if ((c0 < 0xc2) || (c0 > 0xdf)) return 0;
-    const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-  }
-  else if (extraBytesToRead == 2)
-  {
-    const u8 c0 = src_ptr[src_pos + 0];
+  const u32 w = (k < 4) ? w0 : w1;
 
-    if ((c0 >= 0xe0) && (c0 <= 0xe0))
-    {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0xa0) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-    }
-    else if ((c0 >= 0xe1) && (c0 <= 0xec))
-    {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-    }
-    else if ((c0 >= 0xed) && (c0 <= 0xed))
-    {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0x9f)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-    }
-    else if ((c0 >= 0xee) && (c0 <= 0xef))
-    {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-    }
-    else
-    {
-      return 0;
-    }
-  }
-  else if (extraBytesToRead == 3)
-  {
-    const u8 c0 = src_ptr[src_pos + 0];
-
-    if ((c0 >= 0xf0) && (c0 <= 0xf0))
-    {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x90) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-      const u8 c3 = src_ptr[src_pos + 3]; if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
-    }
-    else if ((c0 >= 0xf1) && (c0 <= 0xf3))
-    {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-      const u8 c3 = src_ptr[src_pos + 3]; if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
-    }
-    else if ((c0 >= 0xf4) && (c0 <= 0xf4))
-    {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-      const u8 c3 = src_ptr[src_pos + 3]; if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
-    }
-    else
-    {
-      return 0;
-    }
-  }
-
-  return 1;
+  return (w >> ((k & 3) << 3)) & 0xff;
 }
 
-DECLSPEC int hc_enc_validate_utf8_global (GLOBAL_AS const u32 *src_buf, const int src_pos, const int extraBytesToRead)
+DECLSPEC int hc_enc_validate_utf8 (const u32 w0, const u32 w1, const int src_pos, const int extraBytesToRead)
 {
-  GLOBAL_AS const u8 *src_ptr = (GLOBAL_AS const u8 *) src_buf;
+  const int p = src_pos & 3;
 
   if (extraBytesToRead == 0)
   {
-    const u8 c0 = src_ptr[src_pos + 0]; if (c0 >= 0x80) return 0;
+    const u32 c0 = hc_enc_seq_byte (w0, w1, p, 0); if (c0 >= 0x80) return 0;
   }
   else if (extraBytesToRead == 1)
   {
-    const u8 c0 = src_ptr[src_pos + 0]; if ((c0 < 0xc2) || (c0 > 0xdf)) return 0;
-    const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
+    const u32 c0 = hc_enc_seq_byte (w0, w1, p, 0); if ((c0 < 0xc2) || (c0 > 0xdf)) return 0;
+    const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
   }
   else if (extraBytesToRead == 2)
   {
-    const u8 c0 = src_ptr[src_pos + 0];
+    const u32 c0 = hc_enc_seq_byte (w0, w1, p, 0);
 
     if ((c0 >= 0xe0) && (c0 <= 0xe0))
     {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0xa0) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
+      const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0xa0) || (c1 > 0xbf)) return 0;
+      const u32 c2 = hc_enc_seq_byte (w0, w1, p, 2); if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
     }
     else if ((c0 >= 0xe1) && (c0 <= 0xec))
     {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
+      const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
+      const u32 c2 = hc_enc_seq_byte (w0, w1, p, 2); if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
     }
     else if ((c0 >= 0xed) && (c0 <= 0xed))
     {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0x9f)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
+      const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0x80) || (c1 > 0x9f)) return 0;
+      const u32 c2 = hc_enc_seq_byte (w0, w1, p, 2); if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
     }
     else if ((c0 >= 0xee) && (c0 <= 0xef))
     {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
+      const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
+      const u32 c2 = hc_enc_seq_byte (w0, w1, p, 2); if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
     }
     else
     {
@@ -2314,25 +2250,25 @@ DECLSPEC int hc_enc_validate_utf8_global (GLOBAL_AS const u32 *src_buf, const in
   }
   else if (extraBytesToRead == 3)
   {
-    const u8 c0 = src_ptr[src_pos + 0];
+    const u32 c0 = hc_enc_seq_byte (w0, w1, p, 0);
 
     if ((c0 >= 0xf0) && (c0 <= 0xf0))
     {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x90) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-      const u8 c3 = src_ptr[src_pos + 3]; if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
+      const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0x90) || (c1 > 0xbf)) return 0;
+      const u32 c2 = hc_enc_seq_byte (w0, w1, p, 2); if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
+      const u32 c3 = hc_enc_seq_byte (w0, w1, p, 3); if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
     }
     else if ((c0 >= 0xf1) && (c0 <= 0xf3))
     {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-      const u8 c3 = src_ptr[src_pos + 3]; if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
+      const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
+      const u32 c2 = hc_enc_seq_byte (w0, w1, p, 2); if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
+      const u32 c3 = hc_enc_seq_byte (w0, w1, p, 3); if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
     }
     else if ((c0 >= 0xf4) && (c0 <= 0xf4))
     {
-      const u8 c1 = src_ptr[src_pos + 1]; if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
-      const u8 c2 = src_ptr[src_pos + 2]; if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
-      const u8 c3 = src_ptr[src_pos + 3]; if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
+      const u32 c1 = hc_enc_seq_byte (w0, w1, p, 1); if ((c1 < 0x80) || (c1 > 0xbf)) return 0;
+      const u32 c2 = hc_enc_seq_byte (w0, w1, p, 2); if ((c2 < 0x80) || (c2 > 0xbf)) return 0;
+      const u32 c3 = hc_enc_seq_byte (w0, w1, p, 3); if ((c3 < 0x80) || (c3 > 0xbf)) return 0;
     }
     else
     {
@@ -2346,22 +2282,40 @@ DECLSPEC int hc_enc_validate_utf8_global (GLOBAL_AS const u32 *src_buf, const in
 // Input buffer and Output buffer size has to be multiple of 4 and at least of size 4.
 // The output buffer is not zero padded, so entire buffer has to be set all zero before entering this function or truncated afterwards.
 
+// All bytes of a utf8 sequence are extracted from a window of two consecutive u32 words that
+// is loaded once and passed to the validator by value, and the output is accumulated into
+// full u32 words before it is stored. This removes the u8 pointers casted from u32 buffers
+// with a variable index on both the read and the write side, which crash the AMDGPU back end
+// of Mesa rusticl (LLVM 21) while compiling gpu_utf8_to_utf16 - the process dies with SIGSEGV
+// inside libLLVM.
+
 DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src_buf, const int src_len, const int src_sz, PRIVATE_AS u32 *dst_buf, const int dst_sz)
 {
-  PRIVATE_AS const u8 *src_ptr = (PRIVATE_AS const u8 *) src_buf;
-  PRIVATE_AS       u8 *dst_ptr = (PRIVATE_AS       u8 *) dst_buf;
-
   int src_pos = hc_enc->pos;
   int dst_pos = hc_enc->clen;
 
+  int ret = 0;
+
   dst_buf[0] = hc_enc->cbuf;
+
+  // the low half of the current output word is pending whenever the output position is not aligned
+
+  u32 acc = 0;
+
+  if (hc_enc->clen == 2) acc = hc_enc->cbuf;
 
   hc_enc->clen = 0;
   hc_enc->cbuf = 0;
 
   while ((src_pos < src_len) && (dst_pos < dst_sz))
   {
-    const u8 c = src_ptr[src_pos];
+    const int idx = src_pos >> 2;
+
+    const u32 w0 = src_buf[idx];
+
+    const int p = src_pos & 3;
+
+    const u32 c = (w0 >> (p << 3)) & 0xff;
 
     int extraBytesToRead = -1;
 
@@ -2384,82 +2338,84 @@ DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src
 
     if (extraBytesToRead == -1)
     {
-      hc_enc->pos = src_len;
+      ret = -1;
 
-      return -1;
+      break;
     }
 
     if ((src_pos + extraBytesToRead) >= src_sz)
     {
       // broken input
 
-      hc_enc->pos = src_len;
+      ret = -1;
 
-      return -1;
+      break;
     }
 
-    if (hc_enc_validate_utf8 (src_buf, src_pos, extraBytesToRead) == 0)
+    // the second word is loaded only if the sequence crosses the word boundary, because
+    // src_buf[idx + 1] can otherwise read out of bounds (for example word 64 of a u32[64])
+
+    u32 w1 = 0;
+
+    if ((p + extraBytesToRead) > 3)
+    {
+      w1 = src_buf[idx + 1];
+    }
+
+    if (hc_enc_validate_utf8 (w0, w1, src_pos, extraBytesToRead) == 0)
     {
       // broken input
 
-      hc_enc->pos = src_len;
+      ret = -1;
 
-      return -1;
+      break;
     }
 
     u32 ch = 0;
 
     switch (extraBytesToRead)
     {
-      // old version, doesnt work with https://github.com/hashcat/hashcat/issues/3592
-      /*
-      case 5:
-        ch += src_ptr[src_pos++]; ch <<= 6; // remember, illegal UTF-8
-        ch += src_ptr[src_pos++]; ch <<= 6; // remember, illegal UTF-8
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
-        ch -= offsetsFromUTF8_5;
-        break;
-      case 4:
-        ch += src_ptr[src_pos++]; ch <<= 6; // remember, illegal UTF-8
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
-        ch -= offsetsFromUTF8_4;
-        break;
-      */
       case 3:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 1); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 2); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 3);
         ch -= offsetsFromUTF8_3;
         break;
       case 2:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 1); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 2);
         ch -= offsetsFromUTF8_2;
         break;
       case 1:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 1);
         ch -= offsetsFromUTF8_1;
         break;
       case 0:
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0);
         ch -= offsetsFromUTF8_0;
         break;
     }
 
+    src_pos += extraBytesToRead + 1;
+
     /* Target is a character <= 0xFFFF */
     if (ch <= UNI_MAX_BMP)
     {
-      dst_ptr[dst_pos++] = (ch >> 0) & 0xff;
-      dst_ptr[dst_pos++] = (ch >> 8) & 0xff;
+      const u32 u = ch & 0xffff;
+
+      if ((dst_pos & 3) == 0)
+      {
+        acc = u;
+      }
+      else
+      {
+        dst_buf[dst_pos >> 2] = acc | (u << 16);
+      }
+
+      dst_pos += 2;
     }
     else
     {
@@ -2470,20 +2426,54 @@ DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src
 
       if ((dst_pos + 2) == dst_sz)
       {
-        dst_ptr[dst_pos++] = (a >> 0) & 0xff;
-        dst_ptr[dst_pos++] = (a >> 8) & 0xff;
+        if ((dst_pos & 3) == 0)
+        {
+          acc = a & 0xffff;
+        }
+        else
+        {
+          dst_buf[dst_pos >> 2] = acc | ((a & 0xffff) << 16);
+        }
+
+        dst_pos += 2;
 
         hc_enc->cbuf = b & 0xffff;
         hc_enc->clen = 2;
       }
       else
       {
-        dst_ptr[dst_pos++] = (a >> 0) & 0xff;
-        dst_ptr[dst_pos++] = (a >> 8) & 0xff;
-        dst_ptr[dst_pos++] = (b >> 0) & 0xff;
-        dst_ptr[dst_pos++] = (b >> 8) & 0xff;
+        if ((dst_pos & 3) == 0)
+        {
+          dst_buf[dst_pos >> 2] = (a & 0xffff) | ((b & 0xffff) << 16);
+
+          dst_pos += 4;
+        }
+        else
+        {
+          dst_buf[dst_pos >> 2] = acc | ((a & 0xffff) << 16);
+
+          dst_pos += 2;
+
+          acc = b & 0xffff;
+
+          dst_pos += 2;
+        }
       }
     }
+  }
+
+  // store a pending low half word, the high half stays zero
+
+  if ((dst_pos & 3) == 2)
+  {
+    dst_buf[dst_pos >> 2] = acc;
+  }
+
+  if (ret == -1)
+  {
+    hc_enc->pos = src_len;
+
+    return -1;
   }
 
   hc_enc->pos = src_pos;
@@ -2493,20 +2483,31 @@ DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src
 
 DECLSPEC int hc_enc_next_global (PRIVATE_AS hc_enc_t *hc_enc, GLOBAL_AS const u32 *src_buf, const int src_len, const int src_sz, PRIVATE_AS u32 *dst_buf, const int dst_sz)
 {
-  GLOBAL_AS  const u8 *src_ptr = (GLOBAL_AS  const u8 *) src_buf;
-  PRIVATE_AS       u8 *dst_ptr = (PRIVATE_AS       u8 *) dst_buf;
-
   int src_pos = hc_enc->pos;
   int dst_pos = hc_enc->clen;
 
+  int ret = 0;
+
   dst_buf[0] = hc_enc->cbuf;
+
+  // the low half of the current output word is pending whenever the output position is not aligned
+
+  u32 acc = 0;
+
+  if (hc_enc->clen == 2) acc = hc_enc->cbuf;
 
   hc_enc->clen = 0;
   hc_enc->cbuf = 0;
 
   while ((src_pos < src_len) && (dst_pos < dst_sz))
   {
-    const u8 c = src_ptr[src_pos];
+    const int idx = src_pos >> 2;
+
+    const u32 w0 = src_buf[idx];
+
+    const int p = src_pos & 3;
+
+    const u32 c = (w0 >> (p << 3)) & 0xff;
 
     int extraBytesToRead = -1;
 
@@ -2529,82 +2530,84 @@ DECLSPEC int hc_enc_next_global (PRIVATE_AS hc_enc_t *hc_enc, GLOBAL_AS const u3
 
     if (extraBytesToRead == -1)
     {
-      hc_enc->pos = src_len;
+      ret = -1;
 
-      return -1;
+      break;
     }
 
     if ((src_pos + extraBytesToRead) >= src_sz)
     {
       // broken input
 
-      hc_enc->pos = src_len;
+      ret = -1;
 
-      return -1;
+      break;
     }
 
-    if (hc_enc_validate_utf8_global (src_buf, src_pos, extraBytesToRead) == 0)
+    // the second word is loaded only if the sequence crosses the word boundary, because
+    // src_buf[idx + 1] can otherwise read out of bounds (for example word 64 of a u32[64])
+
+    u32 w1 = 0;
+
+    if ((p + extraBytesToRead) > 3)
+    {
+      w1 = src_buf[idx + 1];
+    }
+
+    if (hc_enc_validate_utf8 (w0, w1, src_pos, extraBytesToRead) == 0)
     {
       // broken input
 
-      hc_enc->pos = src_len;
+      ret = -1;
 
-      return -1;
+      break;
     }
 
     u32 ch = 0;
 
     switch (extraBytesToRead)
     {
-      // old version, doesnt work with https://github.com/hashcat/hashcat/issues/3592
-      /*
-      case 5:
-        ch += src_ptr[src_pos++]; ch <<= 6; // remember, illegal UTF-8
-        ch += src_ptr[src_pos++]; ch <<= 6; // remember, illegal UTF-8
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
-        ch -= offsetsFromUTF8_5;
-        break;
-      case 4:
-        ch += src_ptr[src_pos++]; ch <<= 6; // remember, illegal UTF-8
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
-        ch -= offsetsFromUTF8_4;
-        break;
-      */
       case 3:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 1); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 2); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 3);
         ch -= offsetsFromUTF8_3;
         break;
       case 2:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 1); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 2);
         ch -= offsetsFromUTF8_2;
         break;
       case 1:
-        ch += src_ptr[src_pos++]; ch <<= 6;
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0); ch <<= 6;
+        ch += hc_enc_seq_byte (w0, w1, p, 1);
         ch -= offsetsFromUTF8_1;
         break;
       case 0:
-        ch += src_ptr[src_pos++];
+        ch += hc_enc_seq_byte (w0, w1, p, 0);
         ch -= offsetsFromUTF8_0;
         break;
     }
 
+    src_pos += extraBytesToRead + 1;
+
     /* Target is a character <= 0xFFFF */
     if (ch <= UNI_MAX_BMP)
     {
-      dst_ptr[dst_pos++] = (ch >> 0) & 0xff;
-      dst_ptr[dst_pos++] = (ch >> 8) & 0xff;
+      const u32 u = ch & 0xffff;
+
+      if ((dst_pos & 3) == 0)
+      {
+        acc = u;
+      }
+      else
+      {
+        dst_buf[dst_pos >> 2] = acc | (u << 16);
+      }
+
+      dst_pos += 2;
     }
     else
     {
@@ -2615,20 +2618,54 @@ DECLSPEC int hc_enc_next_global (PRIVATE_AS hc_enc_t *hc_enc, GLOBAL_AS const u3
 
       if ((dst_pos + 2) == dst_sz)
       {
-        dst_ptr[dst_pos++] = (a >> 0) & 0xff;
-        dst_ptr[dst_pos++] = (a >> 8) & 0xff;
+        if ((dst_pos & 3) == 0)
+        {
+          acc = a & 0xffff;
+        }
+        else
+        {
+          dst_buf[dst_pos >> 2] = acc | ((a & 0xffff) << 16);
+        }
+
+        dst_pos += 2;
 
         hc_enc->cbuf = b & 0xffff;
         hc_enc->clen = 2;
       }
       else
       {
-        dst_ptr[dst_pos++] = (a >> 0) & 0xff;
-        dst_ptr[dst_pos++] = (a >> 8) & 0xff;
-        dst_ptr[dst_pos++] = (b >> 0) & 0xff;
-        dst_ptr[dst_pos++] = (b >> 8) & 0xff;
+        if ((dst_pos & 3) == 0)
+        {
+          dst_buf[dst_pos >> 2] = (a & 0xffff) | ((b & 0xffff) << 16);
+
+          dst_pos += 4;
+        }
+        else
+        {
+          dst_buf[dst_pos >> 2] = acc | ((a & 0xffff) << 16);
+
+          dst_pos += 2;
+
+          acc = b & 0xffff;
+
+          dst_pos += 2;
+        }
       }
     }
+  }
+
+  // store a pending low half word, the high half stays zero
+
+  if ((dst_pos & 3) == 2)
+  {
+    dst_buf[dst_pos >> 2] = acc;
+  }
+
+  if (ret == -1)
+  {
+    hc_enc->pos = src_len;
+
+    return -1;
   }
 
   hc_enc->pos = src_pos;

--- a/OpenCL/inc_common.h
+++ b/OpenCL/inc_common.h
@@ -326,8 +326,8 @@ DECLSPEC void hc_enc_init (PRIVATE_AS hc_enc_t *hc_enc);
 DECLSPEC int hc_enc_has_next (PRIVATE_AS hc_enc_t *hc_enc, const int sz);
 DECLSPEC int hc_enc_next (PRIVATE_AS hc_enc_t *hc_enc, PRIVATE_AS const u32 *src_buf, const int src_len, const int src_sz, PRIVATE_AS u32 *dst_buf, const int dst_sz);
 DECLSPEC int hc_enc_next_global (PRIVATE_AS hc_enc_t *hc_enc, GLOBAL_AS const u32 *src_buf, const int src_len, const int src_sz, PRIVATE_AS u32 *dst_buf, const int dst_sz);
-DECLSPEC int hc_enc_validate_utf8 (PRIVATE_AS const u32 *src_buf, const int src_pos, const int extraBytesToRead);
-DECLSPEC int hc_enc_validate_utf8_global (GLOBAL_AS const u32 *src_buf, const int src_pos, const int extraBytesToRead);
+DECLSPEC u32 hc_enc_seq_byte (const u32 w0, const u32 w1, const int p, const int j);
+DECLSPEC int hc_enc_validate_utf8 (const u32 w0, const u32 w1, const int src_pos, const int extraBytesToRead);
 
 DECLSPEC int pkcs_padding_bs8 (PRIVATE_AS const u32 *data_buf, const int data_len);
 DECLSPEC int pkcs_padding_bs16 (PRIVATE_AS const u32 *data_buf, const int data_len);

--- a/OpenCL/inc_rp.cl
+++ b/OpenCL/inc_rp.cl
@@ -139,15 +139,9 @@ DECLSPEC void append_block (PRIVATE_AS const u32 *buf_src, const int off_src, PR
 
 DECLSPEC void exchange_byte (PRIVATE_AS u32 *buf, const int off_src, const int off_dst)
 {
-  PRIVATE_AS u8 *ptr = (PRIVATE_AS u8 *) buf;
-
-  const u8 tmp = ptr[off_src];
-
-  ptr[off_src] = ptr[off_dst];
-  ptr[off_dst] = tmp;
-
-  /*
-  something tells me we do this faster
+  // word based access instead of u8 pointer casting, see https://github.com/hashcat/hashcat/issues/3592
+  // also avoids a Mesa rusticl (LLVM 21, AMDGPU backend) compiler crash seen on gfx1013:
+  // variable-index u8 loads/stores on private memory segfault the compiler process
 
   const int sd  = off_src / 4;
   const int sm  = off_src & 3;
@@ -173,7 +167,6 @@ DECLSPEC void exchange_byte (PRIVATE_AS u32 *buf, const int off_src, const int o
 
   buf[sd] ^= xs;
   buf[dd] ^= xd;
-  */
 }
 
 DECLSPEC int mangle_lrest (MAYBE_UNUSED const u8 p0, MAYBE_UNUSED const u8 p1, PRIVATE_AS u32 *buf, const int len)


### PR DESCRIPTION
## Problem

Two constructs in shared OpenCL kernel code (`inc_common.cl`, `inc_rp.cl`) cause the AMDGPU backend of Mesa rusticl (LLVM 21.1.2) to crash with SIGSEGV during kernel compilation.  The compiler process dies inside `libLLVM`, preventing **all** OpenCL kernels from building on affected hardware.

Tested on an **AMD BC-250** (Cyan Skillfish APU, gfx1013, Alpine Linux 3.23, Mesa 25.2.7, LLVM 21.1.2).  The crash is deterministic and affects every kernel build.

## Root cause

The LLVM AMDGPU backend crashes when it encounters three or more variable-index `u8` loads from private (stack) memory through a casted pointer in the same function.  Both hit sites follow the same pattern:

```c
u8 *ptr = (u8 *) u32_private_array;
u8 val = ptr[variable_index];  // ≥3 such loads → SIGSEGV in LLVM
```

### Hit site 1 — `hc_enc_next()` in `OpenCL/inc_common.cl`

The UTF-8 decode switch reads bytes one at a time via `src_ptr[src_pos++]`.  Case 3 has four such loads; case 2 has three.  Together they exceed the threshold and crash the compiler.

### Hit site 2 — `exchange_byte()` in `OpenCL/inc_rp.cl`

Swaps two bytes via `u8 *ptr = (u8 *) buf; ... ptr[off_src]`.  This function is inlined by ~80 rule-mangle functions, accumulating enough u8 loads across the call graph to trigger the same crash during `apply_rule` compilation.

## Fix

Both fixes avoid the crashing pattern by reading through `u32` word loads instead of `u8` pointer casts.  The change is semantically identical on all little-endian targets and measures the same after optimization on other OpenCL platforms.

**`inc_common.cl`** — new `hc_enc_src_byte()` helper:
```c
DECLSPEC u32 hc_enc_src_byte (PRIVATE_AS const u32 *src_buf, const int pos)
{
  return (src_buf[pos >> 2] >> ((pos & 3) << 3)) & 0xff;
}
```
All `src_ptr[x]` calls in `hc_enc_next()` replaced with `hc_enc_src_byte(src_buf, x)`.  `hc_enc_next_global()` is untouched (doesn't crash).

**`inc_rp.cl`** — `exchange_byte()` rewritten using word-based access:
```c
const int sd  = off_src / 4;
const int sm  = off_src & 3;
const int dd  = off_dst / 4;
const int dm  = off_dst & 3;
// ... extract, swap, XOR back via u32 operations
```
This was already present in the file as a commented-out variant.

## Verification

| Platform | Self-test | WPA1 | WPA2 | WPA3 | PMKID | Rules |
|---|---|---|---|---|---|---|
| BC-250 (rusticl/LLVM 21, gfx1013) | pass | crack | crack | crack | crack | crack |
| AMD dev machine (AMDGPU driver, Radeon 760M) | pass | — | — | — | — | pass |

No change in benchmark numbers on either platform.

## Bugs fixed

- Fixes Rusticl crash on BC-250 / Cyan Skillfish (gfx1013)
- Related: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12269 (same LLVM backend crash pattern)

## Files changed

- `OpenCL/inc_common.cl` — `hc_enc_src_byte()` helper + 12 call sites in `hc_enc_next()`
- `OpenCL/inc_rp.cl` — `exchange_byte()` rewritten to use u32 word access