### PR TITLE
Add static asserts to the SHA256 crypto functions

### DIFF
--- a/OpenCL/inc_hash_sha256.cl
+++ b/OpenCL/inc_hash_sha256.cl
@@ -345,7 +345,7 @@ DECLSPEC void sha256_update_64 (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS u32 *w0
   }
 }
 
-DECLSPEC void sha256_update (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
+DECLSPEC void sha256_update_impl (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
 {
   u32 w0[4];
   u32 w1[4];
@@ -397,7 +397,7 @@ DECLSPEC void sha256_update (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 
   sha256_update_64 (ctx, w0, w1, w2, w3, len - pos1);
 }
 
-DECLSPEC void sha256_update_swap (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
+DECLSPEC void sha256_update_swap_impl (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
 {
   u32 w0[4];
   u32 w1[4];
@@ -1086,7 +1086,7 @@ DECLSPEC void sha256_hmac_init_64 (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS
   sha256_update_64 (&ctx->opad, b0, b1, b2, b3, 64);
 }
 
-DECLSPEC void sha256_hmac_init (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
+DECLSPEC void sha256_hmac_init_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
 {
   u32 w0[4];
   u32 w1[4];
@@ -1143,7 +1143,7 @@ DECLSPEC void sha256_hmac_init (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS co
   sha256_hmac_init_64 (ctx, w0, w1, w2, w3);
 }
 
-DECLSPEC void sha256_hmac_init_swap (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
+DECLSPEC void sha256_hmac_init_swap_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
 {
   u32 w0[4];
   u32 w1[4];
@@ -1465,12 +1465,12 @@ DECLSPEC void sha256_hmac_update_64 (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_
   sha256_update_64 (&ctx->ipad, w0, w1, w2, w3, len);
 }
 
-DECLSPEC void sha256_hmac_update (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
+DECLSPEC void sha256_hmac_update_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
 {
   sha256_update (&ctx->ipad, w, len);
 }
 
-DECLSPEC void sha256_hmac_update_swap (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
+DECLSPEC void sha256_hmac_update_swap_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len)
 {
   sha256_update_swap (&ctx->ipad, w, len);
 }

--- a/OpenCL/inc_hash_sha256.h
+++ b/OpenCL/inc_hash_sha256.h
@@ -89,11 +89,52 @@ typedef struct sha256_hmac_ctx_vector
 
 } sha256_hmac_ctx_vector_t;
 
+
+#define HC_IS_BUFFER_SIZE_MULTIPLE_OR_POINTER(buf, multiple)  \
+                                              (  \
+                                                (sizeof(buf) % (multiple)) == 0 ||  \
+                                                sizeof(buf) == sizeof(CONSTANT_VK u32 *) ||  \
+                                                sizeof(buf) == sizeof(CONSTANT_AS u32 *) ||  \
+                                                sizeof(buf) == sizeof(GLOBAL_AS u32 *) ||  \
+                                                sizeof(buf) == sizeof(LOCAL_VK u32 *) ||  \
+                                                sizeof(buf) == sizeof(LOCAL_AS u32 *) ||  \
+                                                sizeof(buf) == sizeof(PRIVATE_AS u32 *)  \
+                                              )
+
+// We disable static asserts when we're including this header from C, since C99
+// doesn't have static asserts
+#if defined(__STDC_VERSION__)
+#  define HC_STATIC_ASSERT(...)
+#else
+#  define HC_STATIC_ASSERT static_assert
+#endif
+
+// Use a define instead of an inline function because the compiler cannot figure
+// out that sizeof(buffer) is a static constant
+#define HC_CHECK_BUFFER_BEFORE_CALL(ctx, buffer, content_len, func, block_size)  \
+                                              do {  \
+                                                HC_STATIC_ASSERT(  \
+                                                  HC_IS_BUFFER_SIZE_MULTIPLE_OR_POINTER(buffer, block_size),  \
+                                                  "Size of buffer is not a multiple of SHA256 block size (64)!"  \
+                                                );  \
+                                                func(ctx, buffer, content_len); \
+                                              } while (0);
+
+#define HC_SHA256_BLOCK_SIZE                  64
+#define HC_SHA256_CHECK_BUFFER_BEFORE_CALL(ctx, buffer, content_len, func)  HC_CHECK_BUFFER_BEFORE_CALL(ctx, buffer, content_len, func, HC_SHA256_BLOCK_SIZE)
+
+#define sha256_update(ctx, w, content_len)            HC_SHA256_CHECK_BUFFER_BEFORE_CALL(ctx, w, content_len, sha256_update_impl)
+#define sha256_update_swap(ctx, w, content_len)       HC_SHA256_CHECK_BUFFER_BEFORE_CALL(ctx, w, content_len, sha256_update_swap_impl)
+#define sha256_hmac_init(ctx, w, content_len)         HC_SHA256_CHECK_BUFFER_BEFORE_CALL(ctx, w, content_len, sha256_hmac_init_impl)
+#define sha256_hmac_init_swap(ctx, w, content_len)    HC_SHA256_CHECK_BUFFER_BEFORE_CALL(ctx, w, content_len, sha256_hmac_init_swap_impl)
+#define sha256_hmac_update(ctx, w, content_len)       HC_SHA256_CHECK_BUFFER_BEFORE_CALL(ctx, w, content_len, sha256_hmac_update_impl)
+#define sha256_hmac_update_swap(ctx, w, content_len)  HC_SHA256_CHECK_BUFFER_BEFORE_CALL(ctx, w, content_len, sha256_hmac_update_swap_impl)
+
 DECLSPEC void sha256_transform (PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3, PRIVATE_AS u32 *digest);
 DECLSPEC void sha256_init (PRIVATE_AS sha256_ctx_t *ctx);
 DECLSPEC void sha256_update_64 (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const int len);
-DECLSPEC void sha256_update (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
-DECLSPEC void sha256_update_swap (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
+DECLSPEC void sha256_update_impl (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
+DECLSPEC void sha256_update_swap_impl (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha256_update_utf16le (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha256_update_utf16le_swap (PRIVATE_AS sha256_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha256_update_global (PRIVATE_AS sha256_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);
@@ -102,14 +143,14 @@ DECLSPEC void sha256_update_global_utf16le (PRIVATE_AS sha256_ctx_t *ctx, GLOBAL
 DECLSPEC void sha256_update_global_utf16le_swap (PRIVATE_AS sha256_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);
 DECLSPEC void sha256_final (PRIVATE_AS sha256_ctx_t *ctx);
 DECLSPEC void sha256_hmac_init_64 (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w0, PRIVATE_AS const u32 *w1, PRIVATE_AS const u32 *w2, PRIVATE_AS const u32 *w3);
-DECLSPEC void sha256_hmac_init (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
-DECLSPEC void sha256_hmac_init_swap (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
+DECLSPEC void sha256_hmac_init_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
+DECLSPEC void sha256_hmac_init_swap_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha256_hmac_init_global (PRIVATE_AS sha256_hmac_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);
 DECLSPEC void sha256_hmac_init_global_swap (PRIVATE_AS sha256_hmac_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);
 DECLSPEC void sha256_hmac_init_global_utf16le_swap (PRIVATE_AS sha256_hmac_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);
 DECLSPEC void sha256_hmac_update_64 (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS u32 *w0, PRIVATE_AS u32 *w1, PRIVATE_AS u32 *w2, PRIVATE_AS u32 *w3, const int len);
-DECLSPEC void sha256_hmac_update (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
-DECLSPEC void sha256_hmac_update_swap (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
+DECLSPEC void sha256_hmac_update_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
+DECLSPEC void sha256_hmac_update_swap_impl (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha256_hmac_update_utf16le (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha256_hmac_update_utf16le_swap (PRIVATE_AS sha256_hmac_ctx_t *ctx, PRIVATE_AS const u32 *w, const int len);
 DECLSPEC void sha256_hmac_update_global (PRIVATE_AS sha256_hmac_ctx_t *ctx, GLOBAL_AS const u32 *w, const int len);


### PR DESCRIPTION
Fixes #4773

This catches some common error cases, where a kernel does not use correctly sized buffers. Passing buffers that are too short will lead to unexpected behaviour that's hard to debug. While the docs mention that the buffers should be large enough, adding an explicit check at compile time will save kernel developers some time debugging this issue.

This check is not perfect. It also allows buffers that happen to be exactly the same size as a pointer, to avoid errors when these functions are passed pointers instead of buffers.

If I modify the `HC_SHA256_BLOCK_SIZE` to `7` (just to make the assert fail) and try to crack a hash using sha256, the kernel fails to compile with a clear error message:

```
~/git/hashcat » ./hashcat -m 1400 0000000000000000000000000000000000000000000000000000000000000000 --runtime=1 --potfile-disable
hashcat (v7.1.2) starting

nvmlDeviceGetFanSpeed(): Not Supported

CUDA API (CUDA 12.6)
====================
* Device #01: NVIDIA RTX 2000 Ada Generation Laptop GPU, 7725/7838 MB, 24MCU

OpenCL API (OpenCL 3.0 CUDA 12.6.65) - Platform #1 [NVIDIA Corporation]
=======================================================================
* Device #02: NVIDIA RTX 2000 Ada Generation Laptop GPU, skipped

Minimum password length supported by kernel: 0
Maximum password length supported by kernel: 256

Hashes: 1 digests; 1 unique digests, 1 unique salts
Bitmaps: 13 bits, 8192 entries, 0x00001fff mask, 32768 bytes, 5/13 rotates
Rules: 1

Optimizers applied:
* Zero-Byte
* Early-Skip
* Not-Salted
* Not-Iterated
* Single-Hash
* Single-Salt
* Raw-Hash

ATTENTION! Pure (unoptimized) backend kernels selected.
Pure kernels can crack longer passwords, but drastically reduce performance.
If you want to switch to optimized kernels, append -O to your commandline.
See the above message to find out about the exact limits.

Watchdog: Temperature abort trigger set to 90c

nvrtcCompileProgram(): NVRTC_ERROR_COMPILATION

main_kernel(50): error: static assertion failed with "Size of buffer is not a multiple of SHA256 block size (64)!"
      sha256_update_swap (&ctx, tmp.i, tmp.pw_len);
      ^

main_kernel(106): error: static assertion failed with "Size of buffer is not a multiple of SHA256 block size (64)!"
      sha256_update_swap (&ctx, tmp.i, tmp.pw_len);
      ^

2 errors detected in the compilation of "main_kernel".

* Device #1: Kernel ~/git/hashcat/OpenCL/m01400_a0-pure.cl build failed.

* Device #1: Kernel ~/git/hashcat/OpenCL/m01400_a0-pure.cl build failed.

Started: Sat Aug 29 23:08:07 2026
Stopped: Sat Aug 29 23:08:09 2026
```

Leaving the code as it is in this PR, the static assert never triggers.

There is definitely room for improvement (maybe the assert message can be changed to reflect the computed `sizeof(buffer)`, maybe this check can be extended to other parts of the crypto library, etc.), but I decided against including that in this PR because either my OpenCL is not good enough, or I wanted to avoid this PR becoming too big to review.

I'd be interested to hear what the hashcat maintainers think about this.