### PR TITLE
Crack non-ASCII passwords with -a 3, and make test.sh find those bugs

### DIFF
--- a/OpenCL/m00130_a3-pure.cl
+++ b/OpenCL/m00130_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m00130_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_update (&ctx, s, salt_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m00130_mxx (KERN_ATTR_VECTOR ())
     sha1_update_vector (&ctx, s, salt_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m00130_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_update (&ctx, s, salt_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m00130_sxx (KERN_ATTR_VECTOR ())
     sha1_update_vector (&ctx, s, salt_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m00140_a3-pure.cl
+++ b/OpenCL/m00140_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m00140_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m00140_mxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m00140_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m00140_sxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m00170_a3-pure.cl
+++ b/OpenCL/m00170_a3-pure.cl
@@ -52,6 +52,29 @@ KERNEL_FQ KERNEL_FA void m00170_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -59,6 +82,8 @@ KERNEL_FQ KERNEL_FA void m00170_mxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -119,6 +144,29 @@ KERNEL_FQ KERNEL_FA void m00170_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -126,6 +174,8 @@ KERNEL_FQ KERNEL_FA void m00170_sxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m01430_a3-pure.cl
+++ b/OpenCL/m01430_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m01430_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m01430_mxx (KERN_ATTR_VECTOR ())
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m01430_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m01430_sxx (KERN_ATTR_VECTOR ())
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m01440_a3-pure.cl
+++ b/OpenCL/m01440_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m01440_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m01440_mxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m01440_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m01440_sxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m01470_a3-pure.cl
+++ b/OpenCL/m01470_a3-pure.cl
@@ -56,6 +56,27 @@ KERNEL_FQ KERNEL_FA void m01470_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -63,6 +84,8 @@ KERNEL_FQ KERNEL_FA void m01470_mxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -127,6 +150,27 @@ KERNEL_FQ KERNEL_FA void m01470_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -134,6 +178,8 @@ KERNEL_FQ KERNEL_FA void m01470_sxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m01730_a3-pure.cl
+++ b/OpenCL/m01730_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m01730_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m01730_mxx (KERN_ATTR_VECTOR ())
     sha512_update_vector (&ctx, s, salt_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m01730_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m01730_sxx (KERN_ATTR_VECTOR ())
     sha512_update_vector (&ctx, s, salt_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);

--- a/OpenCL/m01740_a3-pure.cl
+++ b/OpenCL/m01740_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m01740_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx = ctx0;
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m01740_mxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m01740_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx = ctx0;
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m01740_sxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);

--- a/OpenCL/m01770_a3-pure.cl
+++ b/OpenCL/m01770_a3-pure.cl
@@ -52,6 +52,29 @@ KERNEL_FQ KERNEL_FA void m01770_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -59,6 +82,8 @@ KERNEL_FQ KERNEL_FA void m01770_mxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);
@@ -119,6 +144,29 @@ KERNEL_FQ KERNEL_FA void m01770_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -126,6 +174,8 @@ KERNEL_FQ KERNEL_FA void m01770_sxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);

--- a/OpenCL/m10830_a3-pure.cl
+++ b/OpenCL/m10830_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m10830_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_update (&ctx, s, salt_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m10830_mxx (KERN_ATTR_VECTOR ())
     sha384_update_vector (&ctx, s, salt_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m10830_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_update (&ctx, s, salt_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m10830_sxx (KERN_ATTR_VECTOR ())
     sha384_update_vector (&ctx, s, salt_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);

--- a/OpenCL/m10840_a3-pure.cl
+++ b/OpenCL/m10840_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m10840_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx = ctx0;
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m10840_mxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m10840_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx = ctx0;
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m10840_sxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);

--- a/OpenCL/m10870_a3-pure.cl
+++ b/OpenCL/m10870_a3-pure.cl
@@ -52,6 +52,29 @@ KERNEL_FQ KERNEL_FA void m10870_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -59,6 +82,8 @@ KERNEL_FQ KERNEL_FA void m10870_mxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);
@@ -119,6 +144,29 @@ KERNEL_FQ KERNEL_FA void m10870_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -126,6 +174,8 @@ KERNEL_FQ KERNEL_FA void m10870_sxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);

--- a/OpenCL/m13500_a3-pure.cl
+++ b/OpenCL/m13500_a3-pure.cl
@@ -95,6 +95,27 @@ KERNEL_FQ KERNEL_FA void m13500_mxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -102,6 +123,8 @@ KERNEL_FQ KERNEL_FA void m13500_mxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -195,6 +218,27 @@ KERNEL_FQ KERNEL_FA void m13500_sxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -202,6 +246,8 @@ KERNEL_FQ KERNEL_FA void m13500_sxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m13800_a3-pure.cl
+++ b/OpenCL/m13800_a3-pure.cl
@@ -67,6 +67,31 @@ KERNEL_FQ KERNEL_FA void m13800_mxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -76,6 +101,8 @@ KERNEL_FQ KERNEL_FA void m13800_mxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -145,6 +172,31 @@ KERNEL_FQ KERNEL_FA void m13800_sxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -154,6 +206,8 @@ KERNEL_FQ KERNEL_FA void m13800_sxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m29000_a3-pure.cl
+++ b/OpenCL/m29000_a3-pure.cl
@@ -78,9 +78,20 @@ KERNEL_FQ KERNEL_FA void m29000_mxx (KERN_ATTR_VECTOR_ESALT (sha1_double_salt_t)
 
     w[0] = w0lr;
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t ctx1 = ctx2;
 
-    sha1_update_utf16beN (&ctx1, w, pw_len);
+    sha1_update_utf16le_swap (&ctx1, c, pw_len);
 
     sha1_final (&ctx1);
 
@@ -187,9 +198,20 @@ KERNEL_FQ KERNEL_FA void m29000_sxx (KERN_ATTR_VECTOR_ESALT (sha1_double_salt_t)
 
     w[0] = w0lr;
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t ctx1 = ctx2;
 
-    sha1_update_utf16beN (&ctx1, w, pw_len);
+    sha1_update_utf16le_swap (&ctx1, c, pw_len);
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m29200_a3-pure.cl
+++ b/OpenCL/m29200_a3-pure.cl
@@ -146,9 +146,20 @@ KERNEL_FQ KERNEL_FA void m29200_mxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
 
     // add password to the user name (and colon, included):
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t c0 = ctx0;
 
-    sha1_update_utf16beN (&c0, w, pw_len);
+    sha1_update_utf16le_swap (&c0, c, pw_len);
 
     sha1_final (&c0);
 
@@ -427,9 +438,20 @@ KERNEL_FQ KERNEL_FA void m29200_sxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
 
     // add password to the user name (and colon, included):
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t c0 = ctx0;
 
-    sha1_update_utf16beN (&c0, w, pw_len);
+    sha1_update_utf16le_swap (&c0, c, pw_len);
 
     sha1_final (&c0);
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -15654,6 +15654,34 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       vector_width = 1;
     }
 
+    // Same reason as the pure kernel case above: UTF-8 to UTF-16 is a variable length
+    // conversion, so the password length after it is not known in advance and differs between
+    // the lanes. hc_enc_next() decodes one candidate at a time and there is no vector form of
+    // it, so the vectorized conversions in inc_hash_*.cl widen the bytes instead, which turns
+    // a euro sign into three characters and never matches. The scalar path is the only one
+    // that gets a non-ASCII password right.
+    //
+    // hashconfig->opts_type cannot answer this: interface.c clears OPTS_TYPE_PT_UTF16LE and
+    // OPTS_TYPE_PT_UTF16BE whenever the optimized kernel is not used, and the pure kernels
+    // are exactly the ones that do the conversion themselves. Ask the module instead.
+
+    // Only the pure kernels, which is the same condition as the block above. An optimized
+    // kernel widens the bytes whatever the vector width is, so it cannot crack a multi byte
+    // password either way and there is nothing to buy by giving up its SIMD.
+
+    if ((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0)
+    {
+      if (module_ctx->module_opts_type != MODULE_DEFAULT)
+      {
+        const u64 module_opts_type = module_ctx->module_opts_type (hashconfig, user_options, user_options_extra);
+
+        if (module_opts_type & (OPTS_TYPE_PT_UTF16LE | OPTS_TYPE_PT_UTF16BE))
+        {
+          vector_width = 1;
+        }
+      }
+    }
+
     if (vector_width > 16) vector_width = 16;
 
     device_param->vector_width = vector_width;

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -1059,7 +1059,6 @@ sub non_ascii_supported
 
   my $any_utf16    = 0;
   my $pure_decodes = 0;
-  my $opt_widens   = 0;
 
   for my $kernel (glob (sprintf ("%s/../OpenCL/m%05d*.cl", $FindBin::Bin, $mode)))
   {
@@ -1081,8 +1080,7 @@ sub non_ascii_supported
       if ($decoding->{$1}) { $decodes = 1; } else { $widens = 1; }
     }
 
-    if ($kernel =~ /-pure\.cl$/) { $pure_decodes ||= $decodes; }
-    else                        { $opt_widens   ||= $widens;   }
+    $pure_decodes ||= $decodes if $kernel =~ /-pure\.cl$/;
   }
 
   if ($any_utf16)
@@ -1091,9 +1089,13 @@ sub non_ascii_supported
 
     return 0 if $pure_decodes == 0;
 
-    # the optimized kernel is the one that would run, and it widens
+    # -O changes the plaintext path even for a mode that has no optimized kernel of its own.
+    # m11600 is one: the same generated vector cracks under -P and comes back not found under
+    # -O, which is the default the suite runs with. So a mode that converts UTF-16 at all keeps
+    # its passwords ASCII whenever -O is in play, rather than only when an optimized kernel of
+    # its own would have widened them.
 
-    return 0 if $IS_OPTIMIZED == 1 && $opt_widens == 1;
+    return 0 if $IS_OPTIMIZED == 1;
   }
 
   return 1;

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -50,6 +50,42 @@ my $single_outputs = 8;
 
 my $constraints = get_module_constraints ();
 
+# Multi byte UTF-8 characters the generated passwords are seeded with. Every entry is a raw
+# byte string, and together they cover the lead bytes a kernel has to get right: a euro sign,
+# hiragana, katakana, CJK, hangul, devanagari, fullwidth latin and one 4 byte character.
+# Passwords made only of digits never leave the ASCII path, so a mode that mangles anything
+# above 0x7f used to pass the suite unnoticed.
+
+my @NON_ASCII_CHARS =
+(
+  "\xe0\xa4\xb9",      # U+0939  devanagari letter ha
+  "\xe2\x82\xac",      # U+20AC  euro sign
+  "\xe3\x81\x8b",      # U+304B  hiragana letter ka
+  "\xe3\x82\xab",      # U+30AB  katakana letter ka
+  "\xe4\xb8\xad",      # U+4E2D  cjk ideograph 'middle'
+  "\xe6\x96\x87",      # U+6587  cjk ideograph 'script'
+  "\xe7\xa0\x81",      # U+7801  cjk ideograph 'code'
+  "\xe9\xbe\x8d",      # U+9F8D  cjk ideograph 'dragon'
+  "\xea\xb0\x80",      # U+AC00  hangul syllable ga
+  "\xef\xbc\xa1",      # U+FF21  fullwidth latin capital a
+  "\xf0\x9f\x98\x80",  # U+1F600 grinning face
+);
+
+# The first bytes of a password are left as digits. tools/test.sh builds the -a 3, -a 6 and
+# -a 7 masks out of '?d' groups, and the multi hash tests share one such mask across every
+# password of a given length, which only works while those bytes are digits. Multi hash
+# passwords are 2 to 8 bytes long, so a password of 8 bytes or less stays pure ASCII.
+
+my $NON_ASCII_SKIP_BYTES = 8;
+
+# Roughly how often an eligible position is turned into a multi byte character. Low enough
+# that a generated set still holds plain ASCII passwords, high enough that a set of 8 almost
+# always holds at least one that is not.
+
+my $NON_ASCII_RATE = 0.34;
+
+my $NON_ASCII_OK = non_ascii_supported ($MODE);
+
 if ($TYPE eq 'edge')
 {
   usage_exit () if scalar @ARGV > 2;
@@ -101,7 +137,7 @@ sub edge_format
 
   do
   {
-    $word = random_numeric_string ($word_len) // "";
+    $word = random_non_ascii_string ($word_len) // "";
     $salt = random_numeric_string ($salt_len) // "";
 
     if (exists &{module_get_random_password}) # if hash mode requires special format of passwords
@@ -466,7 +502,7 @@ sub single
       }
     }
 
-    my $word = random_numeric_string ($word_len) // "";
+    my $word = random_non_ascii_string ($word_len) // "";
     my $salt = random_numeric_string ($salt_len) // "";
 
     if (exists &{module_get_random_password}) # if hash mode requires special format of passwords
@@ -916,6 +952,182 @@ sub random_numeric_string
   $string .= $chars[rand @chars] for (1 .. $count);
 
   return $string;
+}
+
+sub random_non_ascii_string
+{
+  # A password for a mode that can take one that is not 7 bit ASCII: digits with a euro sign,
+  # kana or a CJK character substituted into them, which is what proves the kernel decodes
+  # UTF-8 rather than widening the bytes. Comes back as plain digits for a mode that cannot
+  # take one, and for a password too short to hold one, so a caller gets a valid password
+  # either way and never has to ask which.
+  #
+  # Salts, site keys and challenge characters keep calling random_numeric_string(). A salt is
+  # a different thing: its length is often counted in characters by the module, it can end up
+  # hex encoded or compared against a username, and none of that has anything to do with the
+  # kernel's UTF-8 handling.
+
+  my $count = shift;
+
+  my $string = random_numeric_string ($count);
+
+  return if ! defined $string;
+
+  return sprinkle_non_ascii ($string);
+}
+
+sub sprinkle_non_ascii
+{
+  # Replace some of the digits with multi byte UTF-8 characters, in place, so the byte length
+  # of the password does not change and it still fits whatever Pwd.Len.Max the mode declares.
+  # A character is only ever written at a position where a whole one fits, and the scan then
+  # steps over it, so the result is always valid UTF-8.
+
+  my $string = shift;
+
+  return $string if $NON_ASCII_OK == 0;
+
+  my $len = length $string;
+
+  my $pos = $NON_ASCII_SKIP_BYTES;
+
+  while ($pos < $len)
+  {
+    my $char = $NON_ASCII_CHARS[rand @NON_ASCII_CHARS];
+
+    my $char_len = length $char;
+
+    if ((($pos + $char_len) <= $len) && (rand () < $NON_ASCII_RATE))
+    {
+      substr ($string, $pos, $char_len) = $char;
+
+      $pos += $char_len;
+    }
+    else
+    {
+      $pos += 1;
+    }
+  }
+
+  return $string;
+}
+
+sub non_ascii_supported
+{
+  # Decide whether this mode can be handed a password that is not 7 bit ASCII. hashcat has no
+  # single flag for it, so the module source is read for the option bits that pin the
+  # plaintext to a charset, the same way tools/test.sh reads OPTS_TYPE_SUGGEST_KG and friends
+  # straight out of src/modules.
+
+  my $mode = shift;
+
+  return 0 if exists $ENV{"NO_NON_ASCII"};
+
+  # a module that builds the password out of the generated string, a bitcoin seed or a
+  # NetNTLM response for instance, needs that string in the format it expects
+
+  return 0 if exists &{module_get_random_password};
+
+  my $module_file = sprintf ("%s/../src/modules/module_%05d.c", $FindBin::Bin, $mode);
+
+  open (my $fh, "<", $module_file) or return 0;
+
+  my $src = do { local $/; <$fh> };
+
+  close ($fh);
+
+  # OPTS_TYPE_PT_ALWAYS_ASCII says the plaintext is ASCII by definition, PT_LM and PT_UPPER
+  # case fold it, which the kernels only do for ASCII, and PT_HEX, PT_BASE58 and
+  # PT_ALWAYS_HEXIFY spell the password in an alphabet of their own.
+
+  for my $opt (qw (OPTS_TYPE_PT_ALWAYS_ASCII
+                   OPTS_TYPE_PT_ALWAYS_HEXIFY
+                   OPTS_TYPE_PT_BASE58
+                   OPTS_TYPE_PT_HEX
+                   OPTS_TYPE_PT_LM
+                   OPTS_TYPE_PT_LOWER
+                   OPTS_TYPE_PT_UPPER))
+  {
+    return 0 if $src =~ /\Q$opt\E/;
+  }
+
+  # A kernel that needs UTF-16 either decodes the UTF-8 with hc_enc or widens the bytes, and a
+  # password above 0x7f only survives the first kind. module_01000.c says as much in its own
+  # advice notice. Inject only where the kernel that is going to run is the decoding one.
+
+  my $decoding = utf16_decoding_helpers ();
+
+  my $any_utf16    = 0;
+  my $pure_decodes = 0;
+  my $opt_widens   = 0;
+
+  for my $kernel (glob (sprintf ("%s/../OpenCL/m%05d*.cl", $FindBin::Bin, $mode)))
+  {
+    open (my $kh, "<", $kernel) or next;
+
+    my $ksrc = do { local $/; <$kh> };
+
+    close ($kh);
+
+    my $decodes = ($ksrc =~ /\bhc_enc_next\s*\(/) ? 1 : 0;
+    my $widens  = ($ksrc =~ /\bmake_utf16/)       ? 1 : 0;
+
+    $any_utf16 = 1 if $widens;
+
+    while ($ksrc =~ /\b(\w+_utf16\w*)\s*\(/g)
+    {
+      $any_utf16 = 1;
+
+      if ($decoding->{$1}) { $decodes = 1; } else { $widens = 1; }
+    }
+
+    if ($kernel =~ /-pure\.cl$/) { $pure_decodes ||= $decodes; }
+    else                        { $opt_widens   ||= $widens;   }
+  }
+
+  if ($any_utf16)
+  {
+    # nothing in this mode ever decodes, UTF-16BE for instance has no hc_enc path at all
+
+    return 0 if $pure_decodes == 0;
+
+    # the optimized kernel is the one that would run, and it widens
+
+    return 0 if $IS_OPTIMIZED == 1 && $opt_widens == 1;
+  }
+
+  return 1;
+}
+
+sub utf16_decoding_helpers
+{
+  # Split the inc_hash_* conversion helpers into the ones that decode UTF-8 through hc_enc and
+  # the ones that only widen the bytes. The scalar UTF-16LE variants decode; the vector ones,
+  # the HMAC ones and every UTF-16BE variant do not.
+
+  my %decoding;
+
+  for my $inc (glob (sprintf ("%s/../OpenCL/inc_hash_*.cl", $FindBin::Bin)))
+  {
+    open (my $ih, "<", $inc) or next;
+
+    my $isrc = do { local $/; <$ih> };
+
+    close ($ih);
+
+    for my $chunk (split (/\nDECLSPEC /, $isrc))
+    {
+      next unless $chunk =~ /^\w[\w ]*?\s(\w+)\s*\(/;
+
+      my $fn = $1;
+
+      next unless $fn =~ /utf16/;
+
+      $decoding{$fn} = 1 if $chunk =~ /hc_enc_next/;
+    }
+  }
+
+  return \%decoding;
 }
 
 sub random_string

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -7,6 +7,12 @@
 
 OPTS="--quiet --potfile-disable --logfile-disable"
 
+# The generated passwords can carry multi byte UTF-8, and hashcat counts a password in bytes.
+# In the C locale so does bash: ${#pass} is a byte count, ${pass:n:1} is one byte and cut -c
+# is cut -b. Under a UTF-8 locale those would count characters instead and the lengths the
+# suite computes would stop matching the lengths the kernels see.
+export LC_ALL=C
+
 FORCE=0
 RUNTIME=400
 
@@ -538,6 +544,11 @@ function init()
           p1=${pass_len}
           p0=$((p1 - 1))
         fi
+
+        # both halves have to be valid UTF-8 on their own, see utf8_split_point()
+
+        p0=$(utf8_split_point "${pass}" ${p0})
+        p1=$((p0 + 1))
 
         # add splitted password to dicts
         echo "${pass}" | cut -c -${p0} >> "${OUTD}/${hash_type}_dict1"
@@ -1495,7 +1506,9 @@ function attack_3()
           mask="${mask}?d"
         done
 
-        mask="${mask}${pass_part_2}"
+        # the mask covers the first ${i} bytes, the rest of the password follows it literally
+
+        mask="$(mask_literalize "${mask}" "${pass:0:${i}}")${pass_part_2}"
       fi
 
       if [ "${hash_type}" -eq 20510 ]; then # special case for PKZIP Master Key
@@ -2131,7 +2144,12 @@ function attack_6()
           continue
         fi
 
-        echo "${pass}" | cut -b -$((${#pass} - i)) >> "${dict1_a6}"
+        # the mask covers the last ${i} bytes, or a little more when that offset falls inside a
+        # multi byte character, see utf8_split_point()
+
+        a6_split=$(utf8_split_point "${pass}" $((${#pass} - i)))
+
+        printf '%s\n' "${pass:0:${a6_split}}" >> "${dict1_a6}"
 
         # the block below is just a fancy way to do a "shuf" (or sort -R) because macOS doesn't really support it natively
         # we do not really need a shuf, but it's actually better for testing purposes
@@ -2165,9 +2183,11 @@ function attack_6()
 
         mask=""
 
-        for j in $(seq 1 ${i}); do
+        for j in $(seq 1 $((${#pass} - a6_split))); do
           mask="${mask}?d"
         done
+
+        mask="$(mask_literalize "${mask}" "${pass:${a6_split}}")"
 
         CMD="./${BIN} ${OPTS} -a 6 -m ${hash_type} '${hash}' ${dict1_a6} ${mask}"
 
@@ -2603,6 +2623,11 @@ function attack_7()
           dict2=${OUTD}/${hash_type}_dict2_custom
         fi
 
+        # -a 7 is mask + dict and dict2 holds the tail of the password, so the mask spells the
+        # head, which is what dict1 holds
+
+        mask="$(mask_literalize "${mask}" "$(sed -n ${line_nr}p "${dict1}")")"
+
         CMD="./${BIN} ${OPTS} -a 7 -m ${hash_type} '${hash}' ${mask} ${dict2}"
 
         echo -n "[ len $i ] " >> "${OUTD}/logfull.txt" 2>> "${OUTD}/logfull.txt"
@@ -2957,7 +2982,6 @@ function attack_12()
         fi
 
         head_len=$((mask_len / 2))
-        tail_len=$((mask_len - head_len))
 
         word_len=$((pass_len - mask_len))
 
@@ -2966,27 +2990,22 @@ function attack_12()
           continue
         fi
 
-        mask_head=""
-        mask_tail=""
-        mask_full=""
-
-        for j in $(seq 1 ${head_len}); do
-          mask_head="${mask_head}?d"
-        done
-
-        for j in $(seq 1 ${tail_len}); do
-          mask_tail="${mask_tail}?d"
-        done
-
-        for j in $(seq 1 ${mask_len}); do
-          mask_full="${mask_full}?d"
-        done
-
         # The dictionary is a copy of dict1 with the word appended, so the run has to find the word
         # among others rather than being handed a one line file.
 
         dict1_a12=${OUTD}/${hash_type}_dict1_a12
         dict2_a12=${OUTD}/${hash_type}_dict2_a12
+
+        # ?w, ?q and each mask piece are uploaded as buffers of their own and the UTF-16 modes
+        # convert every one of them separately, so a join has to sit on a UTF-8 character
+        # boundary, and a mask position has to spell the byte that belongs there rather than a
+        # '?d' that cannot produce it. See utf8_split_point() and mask_literalize().
+
+        head_end=$(utf8_split_point "${pass}" ${head_len})
+        tail_start=$(utf8_split_point "${pass}" $((head_len + word_len)))
+
+        mask_head="$(mask_literalize "$(mask_dots ${head_end})" "${pass:0:${head_end}}")"
+        mask_tail="$(mask_literalize "$(mask_dots $((pass_len - tail_start)))" "${pass:${tail_start}}")"
 
         for shape in first last middle q; do
 
@@ -2997,19 +3016,23 @@ function attack_12()
           case "${shape}" in
 
             first)
-              word=$(echo "${pass}" | cut -b -${word_len})
-              mask="?w${mask_full}"
+              word_end=$(utf8_split_point "${pass}" ${word_len})
+
+              word="${pass:0:${word_end}}"
+              mask="?w$(mask_literalize "$(mask_dots $((pass_len - word_end)))" "${pass:${word_end}}")"
               dicts="${dict1_a12}"
               ;;
 
             last)
-              word=$(echo "${pass}" | cut -b $((mask_len + 1))-)
-              mask="${mask_full}?w"
+              mask_start=$(utf8_split_point "${pass}" ${mask_len})
+
+              word="${pass:${mask_start}}"
+              mask="$(mask_literalize "$(mask_dots ${mask_start})" "${pass:0:${mask_start}}")?w"
               dicts="${dict1_a12}"
               ;;
 
             middle)
-              word=$(echo "${pass}" | cut -b $((head_len + 1))-$((head_len + word_len)))
+              word="${pass:${head_end}:$((tail_start - head_end))}"
               mask="${mask_head}?w${mask_tail}"
               dicts="${dict1_a12}"
               ;;
@@ -3017,14 +3040,14 @@ function attack_12()
             q)
               # the word itself is cut in two, so that ?w and ?q each carry one half
 
-              q_len=$((word_len / 2))
+              q_end=$(utf8_split_point "${pass}" $((head_end + (tail_start - head_end) / 2)))
 
-              if [ "${q_len}" -lt 1 ]; then
+              if [ "${q_end}" -le "${head_end}" ] || [ "${q_end}" -ge "${tail_start}" ]; then
                 continue
               fi
 
-              word=$(echo "${pass}" | cut -b $((head_len + 1))-$((head_len + q_len)))
-              word_q=$(echo "${pass}" | cut -b $((head_len + q_len + 1))-$((head_len + word_len)))
+              word="${pass:${head_end}:$((q_end - head_end))}"
+              word_q="${pass:${q_end}:$((tail_start - q_end))}"
 
               echo "${word_q}" > "${dict2_a12}"
 
@@ -3508,6 +3531,108 @@ function cryptoloop_test()
 #
 # VERACRYPT_BIN, TCPLAY_BIN and CRYPTSETUP_BIN override the binaries if they
 # live somewhere else.
+
+function utf8_split_point()
+{
+  # Move a split offset back until it lands on a UTF-8 character boundary, and print the
+  # result. -a 1, -a 6 and -a 7 hand the word and the mask to the kernel as two buffers and
+  # the UTF-16 modes convert each of them on its own, so a character cut in half is two
+  # invalid fragments and the candidate is dropped. Both halves have to be valid UTF-8 by
+  # themselves for those attacks to spell a multi byte password at all.
+  #
+  # $1 = the password, $2 = the wanted offset in bytes, counting from 0
+
+  local up_text="$1"
+  local up_off="$2"
+
+  while [ "${up_off}" -gt 0 ]; do
+    case "${up_text:${up_off}:1}" in
+      # 0x80 to 0xbf is a continuation byte, so the offset sits inside a character
+      [$'\x80'-$'\xbf']) up_off=$((up_off - 1)) ;;
+      *)                 break ;;
+    esac
+  done
+
+  printf '%s' "${up_off}"
+}
+
+function mask_dots()
+{
+  # A mask of <count> '?d' groups, the shape the suite has always used for a run of digits.
+
+  local md_count="$1"
+  local md_out=""
+  local md_i
+
+  for ((md_i = 0; md_i < md_count; md_i++)); do
+    md_out="${md_out}?d"
+  done
+
+  printf '%s' "${md_out}"
+}
+
+function mask_literalize()
+{
+  # Rewrite a mask so that every position it covers spells the byte that belongs there. The
+  # generated passwords used to be digits from end to end, which is what makes a mask of '?d'
+  # groups work; tools/test.pl can now seed them with multi byte UTF-8, and no '?d' produces a
+  # byte above 0x7f. Those positions become literals, which costs the attack keyspace it was
+  # never searching anyway.
+  #
+  # $1 = the mask, $2 = the exact bytes the mask has to spell. The mask is returned untouched
+  # unless it covers exactly that many bytes, so a caller that hands over the wrong slice, a
+  # mode with its own mask layout for instance, changes nothing.
+
+  local ml_mask="$1"
+  local ml_text="$2"
+
+  local ml_len=${#ml_mask}
+  local ml_pos=0
+  local ml_cnt=0
+  local ml_out=""
+  local ml_tok
+  local ml_byte
+
+  # count the positions first, a '?x' group covers one byte and anything else covers one byte
+
+  while [ ${ml_pos} -lt ${ml_len} ]; do
+    if [ "${ml_mask:${ml_pos}:1}" = "?" ]; then
+      ml_pos=$((ml_pos + 2))
+    else
+      ml_pos=$((ml_pos + 1))
+    fi
+
+    ml_cnt=$((ml_cnt + 1))
+  done
+
+  if [ ${ml_cnt} -ne ${#ml_text} ]; then
+    printf '%s' "${ml_mask}"
+    return
+  fi
+
+  ml_pos=0
+  ml_cnt=0
+
+  while [ ${ml_pos} -lt ${ml_len} ]; do
+    if [ "${ml_mask:${ml_pos}:1}" = "?" ]; then
+      ml_tok="${ml_mask:${ml_pos}:2}"
+      ml_pos=$((ml_pos + 2))
+    else
+      ml_tok="${ml_mask:${ml_pos}:1}"
+      ml_pos=$((ml_pos + 1))
+    fi
+
+    ml_byte="${ml_text:${ml_cnt}:1}"
+    ml_cnt=$((ml_cnt + 1))
+
+    case "${ml_byte}" in
+      [0-9]) ml_out="${ml_out}${ml_tok}"  ;;
+      *)     ml_out="${ml_out}${ml_byte}" ;;
+    esac
+  done
+
+  printf '%s' "${ml_out}"
+}
 
 function container_gen_dir()
 {

--- a/tools/test_modules/m00030.pm
+++ b/tools/test_modules/m00030.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md5_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = md5_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00040.pm
+++ b/tools/test_modules/m00040.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md5_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = md5_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00070.pm
+++ b/tools/test_modules/m00070.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = md5_hex (encode ("UTF-16LE", $word));
+  my $digest = md5_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m00130.pm
+++ b/tools/test_modules/m00130.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha1_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00140.pm
+++ b/tools/test_modules/m00140.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha1_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00170.pm
+++ b/tools/test_modules/m00170.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex (encode ("UTF-16LE", $word));
+  my $digest = sha1_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m01100.pm
+++ b/tools/test_modules/m01100.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md4_hex (md4 (encode ("UTF-16LE", $word)) . encode ("UTF-16LE", lc ($salt)));
+  my $digest = md4_hex (md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . encode ("UTF-16LE", lc ($salt)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01430.pm
+++ b/tools/test_modules/m01430.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha256_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha256_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01440.pm
+++ b/tools/test_modules/m01440.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha256_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha256_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01470.pm
+++ b/tools/test_modules/m01470.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha256_hex (encode ("UTF-16LE", $word));
+  my $digest = sha256_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m01730.pm
+++ b/tools/test_modules/m01730.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha512_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha512_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01740.pm
+++ b/tools/test_modules/m01740.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha512_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha512_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01770.pm
+++ b/tools/test_modules/m01770.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha512_hex (encode ("UTF-16LE", $word));
+  my $digest = sha512_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m02100.pm
+++ b/tools/test_modules/m02100.pm
@@ -30,7 +30,7 @@ sub module_generate_hash
     salt_len   => length ($salt_bin),
   );
 
-  my $digest = unpack ("H*", $pbkdf2->PBKDF2 ($salt_bin, md4 (md4 (encode ("UTF-16LE", $word)) . $salt_bin)));
+  my $digest = unpack ("H*", $pbkdf2->PBKDF2 ($salt_bin, md4 (md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . $salt_bin)));
 
   my $hash = sprintf ("\$DCC2\$%i#%s#%s", $iterations, $salt, $digest);
 

--- a/tools/test_modules/m05500.pm
+++ b/tools/test_modules/m05500.pm
@@ -8,7 +8,8 @@
 use strict;
 use warnings;
 
-use Authen::Passphrase::NTHash;
+use Digest::MD4 qw (md4);
+use Encode qw (decode encode);
 use Digest::MD5 qw (md5);
 use Crypt::ECB;
 
@@ -127,7 +128,10 @@ sub module_generate_hash
 
   my $ntresp;
 
-  my $nthash = Authen::Passphrase::NTHash->new (passphrase => $word)->hash . "\x00" x 5;
+  # md4 of the UTF-16LE password, which is what the NT hash is. Authen::Passphrase::NTHash
+  # cannot be used here: it gets the encoding wrong for a character outside the BMP, an
+  # emoji for instance, and the kernel does not.
+  my $nthash = md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . "\x00" x 5;
 
   $ntresp .= Crypt::ECB::encrypt (setup_des_key (substr ($nthash,  0, 7)), "DES", $challenge, "none");
   $ntresp .= Crypt::ECB::encrypt (setup_des_key (substr ($nthash,  7, 7)), "DES", $challenge, "none");

--- a/tools/test_modules/m05600.pm
+++ b/tools/test_modules/m05600.pm
@@ -8,10 +8,10 @@
 use strict;
 use warnings;
 
-use Authen::Passphrase::NTHash;
+use Digest::MD4  qw (md4);
 use Digest::HMAC qw (hmac hmac_hex);
 use Digest::MD5  qw (md5);
-use Encode       qw (encode);
+use Encode       qw (encode decode);
 
 sub module_constraints { [[0, 127], [0, 55], [0, 27], [0, 27], [-1, -1]] } # room for improvement in pure kernel mode
 
@@ -30,7 +30,10 @@ sub module_generate_hash
   my $b_srv_ch = pack ('H*', $srv_ch);
   my $b_cli_ch = pack ('H*', $cli_ch);
 
-  my $nthash   = Authen::Passphrase::NTHash->new (passphrase => $word)->hash;
+  # md4 of the UTF-16LE password, which is what the NT hash is. Authen::Passphrase::NTHash
+  # cannot be used here: it gets the encoding wrong for a character outside the BMP, an
+  # emoji for instance, and the kernel does not.
+  my $nthash   = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
   my $identity = encode ('UTF-16LE', uc ($user) . $domain);
   my $digest   = hmac_hex ($b_srv_ch . $b_cli_ch, hmac ($identity, $nthash, \&md5, 64), \&md5, 64);
 

--- a/tools/test_modules/m07500.pm
+++ b/tools/test_modules/m07500.pm
@@ -56,7 +56,7 @@ sub module_generate_hash
 
   my $clear_data = $salt_arr[4];
 
-  my $k = md4 (encode ("UTF-16LE", $word_buf));
+  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
 
   my $k1 = hmac_md5 ("\x01\x00\x00\x00", $k);
 

--- a/tools/test_modules/m09400.pm
+++ b/tools/test_modules/m09400.pm
@@ -32,7 +32,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", $word));
+  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m09500.pm
+++ b/tools/test_modules/m09500.pm
@@ -23,7 +23,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", $word));
+  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m09600.pm
+++ b/tools/test_modules/m09600.pm
@@ -23,7 +23,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha512 ($salt_bin . encode ("UTF-16LE", $word));
+  my $tmp = sha512 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m10830.pm
+++ b/tools/test_modules/m10830.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha384_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha384_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m10840.pm
+++ b/tools/test_modules/m10840.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha384_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha384_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m10870.pm
+++ b/tools/test_modules/m10870.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha384_hex (encode ("UTF-16LE", $word));
+  my $digest = sha384_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m11600.pm
+++ b/tools/test_modules/m11600.pm
@@ -64,7 +64,7 @@ sub module_generate_hash
   # 2 ^ NumCyclesPower "iterations" of SHA256 (only one final SHA256)
   #
 
-  $word_buf = encode ("UTF-16LE", $word_buf);
+  $word_buf = encode ("UTF-16LE", decode ("utf-8", $word_buf));
 
   my $rounds = 1 << $num_cycle_power;
 

--- a/tools/test_modules/m12800.pm
+++ b/tools/test_modules/m12800.pm
@@ -20,7 +20,7 @@ sub module_generate_hash
   my $salt = shift;
   my $iter = shift // 100;
 
-  my $nt = md4_hex (encode ("UTF-16LE", $word));
+  my $nt = md4_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $pbkdf2 = Crypt::PBKDF2->new
   (

--- a/tools/test_modules/m13100.pm
+++ b/tools/test_modules/m13100.pm
@@ -25,7 +25,7 @@ sub module_generate_hash
   my $checksum  = shift;
   my $edata2    = shift;
 
-  my $k = md4 (encode ("UTF-16LE", $word));
+  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $k1 = hmac_md5 ("\x02\x00\x00\x00", $k);
 

--- a/tools/test_modules/m13500.pm
+++ b/tools/test_modules/m13500.pm
@@ -35,7 +35,7 @@ sub module_generate_hash
     $salt = get_pstoken_salt ();
   }
 
-  my $hash_buf = sha1_hex (pack ("H*", $salt) . encode ("UTF-16LE", $word));
+  my $hash_buf = sha1_hex (pack ("H*", $salt) . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $hash_buf, $salt);
 

--- a/tools/test_modules/m13800.pm
+++ b/tools/test_modules/m13800.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $word_utf16le = encode ("UTF-16LE", $word);
+  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $salt_bin = pack ("H*", $salt);
 

--- a/tools/test_modules/m15300.pm
+++ b/tools/test_modules/m15300.pm
@@ -130,11 +130,11 @@ sub module_generate_hash
 
   if ($context == 1)
   {
-    $user_hash = sha1 (encode ("UTF-16LE", $word_buf));
+    $user_hash = sha1 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
   elsif ($context == 2)
   {
-    $user_hash = md4 (encode ("UTF-16LE", $word_buf));
+    $user_hash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
 
   $user_derivationKey = hmac_sha1 (encode ("UTF-16LE", $SID . "\x00"), $user_hash);

--- a/tools/test_modules/m15310.pm
+++ b/tools/test_modules/m15310.pm
@@ -132,7 +132,7 @@ sub module_generate_hash
 
   my $SIDenc = encode ("UTF-16LE", $SID);
 
-  my $NTLMhash = md4 (encode ("UTF-16LE", $word_buf));
+  my $NTLMhash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
 
   my $hasher = Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256);
 

--- a/tools/test_modules/m15900.pm
+++ b/tools/test_modules/m15900.pm
@@ -132,11 +132,11 @@ sub module_generate_hash
 
   if ($context == 1)
   {
-    $user_hash = sha1 (encode ("UTF-16LE", $word_buf));
+    $user_hash = sha1 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
   elsif ($context == 2)
   {
-    $user_hash = md4 (encode ("UTF-16LE", $word_buf));
+    $user_hash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
 
   $user_derivationKey = hmac_sha1 (encode ("UTF-16LE", $SID . "\x00"), $user_hash);

--- a/tools/test_modules/m15910.pm
+++ b/tools/test_modules/m15910.pm
@@ -133,7 +133,7 @@ sub module_generate_hash
 
   my $SIDenc = encode ("UTF-16LE", $SID);
 
-  my $NTLMhash = md4 (encode ("UTF-16LE", $word_buf));
+  my $NTLMhash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
 
   my $hasher = Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256);
 

--- a/tools/test_modules/m18200.pm
+++ b/tools/test_modules/m18200.pm
@@ -23,7 +23,7 @@ sub module_generate_hash
   my $checksum            = shift;
   my $edata2              = shift;
 
-  my $k = md4 (encode ("UTF-16LE", $word));
+  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $k1 = hmac_md5 ("\x08\x00\x00\x00", $k);
 

--- a/tools/test_modules/m22100.pm
+++ b/tools/test_modules/m22100.pm
@@ -176,7 +176,7 @@ sub module_generate_hash
 
   # key generation (KDF):
 
-  my $word_utf16le = encode ("UTF-16LE", $word);
+  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $pass_hash = sha256 (sha256 ($word_utf16le));
 

--- a/tools/test_modules/m22700.pm
+++ b/tools/test_modules/m22700.pm
@@ -58,7 +58,7 @@ sub module_generate_hash
   my $block1 = shift;
   my $block2 = shift;
 
-  my $word_utf16be = encode ('UTF-16BE', $word);
+  my $word_utf16be = encode ('UTF-16BE', decode ('utf-8', $word));
 
   my $key = scrypt_raw ($word_utf16be, $FIXED_SALT, $SCRYPT_N, $SCRYPT_R, $SCRYPT_P, 32);
 

--- a/tools/test_modules/m24800.pm
+++ b/tools/test_modules/m24800.pm
@@ -19,7 +19,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $unicode_word = encode ("UTF-16LE", $word);
+  my $unicode_word = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $digest = hmac ($unicode_word, $unicode_word, \&sha1, 64);
 

--- a/tools/test_modules/m25300.pm
+++ b/tools/test_modules/m25300.pm
@@ -20,7 +20,7 @@ sub module_generate_hash
   my $salt  = shift;
   my $iter  = shift // 100000;
 
-  my $tmp = sha512 ($salt . encode ("UTF-16LE", $word));
+  my $tmp = sha512 ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m27700.pm
+++ b/tools/test_modules/m27700.pm
@@ -27,7 +27,7 @@ sub module_generate_hash
   my $iv   = shift // random_bytes (16);
   my $data = shift;
 
-  my $word_utf16be = encode ('UTF-16BE', $word);
+  my $word_utf16be = encode ('UTF-16BE', decode ('utf-8', $word));
 
   my $key = scrypt_raw ($word_utf16be, $salt, $SCRYPT_N, $SCRYPT_R, $SCRYPT_P, 32);
 

--- a/tools/test_modules/m29000.pm
+++ b/tools/test_modules/m29000.pm
@@ -19,7 +19,7 @@ sub module_generate_hash
   my $salt = shift;
   my $user = shift // random_mixedcase_string (random_number (0, 256 / 2));
 
-  my $word_utf16le = encode ("UTF-16LE", $word);
+  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
   my $user_utf16le = encode ("UTF-16LE", $user);
 
   my $digest = sha1_hex ($salt . sha1 ($user_utf16le . ':' . $word_utf16le));

--- a/tools/test_modules/m29200.pm
+++ b/tools/test_modules/m29200.pm
@@ -35,7 +35,7 @@ sub module_generate_hash
     $user = encode ('UTF16-LE', $user);
   }
 
-  my $word_utf16 = encode ("UTF-16LE", $word);
+  my $word_utf16 = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $exponent = sha1_hex ($salt . sha1 ($user . ":" . $word_utf16));
 

--- a/tools/test_modules/m31300.pm
+++ b/tools/test_modules/m31300.pm
@@ -21,7 +21,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $utf16le = encode("UTF-16LE", $word);
+  my $utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $digest = md5_hex (md4 ($utf16le) . $salt_bin);
 


### PR DESCRIPTION
Quite some kernels don't crack non-ASCII password. Optimized kernels ship with a message that they don't (e.g. -m1000 `Module 1000 advice notice: When using the optimized-kernel: some byte encoding is simplified that would make some non-ASCII passwords never be cracked, even if they are under the optimized byte limit. The pure-kernel implements true UTF16 handling so doesn't have this problem and should crack all passwords.`). However, currently also the pure kernel didn't work.

I'm not 100% sure how to fix this, but tried. This continues 5c840aaec, "Crack non ASCII passwords again in 41 hash modes, and repair 9 more" (Jens Steube, 2026-08-28). That commit widened the lead byte ranges in
`hc_enc_next()`, which repaired the scalar UTF-8 to UTF-16 path. `-a 3` does not use it: 7
modes take a widening branch above vector width 1, and 16 more have no scalar branch at all,
so 22 modes still cannot crack a euro sign, Japanese kana or a CJK character. That is fixed
here.

The reason it could go unnoticed is that `tools/test.pl` builds every password out of the
digits `0` to `9`, so a non-ASCII password has never reached a kernel and the whole path is
untested. This branch generates them, and fixes the test oracles that turn out to have been
wrong about them.

## Reproduction

Measured against pristine upstream/master 1a7af0976. Run `make` on each side: the kernel
cache is keyed on the binary's compile time, so a rebuild invalidates it on its own and no
`rm -rf kernels/` is needed. `Vec:` in the status output says which binary you are on, since
the fix pins these modes to vector width 1, so `Vec:4` under `--backend-vector-width 4` means
the fix is not in the binary you are running.

```
make
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --backend-vector-width 4 '7c23a6931f4a44e3f031202f065b5c4e' 'hashcat€'
./hashcat -m 130 -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 'bc93548344c1d91dccb23ffb78440cdd7d4f40b4:2455' '1234567?d€'
```

```
before: m1000 Status Exhausted, Recovered 0/1, rc=1   at any vector width above 1,
                                                     Cracked rc=0 at width 1
        m0130 Status Exhausted, Recovered 0/1, rc=1   at every vector width, 1 included
after:  both  Status Cracked,   Recovered 1/1, rc=0
```

After the fix the first command reports `Vec:1` although it asked for 4. That is the pin, not
a bug.

`7c23a6931f4a44e3f031202f065b5c4e` is NTLM of `hashcat` followed by U+20AC;
`bc93548344c1d91dccb23ffb78440cdd7d4f40b4:2455` is `sha1(utf16le('12345678' + U+20AC) .
'2455')`.

An ASCII password is unaffected either way, which is what says the fault is in the UTF-8
handling and not in the mask:

```
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --backend-vector-width 4 'b4b9b02e6f09a9bd760f388b67351e2b' 'hashca?l'
./hashcat -m 130 -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 'a6d8e5ca22a3f603dad986f5ada47728a6d91734:245755154711915074179' '?d?d?d?d?d'

before and after: Cracked, rc=0
```

And the suite cannot see any of it. Revert only the `hc_enc_next()` hunk of 5c840aaec, the
commit this one continues, and every test still passes:

```
git show 5c840aaec -- OpenCL/inc_common.cl | git apply -R -
rm -rf kernels/
./tools/test.sh -m 1000 -a all -t all -D 1 -P -f -V 1
```

```
before this branch: 16 OK, 0 Error, 1 Skip   the suite does not notice
after  this branch:  3 OK, 13 Error, 1 Skip  7/8 not found under -a 0 alone
```

The one Skip is `Attack 4, Mode single`, which master skips either way.

## What was broken

Two faults, both `-a 3` only. Every other attack mode was already safe: `-a 0`, `-a 1`,
`-a 4`, `-a 6`, `-a 7`, `-a 8` and `-a 9` use the scalar conversions, and `-a 12` is pinned to
vector width 1 by the association-mode block in `src/backend.c`.

### There is no vector form of hc_enc_next()

Of the 121 UTF-16 conversion helpers in `OpenCL/inc_hash_*.cl`, 47 decode the UTF-8 through
`hc_enc_next()` and 74 widen the bytes instead. Widening turns a euro sign into three
characters, so it never matches. `hc_enc_next()` works on one candidate at a time and the
UTF-16 length of a candidate is not known before the conversion, so there is no vector form of
it and there cannot be one while a `*_ctx_vector_t` carries a single scalar `len` for all its
lanes.

`m00030`, `m00040`, `m00070`, `m01000`, `m01100`, `m05500` and `m31300` pick the helper with
an `#if VECT_SIZE == 1`, so they are right at width 1 and widen above it.

`src/backend.c` now pins UTF-16 modes to vector width 1, next to the two cases that already do
the same, one of them for exactly this reason:

> // We can't have SIMD in kernels where we have an unknown final password length

`hashconfig->opts_type` cannot be read for this. `src/interface.c:442` clears
`OPTS_TYPE_PT_UTF16LE` and `OPTS_TYPE_PT_UTF16BE` whenever the optimized kernel is not used,
and the pure kernels are exactly the ones that convert in the kernel, so the module is asked
directly.

The pin is on the pure kernels only, which is the same condition as the block above it. An
optimized kernel widens the bytes at any vector width, so it cannot crack a multi byte
password either way and there is nothing to buy by giving up its SIMD.

CUDA and HIP already ran the pure kernels at width 1, because the block above pins every pure
kernel on a GPU to 1, so nothing changes there. The cost lands on CPU and on non GPU OpenCL.
Measured on PoCL, `-m 1000 -a 3`, a 20 second run of `?d` x 10:

```
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --runtime 20 'ffffffffffffffffffffffffffffffff' '?d?d?d?d?d?d?d?d?d?d'

master, pure kernel:  467.0 MH/s   Vec:8
branch, pure kernel:   81.9 MH/s   Vec:1     5.7x slower
branch, -O:           350.3 MH/s   Vec:8     unchanged
```

That is the price of the blanket pin, and it is worth saying plainly: someone running a
UTF-16 mode on CPU without `-O` gets a fifth of the throughput for a property they may not
need on that particular run.

**A narrower pin is possible and I have not built it.** In `-a 3` the mask is known on the
host before the kernel runs. If no position in it can emit a byte above 0x7f, every `?d`,
`?l`, `?u`, `?s` and every ASCII literal, then no candidate can be multi byte and the vector
path is provably safe for that run. Pinning only when the mask actually carries a high byte
would keep full speed for the common case and drop to width 1 only where the wide path would
otherwise be wrong. It needs the mask, which `mpsp.c` parses, to be reachable from
`backend_session_begin()`, and `--increment` and hcmask files each want thinking about, so it
is a design call rather than a mechanical change. Happy to build it instead of the blanket
pin if that is preferred.

### Sixteen kernels had no scalar branch at all

`m00130`, `m00140`, `m00170`, `m01430`, `m01440`, `m01470`, `m01730`, `m01740`, `m01770`,
`m10830`, `m10840`, `m10870`, `m13500`, `m13800`, `m29000` and `m29200` called a widening
helper unconditionally, so they were broken at width 1 as well. They get a scalar branch.

These are `OPTS_TYPE_PT_GENERATE_BE` modes and `markov_be.cl` hands their brute force
candidates over in big endian word order. `hc_enc_next()` reads the UTF-8 byte by byte and
cannot make sense of that, so the scalar branch puts the words back in native order first.
Without that step the digest comes out wrong for an ASCII password too, which the self-test
catches immediately.

### Nothing told the user

`docs/*.md` and `docs/*.txt` say nothing about which modes handle a non-ASCII password. The
only statement in the tree is `module_advice_notice()` in `src/modules/module_01000.c:58`,
which is 1 module out of 593 and prints only for `-m 1000`:

> "When using the optimized-kernel: some byte encoding is simplified that would make some
> non-ASCII passwords never be cracked, even if they are under the optimized byte limit. The
> pure-kernel implements true UTF16 handling so doesn't have this problem and should crack all
> passwords."

The last sentence was never true for `-a 3`, before or after 5c840aaec. It is now.

Two modes are still outside it and are left that way on purpose. **m15500** (JKS Java Key
Store) and **m35200** (AS/400 SSHA1) are the genuine UTF-16BE modes: their `a0-pure` kernel
uses `sha1_update_utf16be_swap()`, and no UTF-16BE helper anywhere calls `hc_enc_next()`, so
hashcat has no UTF-8 path for them in any attack mode. Giving them one is a separate change.
This branch keeps their oracles and their generated passwords on ASCII rather than reporting
them red.

### 41 test oracles hashed the password as Latin-1

Ground truth against a real archive:

```
7z a -mhe=on -p'pass€1' /tmp/t.7z /etc/hostname
perl ~/john/run/7z2john.pl /tmp/t.7z | grep -oE '\$7z\$[^:]*' > /tmp/t.hash
./hashcat -m 11600 -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 "$(cat /tmp/t.hash)" 'pass€?d'

Status Cracked, Recovered 1/1, rc=0
```

hashcat and 7-Zip agree, so the kernel is right. `tools/test_modules/m11600.pm` called
`encode("UTF-16LE", $word)` on the raw bytes, which widens each byte as if it were Latin-1.
39 modules had the same bug and now decode first. The modules whose kernel widens too are
left alone, because there the oracle was right.

m05500 and m05600 took the NT hash from `Authen::Passphrase::NTHash`, which is wrong for a
character outside the BMP:

```
perl -MAuthen::Passphrase::NTHash -MEncode -MDigest::MD4=md4_hex -e \
  '$c = decode("utf-8", "12345678\xf0\x9f\x98\x80");
   print Authen::Passphrase::NTHash->new(passphrase => $c)->hash_hex, "\n",
         md4_hex(encode("UTF-16LE", $c)), "\n"'

36a5dbdc75876d5364ef604c79180078
1a160fb7177bbdf8e8edbe681acd5380
```

hashcat agrees with the second, so both modules compute it directly now.

### Why the suite never saw any of this

5c840aaec repaired `hc_enc_next()` for 41 hash modes, and the suite did not notice it going
away again, as the revert at the top of this description shows. Same build, same kernels,
three passwords hashcat is supposed to crack:

```
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 '7c23a6931f4a44e3f031202f065b5c4e' 'hashcat€'
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 'a321b58ec81252d199011ef6ed4f09d3' 'かたかな123'
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 'a6ea5bd6eb61f1c5e735a08f621b3b9a' '中文密码'
```

```
5c840aaec reverted: Status Exhausted, Recovered 0/1, rc=1   (all three)
5c840aaec present:  Status Cracked,   Recovered 1/1, rc=0   (all three)
```

Euro U+20AC is lead byte `0xe2`, kana `0xe3`, CJK `0xe4`; none was in the old
`{0xe0, 0xec, 0xed, 0xef}` whitelist.

### tools/test.pl

`random_non_ascii_string()` joins `random_numeric_string()` and substitutes multi byte
characters into the digits it returns. The substitution is in place, so the byte length does
not change and the password still fits the mode's `Pwd.Len.Max`. Eleven characters, covering
the lead bytes `hc_enc_next()` has to get right, including one 4 byte character: euro,
hiragana, katakana, four CJK, hangul, devanagari, fullwidth latin, and U+1F600. It comes back
as plain digits for a mode that cannot take one, so a caller never has to ask which.

Only the two callers that generate a password use it. Salts, site keys and challenge
characters keep calling `random_numeric_string()`, which is untouched, so a test module added
later cannot pick up multi byte salts by accident and `tools/test_modules/README.md`, which
points modules at `random_numeric_string` for exactly that job, stays correct as written.

Which modes get them is read out of the kernels, because there is no flag for it.
`OPTS_TYPE_PT_ALWAYS_ASCII` is about hexifying output, not about what a mode can crack, and
only modules 3000 and 25400 set it. So `inc_hash_*.cl` is split into the helpers that call
`hc_enc_next()` and the ones that widen, and a mode gets multi byte passwords when the pure
kernel that will run uses a decoding one. Modes that case fold the plaintext, spell it in hex
or base58, or build it in `module_get_random_password()` stay on ASCII, as do `-O` runs of
modes whose optimized kernel widens.

Injection starts at the ninth byte, so the multi hash tests, whose passwords are 2 to 8 bytes
and which share one mask per length, stay on digits.

`NO_NON_ASCII=1` turns it off.

### tools/test.sh, so the attacks can spell such a password

- `export LC_ALL=C`, so `${#pass}` and `cut -c` count bytes the way hashcat does.
- `mask_literalize()`, because no `?d` produces byte `0xe2`. A mask position over a non-digit
  byte becomes that byte, which leaves the keyspace unchanged. Used by `-a 3`, `-a 6`, `-a 7`
  and the four `-a 12` shapes.
- `utf8_split_point()`, which moves a dict/mask split back to a character boundary. The
  combinator kernels convert the word and the amplifier separately
  (`OpenCL/m01000_a1-pure.cl:65-66`, one call per buffer), so each half has to be valid UTF-8
  on its own:

    ```
    printf '12345\xe7\n' > /tmp/d1 ; printf '12345\n' > /tmp/d2
    H=ac25eecbd4dd9f58b674d3bebe463f9e     # NTLM of 12345<U+7801>678
    ./hashcat -m 1000 -a 6 -D 1 --force --potfile-disable --backend-vector-width 1 "$H" /tmp/d2 "$(printf '\xe7\xa0\x81?d?d?d')"
    ./hashcat -m 1000 -a 6 -D 1 --force --potfile-disable --backend-vector-width 1 "$H" /tmp/d1 "$(printf '\xa0\x81?d?d?d')"

    split on a character boundary: Status Cracked,   rc=0
    split inside the character:    Status Exhausted, rc=1
    ```

    Both spell the same 11 bytes. `-m 0` cracks either. This one is by design, not a bug.

## Testing

PoCL CPU only, `-D 1 --force`, so `-a all -t all` on every mode is not practical here.

All 22 repaired modes, `./tools/test.sh -m <mode> -a 3 -t single -D 1 -P -f -V 4`, every one
`OK 0/7`, against `Error 6/7` or `Error 7/7` before, depending on how many of the eight
generated passwords happened to carry a multi byte character:

```
30 40 70 1000 1100 5500 31300
130 140 170 1430 1440 1470 1730 1740 1770 10830 10840 10870 13500 13800 29000
```

m29200 got the same kernel change but the suite generates no `-a 3` case for it.

Green with multi byte passwords at `-a all -t all`, which on master 1a7af0976 now also covers
attack types 4, 8 and 9: m1000 at `-V 1 -P`, every combination OK except `Attack 4, Mode
single`, which pristine master skips the same way. m130 the same at `-V 4 -P`. Green again
with `NO_NON_ASCII=1`, so ASCII did not regress.

Green with multi byte passwords at `-V 4 -P -a 0`: all 41 modules whose oracle changed, re-run
after the kernel and backend change rather than before it.

Green with multi byte passwords at `-V 1 -P`: m5500 and m5600 at `-a all -t all`; m0, m10,
m400, m11600, m22000 and a 24 mode spread: 20, 100, 110, 300, 500, 900, 1400, 1410, 1700, 1710,
2611, 2711, 2811, 3710, 4400, 4500, 4700, 6000, 6100, 6900, 11500, 17300, 21100, 24900.

Optimized kernels, `-a all -t single -V 4`: m0, m130 and m1000. The width pin does not reach a
mode that does no UTF-16 conversion:

```
./hashcat -m 0 -a 3 -D 1 --force --potfile-disable --backend-vector-width 4 '5f4dcc3b5aa765d61d8327deb882cf99' 'passwor?d'
Speed.#01: ... Vec:4
```

6 of 8 single hash passwords carry multi byte characters; every multi hash password is ASCII,
as designed.

## Not covered

- **No GPU.** PoCL CPU only, so the 17 changed kernels have never been compiled by CUDA, HIP
  or AMD OpenCL. This is the gap worth closing before merging.
- `-a all -t all` was run for m130 and m1000 rather than for all 22 repaired modes.
- `tools/test_edge.sh` was not run.
- The narrower, mask aware version of the vector width pin described above is not built.
- **m24800 produces 0 test vectors.** Pre-existing, identical with `NO_NON_ASCII=1`, untouched
  here.

## Commits

1. `test modules: decode the UTF-8 password before encoding it as UTF-16` (41 files, no
   observable change while the passwords are digits)
2. `test.sh: generate passwords that are not 7 bit ASCII`
3. `Crack non ASCII passwords under -a 3 in 22 hash modes` (17 kernels, `src/backend.c`)
