### PR TITLE
docs: link to LUKS2 (34100) example hash instead of inlining it

### DIFF
--- a/.github/workflows/hashcat-example-hashes_machine-readable2md.py
+++ b/.github/workflows/hashcat-example-hashes_machine-readable2md.py
@@ -10,7 +10,7 @@ import json
 import os
 import re
 
-# Replace LUKS v1 hashes, they're too big: Github no longer shows the .md "(Sorry about that, but we can’t show files that are this big right now.)"
+# Replace LUKS v1 and v2 hashes, they're too big: Github no longer shows the .md "(Sorry about that, but we can’t show files that are this big right now.)"
 EXAMPLE_HASH_REPLACEMENTS = {
     "14600": "https://hashcat.net/misc/example_hashes/hashcat_luks_testfiles.7z",
     "29511": "https://hashcat.net/misc/example_hashes/hashcat_luks_sha1_aes_cbc-essiv_128.txt",
@@ -25,6 +25,7 @@ EXAMPLE_HASH_REPLACEMENTS = {
     "29541": "https://hashcat.net/misc/example_hashes/hashcat_luks_ripemd160_aes_cbc-essiv_256.txt",
     "29542": "https://hashcat.net/misc/example_hashes/hashcat_luks_ripemd160_serpent_xts-plain64_256.txt",
     "29543": "https://hashcat.net/misc/example_hashes/hashcat_luks_ripemd160_twofish_cbc-plain64_128.txt",
+    "34100": "https://hashcat.net/misc/example_hashes/hashcat_luks2_argon2id_sha256_aes_xts-plain64_512.txt",
 }
 
 OPENCL_DIR = "../../OpenCL"


### PR DESCRIPTION
Fixes https://github.com/hashcat/hashcat/issues/4467

Goal is to replace https://hashcat.net/wiki/doku.php?id=example_hashes with

> Bleeding-edge version (current master):
> https://github.com/hashcat/hashcat/blob/master/docs/hashcat-example-hashes.md
> 
> Latest release version (v7.1.2):
> https://github.com/hashcat/hashcat/blob/v7.1.2/docs/hashcat-example-hashes.md


This changes cuts the size of hashcat-example-hashes.md down more than half 360kb (this PR) vs 864kb ([current master](https://github.com/hashcat/hashcat/commit/1a7af0976474eef81d1bb0bc19030d2651383a95))

Also pinging @roycewilliams 