### PR TITLE
Crack non ASCII passwords under -a 3 in 22 hash modes

### DIFF
--- a/OpenCL/m00130_a3-pure.cl
+++ b/OpenCL/m00130_a3-pure.cl
@@ -53,38 +53,44 @@ KERNEL_FQ KERNEL_FA void m00130_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx;
 
     sha1_init (&ctx);
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_update (&ctx, s, salt_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 
@@ -158,38 +164,44 @@ KERNEL_FQ KERNEL_FA void m00130_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx;
 
     sha1_init (&ctx);
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_update (&ctx, s, salt_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 

--- a/OpenCL/m00130_a3-pure.cl
+++ b/OpenCL/m00130_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m00130_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_update (&ctx, s, salt_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m00130_mxx (KERN_ATTR_VECTOR ())
     sha1_update_vector (&ctx, s, salt_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m00130_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_update (&ctx, s, salt_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m00130_sxx (KERN_ATTR_VECTOR ())
     sha1_update_vector (&ctx, s, salt_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m00140_a3-pure.cl
+++ b/OpenCL/m00140_a3-pure.cl
@@ -50,34 +50,40 @@ KERNEL_FQ KERNEL_FA void m00140_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx = ctx0;
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 
@@ -146,34 +152,40 @@ KERNEL_FQ KERNEL_FA void m00140_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx = ctx0;
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 

--- a/OpenCL/m00140_a3-pure.cl
+++ b/OpenCL/m00140_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m00140_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m00140_mxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m00140_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m00140_sxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m00170_a3-pure.cl
+++ b/OpenCL/m00170_a3-pure.cl
@@ -52,6 +52,29 @@ KERNEL_FQ KERNEL_FA void m00170_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -59,6 +82,8 @@ KERNEL_FQ KERNEL_FA void m00170_mxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -119,6 +144,29 @@ KERNEL_FQ KERNEL_FA void m00170_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx;
+
+    sha1_init (&ctx);
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector (&ctx);
@@ -126,6 +174,8 @@ KERNEL_FQ KERNEL_FA void m00170_sxx (KERN_ATTR_VECTOR ())
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m00170_a3-pure.cl
+++ b/OpenCL/m00170_a3-pure.cl
@@ -44,36 +44,42 @@ KERNEL_FQ KERNEL_FA void m00170_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx;
 
     sha1_init (&ctx);
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 
@@ -136,36 +142,42 @@ KERNEL_FQ KERNEL_FA void m00170_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx;
 
     sha1_init (&ctx);
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 

--- a/OpenCL/m01430_a3-pure.cl
+++ b/OpenCL/m01430_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m01430_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m01430_mxx (KERN_ATTR_VECTOR ())
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m01430_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m01430_sxx (KERN_ATTR_VECTOR ())
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m01430_a3-pure.cl
+++ b/OpenCL/m01430_a3-pure.cl
@@ -53,38 +53,44 @@ KERNEL_FQ KERNEL_FA void m01430_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx;
 
     sha256_init (&ctx);
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_update (&ctx, s, salt_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 
@@ -158,38 +164,44 @@ KERNEL_FQ KERNEL_FA void m01430_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx;
 
     sha256_init (&ctx);
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_update (&ctx, s, salt_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 

--- a/OpenCL/m01440_a3-pure.cl
+++ b/OpenCL/m01440_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m01440_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m01440_mxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m01440_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m01440_sxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m01440_a3-pure.cl
+++ b/OpenCL/m01440_a3-pure.cl
@@ -50,34 +50,40 @@ KERNEL_FQ KERNEL_FA void m01440_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx = ctx0;
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 
@@ -146,34 +152,40 @@ KERNEL_FQ KERNEL_FA void m01440_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx = ctx0;
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 

--- a/OpenCL/m01470_a3-pure.cl
+++ b/OpenCL/m01470_a3-pure.cl
@@ -56,6 +56,27 @@ KERNEL_FQ KERNEL_FA void m01470_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -63,6 +84,8 @@ KERNEL_FQ KERNEL_FA void m01470_mxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -127,6 +150,27 @@ KERNEL_FQ KERNEL_FA void m01470_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx = ctx0;
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector_from_scalar (&ctx, &ctx0);
@@ -134,6 +178,8 @@ KERNEL_FQ KERNEL_FA void m01470_sxx (KERN_ATTR_VECTOR ())
     sha256_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m01470_a3-pure.cl
+++ b/OpenCL/m01470_a3-pure.cl
@@ -48,34 +48,40 @@ KERNEL_FQ KERNEL_FA void m01470_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx = ctx0;
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 
@@ -142,34 +148,40 @@ KERNEL_FQ KERNEL_FA void m01470_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx = ctx0;
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 

--- a/OpenCL/m01730_a3-pure.cl
+++ b/OpenCL/m01730_a3-pure.cl
@@ -53,38 +53,44 @@ KERNEL_FQ KERNEL_FA void m01730_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha512_ctx_t ctx;
 
     sha512_init (&ctx);
 
-    sha512_update_utf16le_swap (&ctx, c, pw_len);
+    sha512_update_utf16le_swap (&ctx, w, pw_len);
 
     sha512_update (&ctx, s, salt_len);
 
     sha512_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha512_ctx_vector_t ctx;
 
@@ -158,38 +164,44 @@ KERNEL_FQ KERNEL_FA void m01730_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha512_ctx_t ctx;
 
     sha512_init (&ctx);
 
-    sha512_update_utf16le_swap (&ctx, c, pw_len);
+    sha512_update_utf16le_swap (&ctx, w, pw_len);
 
     sha512_update (&ctx, s, salt_len);
 
     sha512_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha512_ctx_vector_t ctx;
 

--- a/OpenCL/m01730_a3-pure.cl
+++ b/OpenCL/m01730_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m01730_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m01730_mxx (KERN_ATTR_VECTOR ())
     sha512_update_vector (&ctx, s, salt_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m01730_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_update (&ctx, s, salt_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m01730_sxx (KERN_ATTR_VECTOR ())
     sha512_update_vector (&ctx, s, salt_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);

--- a/OpenCL/m01740_a3-pure.cl
+++ b/OpenCL/m01740_a3-pure.cl
@@ -50,34 +50,40 @@ KERNEL_FQ KERNEL_FA void m01740_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha512_ctx_t ctx = ctx0;
 
-    sha512_update_utf16le_swap (&ctx, c, pw_len);
+    sha512_update_utf16le_swap (&ctx, w, pw_len);
 
     sha512_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha512_ctx_vector_t ctx;
 
@@ -146,34 +152,40 @@ KERNEL_FQ KERNEL_FA void m01740_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha512_ctx_t ctx = ctx0;
 
-    sha512_update_utf16le_swap (&ctx, c, pw_len);
+    sha512_update_utf16le_swap (&ctx, w, pw_len);
 
     sha512_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha512_ctx_vector_t ctx;
 

--- a/OpenCL/m01740_a3-pure.cl
+++ b/OpenCL/m01740_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m01740_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx = ctx0;
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m01740_mxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m01740_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx = ctx0;
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m01740_sxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);

--- a/OpenCL/m01770_a3-pure.cl
+++ b/OpenCL/m01770_a3-pure.cl
@@ -44,36 +44,42 @@ KERNEL_FQ KERNEL_FA void m01770_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha512_ctx_t ctx;
 
     sha512_init (&ctx);
 
-    sha512_update_utf16le_swap (&ctx, c, pw_len);
+    sha512_update_utf16le_swap (&ctx, w, pw_len);
 
     sha512_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha512_ctx_vector_t ctx;
 
@@ -136,36 +142,42 @@ KERNEL_FQ KERNEL_FA void m01770_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha512_ctx_t ctx;
 
     sha512_init (&ctx);
 
-    sha512_update_utf16le_swap (&ctx, c, pw_len);
+    sha512_update_utf16le_swap (&ctx, w, pw_len);
 
     sha512_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha512_ctx_vector_t ctx;
 

--- a/OpenCL/m01770_a3-pure.cl
+++ b/OpenCL/m01770_a3-pure.cl
@@ -52,6 +52,29 @@ KERNEL_FQ KERNEL_FA void m01770_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -59,6 +82,8 @@ KERNEL_FQ KERNEL_FA void m01770_mxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);
@@ -119,6 +144,29 @@ KERNEL_FQ KERNEL_FA void m01770_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha512_ctx_t ctx;
+
+    sha512_init (&ctx);
+
+    sha512_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha512_final (&ctx);
+
+    #else
+
     sha512_ctx_vector_t ctx;
 
     sha512_init_vector (&ctx);
@@ -126,6 +174,8 @@ KERNEL_FQ KERNEL_FA void m01770_sxx (KERN_ATTR_VECTOR ())
     sha512_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha512_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[7]);
     const u32x r1 = h32_from_64 (ctx.h[7]);

--- a/OpenCL/m10830_a3-pure.cl
+++ b/OpenCL/m10830_a3-pure.cl
@@ -61,6 +61,31 @@ KERNEL_FQ KERNEL_FA void m10830_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_update (&ctx, s, salt_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -70,6 +95,8 @@ KERNEL_FQ KERNEL_FA void m10830_mxx (KERN_ATTR_VECTOR ())
     sha384_update_vector (&ctx, s, salt_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);
@@ -139,6 +166,31 @@ KERNEL_FQ KERNEL_FA void m10830_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_update (&ctx, s, salt_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -148,6 +200,8 @@ KERNEL_FQ KERNEL_FA void m10830_sxx (KERN_ATTR_VECTOR ())
     sha384_update_vector (&ctx, s, salt_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);

--- a/OpenCL/m10830_a3-pure.cl
+++ b/OpenCL/m10830_a3-pure.cl
@@ -53,38 +53,44 @@ KERNEL_FQ KERNEL_FA void m10830_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha384_ctx_t ctx;
 
     sha384_init (&ctx);
 
-    sha384_update_utf16le_swap (&ctx, c, pw_len);
+    sha384_update_utf16le_swap (&ctx, w, pw_len);
 
     sha384_update (&ctx, s, salt_len);
 
     sha384_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha384_ctx_vector_t ctx;
 
@@ -158,38 +164,44 @@ KERNEL_FQ KERNEL_FA void m10830_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha384_ctx_t ctx;
 
     sha384_init (&ctx);
 
-    sha384_update_utf16le_swap (&ctx, c, pw_len);
+    sha384_update_utf16le_swap (&ctx, w, pw_len);
 
     sha384_update (&ctx, s, salt_len);
 
     sha384_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha384_ctx_vector_t ctx;
 

--- a/OpenCL/m10840_a3-pure.cl
+++ b/OpenCL/m10840_a3-pure.cl
@@ -50,34 +50,40 @@ KERNEL_FQ KERNEL_FA void m10840_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha384_ctx_t ctx = ctx0;
 
-    sha384_update_utf16le_swap (&ctx, c, pw_len);
+    sha384_update_utf16le_swap (&ctx, w, pw_len);
 
     sha384_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha384_ctx_vector_t ctx;
 
@@ -146,34 +152,40 @@ KERNEL_FQ KERNEL_FA void m10840_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha384_ctx_t ctx = ctx0;
 
-    sha384_update_utf16le_swap (&ctx, c, pw_len);
+    sha384_update_utf16le_swap (&ctx, w, pw_len);
 
     sha384_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha384_ctx_vector_t ctx;
 

--- a/OpenCL/m10840_a3-pure.cl
+++ b/OpenCL/m10840_a3-pure.cl
@@ -58,6 +58,27 @@ KERNEL_FQ KERNEL_FA void m10840_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx = ctx0;
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector_from_scalar (&ctx, &ctx0);
@@ -65,6 +86,8 @@ KERNEL_FQ KERNEL_FA void m10840_mxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);
@@ -131,6 +154,27 @@ KERNEL_FQ KERNEL_FA void m10840_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx = ctx0;
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector_from_scalar (&ctx, &ctx0);
@@ -138,6 +182,8 @@ KERNEL_FQ KERNEL_FA void m10840_sxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);

--- a/OpenCL/m10870_a3-pure.cl
+++ b/OpenCL/m10870_a3-pure.cl
@@ -52,6 +52,29 @@ KERNEL_FQ KERNEL_FA void m10870_mxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -59,6 +82,8 @@ KERNEL_FQ KERNEL_FA void m10870_mxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);
@@ -119,6 +144,29 @@ KERNEL_FQ KERNEL_FA void m10870_sxx (KERN_ATTR_VECTOR ())
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha384_ctx_t ctx;
+
+    sha384_init (&ctx);
+
+    sha384_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha384_final (&ctx);
+
+    #else
+
     sha384_ctx_vector_t ctx;
 
     sha384_init_vector (&ctx);
@@ -126,6 +174,8 @@ KERNEL_FQ KERNEL_FA void m10870_sxx (KERN_ATTR_VECTOR ())
     sha384_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha384_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = l32_from_64 (ctx.h[3]);
     const u32x r1 = h32_from_64 (ctx.h[3]);

--- a/OpenCL/m10870_a3-pure.cl
+++ b/OpenCL/m10870_a3-pure.cl
@@ -44,36 +44,42 @@ KERNEL_FQ KERNEL_FA void m10870_mxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha384_ctx_t ctx;
 
     sha384_init (&ctx);
 
-    sha384_update_utf16le_swap (&ctx, c, pw_len);
+    sha384_update_utf16le_swap (&ctx, w, pw_len);
 
     sha384_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha384_ctx_vector_t ctx;
 
@@ -136,36 +142,42 @@ KERNEL_FQ KERNEL_FA void m10870_sxx (KERN_ATTR_VECTOR ())
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha384_ctx_t ctx;
 
     sha384_init (&ctx);
 
-    sha384_update_utf16le_swap (&ctx, c, pw_len);
+    sha384_update_utf16le_swap (&ctx, w, pw_len);
 
     sha384_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha384_ctx_vector_t ctx;
 

--- a/OpenCL/m13500_a3-pure.cl
+++ b/OpenCL/m13500_a3-pure.cl
@@ -95,6 +95,27 @@ KERNEL_FQ KERNEL_FA void m13500_mxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -102,6 +123,8 @@ KERNEL_FQ KERNEL_FA void m13500_mxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -195,6 +218,27 @@ KERNEL_FQ KERNEL_FA void m13500_sxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha1_ctx_t ctx = ctx0;
+
+    sha1_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha1_final (&ctx);
+
+    #else
+
     sha1_ctx_vector_t ctx;
 
     sha1_init_vector_from_scalar (&ctx, &ctx0);
@@ -202,6 +246,8 @@ KERNEL_FQ KERNEL_FA void m13500_sxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
     sha1_update_vector_utf16beN (&ctx, w, pw_len);
 
     sha1_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m13500_a3-pure.cl
+++ b/OpenCL/m13500_a3-pure.cl
@@ -87,34 +87,40 @@ KERNEL_FQ KERNEL_FA void m13500_mxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx = ctx0;
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 
@@ -210,34 +216,40 @@ KERNEL_FQ KERNEL_FA void m13500_sxx (KERN_ATTR_VECTOR_ESALT (pstoken_t))
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha1_ctx_t ctx = ctx0;
 
-    sha1_update_utf16le_swap (&ctx, c, pw_len);
+    sha1_update_utf16le_swap (&ctx, w, pw_len);
 
     sha1_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha1_ctx_vector_t ctx;
 

--- a/OpenCL/m13800_a3-pure.cl
+++ b/OpenCL/m13800_a3-pure.cl
@@ -59,38 +59,44 @@ KERNEL_FQ KERNEL_FA void m13800_mxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx;
 
     sha256_init (&ctx);
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_update (&ctx, s, salt_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 
@@ -164,38 +170,44 @@ KERNEL_FQ KERNEL_FA void m13800_sxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
 
   u32x w0l = w[0];
 
+  #if VECT_SIZE == 1
+
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  #endif
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
     #if VECT_SIZE == 1
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0);
 
     sha256_ctx_t ctx;
 
     sha256_init (&ctx);
 
-    sha256_update_utf16le_swap (&ctx, c, pw_len);
+    sha256_update_utf16le_swap (&ctx, w, pw_len);
 
     sha256_update (&ctx, s, salt_len);
 
     sha256_final (&ctx);
 
     #else
+
+    w[0] = w0;
 
     sha256_ctx_vector_t ctx;
 

--- a/OpenCL/m13800_a3-pure.cl
+++ b/OpenCL/m13800_a3-pure.cl
@@ -67,6 +67,31 @@ KERNEL_FQ KERNEL_FA void m13800_mxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -76,6 +101,8 @@ KERNEL_FQ KERNEL_FA void m13800_mxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];
@@ -145,6 +172,31 @@ KERNEL_FQ KERNEL_FA void m13800_sxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
 
     w[0] = w0;
 
+    #if VECT_SIZE == 1
+
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
+    sha256_ctx_t ctx;
+
+    sha256_init (&ctx);
+
+    sha256_update_utf16le_swap (&ctx, c, pw_len);
+
+    sha256_update (&ctx, s, salt_len);
+
+    sha256_final (&ctx);
+
+    #else
+
     sha256_ctx_vector_t ctx;
 
     sha256_init_vector (&ctx);
@@ -154,6 +206,8 @@ KERNEL_FQ KERNEL_FA void m13800_sxx (KERN_ATTR_VECTOR_ESALT (win8phone_t))
     sha256_update_vector (&ctx, s, salt_len);
 
     sha256_final_vector (&ctx);
+
+    #endif
 
     const u32x r0 = ctx.h[DGST_R0];
     const u32x r1 = ctx.h[DGST_R1];

--- a/OpenCL/m29000_a3-pure.cl
+++ b/OpenCL/m29000_a3-pure.cl
@@ -70,28 +70,28 @@ KERNEL_FQ KERNEL_FA void m29000_mxx (KERN_ATTR_VECTOR_ESALT (sha1_double_salt_t)
 
   u32x w0l = w[0];
 
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0lr = w0l | w0r;
 
-    w[0] = w0lr;
-
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0lr);
 
     sha1_ctx_t ctx1 = ctx2;
 
-    sha1_update_utf16le_swap (&ctx1, c, pw_len);
+    sha1_update_utf16le_swap (&ctx1, w, pw_len);
 
     sha1_final (&ctx1);
 
@@ -190,28 +190,28 @@ KERNEL_FQ KERNEL_FA void m29000_sxx (KERN_ATTR_VECTOR_ESALT (sha1_double_salt_t)
 
   u32x w0l = w[0];
 
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0lr = w0l | w0r;
 
-    w[0] = w0lr;
-
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
+    w[0] = hc_swap32_S (w0lr);
 
     sha1_ctx_t ctx1 = ctx2;
 
-    sha1_update_utf16le_swap (&ctx1, c, pw_len);
+    sha1_update_utf16le_swap (&ctx1, w, pw_len);
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m29000_a3-pure.cl
+++ b/OpenCL/m29000_a3-pure.cl
@@ -78,9 +78,20 @@ KERNEL_FQ KERNEL_FA void m29000_mxx (KERN_ATTR_VECTOR_ESALT (sha1_double_salt_t)
 
     w[0] = w0lr;
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t ctx1 = ctx2;
 
-    sha1_update_utf16beN (&ctx1, w, pw_len);
+    sha1_update_utf16le_swap (&ctx1, c, pw_len);
 
     sha1_final (&ctx1);
 
@@ -187,9 +198,20 @@ KERNEL_FQ KERNEL_FA void m29000_sxx (KERN_ATTR_VECTOR_ESALT (sha1_double_salt_t)
 
     w[0] = w0lr;
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t ctx1 = ctx2;
 
-    sha1_update_utf16beN (&ctx1, w, pw_len);
+    sha1_update_utf16le_swap (&ctx1, c, pw_len);
 
     sha1_final (&ctx1);
 

--- a/OpenCL/m29200_a3-pure.cl
+++ b/OpenCL/m29200_a3-pure.cl
@@ -146,9 +146,20 @@ KERNEL_FQ KERNEL_FA void m29200_mxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
 
     // add password to the user name (and colon, included):
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t c0 = ctx0;
 
-    sha1_update_utf16beN (&c0, w, pw_len);
+    sha1_update_utf16le_swap (&c0, c, pw_len);
 
     sha1_final (&c0);
 
@@ -427,9 +438,20 @@ KERNEL_FQ KERNEL_FA void m29200_sxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
 
     // add password to the user name (and colon, included):
 
+    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+    // by byte. Put the words back in native order for it.
+
+    u32 c[64] = { 0 };
+
+    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+    {
+      c[idx] = hc_swap32_S (w[idx]);
+    }
+
     sha1_ctx_t c0 = ctx0;
 
-    sha1_update_utf16beN (&c0, w, pw_len);
+    sha1_update_utf16le_swap (&c0, c, pw_len);
 
     sha1_final (&c0);
 

--- a/OpenCL/m29200_a3-pure.cl
+++ b/OpenCL/m29200_a3-pure.cl
@@ -135,31 +135,30 @@ KERNEL_FQ KERNEL_FA void m29200_mxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
 
   u32x w0l = w[0];
 
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
+    w[0] = hc_swap32_S (w0);
 
     // add password to the user name (and colon, included):
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
-
     sha1_ctx_t c0 = ctx0;
 
-    sha1_update_utf16le_swap (&c0, c, pw_len);
+    sha1_update_utf16le_swap (&c0, w, pw_len);
 
     sha1_final (&c0);
 
@@ -427,31 +426,30 @@ KERNEL_FQ KERNEL_FA void m29200_sxx (KERN_ATTR_VECTOR_ESALT (radmin3_t))
 
   u32x w0l = w[0];
 
+  // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
+  // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
+  // by byte. Put the words back in native order for it. Only w[0] changes from one
+  // candidate to the next, so everything above it is swapped once here and the loop is
+  // left with the single word it rewrites.
+
+  for (u32 i = 4, idx = 1; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
   for (u32 il_pos = 0; il_pos < IL_CNT; il_pos += VECT_SIZE)
   {
     const u32x w0r = words_buf_r[il_pos / VECT_SIZE];
 
     const u32x w0 = w0l | w0r;
 
-    w[0] = w0;
-
+    w[0] = hc_swap32_S (w0);
 
     // add password to the user name (and colon, included):
 
-    // The mask processor hands a OPTS_TYPE_PT_GENERATE_BE mode its candidates in big endian
-    // word order (markov_be.cl), which hc_enc_next() cannot read: it decodes the UTF-8 byte
-    // by byte. Put the words back in native order for it.
-
-    u32 c[64] = { 0 };
-
-    for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
-    {
-      c[idx] = hc_swap32_S (w[idx]);
-    }
-
     sha1_ctx_t c0 = ctx0;
 
-    sha1_update_utf16le_swap (&c0, c, pw_len);
+    sha1_update_utf16le_swap (&c0, w, pw_len);
 
     sha1_final (&c0);
 

--- a/src/backend.c
+++ b/src/backend.c
@@ -15654,34 +15654,6 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       vector_width = 1;
     }
 
-    // Same reason as the pure kernel case above: UTF-8 to UTF-16 is a variable length
-    // conversion, so the password length after it is not known in advance and differs between
-    // the lanes. hc_enc_next() decodes one candidate at a time and there is no vector form of
-    // it, so the vectorized conversions in inc_hash_*.cl widen the bytes instead, which turns
-    // a euro sign into three characters and never matches. The scalar path is the only one
-    // that gets a non-ASCII password right.
-    //
-    // hashconfig->opts_type cannot answer this: interface.c clears OPTS_TYPE_PT_UTF16LE and
-    // OPTS_TYPE_PT_UTF16BE whenever the optimized kernel is not used, and the pure kernels
-    // are exactly the ones that do the conversion themselves. Ask the module instead.
-
-    // Only the pure kernels, which is the same condition as the block above. An optimized
-    // kernel widens the bytes whatever the vector width is, so it cannot crack a multi byte
-    // password either way and there is nothing to buy by giving up its SIMD.
-
-    if ((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0)
-    {
-      if (module_ctx->module_opts_type != MODULE_DEFAULT)
-      {
-        const u64 module_opts_type = module_ctx->module_opts_type (hashconfig, user_options, user_options_extra);
-
-        if (module_opts_type & (OPTS_TYPE_PT_UTF16LE | OPTS_TYPE_PT_UTF16BE))
-        {
-          vector_width = 1;
-        }
-      }
-    }
-
     if (vector_width > 16) vector_width = 16;
 
     device_param->vector_width = vector_width;

--- a/src/backend.c
+++ b/src/backend.c
@@ -15654,6 +15654,34 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       vector_width = 1;
     }
 
+    // Same reason as the pure kernel case above: UTF-8 to UTF-16 is a variable length
+    // conversion, so the password length after it is not known in advance and differs between
+    // the lanes. hc_enc_next() decodes one candidate at a time and there is no vector form of
+    // it, so the vectorized conversions in inc_hash_*.cl widen the bytes instead, which turns
+    // a euro sign into three characters and never matches. The scalar path is the only one
+    // that gets a non-ASCII password right.
+    //
+    // hashconfig->opts_type cannot answer this: interface.c clears OPTS_TYPE_PT_UTF16LE and
+    // OPTS_TYPE_PT_UTF16BE whenever the optimized kernel is not used, and the pure kernels
+    // are exactly the ones that do the conversion themselves. Ask the module instead.
+
+    // Only the pure kernels, which is the same condition as the block above. An optimized
+    // kernel widens the bytes whatever the vector width is, so it cannot crack a multi byte
+    // password either way and there is nothing to buy by giving up its SIMD.
+
+    if ((hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL) == 0)
+    {
+      if (module_ctx->module_opts_type != MODULE_DEFAULT)
+      {
+        const u64 module_opts_type = module_ctx->module_opts_type (hashconfig, user_options, user_options_extra);
+
+        if (module_opts_type & (OPTS_TYPE_PT_UTF16LE | OPTS_TYPE_PT_UTF16BE))
+        {
+          vector_width = 1;
+        }
+      }
+    }
+
     if (vector_width > 16) vector_width = 16;
 
     device_param->vector_width = vector_width;


### PR DESCRIPTION
`-a 3` cannot crack a password containing a euro sign, Japanese kana or a CJK character in 22
modes. `-a 0`, `-a 1`, `-a 4`, `-a 6`, `-a 7`, `-a 8` and `-a 9` already use the scalar
conversions and were never affected, and `-a 12` is pinned to vector width 1 by the
association-mode block at [backend.c:15651](https://github.com/hashcat/hashcat/blob/1a7af0976474eef81d1bb0bc19030d2651383a95/src/backend.c#L15651).

This .2 of the split discussed in https://github.com/hashcat/hashcat/pull/4810#issuecomment-5483004665. It is the kernel conversion path only. **It does not touch the mask processor or custom charsets**, so the `-1 'a€'` behaviour you described, where a multi byte charset is split into single bytes, is untouched and still yours. The test coverage is part 1, in a separate PR, and this branch is what that coverage catches.

This continues 5c840aaec, "Crack non ASCII passwords again in 41 hash modes, and repair 9
more". That commit widened the lead byte ranges in `hc_enc_next()`, which repaired the scalar
path. `-a 3` does not use it.

## Reproduction

Against master [`1a7af0976`](https://github.com/hashcat/hashcat/commit/1a7af0976474eef81d1bb0bc19030d2651383a95). Run `make` on each side: the kernel cache is keyed on the binary's compile
time, so a rebuild invalidates it on its own. `Vec:` in the status output says which binary you
are on, since the fix pins these modes to vector width 1.

```
make
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --backend-vector-width 4 '7c23a6931f4a44e3f031202f065b5c4e' 'hashcat€'
./hashcat -m 130  -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 'bc93548344c1d91dccb23ffb78440cdd7d4f40b4:2455' '1234567?d€'
```

```
before: m1000 Status Exhausted, Recovered 0/1, rc=1   at any vector width above 1,
                                                     Cracked rc=0 at width 1
        m130  Status Exhausted, Recovered 0/1, rc=1   at every vector width, 1 included
after:  both  Status Cracked,   Recovered 1/1, rc=0
```

`7c23a6931f4a44e3f031202f065b5c4e` is NTLM of `hashcat` followed by U+20AC.
`bc93548344c1d91dccb23ffb78440cdd7d4f40b4:2455` is `sha1(utf16le('12345678' + U+20AC) .
'2455')`.

An ASCII password is unaffected either way, which is what says the fault is in the UTF-8
handling and not in the mask:

```
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --backend-vector-width 4 'b4b9b02e6f09a9bd760f388b67351e2b' 'hashca?l'
./hashcat -m 130  -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 'a6d8e5ca22a3f603dad986f5ada47728a6d91734:245755154711915074179' '?d?d?d?d?d'

before and after: Cracked, rc=0
```

After the fix the first command reports `Vec:1` although it asked for 4. That is the pin, not a
bug.

## Two faults

### There is no vector form of hc_enc_next()

Of the 121 UTF-16 conversion helpers in `OpenCL/inc_hash_*.cl`, 47 decode the UTF-8 through
`hc_enc_next()` and 74 widen the bytes instead. Widening turns a euro sign into three
characters, so it never matches. `hc_enc_next()` works on one candidate at a time and the
UTF-16 length of a candidate is not known before the conversion, so there is no vector form of
it and there cannot be one while a `*_ctx_vector_t` carries a single scalar `len` for all its
lanes.

`m00030`, `m00040`, `m00070`, `m01000`, `m01100`, `m05500` and `m31300` pick the helper with an
`#if VECT_SIZE == 1`, [m01000_a3-pure.cl:55](https://github.com/hashcat/hashcat/blob/1a7af0976474eef81d1bb0bc19030d2651383a95/OpenCL/m01000_a3-pure.cl#L55) for one, so they
are right at width 1 and widen above it.

This branch pins UTF-16 modes to vector width 1, immediately before
[backend.c:15659](https://github.com/hashcat/hashcat/blob/1a7af0976474eef81d1bb0bc19030d2651383a95/src/backend.c#L15659) where the width is assigned, and next to the two
cases that already do the same on master: [backend.c:15637](https://github.com/hashcat/hashcat/blob/1a7af0976474eef81d1bb0bc19030d2651383a95/src/backend.c#L15637) for an
unknown final password length, and [backend.c:15651](https://github.com/hashcat/hashcat/blob/1a7af0976474eef81d1bb0bc19030d2651383a95/src/backend.c#L15651) for association
mode. The first of those says it for this reason too:

> // We can't have SIMD in kernels where we have an unknown final password length

The pin is on the pure kernels only, which is the same condition as the block above it. An
optimized kernel widens the bytes at any vector width, so it cannot crack a multi byte password
either way and there is nothing to buy by giving up its SIMD.

`hashconfig->opts_type` cannot answer this. [interface.c:442](https://github.com/hashcat/hashcat/blob/1a7af0976474eef81d1bb0bc19030d2651383a95/src/interface.c#L442) clears
`OPTS_TYPE_PT_UTF16LE` and `OPTS_TYPE_PT_UTF16BE` whenever the optimized kernel is not used,
and the pure kernels are exactly the ones that convert in the kernel, so the module is asked
directly.

### Sixteen kernels had no scalar branch at all

`m00130`, `m00140`, `m00170`, `m01430`, `m01440`, `m01470`, `m01730`, `m01740`, `m01770`,
`m10830`, `m10840`, `m10870`, `m13500`, `m13800`, `m29000` and `m29200` called a widening
helper unconditionally, so they were broken at width 1 as well. They get a scalar branch.

These are `OPTS_TYPE_PT_GENERATE_BE` modes and `markov_be.cl` hands their brute force
candidates over in big endian word order. `hc_enc_next()` reads the UTF-8 byte by byte and
cannot make sense of that, so the scalar branch puts the words back in native order first.
Without that step the digest comes out wrong for an ASCII password too, which the self test
catches immediately.

## Cost

CUDA and HIP already ran the pure kernels at width 1, because the block above pins every pure
kernel on a GPU to 1, so nothing changes there. The cost lands on CPU and on non GPU OpenCL.
Measured on PoCL, a 20 second run:

```
./hashcat -m 1000 -a 3 -D 1 --force --potfile-disable --runtime 20 'ffffffffffffffffffffffffffffffff' '?d?d?d?d?d?d?d?d?d?d'

master, pure kernel:  467.0 MH/s   Vec:8
branch, pure kernel:   81.9 MH/s   Vec:1     5.7x slower
branch, -O:           350.3 MH/s   Vec:8     unchanged
```

**A narrower pin is possible and I have not built it.** In `-a 3` the mask is known on the host
before the kernel runs. If no position in it can emit a byte above 0x7f, every `?d`, `?l`, `?u`,
`?s` and every ASCII literal, then no candidate can be multi byte and the vector path is
provably safe for that run. Pinning only when the mask actually carries a high byte would keep
full speed for the common case. It needs the mask, which `mpsp.c` parses, to be reachable from
`backend_session_begin()`, and `--increment` and hcmask files each want thinking about, so it
is a design call rather than a mechanical change. Happy to build it instead if you prefer.

## Two modes deliberately left alone

**m15500** (JKS Java Key Store) and **m35200** (AS/400 SSHA1) are the genuine UTF-16BE modes.
Their `a0-pure` kernel uses `sha1_update_utf16be_swap()`, and no UTF-16BE helper anywhere calls
`hc_enc_next()`, so hashcat has no UTF-8 path for them in any attack mode. Giving them one is a
separate change, not a widening of this one.

## Testing

PoCL CPU only, `-D 1 --force`, with the test coverage from part 1 applied on top.

All 22 modes, `./tools/test.sh -m <mode> -a 3 -t single -D 1 -P -f -V 4`, every one `OK 0/7`,
against `Error 6/7` or `Error 7/7` before, depending on how many of the eight generated
passwords happened to carry a multi byte character:

```
30 40 70 1000 1100 5500 31300
130 140 170 1430 1440 1470 1730 1740 1770 10830 10840 10870 13500 13800 29000
```

m29200 got the same kernel change but the suite generates no `-a 3` case for it.

Green at `-a all -t all`: m1000, m130, m5500. Green again with `NO_NON_ASCII=1`, the switch
that turns the multi byte passwords off, so ASCII did not regress. That switch lives in part 1,
not here: this branch changes no test code at all, so on its own it is measured with whatever
passwords master's `tools/test.pl` generates, which are digits. The width pin does not reach a mode that does no UTF-16 conversion:

```
./hashcat -m 0 -a 3 -D 1 --force --potfile-disable --backend-vector-width 4 '5f4dcc3b5aa765d61d8327deb882cf99' 'passwor?d'
Speed.#01: ... Vec:4
```

## Not covered

- **No GPU.** PoCL CPU only, so the 17 changed kernels have never been compiled by CUDA, HIP or
  AMD OpenCL. This is the gap worth closing before merging.
- The narrower, mask aware version of the vector width pin described above is not built.
- `tools/test_edge.sh` was not run.
