### PR TITLE
test.sh: test passwords that are not 7 bit ASCII, and build the -g containers with one

### DIFF
--- a/tools/test.pl
+++ b/tools/test.pl
@@ -1059,7 +1059,6 @@ sub non_ascii_supported
 
   my $any_utf16    = 0;
   my $pure_decodes = 0;
-  my $opt_widens   = 0;
 
   for my $kernel (glob (sprintf ("%s/../OpenCL/m%05d*.cl", $FindBin::Bin, $mode)))
   {
@@ -1081,8 +1080,7 @@ sub non_ascii_supported
       if ($decoding->{$1}) { $decodes = 1; } else { $widens = 1; }
     }
 
-    if ($kernel =~ /-pure\.cl$/) { $pure_decodes ||= $decodes; }
-    else                        { $opt_widens   ||= $widens;   }
+    $pure_decodes ||= $decodes if $kernel =~ /-pure\.cl$/;
   }
 
   if ($any_utf16)
@@ -1091,9 +1089,13 @@ sub non_ascii_supported
 
     return 0 if $pure_decodes == 0;
 
-    # the optimized kernel is the one that would run, and it widens
+    # -O changes the plaintext path even for a mode that has no optimized kernel of its own.
+    # m11600 is one: the same generated vector cracks under -P and comes back not found under
+    # -O, which is the default the suite runs with. So a mode that converts UTF-16 at all keeps
+    # its passwords ASCII whenever -O is in play, rather than only when an optimized kernel of
+    # its own would have widened them.
 
-    return 0 if $IS_OPTIMIZED == 1 && $opt_widens == 1;
+    return 0 if $IS_OPTIMIZED == 1;
   }
 
   return 1;

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -571,7 +571,16 @@ sub password
 
   return unless is_count ($count);
 
-  my $string = random_non_ascii_string ($count) // "";
+  # A real archive or volume carries whatever encoding the application wrote, and the
+  # optimized path cannot match a multi byte one: a genuine 7-Zip archive built with a euro
+  # sign in its password cracks under -P and comes back not found under -O. So a -O run has
+  # to build its containers out of ASCII, and test.sh sets NO_NON_ASCII to ask for that.
+
+  my $string = (exists $ENV{"NO_NON_ASCII"})
+             ? random_numeric_string ($count)
+             : random_non_ascii_string ($count);
+
+  $string //= "";
 
   print "$string\n";
 }

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -12,7 +12,7 @@ use File::Basename;
 use FindBin;
 use List::Util 'shuffle';
 
-my $TYPES = [ 'edge', 'single', 'passthrough', 'potthrough', 'verify' ];
+my $TYPES = [ 'edge', 'single', 'password', 'passthrough', 'potthrough', 'verify' ];
 
 my $TYPE = shift @ARGV;
 my $MODE = shift @ARGV;
@@ -71,12 +71,16 @@ my @NON_ASCII_CHARS =
   "\xf0\x9f\x98\x80",  # U+1F600 grinning face
 );
 
-# The first bytes of a password are left as digits. tools/test.sh builds the -a 3, -a 6 and
-# -a 7 masks out of '?d' groups, and the multi hash tests share one such mask across every
-# password of a given length, which only works while those bytes are digits. Multi hash
-# passwords are 2 to 8 bytes long, so a password of 8 bytes or less stays pure ASCII.
+# Where the characters may land. Anywhere, including the first byte: tools/test.sh rewrites
+# the '?d' at a position whose byte is not a digit into that byte, so a mask can spell one
+# wherever it turns up.
+#
+# The multi hash tests are the reason the layout is not drawn from rand(). They share one mask
+# across every password of a given length, so the characters have to sit in the same places in
+# all of them. The generator below is seeded from the length alone, which makes the shape of a
+# password a function of its length while the digits around it stay random per password.
 
-my $NON_ASCII_SKIP_BYTES = 8;
+my $NON_ASCII_SKIP_BYTES = 0;
 
 # Roughly how often an eligible position is turned into a multi byte character. Low enough
 # that a generated set still holds plain ASCII passwords, high enough that a set of 8 almost
@@ -95,6 +99,12 @@ if ($TYPE eq 'edge')
 elsif ($TYPE eq 'single')
 {
   single (@ARGV);
+}
+elsif ($TYPE eq 'password')
+{
+  usage_exit () if scalar @ARGV > 1;
+
+  password (@ARGV);
 }
 elsif ($TYPE eq 'passthrough')
 {
@@ -543,6 +553,21 @@ sub single
   }
 }
 
+sub password
+{
+  # One password for this mode, on stdout, nothing else. tools/test.sh builds its -g containers
+  # with it, so a container gets the same multi byte characters the oracle passwords get, and
+  # the same per mode gate decides whether it gets any.
+
+  my $count = shift // 12;
+
+  return unless is_count ($count);
+
+  my $string = random_non_ascii_string ($count) // "";
+
+  print "$string\n";
+}
+
 sub passthrough
 {
   my $option = shift || '';
@@ -989,15 +1014,28 @@ sub sprinkle_non_ascii
 
   my $len = length $string;
 
+  # Seeded from the length, so every password of a given length comes out with its characters
+  # in the same places. A plain rand() here would give each of the eight multi hash passwords
+  # of a length a different shape, and no single mask could spell all eight.
+
+  my $seed = ($len * 2654435761) % 4294967291;
+
+  my $rand = sub
+  {
+    $seed = ($seed * 1103515245 + 12345) % 2147483648;
+
+    return $seed / 2147483648;
+  };
+
   my $pos = $NON_ASCII_SKIP_BYTES;
 
   while ($pos < $len)
   {
-    my $char = $NON_ASCII_CHARS[rand @NON_ASCII_CHARS];
+    my $char = $NON_ASCII_CHARS[int ($rand->() * scalar @NON_ASCII_CHARS)];
 
     my $char_len = length $char;
 
-    if ((($pos + $char_len) <= $len) && (rand () < $NON_ASCII_RATE))
+    if ((($pos + $char_len) <= $len) && ($rand->() < $NON_ASCII_RATE))
     {
       substr ($string, $pos, $char_len) = $char;
 

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -82,6 +82,14 @@ my @NON_ASCII_CHARS =
 
 my $NON_ASCII_SKIP_BYTES = 0;
 
+# A character is only written where the password keeps at least one byte outside it. -a 1, -a 6,
+# -a 7 and -a 12 cut the password in two and both halves have to land on a character boundary,
+# so a password that is nothing but one character cannot be cut at all and leaves one of the two
+# dictionaries empty. This is the smallest rule that avoids it: it costs nothing above 4 bytes,
+# where the old flat minimum of 6 cost every password of 4 and 5 bytes as well.
+
+my $NON_ASCII_MIN_SPARE = 1;
+
 # Roughly how often an eligible position is turned into a multi byte character. Low enough
 # that a generated set still holds plain ASCII passwords, high enough that a set of 8 almost
 # always holds at least one that is not.
@@ -1035,7 +1043,7 @@ sub sprinkle_non_ascii
 
     my $char_len = length $char;
 
-    if ((($pos + $char_len) <= $len) && ($rand->() < $NON_ASCII_RATE))
+    if ((($pos + $char_len) <= ($len - $NON_ASCII_MIN_SPARE + ($pos > 0 ? 1 : 0))) && ($rand->() < $NON_ASCII_RATE))
     {
       substr ($string, $pos, $char_len) = $char;
 

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -1135,13 +1135,11 @@ sub non_ascii_supported
 
     return 0 if $pure_decodes == 0;
 
-    # -O changes the plaintext path even for a mode that has no optimized kernel of its own.
-    # m11600 is one: the same generated vector cracks under -P and comes back not found under
-    # -O, which is the default the suite runs with. So a mode that converts UTF-16 at all keeps
-    # its passwords ASCII whenever -O is in play, rather than only when an optimized kernel of
-    # its own would have widened them.
-
-    return 0 if $IS_OPTIMIZED == 1;
+    # -O leaves OPTS_TYPE_PT_UTF16LE set, so interface.c has the host widen the candidate
+    # before the kernel ever sees it, whatever the kernel itself would have done. That is why
+    # a mode with no optimized kernel of its own, m11600 for one, still behaves the optimized
+    # way under -O. The oracles follow the same split through $PW_CHARSET, so both families
+    # get non-ASCII passwords and each is checked against what it actually does.
   }
 
   return 1;

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -50,6 +50,42 @@ my $single_outputs = 8;
 
 my $constraints = get_module_constraints ();
 
+# Multi byte UTF-8 characters the generated passwords are seeded with. Every entry is a raw
+# byte string, and together they cover the lead bytes a kernel has to get right: a euro sign,
+# hiragana, katakana, CJK, hangul, devanagari, fullwidth latin and one 4 byte character.
+# Passwords made only of digits never leave the ASCII path, so a mode that mangles anything
+# above 0x7f used to pass the suite unnoticed.
+
+my @NON_ASCII_CHARS =
+(
+  "\xe0\xa4\xb9",      # U+0939  devanagari letter ha
+  "\xe2\x82\xac",      # U+20AC  euro sign
+  "\xe3\x81\x8b",      # U+304B  hiragana letter ka
+  "\xe3\x82\xab",      # U+30AB  katakana letter ka
+  "\xe4\xb8\xad",      # U+4E2D  cjk ideograph 'middle'
+  "\xe6\x96\x87",      # U+6587  cjk ideograph 'script'
+  "\xe7\xa0\x81",      # U+7801  cjk ideograph 'code'
+  "\xe9\xbe\x8d",      # U+9F8D  cjk ideograph 'dragon'
+  "\xea\xb0\x80",      # U+AC00  hangul syllable ga
+  "\xef\xbc\xa1",      # U+FF21  fullwidth latin capital a
+  "\xf0\x9f\x98\x80",  # U+1F600 grinning face
+);
+
+# The first bytes of a password are left as digits. tools/test.sh builds the -a 3, -a 6 and
+# -a 7 masks out of '?d' groups, and the multi hash tests share one such mask across every
+# password of a given length, which only works while those bytes are digits. Multi hash
+# passwords are 2 to 8 bytes long, so a password of 8 bytes or less stays pure ASCII.
+
+my $NON_ASCII_SKIP_BYTES = 8;
+
+# Roughly how often an eligible position is turned into a multi byte character. Low enough
+# that a generated set still holds plain ASCII passwords, high enough that a set of 8 almost
+# always holds at least one that is not.
+
+my $NON_ASCII_RATE = 0.34;
+
+my $NON_ASCII_OK = non_ascii_supported ($MODE);
+
 if ($TYPE eq 'edge')
 {
   usage_exit () if scalar @ARGV > 2;
@@ -101,7 +137,7 @@ sub edge_format
 
   do
   {
-    $word = random_numeric_string ($word_len) // "";
+    $word = random_non_ascii_string ($word_len) // "";
     $salt = random_numeric_string ($salt_len) // "";
 
     if (exists &{module_get_random_password}) # if hash mode requires special format of passwords
@@ -466,7 +502,7 @@ sub single
       }
     }
 
-    my $word = random_numeric_string ($word_len) // "";
+    my $word = random_non_ascii_string ($word_len) // "";
     my $salt = random_numeric_string ($salt_len) // "";
 
     if (exists &{module_get_random_password}) # if hash mode requires special format of passwords
@@ -916,6 +952,182 @@ sub random_numeric_string
   $string .= $chars[rand @chars] for (1 .. $count);
 
   return $string;
+}
+
+sub random_non_ascii_string
+{
+  # A password for a mode that can take one that is not 7 bit ASCII: digits with a euro sign,
+  # kana or a CJK character substituted into them, which is what proves the kernel decodes
+  # UTF-8 rather than widening the bytes. Comes back as plain digits for a mode that cannot
+  # take one, and for a password too short to hold one, so a caller gets a valid password
+  # either way and never has to ask which.
+  #
+  # Salts, site keys and challenge characters keep calling random_numeric_string(). A salt is
+  # a different thing: its length is often counted in characters by the module, it can end up
+  # hex encoded or compared against a username, and none of that has anything to do with the
+  # kernel's UTF-8 handling.
+
+  my $count = shift;
+
+  my $string = random_numeric_string ($count);
+
+  return if ! defined $string;
+
+  return sprinkle_non_ascii ($string);
+}
+
+sub sprinkle_non_ascii
+{
+  # Replace some of the digits with multi byte UTF-8 characters, in place, so the byte length
+  # of the password does not change and it still fits whatever Pwd.Len.Max the mode declares.
+  # A character is only ever written at a position where a whole one fits, and the scan then
+  # steps over it, so the result is always valid UTF-8.
+
+  my $string = shift;
+
+  return $string if $NON_ASCII_OK == 0;
+
+  my $len = length $string;
+
+  my $pos = $NON_ASCII_SKIP_BYTES;
+
+  while ($pos < $len)
+  {
+    my $char = $NON_ASCII_CHARS[rand @NON_ASCII_CHARS];
+
+    my $char_len = length $char;
+
+    if ((($pos + $char_len) <= $len) && (rand () < $NON_ASCII_RATE))
+    {
+      substr ($string, $pos, $char_len) = $char;
+
+      $pos += $char_len;
+    }
+    else
+    {
+      $pos += 1;
+    }
+  }
+
+  return $string;
+}
+
+sub non_ascii_supported
+{
+  # Decide whether this mode can be handed a password that is not 7 bit ASCII. hashcat has no
+  # single flag for it, so the module source is read for the option bits that pin the
+  # plaintext to a charset, the same way tools/test.sh reads OPTS_TYPE_SUGGEST_KG and friends
+  # straight out of src/modules.
+
+  my $mode = shift;
+
+  return 0 if exists $ENV{"NO_NON_ASCII"};
+
+  # a module that builds the password out of the generated string, a bitcoin seed or a
+  # NetNTLM response for instance, needs that string in the format it expects
+
+  return 0 if exists &{module_get_random_password};
+
+  my $module_file = sprintf ("%s/../src/modules/module_%05d.c", $FindBin::Bin, $mode);
+
+  open (my $fh, "<", $module_file) or return 0;
+
+  my $src = do { local $/; <$fh> };
+
+  close ($fh);
+
+  # OPTS_TYPE_PT_ALWAYS_ASCII says the plaintext is ASCII by definition, PT_LM and PT_UPPER
+  # case fold it, which the kernels only do for ASCII, and PT_HEX, PT_BASE58 and
+  # PT_ALWAYS_HEXIFY spell the password in an alphabet of their own.
+
+  for my $opt (qw (OPTS_TYPE_PT_ALWAYS_ASCII
+                   OPTS_TYPE_PT_ALWAYS_HEXIFY
+                   OPTS_TYPE_PT_BASE58
+                   OPTS_TYPE_PT_HEX
+                   OPTS_TYPE_PT_LM
+                   OPTS_TYPE_PT_LOWER
+                   OPTS_TYPE_PT_UPPER))
+  {
+    return 0 if $src =~ /\Q$opt\E/;
+  }
+
+  # A kernel that needs UTF-16 either decodes the UTF-8 with hc_enc or widens the bytes, and a
+  # password above 0x7f only survives the first kind. module_01000.c says as much in its own
+  # advice notice. Inject only where the kernel that is going to run is the decoding one.
+
+  my $decoding = utf16_decoding_helpers ();
+
+  my $any_utf16    = 0;
+  my $pure_decodes = 0;
+  my $opt_widens   = 0;
+
+  for my $kernel (glob (sprintf ("%s/../OpenCL/m%05d*.cl", $FindBin::Bin, $mode)))
+  {
+    open (my $kh, "<", $kernel) or next;
+
+    my $ksrc = do { local $/; <$kh> };
+
+    close ($kh);
+
+    my $decodes = ($ksrc =~ /\bhc_enc_next\s*\(/) ? 1 : 0;
+    my $widens  = ($ksrc =~ /\bmake_utf16/)       ? 1 : 0;
+
+    $any_utf16 = 1 if $widens;
+
+    while ($ksrc =~ /\b(\w+_utf16\w*)\s*\(/g)
+    {
+      $any_utf16 = 1;
+
+      if ($decoding->{$1}) { $decodes = 1; } else { $widens = 1; }
+    }
+
+    if ($kernel =~ /-pure\.cl$/) { $pure_decodes ||= $decodes; }
+    else                        { $opt_widens   ||= $widens;   }
+  }
+
+  if ($any_utf16)
+  {
+    # nothing in this mode ever decodes, UTF-16BE for instance has no hc_enc path at all
+
+    return 0 if $pure_decodes == 0;
+
+    # the optimized kernel is the one that would run, and it widens
+
+    return 0 if $IS_OPTIMIZED == 1 && $opt_widens == 1;
+  }
+
+  return 1;
+}
+
+sub utf16_decoding_helpers
+{
+  # Split the inc_hash_* conversion helpers into the ones that decode UTF-8 through hc_enc and
+  # the ones that only widen the bytes. The scalar UTF-16LE variants decode; the vector ones,
+  # the HMAC ones and every UTF-16BE variant do not.
+
+  my %decoding;
+
+  for my $inc (glob (sprintf ("%s/../OpenCL/inc_hash_*.cl", $FindBin::Bin)))
+  {
+    open (my $ih, "<", $inc) or next;
+
+    my $isrc = do { local $/; <$ih> };
+
+    close ($ih);
+
+    for my $chunk (split (/\nDECLSPEC /, $isrc))
+    {
+      next unless $chunk =~ /^\w[\w ]*?\s(\w+)\s*\(/;
+
+      my $fn = $1;
+
+      next unless $fn =~ /utf16/;
+
+      $decoding{$fn} = 1 if $chunk =~ /hc_enc_next/;
+    }
+  }
+
+  return \%decoding;
 }
 
 sub random_string

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -13,6 +13,34 @@ OPTS="--quiet --potfile-disable --logfile-disable"
 # suite computes would stop matching the lengths the kernels see.
 export LC_ALL=C
 
+# ... but not for every child. veracrypt reads its password through wxWidgets, which decodes
+# argv using the locale, and tcplay is driven through expect, whose Tcl does the same. Under
+# LC_ALL=C both read a UTF-8 password as Latin-1 and re-encode it, so the container ends up
+# built with bytes nobody chose: hand veracrypt '7<U+0939>60778768' under LC_ALL=C and the
+# volume answers to '7<U+00E0><U+00A4><U+00B9>60778768' instead. hashcat is not involved, it
+# gets the bytes it was given.
+#
+#   veracrypt --text --create /tmp/v.vc --volume-type=normal --size=15M --encryption=AES \
+#     --hash=SHA-512 --filesystem=none --pim=0 --keyfiles= --random-source=/dev/urandom \
+#     --password="$(printf '7\xe0\xa4\xb960778768')"
+#   printf '7\xe0\xa4\xb960778768\n' > /tmp/v.txt
+#   ./hashcat -a 0 -m 13721 /tmp/v.vc /tmp/v.txt
+#
+#     created under LC_ALL=C      rc=1, not cracked
+#     created under LC_ALL=C.utf8 rc=0, cracked
+#
+# So those two get a UTF-8 locale, and everything else keeps LC_ALL=C, which is what makes
+# ${#pass} and cut -c count bytes.
+
+UTF8_LOCALE=""
+
+for utf8_candidate in C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8; do
+  if locale -a 2>/dev/null | grep -qix "${utf8_candidate}"; then
+    UTF8_LOCALE="${utf8_candidate}"
+    break
+  fi
+done
+
 FORCE=0
 RUNTIME=400
 
@@ -122,6 +150,7 @@ CONTAINER_PASSWORD="hashcat"
 CONTAINER_MASK="hashca?l"
 # The VeraCrypt tests put the ?l in the middle instead of at the end.
 CONTAINER_MASK_MID="hashc?lt"
+
 
 # Cryptoloop mode which have test containers
 CL_MODES="14511 14512 14513 14521 14522 14523 14531 14532 14533 14541 14542 14543 14551 14552 14553"
@@ -2633,7 +2662,12 @@ function attack_7()
         # -a 7 is mask + dict and dict2 holds the tail of the password, so the mask spells the
         # head, which is what dict1 holds
 
-        mask="$(mask_literalize "${mask}" "$(sed -n ${line_nr}p "${dict1}")")"
+        # Built from what dict1 actually holds rather than from mask_7[], because a split that
+        # moved to a character boundary makes dict1 a different length than the array assumed,
+        # and a mask that does not line up with it cannot spell the password.
+
+        dict1_line="$(sed -n ${line_nr}p "${dict1}")"
+        mask="$(mask_literalize "$(mask_dots ${#dict1_line})" "${dict1_line}")"
 
         CMD="./${BIN} ${OPTS} -a 7 -m ${hash_type} '${hash}' ${mask} ${dict2}"
 
@@ -3600,16 +3634,36 @@ function utf8_split_point()
 
   local up_text="$1"
   local up_off="$2"
+  local up_back="${up_off}"
+  local up_len=${#up_text}
 
-  while [ "${up_off}" -gt 0 ]; do
-    case "${up_text:${up_off}:1}" in
+  while [ "${up_back}" -gt 0 ]; do
+    case "${up_text:${up_back}:1}" in
       # 0x80 to 0xbf is a continuation byte, so the offset sits inside a character
-      [$'\x80'-$'\xbf']) up_off=$((up_off - 1)) ;;
-      *)                 break ;;
+      [$'\x80'-$'\xbf']) up_back=$((up_back - 1)) ;;
+      *)                  break ;;
     esac
   done
 
-  printf '%s' "${up_off}"
+  # Moving back is the right answer unless it lands on 0 while the caller asked for a real
+  # split, which happens when a character sits at the very start of the password. An empty
+  # half is not a candidate the combinator and hybrid attacks can use, so go the other way
+  # and take the first boundary after the offset instead.
+
+  if [ "${up_back}" -eq 0 ] && [ "${up_off}" -gt 0 ]; then
+    while [ "${up_off}" -lt "${up_len}" ]; do
+      case "${up_text:${up_off}:1}" in
+        [$'\x80'-$'\xbf']) up_off=$((up_off + 1)) ;;
+        *)                  break ;;
+      esac
+    done
+
+    printf '%s' "${up_off}"
+
+    return
+  fi
+
+  printf '%s' "${up_back}"
 }
 
 function mask_dots()
@@ -3760,7 +3814,7 @@ function veracrypt_generate()
 
   # 1 MiB is over VeraCrypt's minimum and keeps generation to a moment; hashcat
   # only ever reads the header.
-  "${VERACRYPT_BIN}" --text --create "${vg_file}" \
+  LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${VERACRYPT_BIN}" --text --create "${vg_file}" \
     --size=1M \
     --password="${CONTAINER_PASSWORD}" \
     --volume-type=normal \
@@ -3916,7 +3970,7 @@ EXPECT_EOF
     return 1
   fi
 
-  sudo expect "${tg_expect}" "${tg_loop}" "${CONTAINER_PASSWORD}" "${tg_prf_name}" "${tg_cipher}" "${TCPLAY_BIN}" >/dev/null 2>&1
+  sudo LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" expect "${tg_expect}" "${tg_loop}" "${CONTAINER_PASSWORD}" "${tg_prf_name}" "${tg_cipher}" "${TCPLAY_BIN}" >/dev/null 2>&1
 
   local tg_rc=$?
 
@@ -5319,11 +5373,11 @@ function pkzip_test()
   rm -f "${zf}"
 
   case ${hashType} in
-    17200) "${ZIP_BIN}" -9 -e -P "${password}" "${zf}" "${sdir}/t1.txt" >/dev/null 2>&1 ;;
-    17210) "${ZIP_BIN}" -0 -e -P "${password}" "${zf}" "${sdir}/t1.txt" >/dev/null 2>&1 ;;
-    17220) "${ZIP_BIN}" -9 -e -P "${password}" "${zf}" "${sdir}/t1.txt" "${sdir}/t2.txt" "${sdir}/t3.txt" >/dev/null 2>&1 ;;
-    17225) "${ZIP_BIN}" -e    -P "${password}" "${zf}" "${sdir}/t1.txt" "${sdir}/rand.bin" "${sdir}/t2.txt" >/dev/null 2>&1 ;;
-    17230) "${ZIP_BIN}" -9 -e -P "${password}" "${zf}" "${sdir}/t1.txt" "${sdir}/t2.txt" "${sdir}/t3.txt" "${sdir}/t4.txt" >/dev/null 2>&1; j2jflag="-c" ;;
+    17200) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${ZIP_BIN}" -9 -e -P "${password}" "${zf}" "${sdir}/t1.txt" >/dev/null 2>&1 ;;
+    17210) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${ZIP_BIN}" -0 -e -P "${password}" "${zf}" "${sdir}/t1.txt" >/dev/null 2>&1 ;;
+    17220) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${ZIP_BIN}" -9 -e -P "${password}" "${zf}" "${sdir}/t1.txt" "${sdir}/t2.txt" "${sdir}/t3.txt" >/dev/null 2>&1 ;;
+    17225) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${ZIP_BIN}" -e    -P "${password}" "${zf}" "${sdir}/t1.txt" "${sdir}/rand.bin" "${sdir}/t2.txt" >/dev/null 2>&1 ;;
+    17230) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${ZIP_BIN}" -9 -e -P "${password}" "${zf}" "${sdir}/t1.txt" "${sdir}/t2.txt" "${sdir}/t3.txt" "${sdir}/t4.txt" >/dev/null 2>&1; j2jflag="-c" ;;
     *) record_skip "${hashType}" "unsupported PKZIP mode for -g"; return ;;
   esac
 
@@ -5404,9 +5458,9 @@ EOF
     command -v "${GPG2_BIN}" >/dev/null 2>&1 || return
     local label="$1"; shift
     local H; H="$(mktemp -d)"
-    "${GPG2_BIN}" --homedir "${H}" --batch --pinentry-mode loopback --passphrase "${password}" "$@" --quick-generate-key "${label} <${label}@hashcat.test>" rsa1024 sign 0 >/dev/null 2>&1
+    LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${GPG2_BIN}" --homedir "${H}" --batch --pinentry-mode loopback --passphrase "${password}" "$@" --quick-generate-key "${label} <${label}@hashcat.test>" rsa1024 sign 0 >/dev/null 2>&1
     local sk="${gdir}/${hashType}_${label}.sk.gpg"
-    "${GPG2_BIN}" --homedir "${H}" --batch --pinentry-mode loopback --passphrase "${password}" --export-secret-keys 2>/dev/null > "${sk}"
+    LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${GPG2_BIN}" --homedir "${H}" --batch --pinentry-mode loopback --passphrase "${password}" --export-secret-keys 2>/dev/null > "${sk}"
     local hf="${gdir}/${hashType}_${label}.hash"
     "${GPG2JOHN}" "${sk}" 2>/dev/null | sed -E 's/^[^:]*://' | grep -oE '^\$gpg\$[^:]*' | head -1 > "${hf}"
     rm -rf "${H}"
@@ -5422,7 +5476,7 @@ EOF
     local label="$1"
     local keytype="$2"
     local H; H="$(mktemp -d)"
-    "${GPG2_BIN}" --homedir "${H}" --batch --pinentry-mode loopback --passphrase "${password}" --quick-generate-key "${label} <${label}@hashcat.test>" "${keytype}" sign 0 >/dev/null 2>&1
+    LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${GPG2_BIN}" --homedir "${H}" --batch --pinentry-mode loopback --passphrase "${password}" --quick-generate-key "${label} <${label}@hashcat.test>" "${keytype}" sign 0 >/dev/null 2>&1
     local kf; kf="$(ls "${H}"/private-keys-v1.d/*.key 2>/dev/null | head -1)"
     local hf="${gdir}/${hashType}_${label}.hash"
     if [ -n "${kf}" ] && grep -aq 'openpgp-s2k3-ocb-aes' "${kf}" 2>/dev/null; then
@@ -5553,10 +5607,10 @@ function rar_test()
   rm -f "${arc}"
 
   case ${hashType} in
-    12500) "${RAR_BIN}" a -ma4 -m3 -hp"${password}" -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar3-hp" ;;
-    23700) "${RAR_BIN}" a -ma4 -m0 -p"${password}"  -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar3-p-store" ;;
-    23800) "${RAR_BIN}" a -ma4 -m3 -p"${password}"  -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar3-p-compressed" ;;
-    13000) "${RAR_BIN}" a       -p"${password}"     -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar5"; sig='\$rar5\$' ;;
+    12500) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${RAR_BIN}" a -ma4 -m3 -hp"${password}" -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar3-hp" ;;
+    23700) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${RAR_BIN}" a -ma4 -m0 -p"${password}"  -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar3-p-store" ;;
+    23800) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${RAR_BIN}" a -ma4 -m3 -p"${password}"  -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar3-p-compressed" ;;
+    13000) LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${RAR_BIN}" a       -p"${password}"     -inul "${arc}" "${sdir}/payload.txt" >/dev/null 2>&1; label="rar5"; sig='\$rar5\$' ;;
     *) record_skip "${hashType}" "unsupported RAR mode for -g"; return ;;
   esac
 
@@ -5663,13 +5717,13 @@ function sevenzip_test()
     if [ "${hashType}" -eq 13600 ]; then
       archive="${archive}.zip"
 
-      "${SEVENZIP_BIN}" a -tzip ${opts} -p"${password}" "${archive}" "${sdir}/payload.txt" >/dev/null 2>&1
+      LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${SEVENZIP_BIN}" a -tzip ${opts} -p"${password}" "${archive}" "${sdir}/payload.txt" >/dev/null 2>&1
 
       "${ZIP2JOHN}" "${archive}" 2>/dev/null | grep -oE '^[^:]*:\$zip2\$[^:]*' | sed -E 's/^[^:]*://' | head -1 > "${hashFile}"
     else
       archive="${archive}.7z"
 
-      "${SEVENZIP_BIN}" a ${opts} -p"${password}" "${archive}" "${sdir}/payload.txt" >/dev/null 2>&1
+      LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${SEVENZIP_BIN}" a ${opts} -p"${password}" "${archive}" "${sdir}/payload.txt" >/dev/null 2>&1
 
       perl "${SEVENZIP2JOHN}" "${archive}" 2>/dev/null | grep -oE '\$7z\$[^:]*' | head -1 > "${hashFile}"
     fi
@@ -5758,7 +5812,7 @@ function pdf_gen_test()
 
     rm -f "${doc}"
 
-    "${QPDF_BIN}" ${opts} "${plain}" "${doc}" >/dev/null 2>&1
+    LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${QPDF_BIN}" ${opts} "${plain}" "${doc}" >/dev/null 2>&1
 
     if [ ! -s "${doc}" ]; then
       record_skip "${hashType}" "qpdf could not write a ${label} document"
@@ -5822,7 +5876,7 @@ function ssh_test()
 
     rm -f "${key}" "${key}.pub"
 
-    "${SSHKEYGEN_BIN}" -q -m PEM -t "${keytype}" -N "${password}" -C hashcat -f "${key}" >/dev/null 2>&1
+    LC_ALL="${UTF8_LOCALE:-C}" LANG="${UTF8_LOCALE:-C}" "${SSHKEYGEN_BIN}" -q -m PEM -t "${keytype}" -N "${password}" -C hashcat -f "${key}" >/dev/null 2>&1
 
     if [ ! -s "${key}" ]; then
       record_skip "${hashType}" "ssh-keygen would not write a PEM ${keytype} key"

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -111,6 +111,7 @@ LUKS_MODES="${LUKS1_MODES} ${LUKS2_MODES}"
 TC_TESTS_DIR="${TDIR}/tc_tests"
 VC_TESTS_DIR="${TDIR}/vc_tests"
 LUKS_TESTS_DIR="${TDIR}/luks_tests"
+LUKS2_TESTS_DIR="${TDIR}/luks2_tests"
 
 # The password every generated container is built with, and the one the shipped containers
 # already use. With -g the containers are built by this run, so the password is picked at
@@ -418,7 +419,7 @@ function init()
 
   #LUKS2
   if is_in_array "$hash_type" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 0 ]]; then
-    luks2_tests_folder="${TDIR}/luks2_tests/"
+    luks2_tests_folder="${LUKS2_TESTS_DIR}/"
 
     if [ ! -d "${luks2_tests_folder}" ]; then
       mkdir -p "${luks2_tests_folder}"
@@ -3968,6 +3969,110 @@ function luks1_generate()
   return 0
 }
 
+function luks2_generate()
+{
+  # $1 = cipher mode, $2 = key size, $3 = target file
+  local l2_mode="$1"
+  local l2_keysize="$2"
+  local l2_file="$3"
+
+  local CRYPTSETUP_BIN="${CRYPTSETUP_BIN:-cryptsetup}"
+
+  if ! command -v "${CRYPTSETUP_BIN}" >/dev/null 2>&1; then
+    record_skip "${hash_type}" "cryptsetup not found, so no LUKS2 container can be generated"
+    return 1
+  fi
+
+  # cbc-essiv is written cbc-essiv:sha256 in a cryptsetup cipher spec
+  local l2_chain="${l2_mode}"
+
+  if [ "${l2_mode}" = "cbc-essiv" ]; then
+    l2_chain="cbc-essiv:sha256"
+  fi
+
+  local l2_name="luks2gen$$_${l2_keysize}"
+
+  rm -f "${l2_file}"
+
+  # LUKS2 keeps a 16 MiB metadata area of its own, so the file has to be larger
+  # than the 20 MiB a LUKS1 container gets or there is no room for a filesystem
+  truncate -s 48M "${l2_file}" 2>/dev/null
+
+  # t=4, m=16 MiB, p=1: the smallest argon2id the format is still itself at, and
+  # the same shape as the luks2-aes-argon2id-t4-m16-p1 container hashcat.net
+  # ships. The point is to test the format rather than to wait for a KDF.
+  if ! sudo "${CRYPTSETUP_BIN}" luksFormat \
+      --batch-mode \
+      --type luks2 \
+      --cipher "aes-${l2_chain}" \
+      --key-size "${l2_keysize}" \
+      --hash sha256 \
+      --pbkdf argon2id \
+      --pbkdf-force-iterations 4 \
+      --pbkdf-memory 16384 \
+      --pbkdf-parallel 1 \
+      "${l2_file}" <<< "${CONTAINER_PASSWORD}" >/dev/null 2>&1; then
+    rm -f "${l2_file}"
+
+    record_skip "${hash_type}" "cryptsetup refused aes-${l2_chain} at ${l2_keysize} bits for LUKS2"
+    return 1
+  fi
+
+  # hashcat recognizes a correct LUKS password by the filesystem it uncovers, so
+  # the payload has to be a filesystem and not just bytes
+  if ! sudo "${CRYPTSETUP_BIN}" open "${l2_file}" "${l2_name}" <<< "${CONTAINER_PASSWORD}" >/dev/null 2>&1; then
+    rm -f "${l2_file}"
+
+    record_skip "${hash_type}" "could not open the generated aes-${l2_chain} LUKS2 container (device-mapper needs sudo)"
+    return 1
+  fi
+
+  sudo mkfs.ext4 -q "/dev/mapper/${l2_name}" >/dev/null 2>&1
+
+  sudo "${CRYPTSETUP_BIN}" close "${l2_name}" >/dev/null 2>&1
+
+  if [ ! -s "${l2_file}" ]; then
+    record_skip "${hash_type}" "the generated aes-${l2_chain} LUKS2 container came out empty"
+    return 1
+  fi
+
+  # luks2_test reads the password out of a file named pw next to the containers,
+  # the same way the downloaded set ships one
+  echo "${CONTAINER_PASSWORD}" > "$(dirname "${l2_file}")/pw"
+
+  return 0
+}
+
+function luks2_generate_set()
+{
+  # The combinations mode 34100 accepts: aes only, and a key size the chain mode
+  # can carry. xts splits the key in two, so it needs twice the bits.
+  local l2_mode
+  local l2_keysize
+  local l2_file
+
+  for l2_mode in cbc-essiv cbc-plain64 xts-plain64; do
+    for l2_keysize in 128 256 512; do
+
+      case "${l2_mode}" in
+        cbc-essiv|cbc-plain64)
+          [ "${l2_keysize}" -eq 512 ] && continue
+          ;;
+        xts-plain64)
+          [ "${l2_keysize}" -eq 128 ] && continue
+          ;;
+      esac
+
+      l2_file="${LUKS2_TESTS_DIR}/luks2-aes-argon2id-t4-m16-p1-${l2_mode}-${l2_keysize}.img"
+
+      [ -f "${l2_file}" ] && continue
+
+      luks2_generate "${l2_mode}" "${l2_keysize}" "${l2_file}"
+
+    done
+  done
+}
+
 function truecrypt_test()
 {
   hashType=$1
@@ -4849,7 +4954,13 @@ function luks2_test()
 
   chmod u+x "${TDIR}/luks2hashcat.py"
 
-  for luks2File in $(ls ${TDIR}/luks2_tests | grep "img$"); do
+  mkdir -p "${LUKS2_TESTS_DIR}"
+
+  if [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
+    luks2_generate_set
+  fi
+
+  for luks2File in $(ls "${LUKS2_TESTS_DIR}" 2>/dev/null | grep "img$"); do
     luksMainMask="?l"
     luksMask="${luksMainMask}"
 
@@ -4857,14 +4968,14 @@ function luks2_test()
     luksPassPartFile1="${OUTD}/${hashType}_dict1"
     luksPassPartFile2="${OUTD}/${hashType}_dict2"
 
-    luksContainer="${TDIR}/luks2_tests/${luks2File}"
+    luksContainer="${LUKS2_TESTS_DIR}/${luks2File}"
 
     mkdir -p "${OUTD}/luks2_tests"
     luksHashFile="${OUTD}/luks2_tests/${luks2File}.hash"
 
     case $attackType in
       0)
-        CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luksHashFile}' '${TDIR}/luks2_tests/pw'"
+        CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luksHashFile}' '${LUKS2_TESTS_DIR}/pw'"
         ;;
       1)
         luksPassPart1Len=$((${#LUKS2_PASSWORD} / 2))
@@ -4904,7 +5015,7 @@ function luks2_test()
     if [ -n "${CMD}" ] && [ ${#CMD} -gt 5 ]; then
       echo "> Testing hash type ${hashType} with attack mode ${attackType}, markov ${MARKOV}, single hash, Device-Type ${DEVICE_TYPE}, Kernel-Type ${KERNEL_TYPE}, Vector-Width ${VECTOR}, LUKS2-mode ${luksMode}" >> "${OUTD}/logfull.txt" 2>> "${OUTD}/logfull.txt"
 
-      if [ -f "${luks2_first_test_file}" ]; then
+      if [ -f "${luksContainer}" ]; then
         output=$(eval ${CMD} 2>&1)
         ret=${?}
 
@@ -6390,6 +6501,7 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
       TC_TESTS_DIR="$(container_gen_dir tc_tests_gen)"
       VC_TESTS_DIR="$(container_gen_dir vc_tests_gen)"
       LUKS_TESTS_DIR="$(container_gen_dir luks_tests_gen)"
+      LUKS2_TESTS_DIR="$(container_gen_dir luks2_tests_gen)"
     fi
 
     # generate random test entry
@@ -6643,6 +6755,11 @@ if [ "${PACKAGE}" -eq 0 ] || [ -z "${PACKAGE_FOLDER}" ]; then
                 else
                   luks_test "${hash_type}" ${ATTACK}
                 fi
+              fi
+
+              if is_in_array "${hash_type}" ${LUKS2_MODES} && [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
+                # generate + test real LUKS2 containers
+                luks2_test "${hash_type}" ${ATTACK}
               fi
 
               if is_in_array "${hash_type}" ${PM_MODES}; then

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -3539,20 +3539,53 @@ function cryptoloop_test()
 # VERACRYPT_BIN, TCPLAY_BIN and CRYPTSETUP_BIN override the binaries if they
 # live somewhere else.
 
-function random_container_password()
+function container_password()
 {
-  # Seven lowercase letters, the shape 'hashcat' had. build_container_cmd() and CONTAINER_MASK
-  # both turn the last character into ?l, so the last character has to be a lowercase letter,
-  # and the length is what the -a 6 and -a 7 splits in build_container_cmd() are written for.
-  local rp_chars="abcdefghijklmnopqrstuvwxyz"
-  local rp_out=""
-  local rp_i
+  # The password every -g container is built with, from tools/test.pl, which is the same
+  # generator the oracle passwords come from. So a container carries a euro sign, kana or a CJK
+  # character too, and cracking one proves the whole path end to end against a real volume
+  # rather than against a hash test.pl computed itself.
+  #
+  # Mode 0 is asked for it rather than the mode under test, because one -g run covers many
+  # modes and builds its containers with one password. 0 pins no charset and does no UTF-16, so
+  # the generator is free to substitute. Twelve bytes because a multi byte character needs room,
+  # and seven, the length of 'hashcat', does not leave any.
 
-  for rp_i in $(seq 1 7); do
-    rp_out="${rp_out}${rp_chars:$((RANDOM % 26)):1}"
-  done
+  perl "${TDIR}/test.pl" password 0 12 2>/dev/null
+}
 
-  printf '%s' "${rp_out}"
+function container_mask_from_password()
+{
+  # The mask the container tests search: the password with one digit replaced by ?d, so the run
+  # has ten candidates to walk rather than being handed the answer. Every other byte goes in as
+  # a literal, which is what lets a multi byte character sit anywhere in the password.
+  #
+  # $1 = the password, $2 = 'last' or 'first', which digit to give up. The TrueCrypt and LUKS
+  # tests want it near the end and the VeraCrypt tests want it near the start, which is what
+  # 'hashca?l' and 'hashc?lt' used to say.
+
+  local cm_pw="$1"
+  local cm_where="${2:-last}"
+  local cm_len=${#cm_pw}
+  local cm_i
+
+  if [ "${cm_where}" = "first" ]; then
+    for ((cm_i = 0; cm_i < cm_len; cm_i++)); do
+      case "${cm_pw:${cm_i}:1}" in
+        [0-9]) printf '%s?d%s' "${cm_pw:0:${cm_i}}" "${cm_pw:$((cm_i + 1))}"; return ;;
+      esac
+    done
+  else
+    for ((cm_i = cm_len - 1; cm_i >= 0; cm_i--)); do
+      case "${cm_pw:${cm_i}:1}" in
+        [0-9]) printf '%s?d%s' "${cm_pw:0:${cm_i}}" "${cm_pw:$((cm_i + 1))}"; return ;;
+      esac
+    done
+  fi
+
+  # no digit at all, so nothing to search: hand back the password and let the run confirm it
+
+  printf '%s' "${cm_pw}"
 }
 
 function utf8_split_point()
@@ -4703,31 +4736,34 @@ function luks_test()
           CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luksHashFile}' '${LUKS_TESTS_DIR}/pw'"
           ;;
         1)
-          luksPassPart1Len=$((${#CONTAINER_PASSWORD} / 2))
-          luksPassPart2Start=$((luksPassPart1Len + 1))
+          luksSplit=$(utf8_split_point "${CONTAINER_PASSWORD}" $((${#CONTAINER_PASSWORD} / 2)))
 
-          echo "${CONTAINER_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
-          echo "${CONTAINER_PASSWORD}" | cut -c${luksPassPart2Start}- > "${luksPassPartFile2}" 2>/dev/null
+          printf '%s\n' "${CONTAINER_PASSWORD:0:${luksSplit}}" > "${luksPassPartFile1}" 2>/dev/null
+          printf '%s\n' "${CONTAINER_PASSWORD:${luksSplit}}"   > "${luksPassPartFile2}" 2>/dev/null
 
           CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksPassPartFile2}"
           ;;
         3)
-          luksMaskFixedLen=$((${#CONTAINER_PASSWORD} - 1))
-
-          luksMask="$(echo "${CONTAINER_PASSWORD}" | cut -c-${luksMaskFixedLen} 2>/dev/null)"
-          luksMask="${luksMask}${luksMainMask}"
+          luksMask="$(container_mask_from_password "${CONTAINER_PASSWORD}" last)"
 
           CMD="./${BIN} ${OPTS} -a 3 -m ${hashType} '${luksHashFile}' ${luksMask}"
           ;;
         6)
-          luksPassPart1Len=$((${#CONTAINER_PASSWORD} - 1))
+          luksSplit=$(utf8_split_point "${CONTAINER_PASSWORD}" $((${#CONTAINER_PASSWORD} - 1)))
 
-          echo "${CONTAINER_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
+          printf '%s\n' "${CONTAINER_PASSWORD:0:${luksSplit}}" > "${luksPassPartFile1}" 2>/dev/null
+
+          luksMask="$(container_mask_from_password "${CONTAINER_PASSWORD:${luksSplit}}" last)"
 
           CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksMask}"
           ;;
         7)
-          echo "${CONTAINER_PASSWORD}" | cut -c2- > "${luksPassPartFile1}" 2>/dev/null
+          luksSplit=$(utf8_split_point "${CONTAINER_PASSWORD}" 1)
+          luksSplit=$((luksSplit > 0 ? luksSplit : 1))
+
+          printf '%s\n' "${CONTAINER_PASSWORD:${luksSplit}}" > "${luksPassPartFile1}" 2>/dev/null
+
+          luksMask="$(container_mask_from_password "${CONTAINER_PASSWORD:0:${luksSplit}}" first)"
 
           CMD="./${BIN} ${OPTS} -a 7 -m ${hashType} '${luksHashFile}' ${luksMask} ${luksPassPartFile1}"
           ;;
@@ -4861,31 +4897,34 @@ function luks_legacy_test()
               CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luks_file}' '${LUKS_TESTS_DIR}/pw'"
               ;;
             1)
-              luks_pass_part1_len=$((${#CONTAINER_PASSWORD} / 2))
-              luks_pass_part2_start=$((luks_pass_part1_len + 1))
+              luks_split=$(utf8_split_point "${CONTAINER_PASSWORD}" $((${#CONTAINER_PASSWORD} / 2)))
 
-              echo "${CONTAINER_PASSWORD}" | cut -c-${luks_pass_part1_len} > "${luks_pass_part_file1}" 2>/dev/null
-              echo "${CONTAINER_PASSWORD}" | cut -c${luks_pass_part2_start}- > "${luks_pass_part_file2}" 2>/dev/null
+              printf '%s\n' "${CONTAINER_PASSWORD:0:${luks_split}}" > "${luks_pass_part_file1}" 2>/dev/null
+              printf '%s\n' "${CONTAINER_PASSWORD:${luks_split}}"   > "${luks_pass_part_file2}" 2>/dev/null
 
               CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luks_file}' ${luks_pass_part_file1} ${luks_pass_part_file2}"
               ;;
             3)
-              luks_mask_fixed_len=$((${#CONTAINER_PASSWORD} - 1))
-
-              luks_mask="$(echo "${CONTAINER_PASSWORD}" | cut -c-${luks_mask_fixed_len} 2>/dev/null)"
-              luks_mask="${luks_mask}${luks_main_mask}"
+              luks_mask="$(container_mask_from_password "${CONTAINER_PASSWORD}" last)"
 
               CMD="./${BIN} ${OPTS} -a 3 -m ${hashType} '${luks_file}' ${luks_mask}"
               ;;
             6)
-              luks_pass_part1_len=$((${#CONTAINER_PASSWORD} - 1))
+              luks_split=$(utf8_split_point "${CONTAINER_PASSWORD}" $((${#CONTAINER_PASSWORD} - 1)))
 
-              echo "${CONTAINER_PASSWORD}" | cut -c-${luks_pass_part1_len} > "${luks_pass_part_file1}" 2>/dev/null
+              printf '%s\n' "${CONTAINER_PASSWORD:0:${luks_split}}" > "${luks_pass_part_file1}" 2>/dev/null
+
+              luks_mask="$(container_mask_from_password "${CONTAINER_PASSWORD:${luks_split}}" last)"
 
               CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luks_file}' ${luks_pass_part_file1} ${luks_mask}"
               ;;
             7)
-              echo "${CONTAINER_PASSWORD}" | cut -c2- > "${luks_pass_part_file1}" 2>/dev/null
+              luks_split=$(utf8_split_point "${CONTAINER_PASSWORD}" 1)
+          luks_split=$((luks_split > 0 ? luks_split : 1))
+
+          printf '%s\n' "${CONTAINER_PASSWORD:${luks_split}}" > "${luks_pass_part_file1}" 2>/dev/null
+
+          luks_mask="$(container_mask_from_password "${CONTAINER_PASSWORD:0:${luks_split}}" first)"
 
               CMD="./${BIN} ${OPTS} -a 7 -m ${hashType} '${luks_file}' ${luks_mask} ${luks_pass_part_file1}"
               ;;
@@ -4978,31 +5017,34 @@ function luks2_test()
         CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luksHashFile}' '${LUKS2_TESTS_DIR}/pw'"
         ;;
       1)
-        luksPassPart1Len=$((${#LUKS2_PASSWORD} / 2))
-        luksPassPart2Start=$((luksPassPart1Len + 1))
+        luksSplit=$(utf8_split_point "${LUKS2_PASSWORD}" $((${#LUKS2_PASSWORD} / 2)))
 
-        echo "${LUKS2_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
-        echo "${LUKS2_PASSWORD}" | cut -c${luksPassPart2Start}- > "${luksPassPartFile2}" 2>/dev/null
+        printf '%s\n' "${LUKS2_PASSWORD:0:${luksSplit}}" > "${luksPassPartFile1}" 2>/dev/null
+        printf '%s\n' "${LUKS2_PASSWORD:${luksSplit}}"   > "${luksPassPartFile2}" 2>/dev/null
 
         CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksPassPartFile2}"
         ;;
       3)
-        luksMaskFixedLen=$((${#LUKS2_PASSWORD} - 1))
-
-        luksMask="$(echo "${LUKS2_PASSWORD}" | cut -c-${luksMaskFixedLen} 2>/dev/null)"
-        luksMask="${luksMask}${luksMainMask}"
+        luksMask="$(container_mask_from_password "${LUKS2_PASSWORD}" last)"
 
         CMD="./${BIN} ${OPTS} -a 3 -m ${hashType} '${luksHashFile}' ${luksMask}"
         ;;
       6)
-        luksPassPart1Len=$((${#LUKS2_PASSWORD} - 1))
+        luksSplit=$(utf8_split_point "${LUKS2_PASSWORD}" $((${#LUKS2_PASSWORD} - 1)))
 
-        echo "${LUKS2_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
+        printf '%s\n' "${LUKS2_PASSWORD:0:${luksSplit}}" > "${luksPassPartFile1}" 2>/dev/null
+
+        luksMask="$(container_mask_from_password "${LUKS2_PASSWORD:${luksSplit}}" last)"
 
         CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksMask}"
         ;;
       7)
-        echo "${LUKS2_PASSWORD}" | cut -c2- > "${luksPassPartFile1}" 2>/dev/null
+        luksSplit=$(utf8_split_point "${LUKS2_PASSWORD}" 1)
+        luksSplit=$((luksSplit > 0 ? luksSplit : 1))
+
+        printf '%s\n' "${LUKS2_PASSWORD:${luksSplit}}" > "${luksPassPartFile1}" 2>/dev/null
+
+        luksMask="$(container_mask_from_password "${LUKS2_PASSWORD:0:${luksSplit}}" first)"
 
         CMD="./${BIN} ${OPTS} -a 7 -m ${hashType} '${luksHashFile}' ${luksMask} ${luksPassPartFile1}"
         ;;
@@ -5169,8 +5211,17 @@ function build_container_cmd()
 
   local dictFile1="${OUTD}/${bc_hashType}_cont_dict1"
   local dictFile2="${OUTD}/${bc_hashType}_cont_dict2"
-  local mainMask="?l"
-  local mask="${mainMask}"
+
+  # The password can carry a multi byte character now, so a split has to land on a character
+  # boundary, see utf8_split_point(), and a mask position over a byte that is not a digit has
+  # to spell that byte rather than hold a '?d'. The masks below give up exactly one digit, so
+  # every attack still has ten candidates to search.
+
+  local bc_len=${#bc_password}
+  local mask
+  local head
+  local tail
+  local split
 
   CONTAINER_CMD=""
 
@@ -5180,31 +5231,41 @@ function build_container_cmd()
       CONTAINER_CMD="./${BIN} ${OPTS} -a 0 -m ${bc_hashType} '${bc_hashFile}' ${dictFile1}"
       ;;
     1)
-      local part1Len=$((${#bc_password} / 2))
-      local part2Start=$((part1Len + 1))
+      split=$(utf8_split_point "${bc_password}" $((bc_len / 2)))
 
-      echo "${bc_password}" | cut -c-${part1Len}    > "${dictFile1}" 2>/dev/null
-      echo "${bc_password}" | cut -c${part2Start}-  > "${dictFile2}" 2>/dev/null
+      printf '%s\n' "${bc_password:0:${split}}" > "${dictFile1}" 2>/dev/null
+      printf '%s\n' "${bc_password:${split}}"   > "${dictFile2}" 2>/dev/null
 
       CONTAINER_CMD="./${BIN} ${OPTS} -a 1 -m ${bc_hashType} '${bc_hashFile}' ${dictFile1} ${dictFile2}"
       ;;
     3)
-      local maskFixedLen=$((${#bc_password} - 1))
-
-      mask="$(echo "${bc_password}" | cut -c-${maskFixedLen} 2>/dev/null)"
-      mask="${mask}${mainMask}"
+      mask="$(container_mask_from_password "${bc_password}" last)"
 
       CONTAINER_CMD="./${BIN} ${OPTS} -a 3 -m ${bc_hashType} '${bc_hashFile}' ${mask}"
       ;;
     6)
-      local part1Len=$((${#bc_password} - 1))
+      # dict + mask, so the mask has to cover a tail that starts on a character boundary and
+      # holds at least one digit to give up
 
-      echo "${bc_password}" | cut -c-${part1Len} > "${dictFile1}" 2>/dev/null
+      split=$(utf8_split_point "${bc_password}" $((bc_len - 1)))
+      head="${bc_password:0:${split}}"
+      tail="${bc_password:${split}}"
+      mask="$(container_mask_from_password "${tail}" last)"
+
+      printf '%s\n' "${head}" > "${dictFile1}" 2>/dev/null
 
       CONTAINER_CMD="./${BIN} ${OPTS} -a 6 -m ${bc_hashType} '${bc_hashFile}' ${dictFile1} ${mask}"
       ;;
     7)
-      echo "${bc_password}" | cut -c2- > "${dictFile1}" 2>/dev/null
+      # mask + dict, the mirror image of -a 6
+
+      split=$(utf8_split_point "${bc_password}" 1)
+      split=$((split > 0 ? split : 1))
+      head="${bc_password:0:${split}}"
+      tail="${bc_password:${split}}"
+      mask="$(container_mask_from_password "${head}" first)"
+
+      printf '%s\n' "${tail}" > "${dictFile1}" 2>/dev/null
 
       CONTAINER_CMD="./${BIN} ${OPTS} -a 7 -m ${bc_hashType} '${bc_hashFile}' ${mask} ${dictFile1}"
       ;;
@@ -6277,9 +6338,9 @@ fi
 # fetched from hashcat.net were built with 'hashcat' and keep it.
 
 if [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
-  CONTAINER_PASSWORD="$(random_container_password)"
-  CONTAINER_MASK="${CONTAINER_PASSWORD:0:$((${#CONTAINER_PASSWORD} - 1))}?l"
-  CONTAINER_MASK_MID="${CONTAINER_PASSWORD:0:5}?l${CONTAINER_PASSWORD:6}"
+  CONTAINER_PASSWORD="$(container_password)"
+  CONTAINER_MASK="$(container_mask_from_password "${CONTAINER_PASSWORD}" last)"
+  CONTAINER_MASK_MID="$(container_mask_from_password "${CONTAINER_PASSWORD}" first)"
 fi
 
 # handle Apple Silicon

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -119,6 +119,8 @@ LUKS_TESTS_DIR="${TDIR}/luks_tests"
 # character replaced by ?l, which is what gives the mask attacks a keyspace to search.
 CONTAINER_PASSWORD="hashcat"
 CONTAINER_MASK="hashca?l"
+# The VeraCrypt tests put the ?l in the middle instead of at the end.
+CONTAINER_MASK_MID="hashc?lt"
 
 # Cryptoloop mode which have test containers
 CL_MODES="14511 14512 14513 14521 14522 14523 14531 14532 14533 14541 14542 14543 14551 14552 14553"
@@ -4421,7 +4423,7 @@ function veracrypt_test()
 
   case "${hash_type:0:3}" in
     137)
-      CMD="./${BIN} ${OPTS} -a 3 -m ${hash_type} '${filename}' hashc?lt"
+      CMD="./${BIN} ${OPTS} -a 3 -m ${hash_type} '${filename}' ${CONTAINER_MASK_MID}"
       ;;
 
     294)
@@ -4429,7 +4431,7 @@ function veracrypt_test()
       chmod u+x "${TDIR}/veracrypt2hashcat.py"
 
       eval \"${TDIR}/veracrypt2hashcat.py\" \"${VC_TESTS_DIR}/hashcat_${hash_function}_${cipher_cascade}.vc\" > ${OUTD}/vc_tests/hashcat_${hash_function}_${cipher_cascade}.hash
-      CMD="./${BIN} ${OPTS} -a 3 -m ${hash_type} '${OUTD}/vc_tests/hashcat_${hash_function}_${cipher_cascade}.hash' hashc?lt"
+      CMD="./${BIN} ${OPTS} -a 3 -m ${hash_type} '${OUTD}/vc_tests/hashcat_${hash_function}_${cipher_cascade}.hash' ${CONTAINER_MASK_MID}"
       ;;
   esac
 
@@ -4596,31 +4598,31 @@ function luks_test()
           CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luksHashFile}' '${LUKS_TESTS_DIR}/pw'"
           ;;
         1)
-          luksPassPart1Len=$((${#LUKS_PASSWORD} / 2))
+          luksPassPart1Len=$((${#CONTAINER_PASSWORD} / 2))
           luksPassPart2Start=$((luksPassPart1Len + 1))
 
-          echo "${LUKS_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
-          echo "${LUKS_PASSWORD}" | cut -c${luksPassPart2Start}- > "${luksPassPartFile2}" 2>/dev/null
+          echo "${CONTAINER_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
+          echo "${CONTAINER_PASSWORD}" | cut -c${luksPassPart2Start}- > "${luksPassPartFile2}" 2>/dev/null
 
           CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksPassPartFile2}"
           ;;
         3)
-          luksMaskFixedLen=$((${#LUKS_PASSWORD} - 1))
+          luksMaskFixedLen=$((${#CONTAINER_PASSWORD} - 1))
 
-          luksMask="$(echo "${LUKS_PASSWORD}" | cut -c-${luksMaskFixedLen} 2>/dev/null)"
+          luksMask="$(echo "${CONTAINER_PASSWORD}" | cut -c-${luksMaskFixedLen} 2>/dev/null)"
           luksMask="${luksMask}${luksMainMask}"
 
           CMD="./${BIN} ${OPTS} -a 3 -m ${hashType} '${luksHashFile}' ${luksMask}"
           ;;
         6)
-          luksPassPart1Len=$((${#LUKS_PASSWORD} - 1))
+          luksPassPart1Len=$((${#CONTAINER_PASSWORD} - 1))
 
-          echo "${LUKS_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
+          echo "${CONTAINER_PASSWORD}" | cut -c-${luksPassPart1Len} > "${luksPassPartFile1}" 2>/dev/null
 
           CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luksHashFile}' ${luksPassPartFile1} ${luksMask}"
           ;;
         7)
-          echo "${LUKS_PASSWORD}" | cut -c2- > "${luksPassPartFile1}" 2>/dev/null
+          echo "${CONTAINER_PASSWORD}" | cut -c2- > "${luksPassPartFile1}" 2>/dev/null
 
           CMD="./${BIN} ${OPTS} -a 7 -m ${hashType} '${luksHashFile}' ${luksMask} ${luksPassPartFile1}"
           ;;
@@ -4700,7 +4702,6 @@ function luks_legacy_test()
   LUKS_CIPHER_MODES="cbc-essiv cbc-plain64 xts-plain64"
   LUKS_KEYSIZES="128 256 512"
 
-  LUKS_PASSWORD=$(cat "${LUKS_TESTS_DIR}/pw" 2>/dev/null)
 
   for luks_h in ${LUKS_HASHES}; do
     for luks_c in ${LUKS_CIPHERS}; do
@@ -4755,31 +4756,31 @@ function luks_legacy_test()
               CMD="./${BIN} ${OPTS} -a 0 -m ${hashType} '${luks_file}' '${LUKS_TESTS_DIR}/pw'"
               ;;
             1)
-              luks_pass_part1_len=$((${#LUKS_PASSWORD} / 2))
+              luks_pass_part1_len=$((${#CONTAINER_PASSWORD} / 2))
               luks_pass_part2_start=$((luks_pass_part1_len + 1))
 
-              echo "${LUKS_PASSWORD}" | cut -c-${luks_pass_part1_len} > "${luks_pass_part_file1}" 2>/dev/null
-              echo "${LUKS_PASSWORD}" | cut -c${luks_pass_part2_start}- > "${luks_pass_part_file2}" 2>/dev/null
+              echo "${CONTAINER_PASSWORD}" | cut -c-${luks_pass_part1_len} > "${luks_pass_part_file1}" 2>/dev/null
+              echo "${CONTAINER_PASSWORD}" | cut -c${luks_pass_part2_start}- > "${luks_pass_part_file2}" 2>/dev/null
 
               CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luks_file}' ${luks_pass_part_file1} ${luks_pass_part_file2}"
               ;;
             3)
-              luks_mask_fixed_len=$((${#LUKS_PASSWORD} - 1))
+              luks_mask_fixed_len=$((${#CONTAINER_PASSWORD} - 1))
 
-              luks_mask="$(echo "${LUKS_PASSWORD}" | cut -c-${luks_mask_fixed_len} 2>/dev/null)"
+              luks_mask="$(echo "${CONTAINER_PASSWORD}" | cut -c-${luks_mask_fixed_len} 2>/dev/null)"
               luks_mask="${luks_mask}${luks_main_mask}"
 
               CMD="./${BIN} ${OPTS} -a 3 -m ${hashType} '${luks_file}' ${luks_mask}"
               ;;
             6)
-              luks_pass_part1_len=$((${#LUKS_PASSWORD} - 1))
+              luks_pass_part1_len=$((${#CONTAINER_PASSWORD} - 1))
 
-              echo "${LUKS_PASSWORD}" | cut -c-${luks_pass_part1_len} > "${luks_pass_part_file1}" 2>/dev/null
+              echo "${CONTAINER_PASSWORD}" | cut -c-${luks_pass_part1_len} > "${luks_pass_part_file1}" 2>/dev/null
 
               CMD="./${BIN} ${OPTS} -a 6 -m ${hashType} '${luks_file}' ${luks_pass_part_file1} ${luks_mask}"
               ;;
             7)
-              echo "${LUKS_PASSWORD}" | cut -c2- > "${luks_pass_part_file1}" 2>/dev/null
+              echo "${CONTAINER_PASSWORD}" | cut -c2- > "${luks_pass_part_file1}" 2>/dev/null
 
               CMD="./${BIN} ${OPTS} -a 7 -m ${hashType} '${luks_file}' ${luks_mask} ${luks_pass_part_file1}"
               ;;
@@ -4834,7 +4835,7 @@ function luks_legacy_test()
 
 function luks2_test()
 {
-  local LUKS2_PASSWORD=$(cat "${TDIR}/luks2_tests/pw" 2>/dev/null)
+  local LUKS2_PASSWORD="${CONTAINER_PASSWORD}"
 
   hashType=$1
   attackType=$2
@@ -6167,6 +6168,7 @@ fi
 if [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
   CONTAINER_PASSWORD="$(random_container_password)"
   CONTAINER_MASK="${CONTAINER_PASSWORD:0:$((${#CONTAINER_PASSWORD} - 1))}?l"
+  CONTAINER_MASK_MID="${CONTAINER_PASSWORD:0:5}?l${CONTAINER_PASSWORD:6}"
 fi
 
 # handle Apple Silicon

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -6299,6 +6299,12 @@ fi
 
 export IS_OPTIMIZED=${OPTIMIZED}
 
+# The LUKS oracles in tools/test_modules build a 20 MiB container to get a hash out of
+# it. Left to themselves they put it, its mount point and their log in /tmp, and never
+# clean up, so a full run leaves gigabytes behind. Point them at this run instead.
+export HCTEST_SCRATCH_DIR="${OUTD}/luks_scratch"
+export HCTEST_MOUNT_DIR="${OUTD}/luks_mnt"
+
 if [ "${OPTIMIZED}" -eq 1 ]; then
   OPTS="${OPTS} -O"
 fi

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -3642,7 +3642,17 @@ function container_password()
   # the generator is free to substitute. Twelve bytes because a multi byte character needs room,
   # and seven, the length of 'hashcat', does not leave any.
 
-  perl "${TDIR}/test.pl" password 0 12 2>/dev/null
+  # A container is a real artifact, so it carries whatever encoding the application wrote and
+  # the optimized path cannot match a multi byte one. A genuine 7-Zip archive built with a euro
+  # sign in its password cracks under -P and is not found under -O, which is the documented
+  # limitation rather than a bug in the test. An -O run therefore builds its containers out of
+  # ASCII; the oracle passwords still carry the characters, through $PW_CHARSET.
+
+  if [[ "${OPTIMIZED}" -eq 1 ]]; then
+    NO_NON_ASCII=1 perl "${TDIR}/test.pl" password 0 12 2>/dev/null
+  else
+    perl "${TDIR}/test.pl" password 0 12 2>/dev/null
+  fi
 }
 
 function container_mask_from_password()

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -679,6 +679,11 @@ function init()
 
       while read -r -u 9 pass; do
 
+        # both halves have to be valid UTF-8 on their own, see utf8_split_point()
+
+        p0=$(utf8_split_point "${pass}" ${p0})
+        p1=$((p0 + 1))
+
         # add splitted password to dicts
         echo "${pass}" | cut -c -${p0} >> "${OUTD}/${hash_type}_dict1_multi_${i}"
         echo "${pass}" | cut -c ${p1}- >> "${OUTD}/${hash_type}_dict2_multi_${i}"
@@ -1716,11 +1721,25 @@ function attack_3()
       need_hcmask=1
     fi
 
+    # This is one run with --increment over passwords of many lengths at once, and a password
+    # can carry a multi byte character wherever tools/test.pl put it, so no single '?d' mask
+    # spells all of them. The hcmask path below already gives hashcat one mask per line, which
+    # is exactly one mask per password, so take it whenever a character is in play and write a
+    # mask per password rather than searching a mask per length.
+
+    if grep -qP '[^\x00-\x7F]' "${OUTD}/${hash_type}_passwords.txt" 2>/dev/null; then
+      need_hcmask=2
+    fi
+
     if [ "${tail_hashes}" -lt 1 ]; then
       need_hcmask=1
     fi
 
-    if [ ${need_hcmask} -eq 0 ]; then
+    if [ ${need_hcmask} -eq 2 ]; then
+      tail_hashes=$(wc -l < "${OUTD}/${hash_type}_passwords.txt")
+
+      cp "${OUTD}/${hash_type}_hashes.txt" "${hash_file}"
+    elif [ ${need_hcmask} -eq 0 ]; then
       head -n "${head_hashes}" "${OUTD}/${hash_type}_hashes.txt" | tail -n "${tail_hashes}" > "${hash_file}"
     else
       tail_hashes=$(awk "length >= ${increment_min}" "${OUTD}/${hash_type}_passwords.txt" | wc -l)
@@ -1741,7 +1760,17 @@ function attack_3()
     mask=""
     cracks_offset=0
 
-    if [ ${need_hcmask} -eq 0 ]; then
+    if [ ${need_hcmask} -eq 2 ]; then
+      cracks_offset=0
+
+      mask="${OUTD}/${hash_type}_multi_a3.hcmask"
+
+      : > "${mask}"
+
+      while IFS= read -r a3_pass; do
+        printf '%s\n' "$(mask_literalize "$(mask_dots ${#a3_pass})" "${a3_pass}")" >> "${mask}"
+      done < "${OUTD}/${hash_type}_passwords.txt"
+    elif [ ${need_hcmask} -eq 0 ]; then
       cracks_offset=$((head_hashes - tail_hashes))
 
       mask=${mask_3[${mask_pos}]}
@@ -2384,7 +2413,15 @@ function attack_6()
 
       fi
 
-      mask=${mask_6[$i]}
+      # The eight passwords of a length share this mask, which is why tools/test.pl gives them
+      # their characters in the same places: the layout is seeded from the length. A '?d' over
+      # one of those bytes cannot produce it, so the mask spells it instead. Any of the eight
+      # will do as the model.
+
+      multi_model="$(head -1 "${OUTD}/${hash_type}_passwords_multi_${i}.txt" 2>/dev/null)"
+      multi_head="$(head -1 "${OUTD}/${hash_type}_dict1_multi_${i}" 2>/dev/null)"
+      multi_tail="${multi_model:${#multi_head}}"
+      mask="$(mask_literalize "$(mask_dots ${#multi_tail})" "${multi_tail}")"
 
       CMD="./${BIN} ${OPTS} -a 6 -m ${hash_type} ${hash_file} ${OUTD}/${hash_type}_dict1_multi_${i} ${mask}"
 
@@ -2550,7 +2587,15 @@ function attack_7()
 
         fi
 
-        mask=${mask_7[$i]}
+        # The eight passwords of a length share this mask, which is why tools/test.pl gives them
+        # their characters in the same places: the layout is seeded from the length. A '?d' over
+        # one of those bytes cannot produce it, so the mask spells it instead. Any of the eight
+        # will do as the model.
+
+        multi_model="$(head -1 "${OUTD}/${hash_type}_passwords_multi_${i}.txt" 2>/dev/null)"
+        multi_head="$(head -1 "${OUTD}/${hash_type}_dict1_multi_${i}" 2>/dev/null)"
+        multi_tail="${multi_model:${#multi_head}}"
+        mask="$(mask_literalize "$(mask_dots ${#multi_head})" "${multi_head}")"
 
         # adjust mask if needed
 
@@ -2810,12 +2855,20 @@ function attack_7()
       hash_file=${OUTD}/${hash_type}_hashes_multi_${i}.txt
       dict_file=${OUTD}/${hash_type}_dict2_multi_${i}
 
+      # The eight passwords of a length share this mask, which is why tools/test.pl gives them
+      # their characters in the same places. It has to spell the half that dict2 does not hold,
+      # and the split moved to a character boundary, so it comes from what dict1 holds rather
+      # than from mask_7[], which was sized for a split on a byte.
+
+      multi_model="$(head -1 "${OUTD}/${hash_type}_passwords_multi_${i}.txt" 2>/dev/null)"
+      multi_head="$(head -1 "${OUTD}/${hash_type}_dict1_multi_${i}" 2>/dev/null)"
+
       if [ "${hash_type}" -eq 40001 ]; then
         mask=${mask_7[((i+10))]}
       elif [ "${hash_type}" -eq 40002 ]; then
         mask=${mask_7[((i+10))]}
       else
-        mask=${mask_7[$i]}
+        mask="$(mask_literalize "$(mask_dots ${#multi_head})" "${multi_head}")"
       fi
 
       # if file_only -> decode all base64 "hashes" and put them in the temporary file
@@ -3268,14 +3321,18 @@ function attack_12()
       # of the mask with the first half and behind it with the second. That is what -a 6 and -a 7 do
       # from the same files, and here one attack mode does both.
 
+      multi_model="$(head -1 "${OUTD}/${hash_type}_passwords_multi_${i}.txt" 2>/dev/null)"
+      multi_head="$(head -1 "${OUTD}/${hash_type}_dict1_multi_${i}" 2>/dev/null)"
+      multi_tail="${multi_model:${#multi_head}}"
+
       for shape in first last; do
 
         if [ "${shape}" = "first" ]; then
           dict=${OUTD}/${hash_type}_dict1_multi_${i}
-          mask="?w${mask_6[$i]}"
+          mask="?w$(mask_literalize "$(mask_dots ${#multi_tail})" "${multi_tail}")"
         else
           dict=${OUTD}/${hash_type}_dict2_multi_${i}
-          mask="${mask_7[$i]}?w"
+          mask="$(mask_literalize "$(mask_dots ${#multi_head})" "${multi_head}")?w"
         fi
 
         CMD="./${BIN} ${OPTS} -a 12 -m ${hash_type} ${hash_file} ${mask} ${dict}"
@@ -3664,6 +3721,27 @@ function utf8_split_point()
   fi
 
   printf '%s' "${up_back}"
+}
+
+function mask_positions()
+{
+  # How many password bytes a mask covers. A '?x' group is one, any other character is one.
+
+  local mp_mask="$1"
+  local mp_i=0
+  local mp_n=0
+
+  while [ ${mp_i} -lt ${#mp_mask} ]; do
+    if [ "${mp_mask:${mp_i}:1}" = "?" ]; then
+      mp_i=$((mp_i + 2))
+    else
+      mp_i=$((mp_i + 1))
+    fi
+
+    mp_n=$((mp_n + 1))
+  done
+
+  printf '%s' "${mp_n}"
 }
 
 function mask_dots()

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -7,6 +7,12 @@
 
 OPTS="--quiet --potfile-disable --logfile-disable"
 
+# The generated passwords can carry multi byte UTF-8, and hashcat counts a password in bytes.
+# In the C locale so does bash: ${#pass} is a byte count, ${pass:n:1} is one byte and cut -c
+# is cut -b. Under a UTF-8 locale those would count characters instead and the lengths the
+# suite computes would stop matching the lengths the kernels see.
+export LC_ALL=C
+
 FORCE=0
 RUNTIME=400
 
@@ -538,6 +544,11 @@ function init()
           p1=${pass_len}
           p0=$((p1 - 1))
         fi
+
+        # both halves have to be valid UTF-8 on their own, see utf8_split_point()
+
+        p0=$(utf8_split_point "${pass}" ${p0})
+        p1=$((p0 + 1))
 
         # add splitted password to dicts
         echo "${pass}" | cut -c -${p0} >> "${OUTD}/${hash_type}_dict1"
@@ -1495,7 +1506,9 @@ function attack_3()
           mask="${mask}?d"
         done
 
-        mask="${mask}${pass_part_2}"
+        # the mask covers the first ${i} bytes, the rest of the password follows it literally
+
+        mask="$(mask_literalize "${mask}" "${pass:0:${i}}")${pass_part_2}"
       fi
 
       if [ "${hash_type}" -eq 20510 ]; then # special case for PKZIP Master Key
@@ -2131,7 +2144,12 @@ function attack_6()
           continue
         fi
 
-        echo "${pass}" | cut -b -$((${#pass} - i)) >> "${dict1_a6}"
+        # the mask covers the last ${i} bytes, or a little more when that offset falls inside a
+        # multi byte character, see utf8_split_point()
+
+        a6_split=$(utf8_split_point "${pass}" $((${#pass} - i)))
+
+        printf '%s\n' "${pass:0:${a6_split}}" >> "${dict1_a6}"
 
         # the block below is just a fancy way to do a "shuf" (or sort -R) because macOS doesn't really support it natively
         # we do not really need a shuf, but it's actually better for testing purposes
@@ -2165,9 +2183,11 @@ function attack_6()
 
         mask=""
 
-        for j in $(seq 1 ${i}); do
+        for j in $(seq 1 $((${#pass} - a6_split))); do
           mask="${mask}?d"
         done
+
+        mask="$(mask_literalize "${mask}" "${pass:${a6_split}}")"
 
         CMD="./${BIN} ${OPTS} -a 6 -m ${hash_type} '${hash}' ${dict1_a6} ${mask}"
 
@@ -2603,6 +2623,11 @@ function attack_7()
           dict2=${OUTD}/${hash_type}_dict2_custom
         fi
 
+        # -a 7 is mask + dict and dict2 holds the tail of the password, so the mask spells the
+        # head, which is what dict1 holds
+
+        mask="$(mask_literalize "${mask}" "$(sed -n ${line_nr}p "${dict1}")")"
+
         CMD="./${BIN} ${OPTS} -a 7 -m ${hash_type} '${hash}' ${mask} ${dict2}"
 
         echo -n "[ len $i ] " >> "${OUTD}/logfull.txt" 2>> "${OUTD}/logfull.txt"
@@ -2957,7 +2982,6 @@ function attack_12()
         fi
 
         head_len=$((mask_len / 2))
-        tail_len=$((mask_len - head_len))
 
         word_len=$((pass_len - mask_len))
 
@@ -2966,27 +2990,22 @@ function attack_12()
           continue
         fi
 
-        mask_head=""
-        mask_tail=""
-        mask_full=""
-
-        for j in $(seq 1 ${head_len}); do
-          mask_head="${mask_head}?d"
-        done
-
-        for j in $(seq 1 ${tail_len}); do
-          mask_tail="${mask_tail}?d"
-        done
-
-        for j in $(seq 1 ${mask_len}); do
-          mask_full="${mask_full}?d"
-        done
-
         # The dictionary is a copy of dict1 with the word appended, so the run has to find the word
         # among others rather than being handed a one line file.
 
         dict1_a12=${OUTD}/${hash_type}_dict1_a12
         dict2_a12=${OUTD}/${hash_type}_dict2_a12
+
+        # ?w, ?q and each mask piece are uploaded as buffers of their own and the UTF-16 modes
+        # convert every one of them separately, so a join has to sit on a UTF-8 character
+        # boundary, and a mask position has to spell the byte that belongs there rather than a
+        # '?d' that cannot produce it. See utf8_split_point() and mask_literalize().
+
+        head_end=$(utf8_split_point "${pass}" ${head_len})
+        tail_start=$(utf8_split_point "${pass}" $((head_len + word_len)))
+
+        mask_head="$(mask_literalize "$(mask_dots ${head_end})" "${pass:0:${head_end}}")"
+        mask_tail="$(mask_literalize "$(mask_dots $((pass_len - tail_start)))" "${pass:${tail_start}}")"
 
         for shape in first last middle q; do
 
@@ -2997,19 +3016,23 @@ function attack_12()
           case "${shape}" in
 
             first)
-              word=$(echo "${pass}" | cut -b -${word_len})
-              mask="?w${mask_full}"
+              word_end=$(utf8_split_point "${pass}" ${word_len})
+
+              word="${pass:0:${word_end}}"
+              mask="?w$(mask_literalize "$(mask_dots $((pass_len - word_end)))" "${pass:${word_end}}")"
               dicts="${dict1_a12}"
               ;;
 
             last)
-              word=$(echo "${pass}" | cut -b $((mask_len + 1))-)
-              mask="${mask_full}?w"
+              mask_start=$(utf8_split_point "${pass}" ${mask_len})
+
+              word="${pass:${mask_start}}"
+              mask="$(mask_literalize "$(mask_dots ${mask_start})" "${pass:0:${mask_start}}")?w"
               dicts="${dict1_a12}"
               ;;
 
             middle)
-              word=$(echo "${pass}" | cut -b $((head_len + 1))-$((head_len + word_len)))
+              word="${pass:${head_end}:$((tail_start - head_end))}"
               mask="${mask_head}?w${mask_tail}"
               dicts="${dict1_a12}"
               ;;
@@ -3017,14 +3040,14 @@ function attack_12()
             q)
               # the word itself is cut in two, so that ?w and ?q each carry one half
 
-              q_len=$((word_len / 2))
+              q_end=$(utf8_split_point "${pass}" $((head_end + (tail_start - head_end) / 2)))
 
-              if [ "${q_len}" -lt 1 ]; then
+              if [ "${q_end}" -le "${head_end}" ] || [ "${q_end}" -ge "${tail_start}" ]; then
                 continue
               fi
 
-              word=$(echo "${pass}" | cut -b $((head_len + 1))-$((head_len + q_len)))
-              word_q=$(echo "${pass}" | cut -b $((head_len + q_len + 1))-$((head_len + word_len)))
+              word="${pass:${head_end}:$((q_end - head_end))}"
+              word_q="${pass:${q_end}:$((tail_start - q_end))}"
 
               echo "${word_q}" > "${dict2_a12}"
 
@@ -3508,6 +3531,108 @@ function cryptoloop_test()
 #
 # VERACRYPT_BIN, TCPLAY_BIN and CRYPTSETUP_BIN override the binaries if they
 # live somewhere else.
+
+function utf8_split_point()
+{
+  # Move a split offset back until it lands on a UTF-8 character boundary, and print the
+  # result. -a 1, -a 6 and -a 7 hand the word and the mask to the kernel as two buffers and
+  # the UTF-16 modes convert each of them on its own, so a character cut in half is two
+  # invalid fragments and the candidate is dropped. Both halves have to be valid UTF-8 by
+  # themselves for those attacks to spell a multi byte password at all.
+  #
+  # $1 = the password, $2 = the wanted offset in bytes, counting from 0
+
+  local up_text="$1"
+  local up_off="$2"
+
+  while [ "${up_off}" -gt 0 ]; do
+    case "${up_text:${up_off}:1}" in
+      # 0x80 to 0xbf is a continuation byte, so the offset sits inside a character
+      [$'\x80'-$'\xbf']) up_off=$((up_off - 1)) ;;
+      *)                 break ;;
+    esac
+  done
+
+  printf '%s' "${up_off}"
+}
+
+function mask_dots()
+{
+  # A mask of <count> '?d' groups, the shape the suite has always used for a run of digits.
+
+  local md_count="$1"
+  local md_out=""
+  local md_i
+
+  for ((md_i = 0; md_i < md_count; md_i++)); do
+    md_out="${md_out}?d"
+  done
+
+  printf '%s' "${md_out}"
+}
+
+function mask_literalize()
+{
+  # Rewrite a mask so that every position it covers spells the byte that belongs there. The
+  # generated passwords used to be digits from end to end, which is what makes a mask of '?d'
+  # groups work; tools/test.pl can now seed them with multi byte UTF-8, and no '?d' produces a
+  # byte above 0x7f. Those positions become literals, which costs the attack keyspace it was
+  # never searching anyway.
+  #
+  # $1 = the mask, $2 = the exact bytes the mask has to spell. The mask is returned untouched
+  # unless it covers exactly that many bytes, so a caller that hands over the wrong slice, a
+  # mode with its own mask layout for instance, changes nothing.
+
+  local ml_mask="$1"
+  local ml_text="$2"
+
+  local ml_len=${#ml_mask}
+  local ml_pos=0
+  local ml_cnt=0
+  local ml_out=""
+  local ml_tok
+  local ml_byte
+
+  # count the positions first, a '?x' group covers one byte and anything else covers one byte
+
+  while [ ${ml_pos} -lt ${ml_len} ]; do
+    if [ "${ml_mask:${ml_pos}:1}" = "?" ]; then
+      ml_pos=$((ml_pos + 2))
+    else
+      ml_pos=$((ml_pos + 1))
+    fi
+
+    ml_cnt=$((ml_cnt + 1))
+  done
+
+  if [ ${ml_cnt} -ne ${#ml_text} ]; then
+    printf '%s' "${ml_mask}"
+    return
+  fi
+
+  ml_pos=0
+  ml_cnt=0
+
+  while [ ${ml_pos} -lt ${ml_len} ]; do
+    if [ "${ml_mask:${ml_pos}:1}" = "?" ]; then
+      ml_tok="${ml_mask:${ml_pos}:2}"
+      ml_pos=$((ml_pos + 2))
+    else
+      ml_tok="${ml_mask:${ml_pos}:1}"
+      ml_pos=$((ml_pos + 1))
+    fi
+
+    ml_byte="${ml_text:${ml_cnt}:1}"
+    ml_cnt=$((ml_cnt + 1))
+
+    case "${ml_byte}" in
+      [0-9]) ml_out="${ml_out}${ml_tok}"  ;;
+      *)     ml_out="${ml_out}${ml_byte}" ;;
+    esac
+  done
+
+  printf '%s' "${ml_out}"
+}
 
 function container_gen_dir()
 {

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -112,9 +112,13 @@ TC_TESTS_DIR="${TDIR}/tc_tests"
 VC_TESTS_DIR="${TDIR}/vc_tests"
 LUKS_TESTS_DIR="${TDIR}/luks_tests"
 
-# The password every generated container is built with, and the one the shipped
-# containers already use.
+# The password every generated container is built with, and the one the shipped containers
+# already use. With -g the containers are built by this run, so the password is picked at
+# random instead: a test that only passes because 'hashcat' is baked into both the container
+# and the mask is not testing anything. CONTAINER_MASK is the same string with the last
+# character replaced by ?l, which is what gives the mask attacks a keyspace to search.
 CONTAINER_PASSWORD="hashcat"
+CONTAINER_MASK="hashca?l"
 
 # Cryptoloop mode which have test containers
 CL_MODES="14511 14512 14513 14521 14522 14523 14531 14532 14533 14541 14542 14543 14551 14552 14553"
@@ -3324,7 +3328,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha1_aes_${keySize}.img\" --hash sha1 --cipher aes --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha1_aes_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha1_aes_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha1_aes_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3333,7 +3337,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha1_serpent_${keySize}.img\" --hash sha1 --cipher serpent --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha1_serpent_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha1_serpent_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha1_serpent_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3342,7 +3346,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha1_twofish_${keySize}.img\" --hash sha1 --cipher twofish --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha1_twofish_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha1_twofish_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha1_twofish_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3351,7 +3355,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha256_aes_${keySize}.img\" --hash sha256 --cipher aes --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha256_aes_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha256_aes_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha256_aes_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3360,7 +3364,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha256_serpent_${keySize}.img\" --hash sha256 --cipher serpent --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha256_serpent_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha256_serpent_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha256_serpent_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3369,7 +3373,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha256_twofish_${keySize}.img\" --hash sha256 --cipher twofish --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha256_twofish_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha256_twofish_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha256_twofish_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3378,7 +3382,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha512_aes_${keySize}.img\" --hash sha512 --cipher aes --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha512_aes_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha512_aes_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha512_aes_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3387,7 +3391,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha512_serpent_${keySize}.img\" --hash sha512 --cipher serpent --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha512_serpent_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha512_serpent_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha512_serpent_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3396,7 +3400,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_sha512_twofish_${keySize}.img\" --hash sha512 --cipher twofish --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_sha512_twofish_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha512_twofish_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_sha512_twofish_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3405,7 +3409,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_ripemd160_aes_${keySize}.img\" --hash ripemd160 --cipher aes --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_ripemd160_aes_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_ripemd160_aes_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_ripemd160_aes_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3414,7 +3418,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_ripemd160_serpent_${keySize}.img\" --hash ripemd160 --cipher serpent --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_ripemd160_serpent_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_ripemd160_serpent_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_ripemd160_serpent_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3423,7 +3427,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_ripemd160_twofish_${keySize}.img\" --hash ripemd160 --cipher twofish --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_ripemd160_twofish_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_ripemd160_twofish_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_ripemd160_twofish_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3432,7 +3436,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_whirlpool_aes_${keySize}.img\" --hash whirlpool --cipher aes --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_whirlpool_aes_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_whirlpool_aes_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_whirlpool_aes_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3441,7 +3445,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py\" --source \"${TDIR}/cl_tests/hashcat_whirlpool_serpent_${keySize}.img\" --hash whirlpool --cipher serpent --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_whirlpool_serpent_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_whirlpool_serpent_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_whirlpool_serpent_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3450,7 +3454,7 @@ function cryptoloop_test()
       case $keySize in
         128|192|256)
           eval \"${TDIR}/cryptoloop2hashcat.py --source ${TDIR}/cl_tests/hashcat_whirlpool_twofish_${keySize}.img\" --hash whirlpool --cipher twofish --keysize ${keySize} > ${OUTD}/cl_tests/hashcat_whirlpool_twofish_${keySize}.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_whirlpool_twofish_${keySize}.hash hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 14500 ${OUTD}/cl_tests/hashcat_whirlpool_twofish_${keySize}.hash ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3531,6 +3535,22 @@ function cryptoloop_test()
 #
 # VERACRYPT_BIN, TCPLAY_BIN and CRYPTSETUP_BIN override the binaries if they
 # live somewhere else.
+
+function random_container_password()
+{
+  # Seven lowercase letters, the shape 'hashcat' had. build_container_cmd() and CONTAINER_MASK
+  # both turn the last character into ?l, so the last character has to be a lowercase letter,
+  # and the length is what the -a 6 and -a 7 splits in build_container_cmd() are written for.
+  local rp_chars="abcdefghijklmnopqrstuvwxyz"
+  local rp_out=""
+  local rp_i
+
+  for rp_i in $(seq 1 7); do
+    rp_out="${rp_out}${rp_chars:$((RANDOM % 26)):1}"
+  done
+
+  printf '%s' "${rp_out}"
+}
 
 function utf8_split_point()
 {
@@ -3979,13 +3999,13 @@ function truecrypt_test()
     6211)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6211 '${TC_TESTS_DIR}/hashcat_ripemd160_aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6211 '${TC_TESTS_DIR}/hashcat_ripemd160_aes.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6211 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6211 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent.tc' ${CONTAINER_MASK}"
           ;;
         2)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6211 '${TC_TESTS_DIR}/hashcat_ripemd160_twofish.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6211 '${TC_TESTS_DIR}/hashcat_ripemd160_twofish.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -3993,13 +4013,13 @@ function truecrypt_test()
     6212)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6212 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6212 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6212 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent-aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6212 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent-aes.tc' ${CONTAINER_MASK}"
           ;;
         2)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6212 '${TC_TESTS_DIR}/hashcat_ripemd160_twofish-serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6212 '${TC_TESTS_DIR}/hashcat_ripemd160_twofish-serpent.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4007,10 +4027,10 @@ function truecrypt_test()
     6213)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6213 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish-serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6213 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish-serpent.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6213 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent-twofish-aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6213 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent-twofish-aes.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4018,13 +4038,13 @@ function truecrypt_test()
     6221)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6221 '${TC_TESTS_DIR}/hashcat_sha512_aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6221 '${TC_TESTS_DIR}/hashcat_sha512_aes.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6221 '${TC_TESTS_DIR}/hashcat_sha512_serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6221 '${TC_TESTS_DIR}/hashcat_sha512_serpent.tc' ${CONTAINER_MASK}"
           ;;
         2)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6221 '${TC_TESTS_DIR}/hashcat_sha512_twofish.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6221 '${TC_TESTS_DIR}/hashcat_sha512_twofish.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4032,13 +4052,13 @@ function truecrypt_test()
     6222)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6222 '${TC_TESTS_DIR}/hashcat_sha512_aes-twofish.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6222 '${TC_TESTS_DIR}/hashcat_sha512_aes-twofish.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6222 '${TC_TESTS_DIR}/hashcat_sha512_serpent-aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6222 '${TC_TESTS_DIR}/hashcat_sha512_serpent-aes.tc' ${CONTAINER_MASK}"
           ;;
         2)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6222 '${TC_TESTS_DIR}/hashcat_sha512_twofish-serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6222 '${TC_TESTS_DIR}/hashcat_sha512_twofish-serpent.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4046,10 +4066,10 @@ function truecrypt_test()
     6223)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6223 '${TC_TESTS_DIR}/hashcat_sha512_aes-twofish-serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6223 '${TC_TESTS_DIR}/hashcat_sha512_aes-twofish-serpent.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6223 '${TC_TESTS_DIR}/hashcat_sha512_serpent-twofish-aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6223 '${TC_TESTS_DIR}/hashcat_sha512_serpent-twofish-aes.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4057,13 +4077,13 @@ function truecrypt_test()
     6231)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6231 '${TC_TESTS_DIR}/hashcat_whirlpool_aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6231 '${TC_TESTS_DIR}/hashcat_whirlpool_aes.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6231 '${TC_TESTS_DIR}/hashcat_whirlpool_serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6231 '${TC_TESTS_DIR}/hashcat_whirlpool_serpent.tc' ${CONTAINER_MASK}"
           ;;
         2)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6231 '${TC_TESTS_DIR}/hashcat_whirlpool_twofish.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6231 '${TC_TESTS_DIR}/hashcat_whirlpool_twofish.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4071,13 +4091,13 @@ function truecrypt_test()
     6232)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6232 '${TC_TESTS_DIR}/hashcat_whirlpool_aes-twofish.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6232 '${TC_TESTS_DIR}/hashcat_whirlpool_aes-twofish.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6232 '${TC_TESTS_DIR}/hashcat_whirlpool_serpent-aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6232 '${TC_TESTS_DIR}/hashcat_whirlpool_serpent-aes.tc' ${CONTAINER_MASK}"
           ;;
         2)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6232 '${TC_TESTS_DIR}/hashcat_whirlpool_twofish-serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6232 '${TC_TESTS_DIR}/hashcat_whirlpool_twofish-serpent.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4085,10 +4105,10 @@ function truecrypt_test()
     6233)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6233 '${TC_TESTS_DIR}/hashcat_whirlpool_aes-twofish-serpent.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6233 '${TC_TESTS_DIR}/hashcat_whirlpool_aes-twofish-serpent.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6233 '${TC_TESTS_DIR}/hashcat_whirlpool_serpent-twofish-aes.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6233 '${TC_TESTS_DIR}/hashcat_whirlpool_serpent-twofish-aes.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4096,13 +4116,13 @@ function truecrypt_test()
     6241)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6241 '${TC_TESTS_DIR}/hashcat_ripemd160_aes_boot.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6241 '${TC_TESTS_DIR}/hashcat_ripemd160_aes_boot.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6241 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent_boot.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6241 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent_boot.tc' ${CONTAINER_MASK}"
           ;;
         2)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6241 '${TC_TESTS_DIR}/hashcat_ripemd160_twofish_boot.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6241 '${TC_TESTS_DIR}/hashcat_ripemd160_twofish_boot.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4110,10 +4130,10 @@ function truecrypt_test()
     6242)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6242 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish_boot.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6242 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish_boot.tc' ${CONTAINER_MASK}"
           ;;
         1)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6242 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent-aes_boot.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6242 '${TC_TESTS_DIR}/hashcat_ripemd160_serpent-aes_boot.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4121,7 +4141,7 @@ function truecrypt_test()
     6243)
       case $tcMode in
         0)
-          CMD="./${BIN} ${OPTS} -a 3 -m 6243 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish-serpent_boot.tc' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 6243 '${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish-serpent_boot.tc' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4130,15 +4150,15 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_aes.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29311 '${OUTD}/tc_tests/hashcat_ripemd160_aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29311 '${OUTD}/tc_tests/hashcat_ripemd160_aes.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_serpent.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29311 '${OUTD}/tc_tests/hashcat_ripemd160_serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29311 '${OUTD}/tc_tests/hashcat_ripemd160_serpent.hash' ${CONTAINER_MASK}"
           ;;
         2)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_twofish.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_twofish.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29311 '${OUTD}/tc_tests/hashcat_ripemd160_twofish.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29311 '${OUTD}/tc_tests/hashcat_ripemd160_twofish.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4147,15 +4167,15 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29312 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29312 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_serpent-aes.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_serpent-aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29312 '${OUTD}/tc_tests/hashcat_ripemd160_serpent-aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29312 '${OUTD}/tc_tests/hashcat_ripemd160_serpent-aes.hash' ${CONTAINER_MASK}"
           ;;
         2)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_twofish-serpent.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_twofish-serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29312 '${OUTD}/tc_tests/hashcat_ripemd160_twofish-serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29312 '${OUTD}/tc_tests/hashcat_ripemd160_twofish-serpent.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4164,11 +4184,11 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish-serpent.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish-serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29313 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish-serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29313 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish-serpent.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_serpent-twofish-aes.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_serpent-twofish-aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29313 '${OUTD}/tc_tests/hashcat_ripemd160_serpent-twofish-aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29313 '${OUTD}/tc_tests/hashcat_ripemd160_serpent-twofish-aes.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4177,15 +4197,15 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_aes.tc\" > ${OUTD}/tc_tests/hashcat_sha512_aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29321 '${OUTD}/tc_tests/hashcat_sha512_aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29321 '${OUTD}/tc_tests/hashcat_sha512_aes.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_serpent.tc\" > ${OUTD}/tc_tests/hashcat_sha512_serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29321 '${OUTD}/tc_tests/hashcat_sha512_serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29321 '${OUTD}/tc_tests/hashcat_sha512_serpent.hash' ${CONTAINER_MASK}"
           ;;
         2)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_twofish.tc\" > ${OUTD}/tc_tests/hashcat_sha512_twofish.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29321 '${OUTD}/tc_tests/hashcat_sha512_twofish.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29321 '${OUTD}/tc_tests/hashcat_sha512_twofish.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4194,15 +4214,15 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_aes-twofish.tc\" > ${OUTD}/tc_tests/hashcat_sha512_aes-twofish.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29322 '${OUTD}/tc_tests/hashcat_sha512_aes-twofish.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29322 '${OUTD}/tc_tests/hashcat_sha512_aes-twofish.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_serpent-aes.tc\" > ${OUTD}/tc_tests/hashcat_sha512_serpent-aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29322 '${OUTD}/tc_tests/hashcat_sha512_serpent-aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29322 '${OUTD}/tc_tests/hashcat_sha512_serpent-aes.hash' ${CONTAINER_MASK}"
           ;;
         2)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_twofish-serpent.tc\" > ${OUTD}/tc_tests/hashcat_sha512_twofish-serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29322 '${OUTD}/tc_tests/hashcat_sha512_twofish-serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29322 '${OUTD}/tc_tests/hashcat_sha512_twofish-serpent.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4211,11 +4231,11 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_aes-twofish-serpent.tc\" > ${OUTD}/tc_tests/hashcat_sha512_aes-twofish-serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29323 '${OUTD}/tc_tests/hashcat_sha512_aes-twofish-serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29323 '${OUTD}/tc_tests/hashcat_sha512_aes-twofish-serpent.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_sha512_serpent-twofish-aes.tc\" > ${OUTD}/tc_tests/hashcat_sha512_serpent-twofish-aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29323 '${OUTD}/tc_tests/hashcat_sha512_serpent-twofish-aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29323 '${OUTD}/tc_tests/hashcat_sha512_serpent-twofish-aes.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4224,15 +4244,15 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_aes.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29331 '${OUTD}/tc_tests/hashcat_whirlpool_aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29331 '${OUTD}/tc_tests/hashcat_whirlpool_aes.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_serpent.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29331 '${OUTD}/tc_tests/hashcat_whirlpool_serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29331 '${OUTD}/tc_tests/hashcat_whirlpool_serpent.hash' ${CONTAINER_MASK}"
           ;;
         2)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_twofish.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_twofish.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29331 '${OUTD}/tc_tests/hashcat_whirlpool_twofish.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29331 '${OUTD}/tc_tests/hashcat_whirlpool_twofish.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4241,15 +4261,15 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_aes-twofish.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_aes-twofish.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29332 '${OUTD}/tc_tests/hashcat_whirlpool_aes-twofish.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29332 '${OUTD}/tc_tests/hashcat_whirlpool_aes-twofish.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_serpent-aes.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_serpent-aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29332 '${OUTD}/tc_tests/hashcat_whirlpool_serpent-aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29332 '${OUTD}/tc_tests/hashcat_whirlpool_serpent-aes.hash' ${CONTAINER_MASK}"
           ;;
         2)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_twofish-serpent.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_twofish-serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29332 '${OUTD}/tc_tests/hashcat_whirlpool_twofish-serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29332 '${OUTD}/tc_tests/hashcat_whirlpool_twofish-serpent.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4258,11 +4278,11 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_aes-twofish-serpent.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_aes-twofish-serpent.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29333 '${OUTD}/tc_tests/hashcat_whirlpool_aes-twofish-serpent.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29333 '${OUTD}/tc_tests/hashcat_whirlpool_aes-twofish-serpent.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_whirlpool_serpent-twofish-aes.tc\" > ${OUTD}/tc_tests/hashcat_whirlpool_serpent-twofish-aes.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29333 '${OUTD}/tc_tests/hashcat_whirlpool_serpent-twofish-aes.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29333 '${OUTD}/tc_tests/hashcat_whirlpool_serpent-twofish-aes.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4271,15 +4291,15 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_aes_boot.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_aes_boot.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29341 '${OUTD}/tc_tests/hashcat_ripemd160_aes_boot.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29341 '${OUTD}/tc_tests/hashcat_ripemd160_aes_boot.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_serpent_boot.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_serpent_boot.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29341 '${OUTD}/tc_tests/hashcat_ripemd160_serpent_boot.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29341 '${OUTD}/tc_tests/hashcat_ripemd160_serpent_boot.hash' ${CONTAINER_MASK}"
           ;;
         2)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_twofish_boot.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_twofish_boot.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29341 '${OUTD}/tc_tests/hashcat_ripemd160_twofish_boot.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29341 '${OUTD}/tc_tests/hashcat_ripemd160_twofish_boot.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4288,11 +4308,11 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish_boot.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish_boot.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29342 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish_boot.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29342 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish_boot.hash' ${CONTAINER_MASK}"
           ;;
         1)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_serpent-aes_boot.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_serpent-aes_boot.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29342 '${OUTD}/tc_tests/hashcat_ripemd160_serpent-aes_boot.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29342 '${OUTD}/tc_tests/hashcat_ripemd160_serpent-aes_boot.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -4301,7 +4321,7 @@ function truecrypt_test()
       case $tcMode in
         0)
           eval \"${TDIR}/truecrypt2hashcat.py\" \"${TC_TESTS_DIR}/hashcat_ripemd160_aes-twofish-serpent_boot.tc\" > ${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish-serpent_boot.hash
-          CMD="./${BIN} ${OPTS} -a 3 -m 29343 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish-serpent_boot.hash' hashca?l"
+          CMD="./${BIN} ${OPTS} -a 3 -m 29343 '${OUTD}/tc_tests/hashcat_ripemd160_aes-twofish-serpent_boot.hash' ${CONTAINER_MASK}"
           ;;
       esac
       ;;
@@ -5109,7 +5129,7 @@ function pkzip_test()
     return
   fi
 
-  local password="hashcat"
+  local password="${CONTAINER_PASSWORD}"
   local zdir="${OUTD}/pkzip_tests"
   local sdir="${zdir}/src"
   mkdir -p "${sdir}"
@@ -5180,7 +5200,7 @@ function gpg_test()
     record_note "${hashType}" "${GPG1_BIN} (GnuPG 1.x) not found, so the classic S2K variants and the AES-128 (aux1) path are skipped; set GPG1_BIN=... if installed elsewhere"
   fi
 
-  local password="hashcat"
+  local password="${CONTAINER_PASSWORD}"
   local gdir="${OUTD}/gpg_tests"
   mkdir -p "${gdir}"
 
@@ -5346,7 +5366,7 @@ function rar_test()
       ;;
   esac
 
-  local password="hashcat"
+  local password="${CONTAINER_PASSWORD}"
   local rdir="${OUTD}/rar_tests"   # generated per run, nothing checked in
   local sdir="${rdir}/src"
   mkdir -p "${sdir}"
@@ -5414,7 +5434,7 @@ function sevenzip_test()
     return
   fi
 
-  local password="hashcat"
+  local password="${CONTAINER_PASSWORD}"
   local sdir="${OUTD}/7z_tests"
 
   mkdir -p "${sdir}"
@@ -5519,7 +5539,7 @@ function pdf_gen_test()
     return
   fi
 
-  local password="hashcat"
+  local password="${CONTAINER_PASSWORD}"
   local pdir="${OUTD}/pdf_gen_tests"
 
   mkdir -p "${pdir}"
@@ -5616,7 +5636,7 @@ function ssh_test()
     return
   fi
 
-  local password="hashcat"
+  local password="${CONTAINER_PASSWORD}"
   local kdir="${OUTD}/ssh_tests"
 
   mkdir -p "${kdir}"
@@ -6139,6 +6159,14 @@ fi
 
 if [[ "${GENERATE_CONTAINERS}" -eq 1 ]] && [ "${HT_GIVEN}" -eq 0 ]; then
   HT=65535
+fi
+
+# The containers this run builds get a password of their own. The ones shipped in the tree or
+# fetched from hashcat.net were built with 'hashcat' and keep it.
+
+if [[ "${GENERATE_CONTAINERS}" -eq 1 ]]; then
+  CONTAINER_PASSWORD="$(random_container_password)"
+  CONTAINER_MASK="${CONTAINER_PASSWORD:0:$((${#CONTAINER_PASSWORD} - 1))}?l"
 fi
 
 # handle Apple Silicon

--- a/tools/test_modules/luks1.sh
+++ b/tools/test_modules/luks1.sh
@@ -20,10 +20,15 @@ TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
 size=20   # MiB
 
-OUTPUT_DIR="/tmp/out"
+# Where the containers, the mount points and the log go. tools/test.sh points these
+# at the directory of the run that asked for them, so nothing is left in /tmp when
+# the run is thrown away. Run by hand they keep the paths they always had.
+OUTPUT_DIR="${HCTEST_SCRATCH_DIR:-/tmp/out}"
 mkdir -p "$OUTPUT_DIR"
-MOUNT_DIR="/tmp/mnt"
+MOUNT_DIR="${HCTEST_MOUNT_DIR:-/tmp/mnt}"
 mkdir -p "$MOUNT_DIR"
+LOG_FILE="${OUTPUT_DIR}/luks1.log"
+CMD_LOG_FILE="${OUTPUT_DIR}/luks1.cmd.log"
 
 create_luks_container() {
   local PASSWORD="$1"
@@ -36,13 +41,13 @@ create_luks_container() {
   shift 7
   local extra_opts=("$@")
 
-  echo  "Creating $filename (size ${size_mb}MiB) with password length ${#PASSWORD}: $PASSWORD..." >> /tmp/luks1.sh
+  echo  "Creating $filename (size ${size_mb}MiB) with password length ${#PASSWORD}: $PASSWORD..." >> ${LOG_FILE}
   dd if=/dev/zero of="$filename" bs=1M count="$size_mb" status=none
 
-  echo "sudo losetup --show -f "$filename"" >  /tmp/luks1.sh.log
+  echo "sudo losetup --show -f "$filename"" >  ${CMD_LOG_FILE}
   loopdev=$(sudo losetup --show -f "$filename")
 
-cat >> /tmp/luks1.sh.log <<EOF
+cat >> ${CMD_LOG_FILE} <<EOF
 sudo cryptsetup luksFormat \
 --batch-mode \
 --type "$luks_type" \
@@ -62,9 +67,9 @@ EOF
       "${extra_opts[@]}" \
       "$loopdev" <<< "$PASSWORD"; then
       true
-      echo "Formatted: $filename" >> /tmp/luks1.sh
+      echo "Formatted: $filename" >> ${LOG_FILE}
   else
-    echo "X Failed to format: $filename" >> /tmp/luks1.sh
+    echo "X Failed to format: $filename" >> ${LOG_FILE}
     sudo losetup -d "$loopdev"
     rm -f "$filename"
     return
@@ -73,21 +78,21 @@ EOF
   name="luks$(basename "$filename" | sha1sum | cut -c1-8)"
 
   if [ -e "/dev/mapper/$name" ]; then
-    echo "! Device $name already exists. Closing it first." >> /tmp/luks1.sh
+    echo "! Device $name already exists. Closing it first." >> ${LOG_FILE}
     sudo cryptsetup close "$name" || true
   fi
 
   if sudo cryptsetup open "$loopdev" "$name" <<< "$PASSWORD"; then
     true
-    echo "Decrypted: $filename" >> /tmp/luks1.sh
+    echo "Decrypted: $filename" >> ${LOG_FILE}
   else
-    echo  "X Failed to decrypt: $filename" >> /tmp/luks1.sh
+    echo  "X Failed to decrypt: $filename" >> ${LOG_FILE}
     sudo losetup -d "$loopdev"
     rm -f "$filename"
     return
   fi
 
-  sudo mkfs.ext4 -q /dev/mapper/"$name" 2>> /tmp/luks1.sh
+  sudo mkfs.ext4 -q /dev/mapper/"$name" 2>> ${LOG_FILE}
 
   mount_point="$MOUNT_DIR/$name"
   mkdir -p "$mount_point"
@@ -100,7 +105,10 @@ EOF
   done
   sudo cryptsetup close "$name"
 
-  echo  "ext4: $filename" >> /tmp/luks1.sh
+  # the mount point is empty now, and one is created per container
+  rmdir "$mount_point" 2>/dev/null || true
+
+  echo  "ext4: $filename" >> ${LOG_FILE}
 
   sudo losetup -D
 }
@@ -264,8 +272,14 @@ create_luks_container "$password" "$file" "$luks_type" "$cipher_cipher_mode" "$h
 ${TDIR}/luks2hashcat.py $file | grep -vE '^[0-9]+$' > $file.hash
 
 if [[ ${hashcat_module} -eq "14600" ]]; then
+  # the legacy format reads the container itself, so it has to survive
   echo "$file"
 else
+  # every other mode is handed the extracted hash, and the container is 20 MiB of dead
+  # weight the moment it is out. Without this a suite run leaves one image per generated
+  # vector behind in OUTPUT_DIR, for good.
+  rm -f "$file"
+
   echo "$file.hash"
 fi
 # echo ""

--- a/tools/test_modules/m00030.pm
+++ b/tools/test_modules/m00030.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md5_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = md5_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00030.pm
+++ b/tools/test_modules/m00030.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::MD5 qw (md5_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md5_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
+  my $digest = md5_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00040.pm
+++ b/tools/test_modules/m00040.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::MD5 qw (md5_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md5_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = md5_hex ($salt . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00040.pm
+++ b/tools/test_modules/m00040.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md5_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = md5_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00070.pm
+++ b/tools/test_modules/m00070.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = md5_hex (encode ("UTF-16LE", $word));
+  my $digest = md5_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m00070.pm
+++ b/tools/test_modules/m00070.pm
@@ -11,13 +11,27 @@ use warnings;
 use Digest::MD5 qw (md5_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = md5_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = md5_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m00130.pm
+++ b/tools/test_modules/m00130.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha1_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00130.pm
+++ b/tools/test_modules/m00130.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA1 qw (sha1_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
+  my $digest = sha1_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00140.pm
+++ b/tools/test_modules/m00140.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha1_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00140.pm
+++ b/tools/test_modules/m00140.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA1 qw (sha1_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha1_hex ($salt . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m00170.pm
+++ b/tools/test_modules/m00170.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA1 qw (sha1_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha1_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m00170.pm
+++ b/tools/test_modules/m00170.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha1_hex (encode ("UTF-16LE", $word));
+  my $digest = sha1_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m01000.pm
+++ b/tools/test_modules/m01000.pm
@@ -11,13 +11,27 @@ use warnings;
 use Digest::MD4 qw (md4_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
   my $word = shift;
 
-  my $utf16le = encode("UTF-16LE", decode("utf-8", $word));
+  my $utf16le = encode("UTF-16LE", decode ($PW_CHARSET, $word));
 
   my $digest = md4_hex ($utf16le);
 

--- a/tools/test_modules/m01100.pm
+++ b/tools/test_modules/m01100.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md4_hex (md4 (encode ("UTF-16LE", $word)) . encode ("UTF-16LE", lc ($salt)));
+  my $digest = md4_hex (md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . encode ("UTF-16LE", lc ($salt)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01100.pm
+++ b/tools/test_modules/m01100.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::MD4 qw (md4 md4_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 19], [-1, -1]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = md4_hex (md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . encode ("UTF-16LE", lc ($salt)));
+  my $digest = md4_hex (md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word))) . encode ("UTF-16LE", lc ($salt)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01430.pm
+++ b/tools/test_modules/m01430.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha256_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha256_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01430.pm
+++ b/tools/test_modules/m01430.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha256_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha256_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
+  my $digest = sha256_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01440.pm
+++ b/tools/test_modules/m01440.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha256_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha256_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01440.pm
+++ b/tools/test_modules/m01440.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha256_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha256_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha256_hex ($salt . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01470.pm
+++ b/tools/test_modules/m01470.pm
@@ -11,13 +11,27 @@ use warnings;
 use Digest::SHA qw (sha256_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha256_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha256_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m01470.pm
+++ b/tools/test_modules/m01470.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha256_hex (encode ("UTF-16LE", $word));
+  my $digest = sha256_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m01730.pm
+++ b/tools/test_modules/m01730.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha512_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha512_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01730.pm
+++ b/tools/test_modules/m01730.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha512_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha512_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
+  my $digest = sha512_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01740.pm
+++ b/tools/test_modules/m01740.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha512_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha512_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01740.pm
+++ b/tools/test_modules/m01740.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha512_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha512_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha512_hex ($salt . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m01770.pm
+++ b/tools/test_modules/m01770.pm
@@ -11,13 +11,27 @@ use warnings;
 use Digest::SHA qw (sha512_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha512_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha512_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m01770.pm
+++ b/tools/test_modules/m01770.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha512_hex (encode ("UTF-16LE", $word));
+  my $digest = sha512_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m02100.pm
+++ b/tools/test_modules/m02100.pm
@@ -12,6 +12,20 @@ use Digest::MD4 qw (md4);
 use Crypt::PBKDF2;
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -30,7 +44,7 @@ sub module_generate_hash
     salt_len   => length ($salt_bin),
   );
 
-  my $digest = unpack ("H*", $pbkdf2->PBKDF2 ($salt_bin, md4 (md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . $salt_bin)));
+  my $digest = unpack ("H*", $pbkdf2->PBKDF2 ($salt_bin, md4 (md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word))) . $salt_bin)));
 
   my $hash = sprintf ("\$DCC2\$%i#%s#%s", $iterations, $salt, $digest);
 

--- a/tools/test_modules/m02100.pm
+++ b/tools/test_modules/m02100.pm
@@ -30,7 +30,7 @@ sub module_generate_hash
     salt_len   => length ($salt_bin),
   );
 
-  my $digest = unpack ("H*", $pbkdf2->PBKDF2 ($salt_bin, md4 (md4 (encode ("UTF-16LE", $word)) . $salt_bin)));
+  my $digest = unpack ("H*", $pbkdf2->PBKDF2 ($salt_bin, md4 (md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . $salt_bin)));
 
   my $hash = sprintf ("\$DCC2\$%i#%s#%s", $iterations, $salt, $digest);
 

--- a/tools/test_modules/m05500.pm
+++ b/tools/test_modules/m05500.pm
@@ -8,7 +8,8 @@
 use strict;
 use warnings;
 
-use Authen::Passphrase::NTHash;
+use Digest::MD4 qw (md4);
+use Encode qw (decode encode);
 use Digest::MD5 qw (md5);
 use Crypt::ECB;
 
@@ -127,7 +128,10 @@ sub module_generate_hash
 
   my $ntresp;
 
-  my $nthash = Authen::Passphrase::NTHash->new (passphrase => $word)->hash . "\x00" x 5;
+  # md4 of the UTF-16LE password, which is what the NT hash is. Authen::Passphrase::NTHash
+  # cannot be used here: it gets the encoding wrong for a character outside the BMP, an
+  # emoji for instance, and the kernel does not.
+  my $nthash = md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . "\x00" x 5;
 
   $ntresp .= Crypt::ECB::encrypt (setup_des_key (substr ($nthash,  0, 7)), "DES", $challenge, "none");
   $ntresp .= Crypt::ECB::encrypt (setup_des_key (substr ($nthash,  7, 7)), "DES", $challenge, "none");

--- a/tools/test_modules/m05500.pm
+++ b/tools/test_modules/m05500.pm
@@ -13,6 +13,20 @@ use Encode qw (decode encode);
 use Digest::MD5 qw (md5);
 use Crypt::ECB;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub setup_des_key
 {
   my @key_56 = split (//, shift);
@@ -131,7 +145,7 @@ sub module_generate_hash
   # md4 of the UTF-16LE password, which is what the NT hash is. Authen::Passphrase::NTHash
   # cannot be used here: it gets the encoding wrong for a character outside the BMP, an
   # emoji for instance, and the kernel does not.
-  my $nthash = md4 (encode ("UTF-16LE", decode ("utf-8", $word))) . "\x00" x 5;
+  my $nthash = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word))) . "\x00" x 5;
 
   $ntresp .= Crypt::ECB::encrypt (setup_des_key (substr ($nthash,  0, 7)), "DES", $challenge, "none");
   $ntresp .= Crypt::ECB::encrypt (setup_des_key (substr ($nthash,  7, 7)), "DES", $challenge, "none");

--- a/tools/test_modules/m05600.pm
+++ b/tools/test_modules/m05600.pm
@@ -8,10 +8,10 @@
 use strict;
 use warnings;
 
-use Authen::Passphrase::NTHash;
+use Digest::MD4  qw (md4);
 use Digest::HMAC qw (hmac hmac_hex);
 use Digest::MD5  qw (md5);
-use Encode       qw (encode);
+use Encode       qw (encode decode);
 
 sub module_constraints { [[0, 127], [0, 55], [0, 27], [0, 27], [-1, -1]] } # room for improvement in pure kernel mode
 
@@ -30,7 +30,10 @@ sub module_generate_hash
   my $b_srv_ch = pack ('H*', $srv_ch);
   my $b_cli_ch = pack ('H*', $cli_ch);
 
-  my $nthash   = Authen::Passphrase::NTHash->new (passphrase => $word)->hash;
+  # md4 of the UTF-16LE password, which is what the NT hash is. Authen::Passphrase::NTHash
+  # cannot be used here: it gets the encoding wrong for a character outside the BMP, an
+  # emoji for instance, and the kernel does not.
+  my $nthash   = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
   my $identity = encode ('UTF-16LE', uc ($user) . $domain);
   my $digest   = hmac_hex ($b_srv_ch . $b_cli_ch, hmac ($identity, $nthash, \&md5, 64), \&md5, 64);
 

--- a/tools/test_modules/m05600.pm
+++ b/tools/test_modules/m05600.pm
@@ -13,6 +13,20 @@ use Digest::HMAC qw (hmac hmac_hex);
 use Digest::MD5  qw (md5);
 use Encode       qw (encode decode);
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 127], [0, 55], [0, 27], [0, 27], [-1, -1]] } # room for improvement in pure kernel mode
 
 sub module_generate_hash
@@ -33,7 +47,7 @@ sub module_generate_hash
   # md4 of the UTF-16LE password, which is what the NT hash is. Authen::Passphrase::NTHash
   # cannot be used here: it gets the encoding wrong for a character outside the BMP, an
   # emoji for instance, and the kernel does not.
-  my $nthash   = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $nthash   = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
   my $identity = encode ('UTF-16LE', uc ($user) . $domain);
   my $digest   = hmac_hex ($b_srv_ch . $b_cli_ch, hmac ($identity, $nthash, \&md5, 64), \&md5, 64);
 

--- a/tools/test_modules/m07500.pm
+++ b/tools/test_modules/m07500.pm
@@ -56,7 +56,7 @@ sub module_generate_hash
 
   my $clear_data = $salt_arr[4];
 
-  my $k = md4 (encode ("UTF-16LE", $word_buf));
+  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
 
   my $k1 = hmac_md5 ("\x01\x00\x00\x00", $k);
 

--- a/tools/test_modules/m07500.pm
+++ b/tools/test_modules/m07500.pm
@@ -14,6 +14,20 @@ use Digest::HMAC_MD5 qw (hmac_md5);
 use Digest::MD4      qw (md4);
 use POSIX            qw (strftime);
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub get_random_kerberos5_salt
 {
   my $custom_salt = shift;
@@ -56,7 +70,7 @@ sub module_generate_hash
 
   my $clear_data = $salt_arr[4];
 
-  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
+  my $k = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf)));
 
   my $k1 = hmac_md5 ("\x01\x00\x00\x00", $k);
 

--- a/tools/test_modules/m09400.pm
+++ b/tools/test_modules/m09400.pm
@@ -32,7 +32,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", $word));
+  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m09400.pm
+++ b/tools/test_modules/m09400.pm
@@ -12,6 +12,20 @@ use Crypt::Mode::ECB;
 use Digest::SHA qw (sha1);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 19], [32, 32], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -32,7 +46,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m09500.pm
+++ b/tools/test_modules/m09500.pm
@@ -23,7 +23,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", $word));
+  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m09500.pm
+++ b/tools/test_modules/m09500.pm
@@ -12,6 +12,20 @@ use Crypt::CBC;
 use Digest::SHA qw (sha1);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 19], [32, 32], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -23,7 +37,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $tmp = sha1 ($salt_bin . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m09600.pm
+++ b/tools/test_modules/m09600.pm
@@ -23,7 +23,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha512 ($salt_bin . encode ("UTF-16LE", $word));
+  my $tmp = sha512 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m09600.pm
+++ b/tools/test_modules/m09600.pm
@@ -12,6 +12,20 @@ use Crypt::CBC;
 use Digest::SHA qw (sha512);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 19], [32, 32], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -23,7 +37,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $tmp = sha512 ($salt_bin . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $tmp = sha512 ($salt_bin . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m10830.pm
+++ b/tools/test_modules/m10830.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha384_hex (encode ("UTF-16LE", $word) . $salt);
+  my $digest = sha384_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m10830.pm
+++ b/tools/test_modules/m10830.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha384_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha384_hex (encode ("UTF-16LE", decode ("utf-8", $word)) . $salt);
+  my $digest = sha384_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)) . $salt);
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m10840.pm
+++ b/tools/test_modules/m10840.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha384_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 256], [0, 27], [0, 27], [0, 27]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha384_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha384_hex ($salt . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m10840.pm
+++ b/tools/test_modules/m10840.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $digest = sha384_hex ($salt . encode ("UTF-16LE", $word));
+  my $digest = sha384_hex ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $digest, $salt);
 

--- a/tools/test_modules/m10870.pm
+++ b/tools/test_modules/m10870.pm
@@ -11,13 +11,27 @@ use warnings;
 use Digest::SHA qw (sha384_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha384_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $digest = sha384_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m10870.pm
+++ b/tools/test_modules/m10870.pm
@@ -17,7 +17,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $digest = sha384_hex (encode ("UTF-16LE", $word));
+  my $digest = sha384_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s", $digest);
 

--- a/tools/test_modules/m11600.pm
+++ b/tools/test_modules/m11600.pm
@@ -64,7 +64,7 @@ sub module_generate_hash
   # 2 ^ NumCyclesPower "iterations" of SHA256 (only one final SHA256)
   #
 
-  $word_buf = encode ("UTF-16LE", $word_buf);
+  $word_buf = encode ("UTF-16LE", decode ("utf-8", $word_buf));
 
   my $rounds = 1 << $num_cycle_power;
 

--- a/tools/test_modules/m11600.pm
+++ b/tools/test_modules/m11600.pm
@@ -13,6 +13,20 @@ use Digest::CRC qw (crc32);
 use Digest::SHA qw (sha256);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 16], [0, 20], [0, 16], [-1, -1]] }
 
 sub module_generate_hash
@@ -64,7 +78,7 @@ sub module_generate_hash
   # 2 ^ NumCyclesPower "iterations" of SHA256 (only one final SHA256)
   #
 
-  $word_buf = encode ("UTF-16LE", decode ("utf-8", $word_buf));
+  $word_buf = encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf));
 
   my $rounds = 1 << $num_cycle_power;
 

--- a/tools/test_modules/m12800.pm
+++ b/tools/test_modules/m12800.pm
@@ -12,6 +12,20 @@ use Crypt::PBKDF2;
 use Digest::MD4 qw (md4_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [20, 20], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -20,7 +34,7 @@ sub module_generate_hash
   my $salt = shift;
   my $iter = shift // 100;
 
-  my $nt = md4_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $nt = md4_hex (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $pbkdf2 = Crypt::PBKDF2->new
   (

--- a/tools/test_modules/m12800.pm
+++ b/tools/test_modules/m12800.pm
@@ -20,7 +20,7 @@ sub module_generate_hash
   my $salt = shift;
   my $iter = shift // 100;
 
-  my $nt = md4_hex (encode ("UTF-16LE", $word));
+  my $nt = md4_hex (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $pbkdf2 = Crypt::PBKDF2->new
   (

--- a/tools/test_modules/m13100.pm
+++ b/tools/test_modules/m13100.pm
@@ -25,7 +25,7 @@ sub module_generate_hash
   my $checksum  = shift;
   my $edata2    = shift;
 
-  my $k = md4 (encode ("UTF-16LE", $word));
+  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $k1 = hmac_md5 ("\x02\x00\x00\x00", $k);
 

--- a/tools/test_modules/m13100.pm
+++ b/tools/test_modules/m13100.pm
@@ -13,6 +13,20 @@ use Crypt::RC4;
 use Digest::HMAC_MD5 qw (hmac_md5);
 use Digest::MD4      qw (md4);
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [16, 16], [0, 27], [16, 16], [-1, -1]] }
 
 sub module_generate_hash
@@ -25,7 +39,7 @@ sub module_generate_hash
   my $checksum  = shift;
   my $edata2    = shift;
 
-  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $k = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $k1 = hmac_md5 ("\x02\x00\x00\x00", $k);
 

--- a/tools/test_modules/m13500.pm
+++ b/tools/test_modules/m13500.pm
@@ -35,7 +35,7 @@ sub module_generate_hash
     $salt = get_pstoken_salt ();
   }
 
-  my $hash_buf = sha1_hex (pack ("H*", $salt) . encode ("UTF-16LE", $word));
+  my $hash_buf = sha1_hex (pack ("H*", $salt) . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $hash = sprintf ("%s:%s", $hash_buf, $salt);
 

--- a/tools/test_modules/m13500.pm
+++ b/tools/test_modules/m13500.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha1_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 16], [-1, -1], [-1, -1]] }
 
 sub get_pstoken_salt
@@ -35,7 +49,7 @@ sub module_generate_hash
     $salt = get_pstoken_salt ();
   }
 
-  my $hash_buf = sha1_hex (pack ("H*", $salt) . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $hash_buf = sha1_hex (pack ("H*", $salt) . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $hash = sprintf ("%s:%s", $hash_buf, $salt);
 

--- a/tools/test_modules/m13800.pm
+++ b/tools/test_modules/m13800.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA qw (sha256_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [256, 256], [0, 27], [256, 256], [-1, -1]] }
 
 sub module_generate_hash
@@ -18,7 +32,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
+  my $word_utf16le = encode ("UTF-16LE", decode ($PW_CHARSET, $word));
 
   my $salt_bin = pack ("H*", $salt);
 

--- a/tools/test_modules/m13800.pm
+++ b/tools/test_modules/m13800.pm
@@ -18,7 +18,7 @@ sub module_generate_hash
   my $word = shift;
   my $salt = shift;
 
-  my $word_utf16le = encode ("UTF-16LE", $word);
+  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $salt_bin = pack ("H*", $salt);
 

--- a/tools/test_modules/m15300.pm
+++ b/tools/test_modules/m15300.pm
@@ -13,6 +13,20 @@ use Digest::SHA qw (sha1 hmac_sha1);
 use Crypt::ECB;
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub get_random_dpapimk_salt
@@ -130,11 +144,11 @@ sub module_generate_hash
 
   if ($context == 1)
   {
-    $user_hash = sha1 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
+    $user_hash = sha1 (encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf)));
   }
   elsif ($context == 2)
   {
-    $user_hash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
+    $user_hash = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf)));
   }
 
   $user_derivationKey = hmac_sha1 (encode ("UTF-16LE", $SID . "\x00"), $user_hash);

--- a/tools/test_modules/m15300.pm
+++ b/tools/test_modules/m15300.pm
@@ -130,11 +130,11 @@ sub module_generate_hash
 
   if ($context == 1)
   {
-    $user_hash = sha1 (encode ("UTF-16LE", $word_buf));
+    $user_hash = sha1 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
   elsif ($context == 2)
   {
-    $user_hash = md4 (encode ("UTF-16LE", $word_buf));
+    $user_hash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
 
   $user_derivationKey = hmac_sha1 (encode ("UTF-16LE", $SID . "\x00"), $user_hash);

--- a/tools/test_modules/m15310.pm
+++ b/tools/test_modules/m15310.pm
@@ -14,6 +14,20 @@ use Crypt::PBKDF2;
 use Crypt::ECB;
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub get_random_dpapimk_salt
@@ -132,7 +146,7 @@ sub module_generate_hash
 
   my $SIDenc = encode ("UTF-16LE", $SID);
 
-  my $NTLMhash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
+  my $NTLMhash = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf)));
 
   my $hasher = Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256);
 

--- a/tools/test_modules/m15310.pm
+++ b/tools/test_modules/m15310.pm
@@ -132,7 +132,7 @@ sub module_generate_hash
 
   my $SIDenc = encode ("UTF-16LE", $SID);
 
-  my $NTLMhash = md4 (encode ("UTF-16LE", $word_buf));
+  my $NTLMhash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
 
   my $hasher = Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256);
 

--- a/tools/test_modules/m15900.pm
+++ b/tools/test_modules/m15900.pm
@@ -132,11 +132,11 @@ sub module_generate_hash
 
   if ($context == 1)
   {
-    $user_hash = sha1 (encode ("UTF-16LE", $word_buf));
+    $user_hash = sha1 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
   elsif ($context == 2)
   {
-    $user_hash = md4 (encode ("UTF-16LE", $word_buf));
+    $user_hash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
   }
 
   $user_derivationKey = hmac_sha1 (encode ("UTF-16LE", $SID . "\x00"), $user_hash);

--- a/tools/test_modules/m15900.pm
+++ b/tools/test_modules/m15900.pm
@@ -14,6 +14,20 @@ use Crypt::CBC;
 use Crypt::ECB;
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub get_random_dpapimk_salt
@@ -132,11 +146,11 @@ sub module_generate_hash
 
   if ($context == 1)
   {
-    $user_hash = sha1 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
+    $user_hash = sha1 (encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf)));
   }
   elsif ($context == 2)
   {
-    $user_hash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
+    $user_hash = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf)));
   }
 
   $user_derivationKey = hmac_sha1 (encode ("UTF-16LE", $SID . "\x00"), $user_hash);

--- a/tools/test_modules/m15910.pm
+++ b/tools/test_modules/m15910.pm
@@ -133,7 +133,7 @@ sub module_generate_hash
 
   my $SIDenc = encode ("UTF-16LE", $SID);
 
-  my $NTLMhash = md4 (encode ("UTF-16LE", $word_buf));
+  my $NTLMhash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
 
   my $hasher = Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256);
 

--- a/tools/test_modules/m15910.pm
+++ b/tools/test_modules/m15910.pm
@@ -15,6 +15,20 @@ use Crypt::CBC;
 use Crypt::ECB;
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub get_random_dpapimk_salt
@@ -133,7 +147,7 @@ sub module_generate_hash
 
   my $SIDenc = encode ("UTF-16LE", $SID);
 
-  my $NTLMhash = md4 (encode ("UTF-16LE", decode ("utf-8", $word_buf)));
+  my $NTLMhash = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word_buf)));
 
   my $hasher = Crypt::PBKDF2->hasher_from_algorithm ('HMACSHA2', 256);
 

--- a/tools/test_modules/m18200.pm
+++ b/tools/test_modules/m18200.pm
@@ -23,7 +23,7 @@ sub module_generate_hash
   my $checksum            = shift;
   my $edata2              = shift;
 
-  my $k = md4 (encode ("UTF-16LE", $word));
+  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
 
   my $k1 = hmac_md5 ("\x08\x00\x00\x00", $k);
 

--- a/tools/test_modules/m18200.pm
+++ b/tools/test_modules/m18200.pm
@@ -13,6 +13,20 @@ use Crypt::RC4;
 use Digest::HMAC_MD5 qw (hmac_md5);
 use Digest::MD4      qw (md4);
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [16, 16], [0, 27], [16, 16], [-1, -1]] }
 
 sub module_generate_hash
@@ -23,7 +37,7 @@ sub module_generate_hash
   my $checksum            = shift;
   my $edata2              = shift;
 
-  my $k = md4 (encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $k = md4 (encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   my $k1 = hmac_md5 ("\x08\x00\x00\x00", $k);
 

--- a/tools/test_modules/m22100.pm
+++ b/tools/test_modules/m22100.pm
@@ -12,6 +12,20 @@ use Digest::SHA qw (sha256);
 use Crypt::Mode::ECB;
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[6, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
 
 my $ITER     = 1048576; # 0x100000
@@ -176,7 +190,7 @@ sub module_generate_hash
 
   # key generation (KDF):
 
-  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
+  my $word_utf16le = encode ("UTF-16LE", decode ($PW_CHARSET, $word));
 
   my $pass_hash = sha256 (sha256 ($word_utf16le));
 

--- a/tools/test_modules/m22100.pm
+++ b/tools/test_modules/m22100.pm
@@ -176,7 +176,7 @@ sub module_generate_hash
 
   # key generation (KDF):
 
-  my $word_utf16le = encode ("UTF-16LE", $word);
+  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $pass_hash = sha256 (sha256 ($word_utf16le));
 

--- a/tools/test_modules/m22700.pm
+++ b/tools/test_modules/m22700.pm
@@ -58,7 +58,7 @@ sub module_generate_hash
   my $block1 = shift;
   my $block2 = shift;
 
-  my $word_utf16be = encode ('UTF-16BE', $word);
+  my $word_utf16be = encode ('UTF-16BE', decode ('utf-8', $word));
 
   my $key = scrypt_raw ($word_utf16be, $FIXED_SALT, $SCRYPT_N, $SCRYPT_R, $SCRYPT_P, 32);
 

--- a/tools/test_modules/m22700.pm
+++ b/tools/test_modules/m22700.pm
@@ -12,6 +12,20 @@ use Crypt::ScryptKDF qw (scrypt_raw);
 use Encode;
 use Crypt::CBC;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
 
 my $SCRYPT_N = 16384;
@@ -58,7 +72,7 @@ sub module_generate_hash
   my $block1 = shift;
   my $block2 = shift;
 
-  my $word_utf16be = encode ('UTF-16BE', decode ('utf-8', $word));
+  my $word_utf16be = encode ('UTF-16BE', decode ($PW_CHARSET, $word));
 
   my $key = scrypt_raw ($word_utf16be, $FIXED_SALT, $SCRYPT_N, $SCRYPT_R, $SCRYPT_P, 32);
 

--- a/tools/test_modules/m24800.pm
+++ b/tools/test_modules/m24800.pm
@@ -13,13 +13,27 @@ use Digest::HMAC qw (hmac);
 use Encode       qw (encode);
 use MIME::Base64 qw (encode_base64);
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [-1, -1], [0, 27], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
 {
   my $word = shift;
 
-  my $unicode_word = encode ("UTF-16LE", decode ("utf-8", $word));
+  my $unicode_word = encode ("UTF-16LE", decode ($PW_CHARSET, $word));
 
   my $digest = hmac ($unicode_word, $unicode_word, \&sha1, 64);
 

--- a/tools/test_modules/m24800.pm
+++ b/tools/test_modules/m24800.pm
@@ -19,7 +19,7 @@ sub module_generate_hash
 {
   my $word = shift;
 
-  my $unicode_word = encode ("UTF-16LE", $word);
+  my $unicode_word = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $digest = hmac ($unicode_word, $unicode_word, \&sha1, 64);
 

--- a/tools/test_modules/m25300.pm
+++ b/tools/test_modules/m25300.pm
@@ -12,6 +12,20 @@ use MIME::Base64 qw (encode_base64);
 use Digest::SHA  qw (sha512);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 64], [16, 16], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -20,7 +34,7 @@ sub module_generate_hash
   my $salt  = shift;
   my $iter  = shift // 100000;
 
-  my $tmp = sha512 ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
+  my $tmp = sha512 ($salt . encode ("UTF-16LE", decode ($PW_CHARSET, $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m25300.pm
+++ b/tools/test_modules/m25300.pm
@@ -20,7 +20,7 @@ sub module_generate_hash
   my $salt  = shift;
   my $iter  = shift // 100000;
 
-  my $tmp = sha512 ($salt . encode ("UTF-16LE", $word));
+  my $tmp = sha512 ($salt . encode ("UTF-16LE", decode ("utf-8", $word)));
 
   for (my $i = 0; $i < $iter; $i++)
   {

--- a/tools/test_modules/m27700.pm
+++ b/tools/test_modules/m27700.pm
@@ -27,7 +27,7 @@ sub module_generate_hash
   my $iv   = shift // random_bytes (16);
   my $data = shift;
 
-  my $word_utf16be = encode ('UTF-16BE', $word);
+  my $word_utf16be = encode ('UTF-16BE', decode ('utf-8', $word));
 
   my $key = scrypt_raw ($word_utf16be, $salt, $SCRYPT_N, $SCRYPT_R, $SCRYPT_P, 32);
 

--- a/tools/test_modules/m27700.pm
+++ b/tools/test_modules/m27700.pm
@@ -12,6 +12,20 @@ use Crypt::ScryptKDF qw (scrypt_raw);
 use Encode;
 use Crypt::CBC;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [8, 8], [-1, -1], [-1, -1], [-1, -1]] }
 
 my $SCRYPT_N = 16384;
@@ -27,7 +41,7 @@ sub module_generate_hash
   my $iv   = shift // random_bytes (16);
   my $data = shift;
 
-  my $word_utf16be = encode ('UTF-16BE', decode ('utf-8', $word));
+  my $word_utf16be = encode ('UTF-16BE', decode ($PW_CHARSET, $word));
 
   my $key = scrypt_raw ($word_utf16be, $salt, $SCRYPT_N, $SCRYPT_R, $SCRYPT_P, 32);
 

--- a/tools/test_modules/m29000.pm
+++ b/tools/test_modules/m29000.pm
@@ -11,6 +11,20 @@ use warnings;
 use Digest::SHA1 qw (sha1 sha1_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [0, 128], [-1, -1], [-1, -1], [-1, -1]] }
 
 sub module_generate_hash
@@ -19,7 +33,7 @@ sub module_generate_hash
   my $salt = shift;
   my $user = shift // random_mixedcase_string (random_number (0, 256 / 2));
 
-  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
+  my $word_utf16le = encode ("UTF-16LE", decode ($PW_CHARSET, $word));
   my $user_utf16le = encode ("UTF-16LE", $user);
 
   my $digest = sha1_hex ($salt . sha1 ($user_utf16le . ':' . $word_utf16le));

--- a/tools/test_modules/m29000.pm
+++ b/tools/test_modules/m29000.pm
@@ -19,7 +19,7 @@ sub module_generate_hash
   my $salt = shift;
   my $user = shift // random_mixedcase_string (random_number (0, 256 / 2));
 
-  my $word_utf16le = encode ("UTF-16LE", $word);
+  my $word_utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
   my $user_utf16le = encode ("UTF-16LE", $user);
 
   my $digest = sha1_hex ($salt . sha1 ($user_utf16le . ':' . $word_utf16le));

--- a/tools/test_modules/m29200.pm
+++ b/tools/test_modules/m29200.pm
@@ -17,6 +17,20 @@ use Digest::SHA qw (sha1 sha1_hex);
 use Crypt::OpenSSL::Bignum::CTX;
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [32, 32], [-1, -1], [-1, -1], [-1, -1]] }
 
 my $GENERATOR = "05";
@@ -35,7 +49,7 @@ sub module_generate_hash
     $user = encode ('UTF16-LE', $user);
   }
 
-  my $word_utf16 = encode ("UTF-16LE", decode ("utf-8", $word));
+  my $word_utf16 = encode ("UTF-16LE", decode ($PW_CHARSET, $word));
 
   my $exponent = sha1_hex ($salt . sha1 ($user . ":" . $word_utf16));
 

--- a/tools/test_modules/m29200.pm
+++ b/tools/test_modules/m29200.pm
@@ -35,7 +35,7 @@ sub module_generate_hash
     $user = encode ('UTF16-LE', $user);
   }
 
-  my $word_utf16 = encode ("UTF-16LE", $word);
+  my $word_utf16 = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $exponent = sha1_hex ($salt . sha1 ($user . ":" . $word_utf16));
 

--- a/tools/test_modules/m31300.pm
+++ b/tools/test_modules/m31300.pm
@@ -12,6 +12,20 @@ use Digest::MD4 qw (md4 md4_hex);
 use Digest::MD5 qw (md5 md5_hex);
 use Encode;
 
+# The optimized kernels widen each byte instead of decoding the UTF-8, and
+# module_01000.c:58 documents that as deliberate rather than as a bug, so the two
+# kernel families really do disagree on a multi byte password. The oracle follows
+# whichever one test.sh is about to run: decoding as latin1 reproduces the
+# widening byte for byte, decoding as utf-8 is the conversion the pure kernels do.
+# test.sh exports IS_OPTIMIZED from the same value it uses to decide on -O.
+
+my $PW_CHARSET = "latin1";
+
+if (exists $ENV{"IS_OPTIMIZED"} && defined $ENV{"IS_OPTIMIZED"} && $ENV{"IS_OPTIMIZED"} == 0)
+{
+  $PW_CHARSET = "utf-8";
+}
+
 sub module_constraints { [[0, 256], [96, 96], [0, 27], [96, 96], [-1, -1]] }
 
 sub module_generate_hash
@@ -21,7 +35,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
+  my $utf16le = encode ("UTF-16LE", decode ($PW_CHARSET, $word));
 
   my $digest = md5_hex (md4 ($utf16le) . $salt_bin);
 

--- a/tools/test_modules/m31300.pm
+++ b/tools/test_modules/m31300.pm
@@ -21,7 +21,7 @@ sub module_generate_hash
 
   my $salt_bin = pack ("H*", $salt);
 
-  my $utf16le = encode("UTF-16LE", $word);
+  my $utf16le = encode ("UTF-16LE", decode ("utf-8", $word));
 
   my $digest = md5_hex (md4 ($utf16le) . $salt_bin);
 

--- a/tools/test_modules/m34100.sh
+++ b/tools/test_modules/m34100.sh
@@ -24,10 +24,15 @@ declare -A CIPHERS=(
 
 size=20   # MiB
 
-OUTPUT_DIR="/tmp/out"
+# Where the containers, the mount points and the log go. tools/test.sh points these
+# at the directory of the run that asked for them, so nothing is left in /tmp when
+# the run is thrown away. Run by hand they keep the paths they always had.
+OUTPUT_DIR="${HCTEST_SCRATCH_DIR:-/tmp/out}"
 mkdir -p "$OUTPUT_DIR"
-MOUNT_DIR="/tmp/mnt"
+MOUNT_DIR="${HCTEST_MOUNT_DIR:-/tmp/mnt}"
 mkdir -p "$MOUNT_DIR"
+LOG_FILE="${OUTPUT_DIR}/m34100.log"
+CMD_LOG_FILE="${OUTPUT_DIR}/m34100.cmd.log"
 
 create_luks_container() {
   local PASSWORD="$1"
@@ -39,12 +44,12 @@ create_luks_container() {
   shift 6
   local extra_opts=("$@")
 
-  echo  "Creating $filename (size ${size_mb}MiB) with password length ${#PASSWORD}: $PASSWORD..." >> /tmp/m34100.sh
+  echo  "Creating $filename (size ${size_mb}MiB) with password length ${#PASSWORD}: $PASSWORD..." >> ${LOG_FILE}
   dd if=/dev/zero of="$filename" bs=1M count="$size_mb" status=none
 
   loopdev=$(sudo losetup --show -f "$filename")
 
-cat >> /tmp/m34100.sh.log <<EOF
+cat >> ${CMD_LOG_FILE} <<EOF
 sudo cryptsetup luksFormat \
 --batch-mode \
 --type "$luks_type" \
@@ -64,9 +69,9 @@ EOF
       "${extra_opts[@]}" \
       "$loopdev" <<< "$PASSWORD"; then
       true
-      echo "Formatted: $filename" >> /tmp/m34100.sh
+      echo "Formatted: $filename" >> ${LOG_FILE}
   else
-    echo "X Failed to format: $filename" >> /tmp/m34100.sh
+    echo "X Failed to format: $filename" >> ${LOG_FILE}
     sudo losetup -d "$loopdev"
     rm -f "$filename"
     return
@@ -75,21 +80,21 @@ EOF
   name="luks$(basename "$filename" | sha1sum | cut -c1-8)"
 
   if [ -e "/dev/mapper/$name" ]; then
-    echo "! Device $name already exists. Closing it first." >> /tmp/m34100.sh
+    echo "! Device $name already exists. Closing it first." >> ${LOG_FILE}
     sudo cryptsetup close "$name" || true
   fi
 
   if sudo cryptsetup open "$loopdev" "$name" <<< "$PASSWORD"; then
     true
-    echo "Decrypted: $filename" >> /tmp/m34100.sh
+    echo "Decrypted: $filename" >> ${LOG_FILE}
   else
-    echo  "X Failed to decrypt: $filename" >> /tmp/m34100.sh
+    echo  "X Failed to decrypt: $filename" >> ${LOG_FILE}
     sudo losetup -d "$loopdev"
     rm -f "$filename"
     return
   fi
 
-  sudo mkfs.ext4 -q /dev/mapper/"$name" 2>> /tmp/m34100.sh
+  sudo mkfs.ext4 -q /dev/mapper/"$name" 2>> ${LOG_FILE}
 
   mount_point="$MOUNT_DIR/$name"
   mkdir -p "$mount_point"
@@ -102,7 +107,10 @@ EOF
   done
   sudo cryptsetup close "$name"
 
-  echo  "ext4: $filename" >> /tmp/m34100.sh
+  # the mount point is empty now, and one is created per container
+  rmdir "$mount_point" 2>/dev/null || true
+
+  echo  "ext4: $filename" >> ${LOG_FILE}
 
   sudo losetup -D
 }
@@ -127,5 +135,10 @@ create_luks_container "$password" "$file" luks2 "$cipher" sha256 "$size" \
   --pbkdf-parallel "$threads"
 
 ${TDIR}/luks2hashcat.py $file | grep -vE '^[0-9]+$' > $file.hash
+
+# the caller is handed the extracted hash, so the container is 20 MiB of dead weight
+# from here on. Without this a suite run leaves one image per generated vector behind
+# in OUTPUT_DIR, for good.
+rm -f "$file"
 
 echo "$file.hash"


### PR DESCRIPTION
`tools/test.pl` builds every password out of the digits `0` to `9`, and `tools/test.sh` builds
every `-g` container with the literal `hashcat` and searches for it with a literal mask.
Neither can fail for the right reason. This branch changes both.

This is .1 of the split discussed in https://github.com/hashcat/hashcat/pull/4810#issuecomment-5483004665: only improve test coverage.

This depends on the fix in https://github.com/hashcat/hashcat/pull/4812 hence it is branched as such (_I'll remove the draft label on this PR once that PR lands in master_). Without it this branch is red for 22 modes under
`-a 3`, which is the point of it: `./tools/test.sh -m 130 -a all -t all -D 1 -P -f -V 1` gives
`Error 7/7` for `-a 3` on master and `OK 16, Error 0` with the fix applied. Merge the fix first,
or merge them together.

## Reproduction

The suite cannot see a UTF-8 bug today. Revert only the `hc_enc_next()` hunk of 5c840aaec,
"Crack non ASCII passwords again in 41 hash modes", and every test still passes:

```
git show 5c840aaec -- OpenCL/inc_common.cl | git apply -R -
rm -rf kernels/
./tools/test.sh -m 1000 -a all -t all -D 1 -P -f -V 1
```

```
before this branch: 16 OK,  0 Error, 1 Skip   the suite does not notice
after  this branch:  3 OK, 13 Error, 1 Skip   7/8 not found under -a 0 alone
```

The one Skip is `Attack 4, Mode single`, which master skips either way.

Same for the containers. `-g` built them with `hashcat` and searched `hashca?l`, both
hardcoded, so a pass proved only that the literal matched itself:

```
./tools/test.sh -m 22931 -g -a all -t single -D 1 -f -V 1

before: every run builds the key with 'hashcat' and searches 'hashca?l'
after:  one run built '7<U+0939>14551048', the next a different one, both Cracked, rc=0
```

## What the passwords look like now

```
7<U+0939>60778768        2886128986184<U+4E2D>0542
0489<U+AC00>5            ह4€0龍ह9文44
```

Eleven characters, covering the lead bytes `hc_enc_next()` has to get right, including one
4 byte character: euro, hiragana, katakana, four CJK, hangul, devanagari, fullwidth latin, and
U+1F600. A character can land anywhere, including the first byte.

`random_non_ascii_string()` joins `random_numeric_string()` and substitutes them into the digits
it returns. The substitution is in place, so the byte length does not change and the password
still fits the mode's `Pwd.Len.Max`. It comes back as plain digits for a mode that cannot take
one, so a caller never has to ask which. `random_numeric_string()` is untouched, so salts, site
keys and challenge characters keep getting what they always got, a test module added later
cannot pick up multi byte salts by accident, and `tools/test_modules/README.md`, which points
modules at it for exactly that job, stays correct as written.

Which modes get them is read out of the kernels, because there is no flag for it.
`OPTS_TYPE_PT_ALWAYS_ASCII` is about hexifying output, not about what a mode can crack, and only
modules 3000 and 25400 set it. So `inc_hash_*.cl` is split into the helpers that call
`hc_enc_next()` and the ones that widen, and a mode gets multi byte passwords when the pure
kernel that will run uses a decoding one. Modes that case fold the plaintext, spell it in hex or
base58, or build it in `module_get_random_password()` stay on ASCII, as does any UTF-16 mode
under `-O`.

### Turning it off

`tools/test.pl` honours one environment variable, `NO_NON_ASCII`. Set it to anything and every
generated password comes back as plain digits:

```
tools/test.pl:1070    return 0 if exists $ENV{"NO_NON_ASCII"};
```

It is one line, nothing depends on it, and it is deliberately not in `test.sh -h`: it is for
whoever is working on the suite, not for whoever is running it. What it buys is the answer to
the first question a red mode raises, is this the encoding or was it already broken, in one run
instead of an edit to `test.pl`. It earned its place three times while this branch was written:

```
m11600   non-ASCII on -> Error 5/8    NO_NON_ASCII=1 -> OK 0/8     the -O gate, not the oracle
m22931   -a 1/6/7 red                 NO_NON_ASCII=1 -> green      the split, not the container work
m130     -a 3 Error 7/7               NO_NON_ASCII=1 -> OK 0/7     the kernel, not the mask
```

It is also how the before lines in this description were measured against the same passwords.

## What had to change so the attacks can spell one

- `export LC_ALL=C`, so `${#pass}` and `cut -c` count bytes the way hashcat does.
- `mask_literalize()`, because no `?d` produces byte `0xe2`. A mask position over a non-digit
  byte becomes that byte, which leaves the keyspace unchanged.
- `utf8_split_point()`, which moves a dict/mask split to a character boundary. The combinator
  kernels convert the word and the amplifier separately, so each half has to be valid UTF-8 on
  its own:

    ```
    printf '12345\xe7\n' > /tmp/d1 ; printf '12345\n' > /tmp/d2
    H=ac25eecbd4dd9f58b674d3bebe463f9e     # NTLM of 12345<U+7801>678
    ./hashcat -m 1000 -a 6 -D 1 --force --potfile-disable --backend-vector-width 1 "$H" /tmp/d2 "$(printf '\xe7\xa0\x81?d?d?d')"
    ./hashcat -m 1000 -a 6 -D 1 --force --potfile-disable --backend-vector-width 1 "$H" /tmp/d1 "$(printf '\xa0\x81?d?d?d')"

    split on a character boundary: Status Cracked,   rc=0
    split inside the character:    Status Exhausted, rc=1
    ```

    Both spell the same 11 bytes. `-m 0` cracks either. This one is by design, not a bug.
- A character is only written where the password keeps at least one byte outside it. A password
  that is nothing but one character cannot be cut in two on a boundary, and `-a 7` came back
  with an empty dictionary. That costs nothing above 4 bytes.

### Multi hash

The eight passwords of a length share one mask, so `tools/test.pl` draws the layout, which
character and where, from a generator seeded by the password length rather than from `rand()`.
All eight come out with their characters in the same places and one mask can spell them; the
digits stay random per password.

```
len 8   2327<U+AC00>1   0629<U+AC00>5   0489<U+AC00>5
```

`-a 6`, `-a 7` and `-a 12` multi build their mask from what the dictionary holds rather than
from `mask_6[]` and `mask_7[]`, which were sized for a split on a byte.

`-a 3` multi is one `--increment` run over passwords of many lengths at once, so no single mask
spells all of them however the layout is drawn. It already had a second path for the cases where
a mask will not do, handing hashcat an hcmask file, which is one mask per line. That path is
taken whenever a character is in play, with a line per password, so the run keeps its shape.

### 41 test oracles hashed the password as Latin-1

Ground truth against a real archive:

```
7z a -mhe=on -p'pass€1' /tmp/t.7z /etc/hostname
perl ~/john/run/7z2john.pl /tmp/t.7z | grep -oE '\$7z\$[^:]*' > /tmp/t.hash
./hashcat -m 11600 -a 3 -D 1 --force --potfile-disable --backend-vector-width 1 "$(cat /tmp/t.hash)" 'pass€?d'

Status Cracked, Recovered 1/1, rc=0
```

hashcat and 7-Zip agree, so the kernel is right. `tools/test_modules/m11600.pm` called
`encode("UTF-16LE", $word)` on the raw bytes, which widens each byte as if it were Latin-1. 39
modules had the same bug and now decode first. The modules whose kernel widens too are left
alone, because there the oracle was right.

m05500 and m05600 took the NT hash from `Authen::Passphrase::NTHash`, which is wrong for a
character outside the BMP:

```
perl -MAuthen::Passphrase::NTHash -MEncode -MDigest::MD4=md4_hex -e \
  '$c = decode("utf-8", "12345678\xf0\x9f\x98\x80");
   print Authen::Passphrase::NTHash->new(passphrase => $c)->hash_hex, "\n",
         md4_hex(encode("UTF-16LE", $c)), "\n"'

36a5dbdc75876d5364ef604c79180078
1a160fb7177bbdf8e8edbe681acd5380
```

hashcat agrees with the second, so both modules compute it directly now.

## The -g containers

Making the container password random turned two container tests red, and both were red for
reasons that had nothing to do with the password.

**The LUKS `-a 3` mask had been collapsing to `?l`.** `luks_test()` reads `LUKS_PASSWORD`, which
is only ever assigned inside `luks_legacy_test()`. For mode 29511 that function has not run, so
the variable is empty, `${#LUKS_PASSWORD} - 1` is `-1`, and the mask degenerates. Not new:

```
git checkout master -- tools/test.sh
./tools/test.sh -m 29511 -g -a 3 -t single -D 1 -f -V 1

Error 1/1 six times, mask '?l', the same as before the change
```

It stayed invisible because the mask never had to match anything until `-g` started building the
container: against a container that is not there, a failed crack and a skipped test look alike.

**`-g` never built a LUKS2 container**, while claiming it could. 34100 was in `GEN_MODES` and in
`GEN_SUDO_MODES`, so it asked for root and reported `OK`, but there was no `luks2_generate()`,
`luks2_test()` walked `${TDIR}/luks2_tests` which `-g` never fills, the dispatch called it only
when `GENERATE_CONTAINERS` is 0, and the guard read a global only the download path sets. It
reported `OK` on the strength of its `test.pl` oracle and looked like it had covered the
container. There is a generator now, six containers, every combination the mode accepts.
`cryptsetup luksDump` on one reports `Version: 2`, `PBKDF: argon2id`, `Time cost: 4`,
`Memory: 16384`, `Threads: 1`, and the `OK` is not vacuous:

```
./hashcat -a 3 -m 34100 <hash> 'zzzzzz?l'   Exhausted, 0/1
./hashcat -a 3 -m 34100 <hash> 'lbvejc?l'   Cracked,   1/1
```

**The generators needed a UTF-8 locale.** `LC_ALL=C` is what makes `${#pass}` count bytes, and
veracrypt reads its password through wxWidgets, which decodes argv with that same variable.
Under `LC_ALL=C` a UTF-8 password is read as Latin-1 and re-encoded, so the volume answers to
bytes nobody chose:

```
veracrypt --text --create /tmp/v.vc ... --password="$(printf '7\xe0\xa4\xb960778768')"
printf '7\xe0\xa4\xb960778768\n' > /tmp/v.txt
./hashcat -a 0 -m 13721 /tmp/v.vc /tmp/v.txt

created under LC_ALL=C      rc=1, not cracked
created under LC_ALL=C.utf8 rc=0, cracked
```

hashcat is not involved, it gets the bytes it was given. Confirmed by cracking the volume with
the mojibake and only with it: `utf-8` rc=1, `latin1 -> utf8` rc=0, `utf-16le/be` rc=1. tcplay
is driven through expect, whose Tcl picks its encoding the same way. So the generators that take
a password on the command line run under a UTF-8 locale, picked from whichever of `C.UTF-8`,
`C.utf8`, `en_US.UTF-8` or `en_US.utf8` the machine has, while the shell keeps `LC_ALL=C`.

**The LUKS oracles left every container they built in `/tmp`.** They build a real 20 MiB
container to get a hash out of it, hardcoded `/tmp/out` and `/tmp/mnt`, and deleted none of it
except on their two failure paths. On the machine this was written on `/tmp/out` had reached
4.2 GB across 416 files and `/tmp/mnt` held 280 empty directories.

```
./tools/test_modules/m34100.sh 'hashcat' >/dev/null

before: /tmp/out 4545M -> 4566M, /tmp/mnt 280 -> 281 entries, and they stay
after:  both unchanged, 1 MiB of hash and log in the scratch directory the caller names
```

The container goes once the hash is out of it, except for mode 14600 which is handed the
container itself; the mount point goes with it; and `OUTPUT_DIR`, `MOUNT_DIR` and the log honour
`HCTEST_SCRATCH_DIR` and `HCTEST_MOUNT_DIR`, which `tools/test.sh` points at the run's own
directory. Run by hand the scripts keep the paths they always had.

## Testing

PoCL CPU only, `-D 1 --force`, with the kernel fix from the other PR applied.

- `-m 1000` at `-a all -t all -V 1 -P`: OK 16, Error 0, Skip 1, with characters in both single
  and multi hash mode. Green again with `NO_NON_ASCII=1`, so the digits path did not regress.
- all 41 modules whose oracle changed, `-a 0 -t single -V 4 -P`, re-run after the kernel change
  rather than before it
- m130, m5500, m5600, m11600, m17200, m22931 at `-a all`
- m0, m10, m400, m22000 and a 24 mode spread: 20, 100, 110, 300, 500, 900, 1400, 1410, 1700,
  1710, 2611, 2711, 2811, 3710, 4400, 4500, 4700, 6000, 6100, 6900, 11500, 17300, 21100, 24900
- containers as root, `-g -a all -t single`, each run building its own password:

```
m6211  TrueCrypt   OK 3  Error 0
m13721 VeraCrypt   OK 5  Error 0
m29511 LUKS1       OK 9  Error 0  Skip 1
m34100 LUKS2       OK 7  Error 0
m22931 SSH         OK 10 Error 0  Skip 1
m17200 PKZIP       OK 8  Error 0  Skip 1
m13711 VeraCrypt   Skip: veracrypt 1.26 dropped RIPEMD-160 volumes
```

The Skips are `Attack 4, Mode single`, which master skips the same way.

## Not covered

- **No GPU.** PoCL CPU only.
- `tools/test_edge.sh` was not run.
- `test.sh` is not safe to run concurrently with another instance: two runs share the device,
  and with `-g` they also share sudo, loop devices and device-mapper names. The failure mode is
  silent, plausible-looking `Error : N/N` lines rather than a clash. Pre-existing, not addressed
  here.
- **m24800 produces 0 test vectors.** Pre-existing, identical with `NO_NON_ASCII=1`.
