### PR TITLE
regression in .pm due to test.sh non-ASCII

### DIFF
--- a/tools/test_modules/m11700.pm
+++ b/tools/test_modules/m11700.pm
@@ -10,25 +10,39 @@ use warnings;
 
 sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
 
+# The password goes over argv as hex. It is arbitrary bytes, and a Python b"..."
+# literal can only hold ASCII, so interpolating it into the source turns every
+# candidate above 0x7f into a SyntaxError.
+#
+# PyGOST outputs digests in little-endian order, while the kernels expect them in
+# big-endian; hence the digest[::-1] mirroring.
+
+my $PY = <<'PYCODE';
+import binascii
+import sys
+from pygost import gost34112012256
+digest = gost34112012256.new (bytes.fromhex (sys.argv[1])).digest ()
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+
+  open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+
+  local $/;
+  my $out = <$fh>;
+  close ($fh);
+
+  return $out;
+}
+
 sub module_generate_hash
 {
   my $word = shift;
 
-  # PyGOST outputs digests in little-endian order, while the kernels
-  # expect them in big-endian; hence the digest[::-1] mirroring.
-  my $python_code = <<"END_CODE";
-
-import binascii
-import sys
-from pygost import gost34112012256
-digest = gost34112012256.new (b"$word").digest ()
-print (binascii.hexlify (digest[::-1]).decode (), end = "")
-
-END_CODE
-
-  my $hash = `python3 -c '$python_code'`;
-
-  return $hash;
+  return _run (unpack ("H*", $word));
 }
 
 sub module_verify_hash

--- a/tools/test_modules/m11750.pm
+++ b/tools/test_modules/m11750.pm
@@ -10,28 +10,44 @@ use warnings;
 
 sub module_constraints { [[0, 256], [0, 256], [-1, -1], [-1, -1], [-1, -1]] }
 
-sub module_generate_hash
-{
-  my $word = shift;
-  my $salt = shift;
-  my $python_code = <<"END_CODE";
+# The password goes over argv as hex. It is arbitrary bytes, and a Python b"..."
+# literal can only hold ASCII, so interpolating it into the source turns every
+# candidate above 0x7f into a SyntaxError.
 
+my $PY = <<'PYCODE';
 import binascii
 import hmac
 import sys
 from pygost import gost34112012256
-key    = b"$word"
-msg    = b"$salt"
+key    = bytes.fromhex (sys.argv[1])
+msg    = bytes.fromhex (sys.argv[2])
 digest = hmac.new (key, msg, gost34112012256).digest ()
 print (binascii.hexlify (digest[::-1]).decode (), end = "")
+PYCODE
 
-END_CODE
+sub _run
+{
+  my @args = @_;
 
-  my $digest = `python3 -c '$python_code'`;
+  open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
 
-  my $hash = sprintf ("%s:%s", $digest, $salt);
+  local $/;
+  my $out = <$fh>;
+  close ($fh);
 
-  return $hash;
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $digest = _run (unpack ("H*", $word), unpack ("H*", $salt));
+
+  return unless defined $digest;
+
+  return sprintf ("%s:%s", $digest, $salt);
 }
 
 sub module_verify_hash

--- a/tools/test_modules/m11760.pm
+++ b/tools/test_modules/m11760.pm
@@ -10,28 +10,44 @@ use warnings;
 
 sub module_constraints { [[0, 256], [0, 256], [-1, -1], [-1, -1], [-1, -1]] }
 
-sub module_generate_hash
-{
-  my $word = shift;
-  my $salt = shift;
-  my $python_code = <<"END_CODE";
+# The password goes over argv as hex. It is arbitrary bytes, and a Python b"..."
+# literal can only hold ASCII, so interpolating it into the source turns every
+# candidate above 0x7f into a SyntaxError.
 
+my $PY = <<'PYCODE';
 import binascii
 import hmac
 import sys
 from pygost import gost34112012256
-key    = b"$salt"
-msg    = b"$word"
+key    = bytes.fromhex (sys.argv[2])
+msg    = bytes.fromhex (sys.argv[1])
 digest = hmac.new (key, msg, gost34112012256).digest ()
 print (binascii.hexlify (digest[::-1]).decode (), end = "")
+PYCODE
 
-END_CODE
+sub _run
+{
+  my @args = @_;
 
-  my $digest = `python3 -c '$python_code'`;
+  open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
 
-  my $hash = sprintf ("%s:%s", $digest, $salt);
+  local $/;
+  my $out = <$fh>;
+  close ($fh);
 
-  return $hash;
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+
+  my $digest = _run (unpack ("H*", $word), unpack ("H*", $salt));
+
+  return unless defined $digest;
+
+  return sprintf ("%s:%s", $digest, $salt);
 }
 
 sub module_verify_hash

--- a/tools/test_modules/m11800.pm
+++ b/tools/test_modules/m11800.pm
@@ -10,23 +10,36 @@ use warnings;
 
 sub module_constraints { [[0, 256], [-1, -1], [0, 55], [-1, -1], [-1, -1]] }
 
+# The password goes over argv as hex. It is arbitrary bytes, and a Python b"..."
+# literal can only hold ASCII, so interpolating it into the source turns every
+# candidate above 0x7f into a SyntaxError.
+
+my $PY = <<'PYCODE';
+import binascii
+import sys
+from pygost import gost34112012512
+digest = gost34112012512.new (bytes.fromhex (sys.argv[1])).digest ()
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+
+  open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+
+  local $/;
+  my $out = <$fh>;
+  close ($fh);
+
+  return $out;
+}
+
 sub module_generate_hash
 {
   my $word = shift;
 
-  my $python_code = <<"END_CODE";
-
-import binascii
-import sys
-from pygost import gost34112012512
-digest = gost34112012512.new (b"$word").digest ()
-print (binascii.hexlify (digest[::-1]).decode (), end = "")
-
-END_CODE
-
-  my $hash = `python3 -c '$python_code'`;
-
-  return $hash;
+  return _run (unpack ("H*", $word));
 }
 
 sub module_verify_hash

--- a/tools/test_modules/m11850.pm
+++ b/tools/test_modules/m11850.pm
@@ -10,29 +10,44 @@ use warnings;
 
 sub module_constraints { [[0, 256], [0, 256], [-1, -1], [-1, -1], [-1, -1]] }
 
+# The password goes over argv as hex. It is arbitrary bytes, and a Python b"..."
+# literal can only hold ASCII, so interpolating it into the source turns every
+# candidate above 0x7f into a SyntaxError.
+
+my $PY = <<'PYCODE';
+import binascii
+import hmac
+import sys
+from pygost import gost34112012512
+key    = bytes.fromhex (sys.argv[1])
+msg    = bytes.fromhex (sys.argv[2])
+digest = hmac.new (key, msg, gost34112012512).digest ()
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+
+  open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+
+  local $/;
+  my $out = <$fh>;
+  close ($fh);
+
+  return $out;
+}
+
 sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
 
-  my $python_code = <<"END_CODE";
+  my $digest = _run (unpack ("H*", $word), unpack ("H*", $salt));
 
-import binascii
-import hmac
-import sys
-from pygost import gost34112012512
-key    = b"$word"
-msg    = b"$salt"
-digest = hmac.new (key, msg, gost34112012512).digest ()
-print (binascii.hexlify (digest[::-1]).decode (), end = "")
+  return unless defined $digest;
 
-END_CODE
-
-  my $digest = `python3 -c '$python_code'`;
-
-  my $hash = sprintf ("%s:%s", $digest, $salt);
-
-  return $hash;
+  return sprintf ("%s:%s", $digest, $salt);
 }
 
 sub module_verify_hash

--- a/tools/test_modules/m11860.pm
+++ b/tools/test_modules/m11860.pm
@@ -10,29 +10,44 @@ use warnings;
 
 sub module_constraints { [[0, 256], [0, 256], [-1, -1], [-1, -1], [-1, -1]] }
 
+# The password goes over argv as hex. It is arbitrary bytes, and a Python b"..."
+# literal can only hold ASCII, so interpolating it into the source turns every
+# candidate above 0x7f into a SyntaxError.
+
+my $PY = <<'PYCODE';
+import binascii
+import hmac
+import sys
+from pygost import gost34112012512
+key    = bytes.fromhex (sys.argv[2])
+msg    = bytes.fromhex (sys.argv[1])
+digest = hmac.new (key, msg, gost34112012512).digest ()
+print (binascii.hexlify (digest[::-1]).decode (), end = "")
+PYCODE
+
+sub _run
+{
+  my @args = @_;
+
+  open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+
+  local $/;
+  my $out = <$fh>;
+  close ($fh);
+
+  return $out;
+}
+
 sub module_generate_hash
 {
   my $word = shift;
   my $salt = shift;
 
-  my $python_code = <<"END_CODE";
+  my $digest = _run (unpack ("H*", $word), unpack ("H*", $salt));
 
-import binascii
-import hmac
-import sys
-from pygost import gost34112012512
-key    = b"$salt"
-msg    = b"$word"
-digest = hmac.new (key, msg, gost34112012512).digest ()
-print (binascii.hexlify (digest[::-1]).decode (), end = "")
+  return unless defined $digest;
 
-END_CODE
-
-  my $digest = `python3 -c '$python_code'`;
-
-  my $hash = sprintf ("%s:%s", $digest, $salt);
-
-  return $hash;
+  return sprintf ("%s:%s", $digest, $salt);
 }
 
 sub module_verify_hash

--- a/tools/test_modules/m24800.pm
+++ b/tools/test_modules/m24800.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::SHA1 qw (sha1);
 use Digest::HMAC qw (hmac);
-use Encode       qw (encode);
+use Encode       qw (encode decode);
 use MIME::Base64 qw (encode_base64);
 
 # The optimized kernels widen each byte instead of decoding the UTF-8, and

--- a/tools/test_modules/m35100.pm
+++ b/tools/test_modules/m35100.pm
@@ -135,12 +135,12 @@ sub sm3crypts
 
   my $python_code = <<'END_CODE';
 
-from sm3utils import sm3
+import hashlib
 import base64
 
 data_raw = base64.b64decode (sm3_data)
 
-m = sm3 ()
+m = hashlib.new ("sm3")
 m.update (data_raw)
 r = m.hexdigest ()
 
@@ -191,12 +191,12 @@ END_CODE
 
   $python_code = <<'END_CODE';
 
-from sm3utils import sm3
+import hashlib
 import base64
 
 data_raw = base64.b64decode (sm3_data)
 
-m = sm3 ()
+m = hashlib.new ("sm3")
 m.update (data_raw)
 r = m.hexdigest ()
 
@@ -228,12 +228,12 @@ END_CODE
 
   $python_code = <<'END_CODE';
 
-from sm3utils import sm3
+import hashlib
 import base64
 
 data_raw = base64.b64decode (sm3_data)
 
-m = sm3 ()
+m = hashlib.new ("sm3")
 m.update (data_raw)
 r = m.hexdigest ()
 
@@ -281,12 +281,12 @@ END_CODE
 
   $python_code = <<'END_CODE';
 
-from sm3utils import sm3
+import hashlib
 import base64
 
 data_raw = base64.b64decode (sm3_data)
 
-m = sm3 ()
+m = hashlib.new ("sm3")
 m.update (data_raw)
 r = m.hexdigest ()
 
@@ -330,7 +330,7 @@ END_CODE
   my $s_base64 = encode_base64 ($s, "");
 
   $python_code = <<'END_CODE';
-from sm3utils import sm3
+import hashlib
 import base64
 
 tmp = base64.b64decode (tmp_data)
@@ -358,7 +358,7 @@ while i < loops:
   else:
     tmp += p
 
-  m = sm3 ()
+  m = hashlib.new ("sm3")
   m.update (tmp)
   c = m.digest ()
 

--- a/tools/test_modules/m35100.pm
+++ b/tools/test_modules/m35100.pm
@@ -10,7 +10,12 @@ use warnings;
 
 use MIME::Base64 qw (encode_base64 decode_base64);
 
-sub module_constraints { [[0, 256], [0, 20], [0, 15], [0, 20], [-1, -1]] }
+# There is no pure kernel: OpenCL/ carries only m35100-optimized.cl, so hashcat
+# falls back to it even under -P and module_pw_max() then caps the password at 15.
+# Declaring a pure range here made test.pl generate up to 256 bytes against a
+# kernel that cannot take them, and every long candidate was skipped as too long.
+
+sub module_constraints { [[-1, -1], [-1, -1], [0, 15], [0, 20], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m35600.pm
+++ b/tools/test_modules/m35600.pm
@@ -10,19 +10,12 @@ use warnings;
 
 sub module_constraints { [[0, 256], [0, 16], [-1, -1], [-1, -1], [-1, -1]] }
 
-sub module_generate_hash
-{
-  my $word = shift;
-  my $salt = shift;
-  my $iter = shift;
+# The password goes over argv as hex. It is arbitrary bytes, and a Python b"..."
+# literal can only hold ASCII, so interpolating it into the source turns every
+# candidate above 0x7f into a SyntaxError.
 
-  if (!defined $iter)
-  {
-    $iter = "";
-  }
-
-  my $python_code = <<"END_CODE";
-
+my $PY = <<'PYCODE';
+import sys
 from pygost import gost34112012512
 
 _c_digest_offsets = (
@@ -111,25 +104,41 @@ def gost12_512_crypt(pwd: bytes, salt: str, rounds: int) -> str:
 def crypt(pw, salt, rounds):
     hash = gost12_512_crypt(pw, salt, rounds)
     if rounds == DEFAULT_ROUNDS:
-        return '\\\$gost12512hash\\\${}\\\${}'.format(salt, hash)
+        return '$gost12512hash${}${}'.format(salt, hash)
     else:
-        return '\\\$gost12512hash\\\$rounds={}\\\${}\\\${}'.format(rounds, salt, hash)
+        return '$gost12512hash$rounds={}${}${}'.format(rounds, salt, hash)
 
-rounds = "$iter"
+rounds = sys.argv[3]
 if not rounds:
     rounds = DEFAULT_ROUNDS
 else:
     rounds = int(rounds)
-print(crypt(b"$word", "$salt", rounds), end = "")
+print(crypt(bytes.fromhex(sys.argv[1]), sys.argv[2], rounds), end = "")
 
-END_CODE
+PYCODE
 
-  my $hash = `python3 - <<END_CODE
-$python_code
-END_CODE
-`;
+sub _run
+{
+  my @args = @_;
 
-  return $hash;
+  open (my $fh, "-|", "python3", "-c", $PY, @args) or return undef;
+
+  local $/;
+  my $out = <$fh>;
+  close ($fh);
+
+  return $out;
+}
+
+sub module_generate_hash
+{
+  my $word = shift;
+  my $salt = shift;
+  my $iter = shift;
+
+  $iter = "" unless defined $iter;
+
+  return _run (unpack ("H*", $word), $salt, $iter);
 }
 
 sub module_verify_hash


### PR DESCRIPTION
# test modules: pass the password to Python as data, not as source

#4813 gave `tools/test.pl` passwords with multi-byte UTF-8 in them. Seven oracles build their
Python program by pasting the password into a `b"..."` literal, which can only hold ASCII, so
those modes have been throwing away most of their test vectors ever since, and three of the seven
still report `OK` while doing it. Two further faults in `m35100.pm`, older than #4813 and hidden
behind a missing Python package, are fixed here too because they block the same run.

## Reproduction

No build needed for this one:

    perl tools/test.pl single 11700

    before:
      File "<string>", line 5
        digest = gost34112012256.new (b"€2😀40439").digest ()
                                      ^^^^^^^^^^^
    SyntaxError: bytes can only contain ASCII literal characters

    seven of those, and one usable line out of eight

    after: eight lines, nothing on stderr

What the suite makes of that, one mode at a time with nothing else running:

    ./tools/test.sh -m <mode> -a 0 -t single -D 1 -f -V 1 -P

    mode    before                     after
    11700   OK    : 0/1 not found      OK : 0/8 not found
    11750   Error : 7/8 not found      OK : 0/8 not found
    11760   Error : 6/8 not found      OK : 0/8 not found
    11800   OK    : 0/1 not found      OK : 0/8 not found
    11850   Error : 7/8 not found      OK : 0/8 not found
    11860   Error : 6/8 not found      OK : 0/8 not found
    24800   Error : 0/0 not found      OK : 0/8 not found
    35100   Error : 8/8 not found      OK : 0/8 not found
    35600   OK    : 0/1 not found      OK : 0/8 not found

`OK : 0/1` is the line to look at. Mode 11700 passes its suite while testing one password out of
eight, and which one survives is whatever the generator happened to build out of plain digits.

## What is wrong

**Seven oracles paste the password into Python source.** m11700, m11750, m11760, m11800, m11850,
m11860 and m35600 each built a program around `b"$word"` and ran it through the shell. They now
send the password over argv as hex and read it with `bytes.fromhex (sys.argv[1])`, which is the
pattern `m17230.pm` already used. m35600 also fed its program through a shell heredoc, which is
why its source carried `'\\\$gost12512hash\\\$...'`; with the shell gone the escaping goes too.

Whether the breakage was visible came down to the shape of the module. An unsalted oracle returns
the empty string, `test.sh` drops the empty hash, and the mode reports `OK` over the one or two
vectors left. A salted one runs the empty digest through `sprintf ("%s:%s", $digest, $salt)`,
which is not empty, so the vector survives as garbage and the mode reports `Error`.

**m24800 could not generate anything at all.**

    perl tools/test.pl single 24800
    Undefined subroutine &main::decode called at tools/test_modules/m24800.pm line 36.

`818e8c535`, on the branch #4813 merged, added `decode ($PW_CHARSET, $word)` to a file whose
import line reads `use Encode qw (encode);`. Now `qw (encode decode)`. This also corrects the
#4813 body, which listed m24800 as producing zero test vectors and called that pre-existing.

**m35100 imported a package nothing installs.** `from sm3utils import sm3` raised
`ModuleNotFoundError` on every call, and `tools/install_modules.sh` has never installed it. It now
uses `hashlib.new ("sm3")`, which `m31100.pm` already relies on, so the dependency is removed
rather than added.

**m35100 declared a pure kernel it does not have.** `OpenCL/` carries only `m35100-optimized.cl`,
so hashcat falls back to the optimized kernel even under `-P`, and `module_pw_max()` then caps the
password at 15. The oracle declared `[[0, 256], [0, 20], ...]`, so `test.pl` generated up to 256
bytes and hashcat answered

    Skipping mask '9761879503077383076...' because it is larger than the maximum password length.

The pure pairs are now `[-1, -1]`, which is what `get_module_constraints()` reads as "no pure
kernel, use the optimized settings".

## Testing

The nine modes above, before and after, in the table. Each `test.sh` invocation ran on its own:
`tools/test.sh` is not safe to run concurrently, and parallel instances report wrong counts
rather than failing.

Nothing changed for ASCII passwords. Four of the nine can be checked against their own entry in
`docs/hashcat-example-hashes.md`:

    $ echo 'hashcat' | perl tools/test.pl passthrough 11700
    57e9e50caec93d72e9498c211d6dc4f4d328248b48ecf46ba7abfa874f666e36

    $ echo 'hashcat' | perl tools/test.pl passthrough 11800
    5d5bdba48c8f89ee6c0a0e11023540424283e84902de08013aeeb626e819950bb32842903593a1d2e8f71897ff7fe72e17ac9ba8ce1d1d2f7e9c4359ea63bdc3

    $ perl -e 'use lib "./tools/test_modules"; require "m35100.pm";
               print module_generate_hash ("hashcat", "KTTUB40dW4mRyRFd")'
    $sm3$KTTUB40dW4mRyRFd$ul2xLiIY3FJtbo8sv1R93sAYCkxQCH/6rmS1kD5vJYA

    $ perl -e 'use lib "./tools/test_modules"; require "m35600.pm";
               print module_generate_hash ("hashcat", "salt")'
    $gost12512hash$salt$w0TCvk4n0JHA/kPNpHEyf3RR5YuUXReihlrize3NdcPCmtLk/ewG63OUWT.G4bvjegPTeMb/xQ2PK7apsCfC7/

all four of which are the documented example hash for that mode. m35100 also passes under `-O`:

    ./tools/test.sh -m 35100 -a 0 -t single -D 1 -f -V 1 -O
    OK : 0/8 not found, 0/8 not matched, 0/8 timeout, 0/8 skipped

## Deviations

`tools/test_edge.sh` was not run for these modes, which CONTRIBUTING.md asks for. The machine has
no GPU and the run is long; the `test.sh` table above exercises the same oracles through the same
generator.

Four causes in one pull request, where CONTRIBUTING.md asks for one problem. They are one problem
from the outside, in that the same command fails on all nine modes, but the two m35100 faults are
independent of #4813 and are their own commits. Say the word and they go out separately.

The reproduction above contains a euro sign and an emoji. They sit inside pasted output where the
password is the entire point, so the ASCII check flags them and they stay.

## Not in this branch

* **m32700 fails 8/8 and it is not the oracle.** hashcat's own OpenCL self-test for the mode fails
  on this CPU backend, and the password is not recovered with `--self-test-disable` either. No
  file in this branch touches it.
* **Fifteen oracles still interpolate the password into a shell command line**, as
  `qx{python3 - "$word" ...}`. Non-ASCII survives that intact, which is why they are not part of
  this fix, but a password containing `"`, `$` or a backtick silently produces a wrong hash.
  Measured against m31100, where the digest can be checked independently:

      [a€b]      correct
      [a"b]      wrong, empty output
      [a$HOME]   wrong, $HOME expanded
      [a`id`b]   wrong, id executed

  Nothing reaches them today: none of the fifteen defines `module_get_random_password`, so they
  all get the standard generator, which emits digits and multi-byte characters and no shell
  metacharacters. `test.pl passthrough` and `module_verify_hash` after `pack_if_HEX_notation` can
  reach them, and `test.sh` calls neither. The comment at `m31100.pm:15` saying "test.pl generates
  numeric-only passwords, so passing $word straight into the shell is safe here" stopped being
  true with #4813.
* **m05200.pm's verify path cannot run.** It calls `MIME::Base64::decode_base64` fully qualified
  and nothing loads the package. Invisible because `test.sh` never calls `test.pl verify`.
