### PR TITLE
regression in test_edge.sh due to test.sh non-ASCII

### DIFF
--- a/tools/test_edge.sh
+++ b/tools/test_edge.sh
@@ -180,6 +180,84 @@ function clean_cache()
 export LC_CTYPE=C
 export LANG=C
 
+function mask_dots()
+{
+  # A mask of <count> '?d' groups, the shape the suite has always used for a run of digits.
+
+  local md_count="$1"
+  local md_out=""
+  local md_i
+
+  for ((md_i = 0; md_i < md_count; md_i++)); do
+    md_out="${md_out}?d"
+  done
+
+  printf '%s' "${md_out}"
+}
+
+function mask_literalize()
+{
+  # Rewrite a mask so that every position it covers spells the byte that belongs there. The
+  # generated passwords used to be digits from end to end, which is what makes a mask of '?d'
+  # groups work; tools/test.pl can now seed them with multi byte UTF-8, and no '?d' produces a
+  # byte above 0x7f. Those positions become literals, which costs the attack keyspace it was
+  # never searching anyway. Same function as the one in tools/test.sh.
+  #
+  # $1 = the mask, $2 = the exact bytes the mask has to spell. The mask is returned untouched
+  # unless it covers exactly that many bytes, so a caller that hands over the wrong slice, a
+  # mode with its own mask layout for instance, changes nothing.
+
+  local ml_mask="$1"
+  local ml_text="$2"
+
+  local ml_len=${#ml_mask}
+  local ml_pos=0
+  local ml_cnt=0
+  local ml_out=""
+  local ml_tok
+  local ml_byte
+
+  # count the positions first, a '?x' group covers one byte and anything else covers one byte
+
+  while [ ${ml_pos} -lt ${ml_len} ]; do
+    if [ "${ml_mask:${ml_pos}:1}" = "?" ]; then
+      ml_pos=$((ml_pos + 2))
+    else
+      ml_pos=$((ml_pos + 1))
+    fi
+
+    ml_cnt=$((ml_cnt + 1))
+  done
+
+  if [ ${ml_cnt} -ne ${#ml_text} ]; then
+    printf '%s' "${ml_mask}"
+    return
+  fi
+
+  ml_pos=0
+  ml_cnt=0
+
+  while [ ${ml_pos} -lt ${ml_len} ]; do
+    if [ "${ml_mask:${ml_pos}:1}" = "?" ]; then
+      ml_tok="${ml_mask:${ml_pos}:2}"
+      ml_pos=$((ml_pos + 2))
+    else
+      ml_tok="${ml_mask:${ml_pos}:1}"
+      ml_pos=$((ml_pos + 1))
+    fi
+
+    ml_byte="${ml_text:${ml_cnt}:1}"
+    ml_cnt=$((ml_cnt + 1))
+
+    case "${ml_byte}" in
+      [0-9]) ml_out="${ml_out}${ml_tok}"  ;;
+      *)     ml_out="${ml_out}${ml_byte}" ;;
+    esac
+  done
+
+  printf '%s' "${ml_out}"
+}
+
 OUTD="test_edge_$(date +%s)"
 
 TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -1009,6 +1087,13 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                     word_1="${word%???}"
                     mask_1="?d?d?d"
                   fi
+
+                  # No '?d' produces a byte above 0x7f, so a mask ending in one cannot spell a
+                  # password that tools/test.pl seeded with a multi byte character. Spell those
+                  # positions instead. The word and the mask are one string here, so a split that
+                  # lands inside a character still reassembles to the right bytes.
+
+                  mask_1="$(mask_literalize "${mask_1}" "${word#"${word_1}"}")"
                 fi
 
                 CMD="./hashcat ${CUR_OPTS_V} -m ${hash_type} ${hash} -a 3 ${word_1}${mask_1}"
@@ -1384,6 +1469,13 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                     word_1="${word%???}"
                     mask_1="?d?d?d"
                   fi
+
+                  # No '?d' produces a byte above 0x7f, so a mask ending in one cannot spell a
+                  # password that tools/test.pl seeded with a multi byte character. Spell those
+                  # positions instead. The word and the mask are one string here, so a split that
+                  # lands inside a character still reassembles to the right bytes.
+
+                  mask_1="$(mask_literalize "${mask_1}" "${word#"${word_1}"}")"
                 fi
 
                 echo -n ${word_1} >> ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}.1.words.masks

--- a/tools/test_edge.sh
+++ b/tools/test_edge.sh
@@ -195,6 +195,73 @@ function mask_dots()
   printf '%s' "${md_out}"
 }
 
+function utf8_split_point()
+{
+  # Move a split offset back until it lands on a UTF-8 character boundary, and print the
+  # result. -a 1, -a 6 and -a 7 hand the word and the mask to the kernel as two buffers and
+  # the UTF-16 modes convert each of them on its own, so a character cut in half is two
+  # invalid fragments and the candidate is dropped. Both halves have to be valid UTF-8 by
+  # themselves for those attacks to spell a multi byte password at all.
+  #
+  # $1 = the password, $2 = the wanted offset in bytes, counting from 0
+
+  local up_text="$1"
+  local up_off="$2"
+  local up_back="${up_off}"
+  local up_len=${#up_text}
+
+  while [ "${up_back}" -gt 0 ]; do
+    case "${up_text:${up_back}:1}" in
+      # 0x80 to 0xbf is a continuation byte, so the offset sits inside a character
+      [$'\x80'-$'\xbf']) up_back=$((up_back - 1)) ;;
+      *)                  break ;;
+    esac
+  done
+
+  # Moving back is the right answer unless it lands on 0 while the caller asked for a real
+  # split, which happens when a character sits at the very start of the password. An empty
+  # half is not a candidate the combinator and hybrid attacks can use, so go the other way
+  # and take the first boundary after the offset instead.
+
+  if [ "${up_back}" -eq 0 ] && [ "${up_off}" -gt 0 ]; then
+    while [ "${up_off}" -lt "${up_len}" ]; do
+      case "${up_text:${up_off}:1}" in
+        [$'\x80'-$'\xbf']) up_off=$((up_off + 1)) ;;
+        *)                  break ;;
+      esac
+    done
+
+    printf '%s' "${up_off}"
+
+    return
+  fi
+
+  printf '%s' "${up_back}"
+}
+function mask_for()
+{
+  # A mask covering exactly the bytes of $2, built out of the token $1. A '?d' cannot produce a
+  # byte above 0x7f, so for that token the positions that are not digits are written as literals.
+  # The hex and base58 charsets already cover their own alphabets and are left alone.
+
+  local mf_tok="$1"
+  local mf_text="$2"
+  local mf_out=""
+  local mf_i
+
+  for ((mf_i = 0; mf_i < ${#mf_text}; mf_i++)); do
+    mf_out="${mf_out}${mf_tok}"
+  done
+
+  if [ "${mf_tok}" = "?d" ]; then
+    mask_literalize "${mf_out}" "${mf_text}"
+
+    return
+  fi
+
+  printf '%s' "${mf_out}"
+}
+
 function mask_literalize()
 {
   # Rewrite a mask so that every position it covers spells the byte that belongs there. The
@@ -1051,18 +1118,13 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
               elif [ "${attack_type}" -eq 1 ]; then
                 word=$(eval $x)
 
-                if [ "${word_len}" -eq 2 ]; then
-                  word_1=$(echo $word | cut -c -1)
-                  word_2=$(echo $word | cut -c 2-)
-                elif [ "${word_len}" -gt 2 ]; then
-                  word_1_cnt=$((word_len/2))
+                # Both halves reach the kernel as a buffer of their own, and a UTF-16 mode converts
+                # each on its own, so a character cut in half is two invalid fragments rather than
+                # one character. Split on a boundary.
 
-                  word_1=$(echo $word | cut -c -${word_1_cnt})
-
-                  ((word_1_cnt++))
-
-                  word_2=$(echo $word | cut -c ${word_1_cnt}-)
-                fi
+                word_1_cnt=$(utf8_split_point "${word}" $((word_len / 2)))
+                word_1="${word:0:${word_1_cnt}}"
+                word_2="${word:${word_1_cnt}}"
 
                 echo ${word_1} > ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}_${i}.1.word
                 echo ${word_2} > ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}_${i}.2.word
@@ -1107,12 +1169,17 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                   mask_1="?a?a"
                 else
                   if [ "${word_len}" -eq 2 ] || [ "${slow_hash}" -eq 1 ]; then
-                    word_1="${word%?}"
-                    mask_1="?d"
+                    tail_len=1
                   else
-                    word_1="${word%??}"
-                    mask_1="?d?d"
+                    tail_len=2
                   fi
+
+                  # The word and the mask are two separate buffers here, so the word has to end on
+                  # a character boundary and the mask has to spell whatever that leaves it.
+
+                  split=$(utf8_split_point "${word}" $(( ${#word} - tail_len )))
+                  word_1="${word:0:${split}}"
+                  mask_1="$(mask_for "?d" "${word:${split}}")"
                 fi
 
                 echo -n ${word_1} > ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}_${i}_1.word
@@ -1128,12 +1195,17 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                   mask_1="?a?a"
                 else
                   if [ "${word_len}" -eq 2 ] || [ "${slow_hash}" -eq 1 ]; then
-                    word_1="${word#?}"
-                    mask_1="?d"
+                    head_len=1
                   else
-                    word_1="${word#??}"
-                    mask_1="?d?d"
+                    head_len=2
                   fi
+
+                  # As -a 6, from the other end: the mask covers the head, so the head has to end
+                  # on a character boundary and the mask has to spell it.
+
+                  split=$(utf8_split_point "${word}" ${head_len})
+                  word_1="${word:${split}}"
+                  mask_1="$(mask_for "?d" "${word:0:${split}}")"
                 fi
 
                 echo -n ${word_1} > ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}_${i}_2.word
@@ -1163,14 +1235,36 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                   both_sides=0
                 fi
 
-                mid_len=$((${#word} - cut_len - cut_len))
+                # The word and each side of the mask are separate buffers, so the word has to
+                # start and end on a character boundary and a '?d' side has to spell what it now
+                # covers. The hex and base58 charsets keep their single token shape.
+
+                left=${cut_len}
+                right=$(( ${#word} - cut_len ))
+
+                if [ "${mask_c}" = "?d" ]; then
+                  left=$(utf8_split_point "${word}" ${left})
+                  right=$(utf8_split_point "${word}" ${right})
+                fi
+
+                mid_len=$(( right - left ))
 
                 if [ ${both_sides} -eq 1 ] && [ ${mid_len} -ge 1 ]; then
-                  word_1="${word:${cut_len}:${mid_len}}"
-                  mask_1="${mask_c}?w${mask_c}"
+                  word_1="${word:${left}:${mid_len}}"
+
+                  if [ "${mask_c}" = "?d" ]; then
+                    mask_1="$(mask_for "?d" "${word:0:${left}}")?w$(mask_for "?d" "${word:${right}}")"
+                  else
+                    mask_1="${mask_c}?w${mask_c}"
+                  fi
                 else
-                  word_1="${word:${cut_len}}"
-                  mask_1="${mask_c}?w"
+                  word_1="${word:${left}}"
+
+                  if [ "${mask_c}" = "?d" ]; then
+                    mask_1="$(mask_for "?d" "${word:0:${left}}")?w"
+                  else
+                    mask_1="${mask_c}?w"
+                  fi
                 fi
 
                 echo -n "${word_1}" > ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}_${i}_12.word
@@ -1435,15 +1529,13 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
               elif [ "${attack_type}" -eq 1 ]; then
                 ((hash_cnt++))
 
-                if [ "${word_len}" -eq 2 ]; then
-                  word_1=$(echo $word | cut -c -1)
-                  word_2=$(echo $word | cut -c 2-)
-                elif [ "${word_len}" -gt 2 ]; then
-                  word_1_cnt=$((word_len/2))
-                  word_1=$(echo $word | cut -c -${word_1_cnt})
-                 ((word_1_cnt++))
-                 word_2=$(echo $word | cut -c ${word_1_cnt}-)
-                fi
+                # Both halves reach the kernel as a buffer of their own, and a UTF-16 mode converts
+                # each on its own, so a character cut in half is two invalid fragments rather than
+                # one character. Split on a boundary.
+
+                word_1_cnt=$(utf8_split_point "${word}" $((word_len / 2)))
+                word_1="${word:0:${word_1_cnt}}"
+                word_2="${word:${word_1_cnt}}"
 
                 echo ${word_1} >> ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}.1.words
                 echo ${word_2} >> ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}.2.words
@@ -1493,12 +1585,17 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                   mask_1="?a?a"
                 else
                   if [ "${word_len}" -eq 2 ] || [ "${slow_hash}" -eq 1 ]; then
-                    word_1="${word%?}"
-                    mask_1="?d"
+                    tail_len=1
                   else
-                    word_1="${word%??}"
-                    mask_1="?d?d"
+                    tail_len=2
                   fi
+
+                  # The word and the mask are two separate buffers here, so the word has to end on
+                  # a character boundary and the mask has to spell whatever that leaves it.
+
+                  split=$(utf8_split_point "${word}" $(( ${#word} - tail_len )))
+                  word_1="${word:0:${split}}"
+                  mask_1="$(mask_for "?d" "${word:${split}}")"
                 fi
 
                 echo ${word_1} >> ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}.1.words
@@ -1516,12 +1613,17 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                   mask_1="?a?a"
                 else
                   if [ "${word_len}" -eq 2 ] || [ "${slow_hash}" -eq 1 ]; then
-                    word_1="${word#?}"
-                    mask_1="?d"
+                    head_len=1
                   else
-                    word_1="${word#??}"
-                    mask_1="?d?d"
+                    head_len=2
                   fi
+
+                  # As -a 6, from the other end: the mask covers the head, so the head has to end
+                  # on a character boundary and the mask has to spell it.
+
+                  split=$(utf8_split_point "${word}" ${head_len})
+                  word_1="${word:${split}}"
+                  mask_1="$(mask_for "?d" "${word:0:${split}}")"
                 fi
 
                 echo ${word_1} >> ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}.2.words
@@ -1550,14 +1652,36 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
                   both_sides=0
                 fi
 
-                mid_len=$((${#word} - cut_len - cut_len))
+                # The word and each side of the mask are separate buffers, so the word has to
+                # start and end on a character boundary and a '?d' side has to spell what it now
+                # covers. The hex and base58 charsets keep their single token shape.
+
+                left=${cut_len}
+                right=$(( ${#word} - cut_len ))
+
+                if [ "${mask_c}" = "?d" ]; then
+                  left=$(utf8_split_point "${word}" ${left})
+                  right=$(utf8_split_point "${word}" ${right})
+                fi
+
+                mid_len=$(( right - left ))
 
                 if [ ${both_sides} -eq 1 ] && [ ${mid_len} -ge 1 ]; then
-                  word_1="${word:${cut_len}:${mid_len}}"
-                  mask_1="${mask_c}?w${mask_c}"
+                  word_1="${word:${left}:${mid_len}}"
+
+                  if [ "${mask_c}" = "?d" ]; then
+                    mask_1="$(mask_for "?d" "${word:0:${left}}")?w$(mask_for "?d" "${word:${right}}")"
+                  else
+                    mask_1="${mask_c}?w${mask_c}"
+                  fi
                 else
-                  word_1="${word:${cut_len}}"
-                  mask_1="${mask_c}?w"
+                  word_1="${word:${left}}"
+
+                  if [ "${mask_c}" = "?d" ]; then
+                    mask_1="$(mask_for "?d" "${word:0:${left}}")?w"
+                  else
+                    mask_1="${mask_c}?w"
+                  fi
                 fi
 
                 echo "${word_1}" >> ${OUTD}/test_${hash_type}_${kernel_type}_${attack_type}_${vector_width}.12.words


### PR DESCRIPTION
# test_edge.sh: build masks that can spell a non-ASCII password

#4813 taught `tools/test.sh` about multi-byte passwords and never touched
`tools/test_edge.sh`, so every mask attack in the edge suite still assumes a password is digits
from end to end. It is not one mode: on master the suite fails on `-a 3`, `-a 6`, `-a 7` and
`-a 12` for every hash mode whose oracle produces a non-ASCII password, which is most of them.

## Reproduction

Mode 0, every attack type, both kernel families, single and multi:

    ./tools/test_edge.sh -m 0 -V 1 -D 1 -f --skip-clean-cache

    before: Errors detected: 10      failing attack types 3, 6, 7 and 12
    after:  Errors detected: 0

One of the ten, verbatim:

    !> error (1) detected with CMD: ./hashcat ... -O --backend-vector-width 1
       -m 0 '4d129e1dab3361502...' -a 3 €文65中2가33Ａ0912771973😀90가ह262か110가9
    !> Hash-Type 0, Attack-Type 3, Kernel-Type optimized, Vector-Width 1, Test ID 2,
       Word len 55, Word '€文65中2가33Ａ0912771973😀90가ह262か110가9'

Distilled to hashcat, no suite involved. The password is 1234가0 and its MD5 is
82bf84a88f5aab445c56ebb28a227ad6:

    ./hashcat -m 0 -a 3 -D 1 --force --potfile-disable '82bf84a88f5aab445c56ebb28a227ad6' '123?d?d?d'
    Status Exhausted, rc=1

    ./hashcat -m 0 -a 3 -D 1 --force --potfile-disable '82bf84a88f5aab445c56ebb28a227ad6' '1234가?d'
    Status Cracked, rc=0

The first mask is what `test_edge.sh` builds. The second is what it builds now.

## What is wrong

Two independent faults in the same few lines.

**A `?d` cannot produce a byte above 0x7f.** `-a 3` does
`word_1="${word%???}"` with `mask_1="?d?d?d"`
([test_edge.sh:1009](tools/test_edge.sh#L1009)). One of the three characters it strips is
usually not a digit, so no candidate the mask emits can equal the password. `test.sh` solved this
with `mask_literalize()`, which rewrites the positions that are not digits as literals.

**The split counts bytes, not characters.** `test_edge.sh` exports `LANG=C`
([test_edge.sh:181](tools/test_edge.sh#L181)), under which bash's `${word%???}` and `cut -c`
strip three *bytes*, so the cut lands inside a multi-byte character:

    LC_ALL=C.UTF-8  mask = 123?d?d?d       valid
    LC_ALL=C        mask = 1234M-j?d?d?d   BROKEN utf8

`M-j` is `\xea`, the orphaned lead byte of `가`, and it is the `?` in the error line above.

The two faults need different answers. For `-a 3` the word and the mask are **one string**, so a
split inside a character still reassembles to the right bytes once the tail is literalized, and
the boundary needs no separate fix. `-a 1`, `-a 6`, `-a 7` and `-a 12` hand the two halves over
as **separate buffers**, and a UTF-16 mode converts each on its own, so half a character is two
invalid fragments and the candidate is dropped. Those need the split moved onto a boundary as
well, which is what `test.sh`'s `utf8_split_point()` does.

## What changed

`mask_dots()`, `mask_literalize()` and `utf8_split_point()` are copied from `tools/test.sh`
unchanged. `mask_for()` is new: it builds a mask covering exactly the bytes one side now spans,
and runs it through `mask_literalize()` when the token is `?d`.

Both the single-target and multi-target blocks are patched for `-a 3`, `-a 1`, `-a 6`, `-a 7`
and `-a 12`. The `pt_hex` and `pt_base58` paths keep their `?b` and `?a` shapes and are not
touched: those alphabets are ASCII and the fault does not reach them.

`-a 1` did not fail in any run here, having no mask at all, and is changed for the boundary
alone. It also loses two subshells: `word_1=$(echo $word | cut -c -${word_1_cnt})` left `$word`
unquoted, so a password carrying whitespace or a glob character was already at risk there.

## Testing

    ./tools/test_edge.sh -m <mode> -V 1 -D 1 -f --skip-clean-cache

    mode    master                                 this branch
    0       Errors detected: 10   (-a 3, 6, 7, 12)  Errors detected: 0
    100     Errors detected: 10   (-a 3, 6, 7, 12)  Errors detected: 0
    1400    Errors detected: 10   (-a 3, 6, 7, 12)  Errors detected: 0

34 attack, kernel-type and target-type combinations processed per mode, all green.

## Deviations

The three helpers are copied into `test_edge.sh` rather than shared with `test.sh`. The two
scripts are independent today and neither sources the other, so factoring them out is a change to
both and a wider one than this. Worth doing, and not here.

No GPU on this machine, so everything above is the CPU backend, `-D 1 -f`, and `-V 1` only.

Three modes swept, not all of them. They were picked as plain fast hashes with no salt, one salt
and a slow KDF; the code path is shared by every mode, so a fourth adds little, but a full
`./tools/test_edge.sh` on a GPU box is the run that would settle it.

The reproduction contains a euro sign and other multi-byte characters. They are inside pasted
output where the password is the entire point, so the ASCII check flags them and they stay.
