### PR TITLE
Metal: name the remaining valueless -D options so they are not dropped

### DIFF
--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -179,12 +179,23 @@ static int hc_mtlBuildOptionsToDict (void *hashcat_ctx, const char *build_option
 
     if ([components count] != 2)
     {
+      // Every -D the rest of hashcat can emit without a value has to be named here, because a
+      // preprocessor macro reaches Metal as a dictionary entry and a dictionary entry needs one.
+      // A name missing from this list is dropped silently, so the kernel compiles as if the option
+      // had never been given.
+
       if ([key isEqualToString:@"KERNEL_STATIC"] ||
           [key isEqualToString:@"IS_APPLE_SILICON"] ||
           [key isEqualToString:@"DYNAMIC_LOCAL"] ||
           [key isEqualToString:@"_unroll"] ||
           [key isEqualToString:@"NO_UNROLL"] ||
-          [key isEqualToString:@"FORCE_DISABLE_SHM"])
+          [key isEqualToString:@"NO_INLINE"] ||
+          [key isEqualToString:@"FORCE_NO_INLINE"] ||
+          [key isEqualToString:@"NO_FUNNELSHIFT"] ||
+          [key isEqualToString:@"FORCE_DISABLE_SHM"] ||
+          [key isEqualToString:@"COOP_SBOX_LDS"] ||
+          [key isEqualToString:@"COOP_X_REGS"] ||
+          [key isEqualToString:@"COOP_X_GLOBAL"])
       {
         value = @"1";
       }


### PR DESCRIPTION
Metal takes preprocessor macros as a dictionary, and a dictionary entry needs a value. So `hc_mtlBuildOptionsToDict ()` splits each build option on `=` and, when there is no `=`, looks the name up in a hardcoded list to give it the value `1`. A name that is not in that list falls into the `else` branch, which does `continue`: the option is dropped, and the warning that says so is behind `#ifdef DEBUG`. On a release build the kernel simply compiles as if the option had never been given.

Six options hashcat can emit without a value are missing from the list:

| option | emitted by | what its absence changes |
|---|---|---|
| `NO_INLINE` | `module_33000.c` | `HC_INLINE` stays `inline static` instead of empty |
| `FORCE_NO_INLINE` | `backend.c`, under `force_no_inline_enabled ()` | the same, for the runtimes that ask for it |
| `NO_FUNNELSHIFT` | 11 modules: 00150, 01100, 06000, 06211, 06212, 06213, 11000, 14400, 29311, 29312, 29313 | `USE_FUNNELSHIFT` stays defined for modes whose comment in `inc_vendor.h` says they do not like it |
| `COOP_SBOX_LDS` | `yescrypt_common.c` (36100, 36200, 70200) | the Sbox is addressed `GLOBAL_AS` instead of `LOCAL_AS` |
| `COOP_X_REGS` | `yescrypt_common.c` | X does not go to registers |
| `COOP_X_GLOBAL` | `yescrypt_common.c` | X is declared in local memory, which is the case the module emits this option precisely to avoid |

The last row is the one that matters most. `yescrypt_common.c` emits `COOP_X_GLOBAL` only after computing that the X block plus the Sbox do not fit in `device_local_mem_size`. With the option dropped the kernel takes the `#else` and declares X in local memory anyway, which is the placement the host had already ruled out.

None of this is visible: no error, no warning outside a DEBUG build, and the kernel builds.