### PR TITLE
Metal: take the threadgroup ceiling from the pipeline instead of the wave width

### DIFF
--- a/src/backend.c
+++ b/src/backend.c
@@ -18552,7 +18552,27 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
     }
     else if (device_param->is_metal == true)
     {
+      // Ask the pipeline what it will take, the way the other three runtimes are asked.
+      // kernel_preferred_wgs_multiple is the width of a wave, not the ceiling of a threadgroup, and
+      // this becomes kernel_threads_max below. It stays as the answer where the pipeline has none,
+      // and as the whole answer off Apple, where there is no Metal to ask.
+
       threads_per_block = device_param->kernel_preferred_wgs_multiple;
+
+      #if defined (__APPLE__)
+
+      const int kern_run = find_tuning_function (hashcat_ctx, device_param);
+
+      mtl_pipeline pipeline = metal_pipeline_with_id (device_param, kern_run);
+
+      u32 wgs = 0;
+
+      if ((pipeline != NULL) && (get_metal_kernel_wgs (hashcat_ctx, pipeline, &wgs) == 0) && (wgs > 0))
+      {
+        threads_per_block = wgs;
+      }
+
+      #endif
     }
 
     u32 local_size_bytes = 0;


### PR DESCRIPTION
In `backend_session_begin ()`, `threads_per_block` is settled per runtime and then becomes `device_param->kernel_threads_max`. Three of the four runtimes ask the runtime itself what the kernel will take:

```c
if (device_param->is_cuda == true)          ... cuda_query_threads_per_block ()
else if (device_param->is_hip == true)      ... hip_query_threads_per_block ()
else if (device_param->is_opencl == true)   threads_per_block = opencl_query_threads_per_block (...)
else if (device_param->is_metal == true)    threads_per_block = device_param->kernel_preferred_wgs_multiple;
```

The Metal branch asks nothing. `kernel_preferred_wgs_multiple` is set for Metal at `device_param->kernel_preferred_wgs_multiple = metal_warp_size` (it is the width of a wave, which is a granularity, not the ceiling of a threadgroup). Using it as the ceiling caps `kernel_threads_max` at the wave width regardless of what the compiled pipeline would actually accept.

Metal already answers the real question. `hc_mtlGetMaxTotalThreadsPerThreadgroup ()` is declared in `ext_metal.h`, implemented in `ext_metal.m`, and wrapped in `backend.c` as `get_metal_kernel_wgs ()`. The pipeline for the tuning kernel is reachable through `metal_pipeline_with_id ()`, which is defined in `backend.c` and **never called**. Every macOS build carries the resulting warning:

```
src/backend.c:128:21: warning: unused function 'metal_pipeline_with_id' [-Wunused-function]
```