### PR TITLE
Fix segfault on -a 8 / -a 4 with --backend-info or --hash-info

### DIFF
--- a/src/user_options.c
+++ b/src/user_options.c
@@ -4117,36 +4117,44 @@ int user_options_check_files (hashcat_ctx_t *hashcat_ctx)
     // The first argument is a plugin name and only falls back to being a path, so it is checked
     // against the shipped feeds first. A name that matches neither is reported as the path it would
     // have been, because that is the form the user typed.
+    //
+    // There may be no argument at all. --backend-info and --hash-info answer without running an
+    // attack, so they leave hc_workv null whatever else is on the command line, and reading
+    // hc_workv[0] read through it. --benchmark leaves it null for the same reason but refuses -a
+    // before reaching here, so it cannot get this far today.
 
-    char *plugin_name = user_options_extra->hc_workv[0];
-
-    bool by_name = false;
-
-    char *library_filename = generic_resolve (folder_config, plugin_name, &by_name);
-
-    hcfree (library_filename);
-
-    if (by_name == false)
+    if (user_options_extra->hc_workc > 0)
     {
-      if (hc_path_exist (plugin_name) == false)
+      char *plugin_name = user_options_extra->hc_workv[0];
+
+      bool by_name = false;
+
+      char *library_filename = generic_resolve (folder_config, plugin_name, &by_name);
+
+      hcfree (library_filename);
+
+      if (by_name == false)
       {
-        event_log_error (hashcat_ctx, "%s: %s", plugin_name, strerror (errno));
+        if (hc_path_exist (plugin_name) == false)
+        {
+          event_log_error (hashcat_ctx, "%s: %s", plugin_name, strerror (errno));
 
-        return -1;
-      }
+          return -1;
+        }
 
-      if (hc_path_is_directory (plugin_name) == true)
-      {
-        event_log_error (hashcat_ctx, "%s: A directory cannot be used as first plugin argument.", plugin_name);
+        if (hc_path_is_directory (plugin_name) == true)
+        {
+          event_log_error (hashcat_ctx, "%s: A directory cannot be used as first plugin argument.", plugin_name);
 
-        return -1;
-      }
+          return -1;
+        }
 
-      if (hc_path_read (plugin_name) == false)
-      {
-        event_log_error (hashcat_ctx, "%s: %s", plugin_name, strerror (errno));
+        if (hc_path_read (plugin_name) == false)
+        {
+          event_log_error (hashcat_ctx, "%s: %s", plugin_name, strerror (errno));
 
-        return -1;
+          return -1;
+        }
       }
     }
 


### PR DESCRIPTION
`user_options_check_files ()` reads the first work argument as a plugin name:

```c
else if (user_options->attack_mode == ATTACK_MODE_GENERIC)
{
  char *plugin_name = user_options_extra->hc_workv[0];
```

There may be no such argument. `user_options_extra_init ()` leaves the work vector null for the options that answer without running an attack:

```c
user_options_extra->hc_workv = NULL;
user_options_extra->hc_workc = 0;

if (user_options->benchmark == true)       { }
else if (user_options->hash_info > 0)      { }
else if (user_options->backend_info > 0)   { }
else if ...
```

So `-a 8` or `-a 4` together with `--backend-info` or `--hash-info` dereferences a null pointer before anything else happens. `-a 4` reaches it because `user_options_alias_attack_mode ()` rewrites it into `-a 8` well before this runs:

```
hashcat --backend-info                 exit 0
hashcat -a 8 --backend-info            Segmentation fault: 11
hashcat -a 4 --backend-info            Segmentation fault: 11
hashcat --hash-info -m 0               exit 0
hashcat -a 8 --hash-info -m 0          Segmentation fault: 11
hashcat -a 4 --hash-info -m 0          Segmentation fault: 11
```