### PR TITLE
Fix a4-pure kernel build failures on Apple (Metal and OpenCL)

### DIFF
--- a/OpenCL/m11100_a4-pure.cl
+++ b/OpenCL/m11100_a4-pure.cl
@@ -80,29 +80,29 @@ DECLSPEC bool pcfg_hash (PRIVATE_AS const pcfg_hash_ctx_t *hc, PRIVATE_AS u32 *w
 
   md5_update (&ctx1, w, len);
 
-  u32 s0[4];
-  u32 s1[4];
-  u32 s2[4];
-  u32 s3[4];
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
 
-  s0[0] = hc->salt_buf0[0];
-  s0[1] = hc->salt_buf0[1];
-  s0[2] = hc->salt_buf0[2];
-  s0[3] = hc->salt_buf0[3];
-  s1[0] = hc->salt_buf1[0];
-  s1[1] = hc->salt_buf1[1];
-  s1[2] = hc->salt_buf1[2];
-  s1[3] = hc->salt_buf1[3];
-  s2[0] = 0;
-  s2[1] = 0;
-  s2[2] = 0;
-  s2[3] = 0;
-  s3[0] = 0;
-  s3[1] = 0;
-  s3[2] = 0;
-  s3[3] = 0;
+  w0[0] = hc->salt_buf0[0];
+  w0[1] = hc->salt_buf0[1];
+  w0[2] = hc->salt_buf0[2];
+  w0[3] = hc->salt_buf0[3];
+  w1[0] = hc->salt_buf1[0];
+  w1[1] = hc->salt_buf1[1];
+  w1[2] = hc->salt_buf1[2];
+  w1[3] = hc->salt_buf1[3];
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
 
-  md5_update_64 (&ctx1, s0, s1, s2, s3, hc->salt_len);
+  md5_update_64 (&ctx1, w0, w1, w2, w3, hc->salt_len);
 
   md5_final (&ctx1);
 
@@ -162,29 +162,29 @@ DECLSPEC bool pcfg_hash_global (PRIVATE_AS const pcfg_hash_ctx_t *hc, GLOBAL_AS 
 
   md5_update_global (&ctx1, w, len);
 
-  u32 s0[4];
-  u32 s1[4];
-  u32 s2[4];
-  u32 s3[4];
+  u32 w0[4];
+  u32 w1[4];
+  u32 w2[4];
+  u32 w3[4];
 
-  s0[0] = hc->salt_buf0[0];
-  s0[1] = hc->salt_buf0[1];
-  s0[2] = hc->salt_buf0[2];
-  s0[3] = hc->salt_buf0[3];
-  s1[0] = hc->salt_buf1[0];
-  s1[1] = hc->salt_buf1[1];
-  s1[2] = hc->salt_buf1[2];
-  s1[3] = hc->salt_buf1[3];
-  s2[0] = 0;
-  s2[1] = 0;
-  s2[2] = 0;
-  s2[3] = 0;
-  s3[0] = 0;
-  s3[1] = 0;
-  s3[2] = 0;
-  s3[3] = 0;
+  w0[0] = hc->salt_buf0[0];
+  w0[1] = hc->salt_buf0[1];
+  w0[2] = hc->salt_buf0[2];
+  w0[3] = hc->salt_buf0[3];
+  w1[0] = hc->salt_buf1[0];
+  w1[1] = hc->salt_buf1[1];
+  w1[2] = hc->salt_buf1[2];
+  w1[3] = hc->salt_buf1[3];
+  w2[0] = 0;
+  w2[1] = 0;
+  w2[2] = 0;
+  w2[3] = 0;
+  w3[0] = 0;
+  w3[1] = 0;
+  w3[2] = 0;
+  w3[3] = 0;
 
-  md5_update_64 (&ctx1, s0, s1, s2, s3, hc->salt_len);
+  md5_update_64 (&ctx1, w0, w1, w2, w3, hc->salt_len);
 
   md5_final (&ctx1);
 

--- a/OpenCL/m18700_a4-pure.cl
+++ b/OpenCL/m18700_a4-pure.cl
@@ -80,14 +80,11 @@ DECLSPEC bool pcfg_hash (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, PRIV
 
 DECLSPEC bool pcfg_hash_global (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, GLOBAL_AS const u32 *w, const u32 len, PRIVATE_AS u32 *dgst)
 {
-  const u32 hash = hashCode (0, w, len);
+  u32 t[64];
 
-  dgst[0] = hash;
-  dgst[1] = 0;
-  dgst[2] = 0;
-  dgst[3] = 0;
+  for (u32 i = 0; i < 64; i++) t[i] = w[i];
 
-  return true;
+  return pcfg_hash (hc, t, len, dgst);
 }
 
 #define PCFG_KERNEL_MXX m18700_mxx

--- a/OpenCL/m26200_a4-pure.cl
+++ b/OpenCL/m26200_a4-pure.cl
@@ -116,69 +116,11 @@ DECLSPEC bool pcfg_hash (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, PRIV
 
 DECLSPEC bool pcfg_hash_global (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, GLOBAL_AS const u32 *w, const u32 len, PRIVATE_AS u32 *dgst)
 {
-  u32 hash = 17;
+  u32 t[64];
 
-  u8  scratch[16] = { 0 };
+  for (u32 i = 0; i < 64; i++) t[i] = w[i];
 
-  PRIVATE_AS u8 *input = (PRIVATE_AS u8 *) w;
-
-  for (u32 i = 0; i < 5; i++)
-  {
-    for (u32 j = 0; j < len; j++)
-    {
-      int idx = 15 - (j & 15);
-
-      scratch[idx] ^= input[j];
-    }
-
-    for (u32 j = 0; j < 16; j += 2)
-    {
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[15]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[14]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[13]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[12]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[11]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[10]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 9]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 8]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 7]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 6]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 5]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 4]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 3]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 2]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 1]]);
-      hash = (hash >> 8 ^ PE_CONST[hash & 0xff] ^ PE_CONST[scratch[ 0]]);
-
-      scratch[j]     = (unsigned char)( hash       & 0xff);
-      scratch[j + 1] = (unsigned char)((hash >> 8) & 0xff);
-    }
-  }
-
-  u8 target[16] = { 0 };
-
-  for (u32 i = 0; i < 16; i++)
-  {
-    u8 lower = (scratch[i] & 0x7f);
-
-    if ((lower >= 'A' && lower <= 'Z') || (lower >= 'a' && lower <= 'z'))
-    {
-      target[i] = lower;
-    }
-    else
-    {
-      target[i] = (u8)((scratch[i] >> 4) + 0x61);
-    }
-  }
-
-  PRIVATE_AS u32 *digest = (PRIVATE_AS u32 *) target;
-
-  dgst[0] = digest[DGST_R0];
-  dgst[1] = digest[DGST_R1];
-  dgst[2] = digest[DGST_R2];
-  dgst[3] = digest[DGST_R3];
-
-  return true;
+  return pcfg_hash (hc, t, len, dgst);
 }
 
 #define PCFG_KERNEL_MXX m26200_mxx

--- a/OpenCL/m28501_a4-pure.cl
+++ b/OpenCL/m28501_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m28502_a4-pure.cl
+++ b/OpenCL/m28502_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m28505_a4-pure.cl
+++ b/OpenCL/m28505_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m28506_a4-pure.cl
+++ b/OpenCL/m28506_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m30901_a4-pure.cl
+++ b/OpenCL/m30901_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m30902_a4-pure.cl
+++ b/OpenCL/m30902_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m30905_a4-pure.cl
+++ b/OpenCL/m30905_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m30906_a4-pure.cl
+++ b/OpenCL/m30906_a4-pure.cl
@@ -3,6 +3,8 @@
  * License.....: MIT
  */
 
+#define SECP256K1_TMPS_TYPE PRIVATE_AS
+
 #ifdef KERNEL_STATIC
 #include M2S(INCLUDE_PATH/inc_vendor.h)
 #include M2S(INCLUDE_PATH/inc_types.h)

--- a/OpenCL/m34200_a4-pure.cl
+++ b/OpenCL/m34200_a4-pure.cl
@@ -96,14 +96,11 @@ DECLSPEC bool pcfg_hash (PRIVATE_AS const pcfg_hash_ctx_t *hc, PRIVATE_AS u32 *w
 
 DECLSPEC bool pcfg_hash_global (PRIVATE_AS const pcfg_hash_ctx_t *hc, GLOBAL_AS const u32 *w, const u32 len, PRIVATE_AS u32 *dgst)
 {
-  u64x hash = MurmurHash64A (hc->seed, w, len);
+  u32 t[64];
 
-  dgst[0] = l32_from_64 (hash);
-  dgst[1] = h32_from_64 (hash);
-  dgst[2] = 0;
-  dgst[3] = 0;
+  for (u32 i = 0; i < 64; i++) t[i] = w[i];
 
-  return true;
+  return pcfg_hash (hc, t, len, dgst);
 }
 
 #define PCFG_KERNEL_MXX m34200_mxx

--- a/OpenCL/m34201_a4-pure.cl
+++ b/OpenCL/m34201_a4-pure.cl
@@ -88,14 +88,11 @@ DECLSPEC bool pcfg_hash (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, PRIV
 
 DECLSPEC bool pcfg_hash_global (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, GLOBAL_AS const u32 *w, const u32 len, PRIVATE_AS u32 *dgst)
 {
-  u64 hash = MurmurHash64A (w, len);
+  u32 t[64];
 
-  dgst[0] = l32_from_64 (hash);
-  dgst[1] = h32_from_64 (hash);
-  dgst[2] = 0;
-  dgst[3] = 0;
+  for (u32 i = 0; i < 64; i++) t[i] = w[i];
 
-  return true;
+  return pcfg_hash (hc, t, len, dgst);
 }
 
 #define PCFG_KERNEL_MXX m34201_mxx

--- a/OpenCL/m34211_a4-pure.cl
+++ b/OpenCL/m34211_a4-pure.cl
@@ -86,12 +86,11 @@ DECLSPEC bool pcfg_hash (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, PRIV
 
 DECLSPEC bool pcfg_hash_global (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *hc, GLOBAL_AS const u32 *w, const u32 len, PRIVATE_AS u32 *dgst)
 {
-  dgst[0] = MurmurHash64A_truncated (w, len);
-  dgst[1] = 0;
-  dgst[2] = 0;
-  dgst[3] = 0;
+  u32 t[64];
 
-  return true;
+  for (u32 i = 0; i < 64; i++) t[i] = w[i];
+
+  return pcfg_hash (hc, t, len, dgst);
 }
 
 #define PCFG_KERNEL_MXX m34211_mxx

--- a/OpenCL/m34800_a4-pure.cl
+++ b/OpenCL/m34800_a4-pure.cl
@@ -51,7 +51,7 @@ DECLSPEC bool pcfg_hash_global (MAYBE_UNUSED PRIVATE_AS const pcfg_hash_ctx_t *h
   blake2b_ctx_t ctx;
 
   blake2b_256_init (&ctx);
-  blake2b_update   (&ctx, w, len);
+  blake2b_update_global (&ctx, w, len);
   blake2b_final    (&ctx);
 
   dgst[0] = h32_from_64_S (ctx.h[0]);


### PR DESCRIPTION
Fifteen `mNNNNN_a4-pure.cl` kernels do not build on Apple, so `-a 4` on those hash modes ends before the first launch. Measured on an M4 Pro against 9c122b93b: the kernel build fails and hashcat exits 251.

There are three causes, all of them address space or naming, and none of them visible on a backend where the qualifiers compile away.

### 1. A global pointer handed to a private parameter

`pcfg_hash_global ()` receives the candidate as `GLOBAL_AS const u32 *w` and passes it straight to a helper declared `PRIVATE_AS`:

```
program_source:83:33: error: passing 'const __global u32 *' to parameter of type
                             'const __private u32 *' changes address space of pointer
  const u32 hash = hashCode (0, w, len);
```

Affects 18700, 26200, 34200, 34201, 34211. Fixed by copying the candidate into a private array and calling the private `pcfg_hash ()`, which is what the two functions are for.

34800 is the same shape with a different helper: `blake2b_update ()` takes `PRIVATE_AS`, and `blake2b_update_global ()` exists for exactly this case and was not being used.

### 2. secp256k1 tmps defaulting to global

`inc_ecc_secp256k1.h` has:

```c
#ifndef SECP256K1_TMPS_TYPE
#define SECP256K1_TMPS_TYPE GLOBAL_AS
#endif
```

The eight kernels 28501, 28502, 28505, 28506, 30901, 30902, 30905, 30906 pass a `secp256k1_t` that lives in private memory, so they have to say so before the include. They did not.

### 3. A local name that Metal turns into the parameter's name

`inc_vendor.h` defines, under Metal:

```c
#define s0 x
#define s1 y
#define s2 z
#define s3 w
```

11100 declares `u32 s0[4] .. s3[4]` as locals, so `s3` becomes `w`, which is already the name of the candidate parameter:

```
program_source:86:7: error: redefinition of 'w' with a different type: 'u32[4]' vs 'u32 *'
program_source:168:7: error: redefinition of 'w' with a different type: 'u32[4]' vs 'const device u32 *'
```

Renamed to `w0 .. w3`, matching what the rest of the kernels call these.