### PR TITLE
Count the rejects of the pcfg device engine, which were not counted at all

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -1355,6 +1355,13 @@ typedef struct pw_batch
   u64 words_fin;
   u64 words_extra;
 
+  // A rejected word of a feed that amplifies cost a whole cell rather than one candidate, and this
+  // holds what those cells came to, in candidates. The cell itself does not survive the rejection,
+  // because pws_cnt does not advance over a refused word and the next one is written at the same
+  // index, so the count is made where the word is refused rather than from a multiplier at the end.
+
+  u64 words_extra_amp;
+
 } pw_batch_t;
 
 typedef struct cpt

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -519,7 +519,7 @@ static int fill_slow (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_para
 // later word onto the previous hash, and there is nothing to put in its place. The run stops instead
 // and says which word it was.
 
-static int fill_reject (hashcat_ctx_t *hashcat_ctx, const bool reject_fatal, pw_batch_t *batch, u64 *words_extra, const u64 word_pos)
+static int fill_reject (hashcat_ctx_t *hashcat_ctx, const bool reject_fatal, pw_batch_t *batch, u64 *words_extra, const u64 word_pos, const u32 rect)
 {
   if (reject_fatal == true)
   {
@@ -530,6 +530,14 @@ static int fill_reject (hashcat_ctx_t *hashcat_ctx, const bool reject_fatal, pw_
   }
 
   batch->words_extra++;
+
+  // A refused word of a feed that amplifies stood for a whole cell rather than one candidate.
+  // reject_amplifier is set for ATTACK_KERN_STRAIGHT and ATTACK_KERN_COMBI only, so for the device
+  // engine it stays zero and the cell was booked nowhere: neither hashed nor rejected, it went
+  // missing out of both counters at once. The rectangle is passed in because the caller has it while
+  // the cell is still this word's.
+
+  if (batch->pcfg_cells != NULL) batch->words_extra_amp += (rect > 0) ? rect : 1;
 
   words_extra[0]++;
 
@@ -733,9 +741,18 @@ static int fill_generic (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
       int pw_len;
 
+      // The cell is read straight after the feed writes it, because a rejected word does not advance
+      // pws_cnt and the next word then overwrites it at the same index.
+
+      u32 cell_rect = 0;
+
       if (gf->amp == true)
       {
+        batch->pcfg_cells[batch->pws_cnt].rect = 0;
+
         pw_len = generic_thread_next_dev (hashcat_ctx, GENERIC_ROLE_BASE, device_param->device_id, pw_buf, PW_MAX, &batch->pcfg_cells[batch->pws_cnt]);
+
+        cell_rect = batch->pcfg_cells[batch->pws_cnt].rect;
       }
       else
       {
@@ -768,7 +785,7 @@ static int fill_generic (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
       {
         if (gf->can_shrink == false)
         {
-          if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur) == -1) return -1;
+          if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur, cell_rect) == -1) return -1;
 
           continue;
         }
@@ -791,7 +808,7 @@ static int fill_generic (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
         if (pw_len > gf->scratch_size)
         {
-          if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur) == -1) return -1;
+          if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur, cell_rect) == -1) return -1;
 
           continue;
         }
@@ -805,7 +822,7 @@ static int fill_generic (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
       if (pw_len < 0)
       {
-        if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur) == -1) return -1;
+        if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur, cell_rect) == -1) return -1;
 
         continue;
       }
@@ -816,7 +833,7 @@ static int fill_generic (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
       if (pw_len > PW_MAX)
       {
-        if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur) == -1) return -1;
+        if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur, cell_rect) == -1) return -1;
 
         continue;
       }
@@ -830,7 +847,7 @@ static int fill_generic (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_p
 
         if ((too_short == true) || (too_long == true))
         {
-          if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur) == -1) return -1;
+          if (fill_reject (hashcat_ctx, gf->reject_fatal, batch, &words_extra, words_off + work_cur, cell_rect) == -1) return -1;
 
           continue;
         }
@@ -898,13 +915,21 @@ static int pipe_run (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param
 
     if (batch == NULL) break;
 
-    if ((reject_amplifier > 0) && (batch->words_extra > 0))
+    // A feed that amplifies counted its own rejects as they happened, cell by cell, because a
+    // rejected cell is gone by the time the batch gets here. Everyone else multiplies by the one
+    // amplifier the whole run shares.
+
+    const u64 rejected = (batch->words_extra_amp > 0)
+                       ? batch->words_extra_amp
+                       : ((reject_amplifier > 0) ? (batch->words_extra * reject_amplifier) : 0);
+
+    if (rejected > 0)
     {
       hc_thread_mutex_lock (status_ctx->mux_counter);
 
       for (u32 salt_pos = 0; salt_pos < hashes->salts_cnt; salt_pos++)
       {
-        status_ctx->words_progress_rejected[salt_pos] += batch->words_extra * reject_amplifier;
+        status_ctx->words_progress_rejected[salt_pos] += rejected;
       }
 
       hc_thread_mutex_unlock (status_ctx->mux_counter);

--- a/src/wordlist.c
+++ b/src/wordlist.c
@@ -274,9 +274,10 @@ void pw_batch_reset (pw_batch_t *batch)
   batch->pws_base_cnt = 0;
   batch->pcfg_waves   = 0;
 
-  batch->words_off   = 0;
-  batch->words_fin   = 0;
-  batch->words_extra = 0;
+  batch->words_off       = 0;
+  batch->words_fin       = 0;
+  batch->words_extra     = 0;
+  batch->words_extra_amp = 0;
 
   batch->pws_idx[0].off = 0;
   batch->pws_idx[0].cnt = 0;


### PR DESCRIPTION
`pipe_run ()` books rejected words as `batch->words_extra * reject_amplifier`, and that amplifier is set for two attack kernels only:

```c
u64 reject_amplifier = 0;

if (attack_kern == ATTACK_KERN_STRAIGHT) reject_amplifier = straight_ctx->kernel_rules_cnt;
if (attack_kern == ATTACK_KERN_COMBI)    reject_amplifier = combinator_ctx->combs_cnt;
```

The pcfg device engine runs as ATTACK_KERN_PCFG, so the amplifier stays zero and its rejects are booked nowhere. A candidate that is neither hashed nor rejected is not counted at all, so progress under-reports by whatever the feed refused while the rejected line reads zero.

There is no single amplifier to use here: each base word carries its own cell and a cell stops at the carry out of its own rectangle, so only the producer knows what a refused word stood for. `fill_generic ()` reads the rectangle of the cell it has just written and hands it to `fill_reject ()`, which adds it to a new `words_extra_amp` on the batch. `pipe_run ()` uses that when it is set and keeps the multiplier for everyone else.

`-m 1500` has a pw_max of 8, so a run against the shipped ruleset refuses a large share of what the feed produces, and `-l 20000` takes it to exhaustion against a known keyspace:

```
without   Status: Exhausted   Progress: 16653056/54800000   Rejected: 0/16653056 (0.00%)
with      Status: Exhausted   Progress: 29141156/54800000   Rejected: 12488100/29141156 (42.85%)
```

Both builds hash the same candidates: 29141156 - 12488100 = 16653056, which is the progress the unchanged build reports. Neither reaches the keyspace because `-l` bounds the run to a segment, while the keyspace is base words times the feed's average rectangle over the whole ruleset.