### PR TITLE
autotune: size fast hash launches on their rate instead of on the tie margin

### DIFF
--- a/src/autotune.c
+++ b/src/autotune.c
@@ -773,7 +773,16 @@ static void autotune2_solve (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *devi
   // A fit that could not separate the accel axis scores every accel alike, so greed below 1 would hand
   // the answer to the smallest and starve the launch whatever the profile asked for.
 
-  const double margin = (accel_fit == true) ? greed : 1.0;
+  // Frugality trades throughput for fewer candidates in flight, and that is worth paying for only
+  // where an abandoned launch is expensive. A mode whose work sits outside the attack kernel holds
+  // the device in its loop kernel for the whole budget, so a launch it has to give up costs the
+  // budget. A mode that hashes inside the attack kernel finishes a launch in milliseconds and has
+  // nothing worth saving, while its rate flattens as soon as accel * F passes A, so the margin
+  // hands it the smallest accel and starves the launch.
+
+  const bool margin_applies = (hashconfig->attack_exec == ATTACK_EXEC_OUTSIDE_KERNEL);
+
+  const double margin = ((accel_fit == true) && (margin_applies == true)) ? greed : 1.0;
 
   double best_rate  = 0;
   u32    best_accel = accel_min;


### PR DESCRIPTION
Since 656f4406e the autotune settles on kernel-accel 1 for attack mode 4 and the launch is starved, which costs a factor of 4.5 on an NVIDIA card and 5.6 on an AMD one. This adds one condition to the line that already drops the margin, so that a mode which hashes inside the attack kernel is sized on its rate rather than on frugality.

### Reproduction

    ./hashcat -m 0 -a 4 ffffffffffffffffffffffffffffffff pcfg/default-passwords.tar.xz --potfile-disable -d 1 --runtime 30 --status --self-test-disable

The ruleset is the one hashcat ships, the digest is one nothing will crack so the run always reaches the time limit, and nothing has to be created first.

    before: Speed  3944.0 MH/s @ Accel:1  Loops:1024, Status Aborted (Runtime), rc=4
    after:  Speed 13941.3 MH/s @ Accel:28 Loops:1024, Status Aborted (Runtime), rc=4

That run of the changed build landed on accel 28, the less favourable of the two it settles on, so it shows 3.5 times rather than the 4.4 the medians below give.

Medians, five rounds a side on the NVIDIA card and three on the AMD one:

```
                   NVIDIA -d 1                  AMD -d 2
master             median  3703.9 MH/s Accel:1  median  1974.2 MH/s Accel:2
with this change   median 16389.6 MH/s Accel:42 median 10223.5 MH/s Accel:42
656f4406e reverted median 15717.7 MH/s Accel:44 median 11033.9 MH/s Accel:58
```

Master settled on accel 1 in every run. This change settled on accel 42 in eight runs out of nine on the NVIDIA card, between 15552 and 16738 MH/s, and on accel 28 once, at 14040: the fitted per-accel cost moves between runs and with it the largest accel that fits the budget.

### Why the margin returns the smallest accel here

`HASHCAT_AUTOTUNE2_VERBOSE=1` on master, same command:

```
AT2 fit L=8 A=16 t(1)=0.299 t(16)=4.460 -> A=0.022 F=0.26304 P=0.00179
AT2 accel=1  loops=1 loop_msec=0.286  total=0.286  rate=3.49074
AT2 accel=4  loops=1 loop_msec=1.081  total=1.081  rate=3.70039
AT2 accel=13 loops=1 loop_msec=3.464  total=3.464  rate=3.75240
AT2 accel=42 loops=1 loop_msec=11.145 total=11.145 rate=3.76865
AT2 A=0.022 F=0.26304 P=0.00179 I=0.000 W=1 -> accel=2 loops=1 threads=64
```

The fit is good: 0.299 ms at accel 1 against 4.460 at accel 16 separate the axis, and the intercept comes back as 0.022 rather than the zero the degenerate branch would leave. So the guard that already drops the margin when the fit fails does not apply. The rate is flat all the same, 3.49 at accel 1 against 3.77 at accel 42, because one unit of accel costs 0.263 ms while the intercept is 0.022: `accel * F` passes `A` at the first point. Frugality then hands the tie to the smallest accel.

The intercept is small for a structural reason rather than a fitting accident. One work item already carries thousands of hashes, since the device engine expands a base word inside the kernel, so even accel 1 fills the device and the kernel time is linear in accel from the first point. There is no fill penalty for the model to find, and the cost that does punish a small launch sits outside the kernel, where `autotune2_fixed_msec ()` returns 0 for `ATTACK_EXEC_INSIDE_KERNEL` before measuring
anything: the trace shows `I=0.000`.

That the margin is what returns accel 1 can be seen without changing any code. `-w 3` sets `AUTOTUNE2_GREED` to 1.00, and on master that alone takes this run from 3819.6 MH/s at accel 1 to 17028.3 at accel 316.

### What it does not change

One round each, NVIDIA:

```
                                master   this change   reverted
-m 100  -a 4  (pcfg ruleset)      3259       7994         8673 MH/s
-m 0    -a 1  (two wordlists)    23350      28802        28516 MH/s
-m 0    -a 3  (?d x 8)           16537      18734        16402 MH/s
-m 3200 -a 3 (bcrypt)            131.1      132.2        132.1 kH/s
```

bcrypt keeps Accel:1 Loops:32 on all three, which is the case the margin is there for: its `attack_exec` is `ATTACK_EXEC_OUTSIDE_KERNEL`, so the margin still applies to it. `-a 3` comes out ahead of the autotune this replaced as well.

Where this change stays below the reverted build, on AMD and on `-m 100`, the reason is the launch budget rather than the margin. For `-w 2` that budget is 12 ms, and on the Radeon the fitted cost is `A = 0.028` with `F = 0.21320`, so accel 42 asks for 8.98 ms while accel 58, the one the old autotune chose, asks for 12.39 and is refused. The same arithmetic on the NVIDIA card puts accel 42 at 11.07 ms, just inside, which is why the two agree there.

### tools/test_edge.sh -m 0 -K 0

```
[ test_edge_1788695780 ] > All tests done in 0d:00h:02m:06s
[ test_edge_1788695780 ] > Errors detected: 0
```

Run with -K 0, the pure kernels, rather than the whole suite. The optimized half is not runnable for -a 4 at all: the device engine has only pure kernels and generic.c refuses -O rather than clearing it, so those five combinations fail the same way on master. Everything else passes.

### Environment

```
NVIDIA GeForce RTX 4080 [10de:2704], 76 processors, driver 610.57.04, CUDA 13.3
AMD Radeon RX 6900 XT (Navi 21) [1002:73bf], 40 processors, amdgpu 6.16.13
```
