### PR TITLE
pcfg: fall back to the host engine when the pcfg device index is empty

### DIFF
--- a/src/feeds/feed_pcfg.c
+++ b/src/feeds/feed_pcfg.c
@@ -6682,11 +6682,27 @@ bool global_dev_init (generic_global_ctx_t *global_ctx, const u32 **pool, u64 *p
 
   build_unit_index (pg);
 
+  // Not a failure. Nothing here is a base word this engine can carry, which is what a grammar whose
+  // mass sits on the escape looks like from the device side, and the host engine still enumerates it.
+  // Reported as an empty inner loop so the core can move the run there, the way it already does when
+  // the kernel for this mode is missing.
+
   if (pg->units == 0)
   {
-    gerr (global_ctx, "device engine index is empty");
+    if (global_ctx->quiet == false) pmsg (pg, "pcfg: no base words for the device engine, the host engine takes the run");
 
-    return false;
+    pool[0]      = pg->pool;
+    pool_size[0] = pg->pool_size;
+    il_cnt[0]    = 0;
+    maxword[0]   = pg->maxword;
+    avg[0]       = 1;
+    front[0]     = 1;
+    step[0]      = 1;
+    varlen[0]    = (pg->varlen == true) ? 1 : 0;
+
+    memset (probe, 0, sizeof (pcfg_cell_t));
+
+    return true;
   }
 
   // The device engine's half of lookup=, answered here rather than beside the host engine's. A base

--- a/src/generic.c
+++ b/src/generic.c
@@ -555,7 +555,21 @@ static int generic_instance_init (hashcat_ctx_t *hashcat_ctx, generic_ctx_t *gen
       return -1;
     }
 
-    user_options_extra->attack_kern = ATTACK_KERN_PCFG;
+    // An empty inner loop is the feed saying it has no base word for this engine. The run moves to
+    // the host engine, and source_ident carries the same mark the earlier fallbacks give it, so a
+    // restore point taken on the device engine is not handed to a host engine run.
+
+    if (generic_ctx->dev_il_cnt == 0)
+    {
+      generic_ctx->dev_enable            = false;
+      generic_ctx->global_ctx.dev_enable = false;
+
+      generic_ctx->global_ctx.source_ident ^= 0x50434647534c4f57ULL;
+    }
+    else
+    {
+      user_options_extra->attack_kern = ATTACK_KERN_PCFG;
+    }
 
   }
 


### PR DESCRIPTION
An -a 4 run whose grammar leaves the device engine with no base word exits 255 today, while the same run under -S exits 0 with a keyspace of 0. This makes the two engines answer the same input the same way, by moving the run to the host engine rather than failing the session.

### Reproduction

    ./hashcat -m 0 -a 4 pcfg/default-passwords.tar.xz costmax=4 --keyspace
    ./hashcat -m 0 -a 4 pcfg/default-passwords.tar.xz costmax=4 -S --keyspace

The ruleset is the one hashcat ships and nothing has to be created first. costmax=4 prices every structure out of the device engine's reach on that ruleset, which is what leaves the index empty.

```
before, without -S: device engine init failed: device engine index is empty, rc=255
before, with -S:    0, rc=0
after,  without -S: 0, rc=0
after,  with -S:    0, rc=0
```

The same happens on a crack run, where the session ends before a single candidate is tried:

    ./hashcat -m 0 -a 4 ffffffffffffffffffffffffffffffff pcfg/default-passwords.tar.xz costmax=4 \
      --potfile-disable -d 1

### Why

build_unit_index () leaves pg->units at zero when no structure reaches the device engine, and global_dev_init () treats that as a failure and returns false. generic.c takes a false there as fatal and stops the session.

An empty index is a property of the engine and not of the attack. A grammar whose mass sits on the escape has nothing for the device engine and a full keyspace for the host engine, and today that run dies where the host engine could have carried it. Eight other conditions in generic_instance_init () already handle this shape by clearing dev_enable and going on: a slow hash, --stdout, rules, --slow-candidates, and a device engine kernel that is not on disk among them. This adds the ninth.

The feed reports an empty inner loop instead of failing, and the core clears dev_enable and marks source_ident with the same value the earlier fallbacks use, so a restore point taken on the device engine is not handed to a host engine run.

### What does not change

The shipped ruleset still reports 12747516022634 base words, and the first 20000 and 500000 candidates hash to the same digests as master's.

### tools/test_edge.sh -m 0 -K 0

```
[ test_edge_1788701995 ] > All tests done in 0d:00h:02m:08s
[ test_edge_1788701995 ] > Errors detected: 0
```

Run with -K 0, the pure kernels. The optimized half is not runnable for -a 4 at all, since the device engine has only pure kernels and generic.c refuses -O rather than clearing it, so those five combinations fail the same way on master.
