### PR TITLE
Refuse a pcfg attack that has nothing to enumerate

### DIFF
--- a/src/feeds/feed_pcfg.c
+++ b/src/feeds/feed_pcfg.c
@@ -7877,23 +7877,6 @@ bool global_init (generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_
     return false;
   }
 
-  // The M line that let a grammar with no structures load was counted before the escape was read,
-  // so it could not tell whether the escape survives. omen=0 drops it, and so does a Grammar that
-  // names an M line beside no Omen directory, and either way nothing is left to enumerate.
-
-  if ((pg->structs_cnt == 0) && (pg->omen_lvl_cnt == 0))
-  {
-    char named[256];
-
-    roots_join (named, sizeof (named), roots, nroots);
-
-    gerr (global_ctx, "%s: nothing to enumerate, no structures and the escape is not carried", named);
-
-    roots_free (roots, nroots);
-
-    return false;
-  }
-
   char display[32];
 
   if (global_ctx->quiet == false) pmsg (pg, "pcfg: OMEN tables loaded in %s", pcfg_duration ((hc_timer_get (t_omen) / 1000.0), display, sizeof (display)));
@@ -7917,6 +7900,32 @@ bool global_init (generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_
     {
       pmsg (pg, "pcfg: level index built in %s, %u levels", pcfg_duration ((hc_timer_get (t_ix) / 1000.0), display, sizeof (display)), pg->lvl_cnt);
     }
+  }
+
+  // build_index () counts the structures and the escape into the same ladder, so a keyspace of zero
+  // here is both of them empty: a grammar carrying no structures and no escape, or one whose
+  // structures are all priced out of reach. Either is a run with nothing to do, and reporting it as
+  // a success is worse than refusing, because a keyspace of zero is the number work is divided by
+  // and an Exhausted run at Progress 0 reads like one that ran and missed.
+
+  if (pg->keyspace == 0)
+  {
+    char named[256];
+
+    roots_join (named, sizeof (named), roots, nroots);
+
+    if (pg->structs_cnt == 0)
+    {
+      gerr (global_ctx, "%s: nothing to enumerate, no structures and the escape is not carried", named);
+    }
+    else
+    {
+      gerr (global_ctx, "%s: nothing to enumerate, no level of the index lands at or below costmax %" PRIu64 ", and the escape is not carried", named, pg->costmax);
+    }
+
+    roots_free (roots, nroots);
+
+    return false;
   }
 
   // lookup= is answered here and not earlier, because it reads the grammar grammar_load () parsed,

--- a/src/feeds/feed_pcfg.c
+++ b/src/feeds/feed_pcfg.c
@@ -2795,7 +2795,7 @@ static int grammar_load (generic_global_ctx_t *global_ctx, pcfg_global_t *pg, co
 
     if (dropped_c > 0)
     {
-      gerr (global_ctx, "%s: all %u structures cost more than costmax %" PRIu64 ", nothing is reachable", named, dropped_c, pg->costmax);
+      gerr (global_ctx, "%s: all %u structures cost more than costmax %" PRIu64 ", nothing is reachable", named, dropped_c, pg->costmax / pg->scale);
 
       return -1;
     }
@@ -7914,13 +7914,13 @@ bool global_init (generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_
 
     roots_join (named, sizeof (named), roots, nroots);
 
-    if (pg->structs_cnt == 0)
+    if ((pg->omen_cnt == 0) && (pg->structs_cnt == 0))
     {
-      gerr (global_ctx, "%s: nothing to enumerate, no structures and the escape is not carried", named);
+      gerr (global_ctx, "%s: nothing to enumerate, no structures and no escape to carry", named);
     }
     else
     {
-      gerr (global_ctx, "%s: nothing to enumerate, no level of the index lands at or below costmax %" PRIu64 ", and the escape is not carried", named, pg->costmax);
+      gerr (global_ctx, "%s: nothing to enumerate, no level of the grammar or of the escape lands at or below costmax %" PRIu64, named, pg->costmax / pg->scale);
     }
 
     roots_free (roots, nroots);


### PR DESCRIPTION
A pcfg attack whose candidates are all priced out of reach is accepted rather than refused, so it
reports a keyspace of 0 at rc 0 and a run of it reports Exhausted at Progress 0. This refuses it and
says which of the two ways it arrived with nothing.

Deviation from CONTRIBUTING.md, as AGENTS.md asks for: no issue was opened for the bug first. All of
it is the two commands below, so the issue would carry the same text this description does.

    ./hashcat -a 4 pcfg/default-passwords.tar.xz --keyspace costmax=4

    before: 0, rc=0
    after:  pcfg/default-passwords.tar.xz: nothing to enumerate, no level of the index lands at or below costmax 4, and the escape is not carried, rc=255

    ./hashcat -m 0 -a 4 8743b52063cd84097a65d1633f5c74f5 pcfg/default-passwords.tar.xz --potfile-disable -d 1 costmax=4 --status

    before: Status Exhausted, Progress 0, rc=1
    after:  the same refusal, rc=255

Both engines are affected and the second command behaves the same under -S, because neither engine
has anything to walk.

build_index () counts the structures and the escape into one ladder, and assigns pg->keyspace only
where that ladder holds a level, so a keyspace of zero there means both are empty. The refusal #4825
added for a grammar with no structures sat above build_index (), before the structures had been
priced, so it saw only one of the two ways to arrive with nothing to do. It moves below the index
build and is keyed on the keyspace, which covers both, and it names the one it found: no structures
and no escape, or no level at or below costmax.

Refusing is what master did here before #4827, which turned "device engine index is empty" into a
fallback to the host engine. That fallback is right for an engine with no base words, and this is
the case it left over, where neither engine has any.

A keyspace of zero is the number a distribution script divides by, and an Exhausted run at Progress 0
cannot be told apart from one that ran and missed, so a mistyped costmax reads as an attack that did
not find the password.

### Checked

Nothing that has a keyspace loses it. Against master at e2a7ab834, on the shipped ruleset:

    costmax   master                  this PR
    2         refused, rc=255         the same
    3         refused, rc=255         the same
    4         0, rc=0                 refused, rc=255
    5         0, rc=0                 refused, rc=255
    6         0, rc=0                 refused, rc=255
    7         0, rc=0                 refused, rc=255
    8         1, rc=0                 the same
    9         2, rc=0                 the same
    12        14, rc=0                the same
    unset     12747516022634, rc=0    the same

2 and 3 are refused on both sides, where every structure is priced above the cap and the load says
so. From 8 up nothing that has a keyspace is turned away.

A grammar whose whole mass sits on the escape still answers 26386266585, and one that has lost the
escape to omen=0 is refused as before, naming no structures. The first 20000 and 500000 candidates
still hash to 43b848a00665a0e0220e64760a247760 and 52c6693e92e780700c5766cc7662fc98.

    ./tools/test_edge.sh -m 0 -K 0

    [ test_edge_1788721754 ] > All tests done in 0d:00h:02m:18s
    [ test_edge_1788721754 ] > Errors detected: 0

-K 0 because -a 4 has no optimized kernel: generic.c refuses -O rather than ignoring it, since the
hashes were parsed under the flag on the way in, so the full suite reports that refusal on master as
well.

It builds on Linux with the same six warnings master already has and none of them new.