### PR TITLE
Hand the pcfg pool over in up to four buffers, and without a copy

### DIFF
--- a/OpenCL/inc_common.h
+++ b/OpenCL/inc_common.h
@@ -99,10 +99,16 @@
 #define _KERN_ATTR_PCFG()                  KERN_ATTR (GLOBAL_AS,   GLOBAL_AS   const bf_t      *g_bfs_buf,     void, void, void),  \
   MAYBE_UNUSED GLOBAL_AS const pcfg_cell_t *pcfg_cells,                                                                            \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool,                                                                            \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool1,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool2,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool3,                                                                           \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_wmap
 #define _KERN_ATTR_PCFG_ESALT(e)           KERN_ATTR (GLOBAL_AS,   GLOBAL_AS   const bf_t      *g_bfs_buf,     void, void, e),     \
   MAYBE_UNUSED GLOBAL_AS const pcfg_cell_t *pcfg_cells,                                                                            \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool,                                                                            \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool1,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool2,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool3,                                                                           \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_wmap
 #define _KERN_ATTR_TMPS(t)                 KERN_ATTR (GLOBAL_AS,   GLOBAL_AS   const bf_t      *g_bfs_buf,     t,    void, void)
 #define _KERN_ATTR_TMPS_ESALT(t,e)         KERN_ATTR (GLOBAL_AS,   GLOBAL_AS   const bf_t      *g_bfs_buf,     t,    void, e)
@@ -119,10 +125,16 @@
 #define _KERN_ATTR_PCFG()                  KERN_ATTR (GLOBAL_AS,   CONSTANT_AS const bf_t      *bfs_buf,       void, void, void),  \
   MAYBE_UNUSED GLOBAL_AS const pcfg_cell_t *pcfg_cells,                                                                            \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool,                                                                            \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool1,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool2,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool3,                                                                           \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_wmap
 #define _KERN_ATTR_PCFG_ESALT(e)           KERN_ATTR (GLOBAL_AS,   CONSTANT_AS const bf_t      *bfs_buf,       void, void, e),     \
   MAYBE_UNUSED GLOBAL_AS const pcfg_cell_t *pcfg_cells,                                                                            \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool,                                                                            \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool1,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool2,                                                                           \
+  MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_pool3,                                                                           \
   MAYBE_UNUSED GLOBAL_AS const u32          *pcfg_wmap
 #define _KERN_ATTR_TMPS(t)                 KERN_ATTR (GLOBAL_AS,   CONSTANT_AS const bf_t      *bfs_buf,       t,    void, void)
 #define _KERN_ATTR_TMPS_ESALT(t,e)         KERN_ATTR (GLOBAL_AS,   CONSTANT_AS const bf_t      *bfs_buf,       t,    void, e)

--- a/OpenCL/inc_pcfg.cl
+++ b/OpenCL/inc_pcfg.cl
@@ -9,13 +9,34 @@
 #include "inc_common.h"
 #include "inc_pcfg.h"
 
-DECLSPEC u32 pcfg_pool_byte (GLOBAL_AS const u32 *pool, const u32 off)
+DECLSPEC u32 pcfg_pool_byte (PCFG_POOL_ARGS, const u32 off)
 {
-  GLOBAL_AS const u8 *pb = (GLOBAL_AS const u8 *) pool;
+  // A byte is loaded as a byte. Reading the word around it and shifting the byte out, together with a
+  // copy that accumulates words, measured 54.3 ms of kernel time against 48.5 on an RX 6900 XT under
+  // HIP at identical work, and the same either way on CUDA.
+
+  #if PCFG_POOL_SPLIT == 0
+
+  GLOBAL_AS const u8 *pb = (GLOBAL_AS const u8 *) pool0;
 
   const u32 b = pb[off];
 
   return b;
+
+  #else
+
+  u32 base = 0;
+  u32 end  = 0;
+
+  GLOBAL_AS const u32 *p = pcfg_pool_span (PCFG_POOL_PASS, off / 4, &base, &end);
+
+  GLOBAL_AS const u8 *pb = (GLOBAL_AS const u8 *) p;
+
+  const u32 b = pb[off - (base * 4)];
+
+  return b;
+
+  #endif
 }
 
 DECLSPEC void pcfg_put_byte (PRIVATE_AS u32 *w, const u32 off, const u32 b)
@@ -34,11 +55,121 @@ DECLSPEC u32 pcfg_get_byte (PRIVATE_AS const u32 *w, const u32 off)
   return b;
 }
 
-DECLSPEC u32 pcfg_ent_off (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, const u32 j, const u32 n)
+DECLSPEC GLOBAL_AS const u32 *pcfg_pool_span (PCFG_POOL_ARGS, MAYBE_UNUSED const u32 at, PRIVATE_AS u32 *base, PRIVATE_AS u32 *end)
+{
+  #if PCFG_POOL_SPLIT == 0
+
+  base[0] = 0;
+  end[0]  = 0xffffffff;
+
+  return pool0;
+
+  #else
+
+  if (at < pool_at2)
+  {
+    if (at < pool_at1) { base[0] = 0;         end[0] = pool_at1; return pool0; }
+
+    base[0] = pool_at1; end[0] = pool_at2; return pool1;
+  }
+
+  if (at < pool_at3) { base[0] = pool_at2;  end[0] = pool_at3; return pool2; }
+
+  base[0] = pool_at3;
+  end[0]  = 0xffffffff;
+
+  return pool3;
+
+  #endif
+}
+
+// The part is found once for the whole run rather than once a byte. Accumulating words and shifting
+// the bytes out saves loads but puts a branch in the innermost loop of the write path, and where the
+// pool is split that measured 3.3% on AMD and nothing on CUDA.
+
+DECLSPEC void pcfg_pool_copy (PCFG_POOL_ARGS, PRIVATE_AS u32 *w, const u32 dst, const u32 src, const u32 len)
+{
+  if (len == 0) return;
+
+  #if PCFG_POOL_SPLIT == 0
+
+  GLOBAL_AS const u8 *pb = (GLOBAL_AS const u8 *) pool0;
+
+  for (u32 k = 0; k < len; k++) pcfg_put_byte (w, dst + k, pb[src + k]);
+
+  #else
+
+  u32 base = 0;
+  u32 end  = 0;
+
+  GLOBAL_AS const u32 *p = pcfg_pool_span (PCFG_POOL_PASS, src / 4, &base, &end);
+
+  // A run that ends in the part it began in is every run but the few that straddle a boundary.
+
+  if (((src + len - 1) / 4) < end)
+  {
+    GLOBAL_AS const u8 *pb = (GLOBAL_AS const u8 *) p;
+
+    const u32 off = src - (base * 4);
+
+    for (u32 k = 0; k < len; k++) pcfg_put_byte (w, dst + k, pb[off + k]);
+
+    return;
+  }
+
+  for (u32 k = 0; k < len; k++) pcfg_put_byte (w, dst + k, pcfg_pool_byte (PCFG_POOL_PASS, src + k));
+
+  #endif
+}
+
+DECLSPEC u32 pcfg_pool_u32 (PCFG_POOL_ARGS, const u32 at)
+{
+  // The comparisons nest rather than chain. A read here is divergent, so a GPU turns each one into a
+  // region under its own exec mask, and nested a lane walks two of them where chained it walks four.
+  // On this kernel the two measure the same, because a part is found once per slot and not once per
+  // byte, so this is the shape that has nothing to lose.
+
+  #if PCFG_POOL_SPLIT == 0
+
+  const u32 v = pool0[at];
+
+  return v;
+
+  #else
+
+  if (at < pool_at2)
+  {
+    if (at < pool_at1)
+    {
+      const u32 v0 = pool0[at];
+
+      return v0;
+    }
+
+    const u32 v1 = pool1[at - pool_at1];
+
+    return v1;
+  }
+
+  if (at < pool_at3)
+  {
+    const u32 v2 = pool2[at - pool_at2];
+
+    return v2;
+  }
+
+  const u32 v3 = pool3[at - pool_at3];
+
+  return v3;
+
+  #endif
+}
+
+DECLSPEC u32 pcfg_ent_off (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, const u32 j, const u32 n)
 {
   #if PCFG_DEV_VARLEN
 
-  const u32 off = pool[cell->slots[j].pool_off + n];
+  const u32 off = pcfg_pool_u32 (PCFG_POOL_PASS, cell->slots[j].pool_off + n);
 
   return off;
 
@@ -51,11 +182,14 @@ DECLSPEC u32 pcfg_ent_off (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32
   #endif
 }
 
-DECLSPEC u32 pcfg_ent_len (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, const u32 j, const u32 n)
+DECLSPEC u32 pcfg_ent_len (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, const u32 j, const u32 n)
 {
   #if PCFG_DEV_VARLEN
 
-  const u32 len = pool[cell->slots[j].pool_off + n + 1] - pool[cell->slots[j].pool_off + n];
+  const u32 hi = pcfg_pool_u32 (PCFG_POOL_PASS, cell->slots[j].pool_off + n + 1);
+  const u32 lo = pcfg_pool_u32 (PCFG_POOL_PASS, cell->slots[j].pool_off + n);
+
+  const u32 len = hi - lo;
 
   return len;
 
@@ -68,7 +202,7 @@ DECLSPEC u32 pcfg_ent_len (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32
   #endif
 }
 
-DECLSPEC void pcfg_case_slot (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, LOCAL_AS const u32 *digit, PRIVATE_AS u32 *w, const u32 j)
+DECLSPEC void pcfg_case_slot (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, LOCAL_AS const u32 *digit, PRIVATE_AS u32 *w, const u32 j)
 {
   const u32 packed = cell->slots[j].packed;
 
@@ -77,15 +211,15 @@ DECLSPEC void pcfg_case_slot (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const 
   const u32 dj = PCFG_ODO_DIGIT (digit[j]);
   const u32 df = PCFG_ODO_DIGIT (digit[from]);
 
-  const u32 mask_len = pcfg_ent_len (cell, pool, j,    dj);
-  const u32 tok_len  = pcfg_ent_len (cell, pool, from, df);
+  const u32 mask_len = pcfg_ent_len (cell, PCFG_POOL_PASS, j,    dj);
+  const u32 tok_len  = pcfg_ent_len (cell, PCFG_POOL_PASS, from, df);
 
-  const u32 mask_src = pcfg_ent_off (cell, pool, j, dj);
+  const u32 mask_src = pcfg_ent_off (cell, PCFG_POOL_PASS, j, dj);
 
   #if PCFG_DEV_VARLEN
 
   const u32 dst_off = PCFG_ODO_POS (digit[from]);
-  const u32 up_src  = pcfg_ent_off (cell, pool, from, df) + cell->slots[j].digit;
+  const u32 up_src  = pcfg_ent_off (cell, PCFG_POOL_PASS, from, df) + cell->slots[j].digit;
 
   #else
 
@@ -99,9 +233,9 @@ DECLSPEC void pcfg_case_slot (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const 
 
   while ((at < tok_len) && (ci < mask_len))
   {
-    if (pcfg_pool_byte (pool, mask_src + ci) == 'U')
+    if (pcfg_pool_byte (PCFG_POOL_PASS, mask_src + ci) == 'U')
     {
-      pcfg_put_byte (w, dst_off + at, pcfg_pool_byte (pool, up_src + at));
+      pcfg_put_byte (w, dst_off + at, pcfg_pool_byte (PCFG_POOL_PASS, up_src + at));
     }
 
     at++;
@@ -110,9 +244,9 @@ DECLSPEC void pcfg_case_slot (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const 
     {
       if ((pcfg_get_byte (w, dst_off + at) & 0xc0) != 0x80) break;
 
-      if (pcfg_pool_byte (pool, mask_src + ci) == 'U')
+      if (pcfg_pool_byte (PCFG_POOL_PASS, mask_src + ci) == 'U')
       {
-        pcfg_put_byte (w, dst_off + at, pcfg_pool_byte (pool, up_src + at));
+        pcfg_put_byte (w, dst_off + at, pcfg_pool_byte (PCFG_POOL_PASS, up_src + at));
       }
 
       at++;
@@ -192,7 +326,7 @@ DECLSPEC int pcfg_odo_next (LOCAL_AS const pcfg_cell_t *cell, LOCAL_AS u32 *digi
   return -1;
 }
 
-DECLSPEC u32 pcfg_write_from (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w, const u32 from)
+DECLSPEC u32 pcfg_write_from (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w, const u32 from)
 {
   const u32 slot_cnt = (cell->slot_cnt < PCFG_DEV_MAXSLOT) ? cell->slot_cnt : PCFG_DEV_MAXSLOT;
 
@@ -216,8 +350,8 @@ DECLSPEC u32 pcfg_write_from (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const 
 
       digit[j] = PCFG_ODO_PACK (d, pos);
 
-      const u32 src     = pcfg_ent_off (cell, pool, j, d);
-      const u32 ent_len = pcfg_ent_len (cell, pool, j, d);
+      const u32 src     = pcfg_ent_off (cell, PCFG_POOL_PASS, j, d);
+      const u32 ent_len = pcfg_ent_len (cell, PCFG_POOL_PASS, j, d);
       const u32 dst_off = pos;
 
       pos += ent_len;
@@ -231,14 +365,11 @@ DECLSPEC u32 pcfg_write_from (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const 
 
       #endif
 
-      for (u32 k = 0; k < ent_len; k++)
-      {
-        pcfg_put_byte (w, dst_off + k, pcfg_pool_byte (pool, src + k));
-      }
+      pcfg_pool_copy (PCFG_POOL_PASS, w, dst_off, src, ent_len);
     }
     else
     {
-      pcfg_case_slot (cell, pool, digit, w, j);
+      pcfg_case_slot (cell, PCFG_POOL_PASS, digit, w, j);
     }
   }
 
@@ -249,9 +380,9 @@ DECLSPEC u32 pcfg_write_from (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const 
   #endif
 }
 
-DECLSPEC u32 pcfg_write (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w)
+DECLSPEC u32 pcfg_write (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w)
 {
-  const u32 len = pcfg_write_from (cell, pool, digit, w, 0);
+  const u32 len = pcfg_write_from (cell, PCFG_POOL_PASS, digit, w, 0);
 
   return len;
 }

--- a/OpenCL/inc_pcfg.h
+++ b/OpenCL/inc_pcfg.h
@@ -6,18 +6,19 @@
 #ifndef INC_PCFG_H
 #define INC_PCFG_H
 
-DECLSPEC u32  pcfg_pool_byte (GLOBAL_AS const u32 *pool, const u32 off);
+#include "inc_pcfg_pool.h"
+
 DECLSPEC u32  pcfg_get_byte  (PRIVATE_AS const u32 *w, const u32 off);
 DECLSPEC void pcfg_put_byte  (PRIVATE_AS u32 *w, const u32 off, const u32 b);
 
-DECLSPEC void pcfg_case_slot (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, LOCAL_AS const u32 *digit, PRIVATE_AS u32 *w, const u32 j);
+DECLSPEC void pcfg_case_slot (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, LOCAL_AS const u32 *digit, PRIVATE_AS u32 *w, const u32 j);
 
-DECLSPEC u32  pcfg_ent_off    (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, const u32 j, const u32 n);
-DECLSPEC u32  pcfg_ent_len    (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, const u32 j, const u32 n);
+DECLSPEC u32  pcfg_ent_off    (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, const u32 j, const u32 n);
+DECLSPEC u32  pcfg_ent_len    (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, const u32 j, const u32 n);
 
 DECLSPEC bool pcfg_odo_seed   (LOCAL_AS const pcfg_cell_t *cell, const u32 il_pos, LOCAL_AS u32 *digit);
 DECLSPEC int  pcfg_odo_next   (LOCAL_AS const pcfg_cell_t *cell, LOCAL_AS u32 *digit);
-DECLSPEC u32  pcfg_write      (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w);
-DECLSPEC u32  pcfg_write_from (LOCAL_AS const pcfg_cell_t *cell, GLOBAL_AS const u32 *pool, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w, const u32 from);
+DECLSPEC u32  pcfg_write      (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w);
+DECLSPEC u32  pcfg_write_from (LOCAL_AS const pcfg_cell_t *cell, PCFG_POOL_ARGS, LOCAL_AS u32 *digit, PRIVATE_AS u32 *w, const u32 from);
 
 #endif

--- a/OpenCL/inc_pcfg_kernel.cl
+++ b/OpenCL/inc_pcfg_kernel.cl
@@ -54,6 +54,8 @@ DECLSPEC void pcfg_pt_case (MAYBE_UNUSED PRIVATE_AS u32 *w, MAYBE_UNUSED const u
 KERNEL_FQ KERNEL_FA void PCFG_KERNEL_MXX (PCFG_KERN_ATTR)
 {
 
+  PCFG_POOL_KERN (pcfg_pool_v)
+
   const u64 lid = get_local_id (0);
 
   MAYBE_UNUSED const u64 lsz = get_local_size (0);
@@ -163,7 +165,7 @@ KERNEL_FQ KERNEL_FA void PCFG_KERNEL_MXX (PCFG_KERN_ATTR)
 
   u32 cur_len = pw_len;
 
-  u32 nxt = (s_cells[wid].slot_cnt > 0) ? pcfg_write (&s_cells[wid], pcfg_pool, s_digit[lid], w) : pw_len;
+  u32 nxt = (s_cells[wid].slot_cnt > 0) ? pcfg_write (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w) : pw_len;
 
   for (u32 il_pos = beg; il_pos < end; il_pos++)
   {
@@ -192,12 +194,12 @@ KERNEL_FQ KERNEL_FA void PCFG_KERNEL_MXX (PCFG_KERN_ATTR)
 
     if (from < 0) break;
 
-    nxt = pcfg_write_from (&s_cells[wid], pcfg_pool, s_digit[lid], w, (u32) from);
+    nxt = pcfg_write_from (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w, (u32) from);
   }
 
   #else
 
-  pcfg_write (&s_cells[wid], pcfg_pool, s_digit[lid], w);
+  pcfg_write (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w);
 
   for (u32 il_pos = beg; il_pos < end; il_pos++)
   {
@@ -221,7 +223,7 @@ KERNEL_FQ KERNEL_FA void PCFG_KERNEL_MXX (PCFG_KERN_ATTR)
 
     if (from < 0) break;
 
-    pcfg_write_from (&s_cells[wid], pcfg_pool, s_digit[lid], w, (u32) from);
+    pcfg_write_from (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w, (u32) from);
   }
 
   #endif
@@ -229,6 +231,8 @@ KERNEL_FQ KERNEL_FA void PCFG_KERNEL_MXX (PCFG_KERN_ATTR)
 
 KERNEL_FQ KERNEL_FA void PCFG_KERNEL_SXX (PCFG_KERN_ATTR)
 {
+
+  PCFG_POOL_KERN (pcfg_pool_v)
 
   const u64 lid = get_local_id (0);
 
@@ -347,7 +351,7 @@ KERNEL_FQ KERNEL_FA void PCFG_KERNEL_SXX (PCFG_KERN_ATTR)
 
   u32 cur_len = pw_len;
 
-  u32 nxt = (s_cells[wid].slot_cnt > 0) ? pcfg_write (&s_cells[wid], pcfg_pool, s_digit[lid], w) : pw_len;
+  u32 nxt = (s_cells[wid].slot_cnt > 0) ? pcfg_write (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w) : pw_len;
 
   for (u32 il_pos = beg; il_pos < end; il_pos++)
   {
@@ -376,12 +380,12 @@ KERNEL_FQ KERNEL_FA void PCFG_KERNEL_SXX (PCFG_KERN_ATTR)
 
     if (from < 0) break;
 
-    nxt = pcfg_write_from (&s_cells[wid], pcfg_pool, s_digit[lid], w, (u32) from);
+    nxt = pcfg_write_from (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w, (u32) from);
   }
 
   #else
 
-  pcfg_write (&s_cells[wid], pcfg_pool, s_digit[lid], w);
+  pcfg_write (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w);
 
   for (u32 il_pos = beg; il_pos < end; il_pos++)
   {
@@ -405,7 +409,7 @@ KERNEL_FQ KERNEL_FA void PCFG_KERNEL_SXX (PCFG_KERN_ATTR)
 
     if (from < 0) break;
 
-    pcfg_write_from (&s_cells[wid], pcfg_pool, s_digit[lid], w, (u32) from);
+    pcfg_write_from (&s_cells[wid], PCFG_POOL_REF (pcfg_pool_v), s_digit[lid], w, (u32) from);
   }
 
   #endif

--- a/OpenCL/inc_pcfg_pool.h
+++ b/OpenCL/inc_pcfg_pool.h
@@ -1,0 +1,69 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifndef INC_PCFG_POOL_H
+#define INC_PCFG_POOL_H
+
+// One logical array of words, handed over in up to PCFG_POOL_PARTS buffers.
+//
+// A device will not always allocate the whole pool in one block: the largest single allocation it
+// offers is often a fraction of the memory it has. A grammar trained on the whole of hashmob's
+// combined founds packs 4269 MiB of terminals, against 3456 MiB on one OpenCL runtime and 3993 on
+// another, so the pool is refused whole on cards with memory to spare. Cutting it into equal parts
+// takes that ceiling off the total and leaves it only on a part.
+//
+// A read finds its part by where the logical index falls, which costs a few comparisons but lets a
+// part be as large as the device will hand out rather than the power of two below it. Whether the
+// pool was cut is settled before the kernel is built, so where it went over in one piece the search
+// is compiled out and a read is a read.
+
+// Four is written out by hand elsewhere: the buffers a kernel takes in inc_common.h, the starts
+// carried in kernel_param, the macros below, and the branches of the search. None of them would fail
+// to build if this changed, they would read the wrong part, so the coupling is made to fail here.
+
+#if PCFG_POOL_PARTS != 4
+#error "PCFG_POOL_PARTS is written out by hand in inc_common.h, kernel_param and the search in inc_pcfg.cl"
+#endif
+
+// The parts travel as arguments rather than as a struct. A local struct whose address is taken goes
+// to private memory, and every read of the descriptor is then a scratch access. Measured on gfx1030,
+// one buffer takes 608 bytes of private memory and 70 buffer_load, four buffers behind a struct take
+// 656 and 226, and the 48 bytes between them are the struct. As arguments, four buffers cost what
+// one does, which is a fifth off the kernel time on that card and nothing either way on NVIDIA.
+
+#define PCFG_POOL_ARGS                                        \
+  MAYBE_UNUSED GLOBAL_AS const u32 *pool0,                    \
+  MAYBE_UNUSED GLOBAL_AS const u32 *pool1,                    \
+  MAYBE_UNUSED GLOBAL_AS const u32 *pool2,                    \
+  MAYBE_UNUSED GLOBAL_AS const u32 *pool3,                    \
+  MAYBE_UNUSED const u32 pool_at1,                            \
+  MAYBE_UNUSED const u32 pool_at2,                            \
+  MAYBE_UNUSED const u32 pool_at3
+
+#define PCFG_POOL_PASS  pool0, pool1, pool2, pool3, pool_at1, pool_at2, pool_at3
+
+#define PCFG_POOL_REF(v)  v##0, v##1, v##2, v##3, v##_at1, v##_at2, v##_at3
+
+#define PCFG_POOL_KERN(v)                                     \
+  MAYBE_UNUSED GLOBAL_AS const u32 *v##0 = pcfg_pool;         \
+  MAYBE_UNUSED GLOBAL_AS const u32 *v##1 = pcfg_pool1;        \
+  MAYBE_UNUSED GLOBAL_AS const u32 *v##2 = pcfg_pool2;        \
+  MAYBE_UNUSED GLOBAL_AS const u32 *v##3 = pcfg_pool3;        \
+  MAYBE_UNUSED const u32 v##_at1 = PCFG_POOL_AT1;             \
+  MAYBE_UNUSED const u32 v##_at2 = PCFG_POOL_AT2;             \
+  MAYBE_UNUSED const u32 v##_at3 = PCFG_POOL_AT3;
+
+// The part a word falls in, with the word it starts at and the word the next part starts at. A caller
+// that reads a run of bytes asks once and then indexes the buffer itself, rather than asking again
+// for every byte.
+
+DECLSPEC GLOBAL_AS const u32 *pcfg_pool_span (PCFG_POOL_ARGS, MAYBE_UNUSED const u32 at, PRIVATE_AS u32 *base, PRIVATE_AS u32 *end);
+
+DECLSPEC void pcfg_pool_copy (PCFG_POOL_ARGS, PRIVATE_AS u32 *w, const u32 dst, const u32 src, const u32 len);
+
+DECLSPEC u32 pcfg_pool_u32  (PCFG_POOL_ARGS, const u32 at);
+DECLSPEC u32 pcfg_pool_byte (PCFG_POOL_ARGS, const u32 off);
+
+#endif // INC_PCFG_POOL_H

--- a/OpenCL/inc_types.h
+++ b/OpenCL/inc_types.h
@@ -8,6 +8,9 @@
 
 #if ATTACK_MODE == 9
 #define BITMAP_MASK         kernel_param->bitmap_mask
+#define PCFG_POOL_AT1       kernel_param->pcfg_pool_at1
+#define PCFG_POOL_AT2       kernel_param->pcfg_pool_at2
+#define PCFG_POOL_AT3       kernel_param->pcfg_pool_at3
 #define SALT_POS_HOST       (kernel_param->pws_pos + gid)
 #define SALT_POS_HOST_BID   (kernel_param->pws_pos + bid)
 #define LOOP_POS            kernel_param->loop_pos
@@ -23,6 +26,9 @@
 #define PCFG_LANE_STRIDE    kernel_param->pcfg_lane_stride
 #else
 #define BITMAP_MASK         kernel_param->bitmap_mask
+#define PCFG_POOL_AT1       kernel_param->pcfg_pool_at1
+#define PCFG_POOL_AT2       kernel_param->pcfg_pool_at2
+#define PCFG_POOL_AT3       kernel_param->pcfg_pool_at3
 #define SALT_POS_HOST       kernel_param->salt_pos_host
 #define SALT_POS_HOST_BID   SALT_POS_HOST
 #define LOOP_POS            kernel_param->loop_pos
@@ -2090,6 +2096,13 @@ typedef struct kernel_param
 
   u64 pcfg_lane_stride;     // 39
 
+  // Where each part of the device engine's pool begins, in words. Last, so that adding them does not
+  // renumber every field after them.
+
+  u32 pcfg_pool_at1;        // 40
+  u32 pcfg_pool_at2;        // 41
+  u32 pcfg_pool_at3;        // 42
+
 } kernel_param_t;
 
 typedef struct salt
@@ -2387,6 +2400,15 @@ typedef struct pcfg_cell
 } pcfg_cell_t;
 
 #define PCFG_CELL_VARLEN 1
+
+// How many buffers the pool may be handed over in. inc_pcfg_pool.h says how a read finds its part.
+
+#define PCFG_POOL_PARTS 4
+
+// What the pool is aligned to and rounded up to, so a device whose memory is the host's can be handed
+// the feed's bytes instead of a copy. A multiple of every page size hashcat runs on.
+
+#define PCFG_POOL_ALIGN 65536
 
 typedef struct bf
 {

--- a/include/ext_metal.h
+++ b/include/ext_metal.h
@@ -27,6 +27,12 @@ typedef struct mtl_mem
 
   unsigned int buf_mode;
 
+  // Whether the buffer reads the caller's own bytes or a copy of them. A host pointer is only taken
+  // on a Shared buffer, and the mode asked for is not always the mode given, so a caller that hands
+  // one over reads this afterwards rather than working out beforehand which it would be.
+
+  unsigned int buf_host;
+
 } mtl_mem_t;
 
 typedef enum metalResourceStorageMode

--- a/include/types.h
+++ b/include/types.h
@@ -1679,11 +1679,18 @@ typedef struct hc_device_param
   u64  size_combs_c;
 
   // The device engine's two buffers. The cells are per work item and are rewritten every launch beside
-  // pws_buf; the pool is the terminal bytes every cell indexes into and is uploaded once.
+  // pws_buf. The pool is the terminal bytes every cell indexes into, and it is handed over once.
 
   u64  size_pcfg_cells;
   u64  size_pcfg_pool;
   u64  size_pcfg_wmap;
+
+  // One buffer where the device will allocate the pool in one, equal parts where it will not. A part
+  // is a whole number of pages, not a power of two: see pcfg_pool_budget ().
+
+  u64  size_pcfg_pool_part;
+  u32  pcfg_pool_parts;
+
   u64  size_rules;
   u64  size_rules_c;
   u64  size_root_css;
@@ -1936,7 +1943,7 @@ typedef struct hc_device_param
   CUdeviceptr       cuda_d_combs;
   CUdeviceptr       cuda_d_combs_c;
   CUdeviceptr       cuda_d_pcfg_cells;
-  CUdeviceptr       cuda_d_pcfg_pool;
+  CUdeviceptr       cuda_d_pcfg_pool[PCFG_POOL_PARTS];
   CUdeviceptr       cuda_d_pcfg_wmap;
   CUdeviceptr       cuda_d_bfs;
   CUdeviceptr       cuda_d_bfs_c;
@@ -2022,7 +2029,7 @@ typedef struct hc_device_param
   hipDeviceptr_t    hip_d_combs;
   hipDeviceptr_t    hip_d_combs_c;
   hipDeviceptr_t    hip_d_pcfg_cells;
-  hipDeviceptr_t    hip_d_pcfg_pool;
+  hipDeviceptr_t    hip_d_pcfg_pool[PCFG_POOL_PARTS];
   hipDeviceptr_t    hip_d_pcfg_wmap;
   hipDeviceptr_t    hip_d_bfs;
   hipDeviceptr_t    hip_d_bfs_c;
@@ -2146,7 +2153,7 @@ typedef struct hc_device_param
   mtl_mem_t         metal_d_combs;
   mtl_mem_t         metal_d_combs_c;
   mtl_mem_t         metal_d_pcfg_cells;
-  mtl_mem_t         metal_d_pcfg_pool;
+  mtl_mem_t         metal_d_pcfg_pool[PCFG_POOL_PARTS];
   mtl_mem_t         metal_d_pcfg_wmap;
   mtl_mem_t         metal_d_bfs;
   mtl_mem_t         metal_d_bfs_c;
@@ -2246,7 +2253,7 @@ typedef struct hc_device_param
   cl_mem            opencl_d_combs;
   cl_mem            opencl_d_combs_c;
   cl_mem            opencl_d_pcfg_cells;
-  cl_mem            opencl_d_pcfg_pool;
+  cl_mem            opencl_d_pcfg_pool[PCFG_POOL_PARTS];
   cl_mem            opencl_d_pcfg_wmap;
   cl_mem            opencl_d_bfs;
   cl_mem            opencl_d_bfs_c;
@@ -3536,7 +3543,8 @@ typedef struct generic_ctx
   bool dev_enable;
 
   // What global_dev_init () handed over: the terminal pool every cell indexes into, and how wide the
-  // device side inner loop is. The pool is read only and uploaded once per device.
+  // device side inner loop is. The pool is read only, and a device whose memory is the host's reads
+  // these bytes rather than a copy, so the buffers over it are released before the feed frees it.
 
   const u32 *dev_pool;
   u64        dev_pool_size;

--- a/src/backend.c
+++ b/src/backend.c
@@ -3461,10 +3461,11 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
 
     if (hc_mtlCreateBuffer (hashcat_ctx, device_param->metal_device, sizeof (u8), NULL, &mem, metal_private_storageMode) == -1) return -1;
 
-    // kernel_params[24] is the last of the shared list, and the device engine adds three behind it: see
-    // the same bound on the OpenCL path below. Stopping at 24 left all three of them unbound.
+    // kernel_params[24] is the last of the shared list and the device engine adds the ones behind it,
+    // so this has to be counted the same way as the OpenCL path below. An encoder that stops short
+    // leaves an argument bound to nothing at all.
 
-    const u32 kernel_params_max = (hashcat_ctx->user_options_extra->attack_kern == ATTACK_KERN_PCFG) ? 27 : 24;
+    const u32 kernel_params_max = (hashcat_ctx->user_options_extra->attack_kern == ATTACK_KERN_PCFG) ? (26 + PCFG_POOL_PARTS) : 24;
 
     // all buffers must be allocated
     for (u32 i = 0; i <= kernel_params_max; i++)
@@ -3659,12 +3660,13 @@ int run_kernel (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, con
     // the only one whose extra arguments may be set. Setting them on any other kernel is an error from
     // the runtime, not a no-op.
 
-    // kernel_params[24] is the last of the shared list, and the device engine adds three: pcfg_cells at
-    // 25, pcfg_pool at 26 and pcfg_wmap at 27. Stopping at 26 left the wave map unbound, so an OpenCL
-    // device read whatever that argument slot happened to hold and every work item looked up the wrong
-    // cell. CUDA and HIP pass the whole array and were never affected, which is why it was not seen.
+    // kernel_params[24] is the last of the shared list, and the device engine adds the cells at 25, the
+    // pool in as many buffers as it took at 26, and the wave map after them. Stopping short leaves an
+    // argument unbound, so an OpenCL device reads whatever that slot happened to hold and every work
+    // item looks up the wrong cell. CUDA and HIP pass the whole array and were never affected, which
+    // is why it was not seen.
 
-    const u32 kernel_params_max = (hashcat_ctx->user_options_extra->attack_kern == ATTACK_KERN_PCFG) ? 27 : 24;
+    const u32 kernel_params_max = (hashcat_ctx->user_options_extra->attack_kern == ATTACK_KERN_PCFG) ? (26 + PCFG_POOL_PARTS) : 24;
 
     for (u32 i = 0; i <= kernel_params_max; i++)
     {
@@ -15918,6 +15920,198 @@ static u32 backend_device_sharers (const backend_ctx_t *backend_ctx, const hc_de
   return result;
 }
 
+// Whether the feed's bytes are worth offering to this device rather than copying them, through
+// newBufferWithBytesNoCopy on Metal and CL_MEM_USE_HOST_PTR on OpenCL. Both want the pointer page
+// aligned, which is why the feed aligns the pool.
+//
+// Offering is not the same as being taken. On Metal the storage mode asked for is not always the one
+// given, and hc_mtlCreateBuffer () answers in mem->buf_host which of the two it did, so the copy is
+// decided from that rather than from anything guessed here. What this answers is only whether there
+// is any point in offering, which is a property of the memory and not of the device.
+
+static bool pcfg_pool_shared (const hc_device_param_t *device_param)
+{
+  if (device_param->device_host_unified_memory == 0) return false;
+
+  if (device_param->is_metal  == true) return true;
+  if (device_param->is_opencl == true) return true;
+
+  return false;
+}
+
+// What one device can hold of the pool, and the largest piece it will take at a time. The two are
+// different bounds, and reading the second as if it were also the first splits a pool the device
+// would have taken whole.
+//
+// An eighth of the free memory is kept back rather than the launch floor, because what the run needs
+// beside the pool is elastic: measured on an RTX 4080 with the shipped ruleset, whose pool is 17 MiB,
+// the same attack held 264 MiB of device memory at an accel of 1 and 3970 MiB at the accel autotune
+// settled on. Leaving only the floor starts a run that crawls. Free memory is divided the way the
+// memory check further down divides it, because every device on one physical device allocates its own
+// copy of the pool.
+
+static u64 pcfg_pool_budget (const hc_device_param_t *device_param, const u32 sharers, u64 *part_max)
+{
+  u64 total = device_param->device_maxmem_alloc * PCFG_POOL_PARTS;
+
+  // The feed keeps its pool for the whole run, so a device that is not offered those bytes holds a
+  // second copy, and on unified memory that second copy comes out of this budget too. Offered and
+  // taken are not the same, and this runs before any buffer exists, so a device that is offered the
+  // pointer and declines it holds a copy this did not count.
+
+  const bool twice = (device_param->device_host_unified_memory == 1) && (pcfg_pool_shared (device_param) == false);
+
+  if (twice == true) total /= 2;
+
+  if (device_param->device_available_mem != 0)
+  {
+    const u64 avail = device_param->device_available_mem / sharers;
+
+    const u64 keep_launch = avail / 8;
+
+    const u64 keep_floor  = device_param->device_global_mem / 100;
+
+    const u64 keep = (keep_launch > keep_floor) ? keep_launch : keep_floor;
+
+    u64 free = (avail > keep) ? (avail - keep) : 0;
+
+    if (twice == true) free /= 2;
+
+    if (free < total) total = free;
+  }
+
+  u64 part = device_param->device_maxmem_alloc;
+
+  if (total < part) part = total;
+
+  // Whole pages, which is what both wrappers ask before they read the feed's bytes instead of a copy.
+  // Not powers of two: rounding down to one threw away up to half of what the device offered.
+
+  const u64 grain = PCFG_POOL_ALIGN;
+
+  *part_max = (part / grain) * grain;
+
+  u64 budget = (total / grain) * grain;
+
+  // A part is a whole number of pages, so on a device whose ceiling is not one the parts hold a page
+  // less than the raw budget. Reporting the raw one asks the split for a part more than there are.
+
+  const u64 fits = *part_max * PCFG_POOL_PARTS;
+
+  if (budget > fits) budget = fits;
+
+  return budget;
+}
+
+// Where a part's bytes already are, for a device that can read them there. Nothing for a device that
+// cannot, and nothing for the parts past the end of the pool, which are placeholders a kernel argument
+// needs rather than anything a read reaches.
+
+static void *pcfg_pool_part_host (const hashcat_ctx_t *hashcat_ctx, const hc_device_param_t *device_param, const u32 i)
+{
+  if (hashcat_ctx->user_options_extra->attack_kern != ATTACK_KERN_PCFG) return NULL;
+
+  if (pcfg_pool_shared (device_param) == false) return NULL;
+
+  if (i >= device_param->pcfg_pool_parts) return NULL;
+
+  const u8 *pool = (const u8 *) hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool;
+
+  if (pool == NULL) return NULL;
+
+  const u64 at = (u64) i * device_param->size_pcfg_pool_part;
+
+  const u8 *base = pool + at;
+
+  return (void *) base;
+}
+
+// How large the buffer for one part is. Every part is a kernel argument whether the pool reaches it
+// or not, and an argument has to be a buffer the device can read, so a part past the end is made as
+// small as one gets rather than left unallocated.
+
+static u64 pcfg_pool_part_size (const hc_device_param_t *device_param, const u64 size_pcfg_pool, const u32 i)
+{
+  if (i >= device_param->pcfg_pool_parts) return 4;
+
+  const u64 at = (u64) i * device_param->size_pcfg_pool_part;
+
+  const u64 left = size_pcfg_pool - at;
+
+  const u64 size = (left < device_param->size_pcfg_pool_part) ? left : device_param->size_pcfg_pool_part;
+
+  return size;
+}
+
+// How many buffers this device takes the pool in, and how large each is. Returns -1 where it cannot
+// take it at all, which the caller reads as one device out of the run rather than the end of it.
+
+static int pcfg_pool_split (hashcat_ctx_t *hashcat_ctx, hc_device_param_t *device_param, const u64 size_pcfg_pool)
+{
+  u64 part_max = 0;
+
+  const u64 total = pcfg_pool_budget (device_param, backend_device_sharers (hashcat_ctx->backend_ctx, device_param), &part_max);
+
+  // A total of nothing is refused rather than exempted. It means the device has no room for the pool,
+  // which is what the message says, and there is no case where zero has to mean unknown.
+
+  if (size_pcfg_pool > total)
+  {
+    event_log_warning (hashcat_ctx, "* Device #%u: the pcfg pool needs %" PRIu64 " MiB and this device can spare %" PRIu64 " MiB.", device_param->device_id + 1, size_pcfg_pool / (1024 * 1024), total / (1024 * 1024));
+
+    return -1;
+  }
+
+  u64 part = (size_pcfg_pool > 0) ? size_pcfg_pool : 4;
+
+  if ((part_max != 0) && (part > part_max))
+  {
+    // As few parts as the ceiling on one allows, and then cut equal instead of filling each part to
+    // that ceiling. Equal parts leave no sliver at the end and stay under the ceiling either way.
+
+    const u64 n = (size_pcfg_pool + part_max - 1) / part_max;
+
+    part = (((size_pcfg_pool + n - 1) / n) + (PCFG_POOL_ALIGN - 1)) & ~((u64) (PCFG_POOL_ALIGN - 1));
+  }
+
+  device_param->size_pcfg_pool_part = part;
+  device_param->pcfg_pool_parts     = (u32) ((size_pcfg_pool + part - 1) / part);
+
+  if (device_param->pcfg_pool_parts == 0) device_param->pcfg_pool_parts = 1;
+
+  if (device_param->pcfg_pool_parts > PCFG_POOL_PARTS)
+  {
+    event_log_warning (hashcat_ctx, "* Device #%u: the pcfg pool needs %u buffers and this device allows %u.", device_param->device_id + 1, device_param->pcfg_pool_parts, PCFG_POOL_PARTS);
+
+    return -1;
+  }
+
+  // Say what the split came to where there is one, so that the size a device could not hold in one
+  // piece and the sizes it was cut into are both on the screen rather than inferred from the run not
+  // having failed. A single buffer holds the whole pool the feed already reported, so there is
+  // nothing there this would add.
+
+  if ((device_param->pcfg_pool_parts > 1) && (hashcat_ctx->user_options->quiet == false))
+  {
+    char sizes[128];
+
+    int sizes_len = 0;
+
+    for (u32 i = 0; i < device_param->pcfg_pool_parts; i++)
+    {
+      const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+      sizes_len += snprintf (sizes + sizes_len, sizeof (sizes) - sizes_len, "%s%" PRIu64 " MiB", (i > 0) ? ", " : "", sz / (1024 * 1024));
+
+      if (sizes_len >= (int) sizeof (sizes)) break;
+    }
+
+    event_log_info (hashcat_ctx, "* Device #%u: pcfg pool of %" PRIu64 " MiB in %u buffers of %s", device_param->device_id + 1, size_pcfg_pool / (1024 * 1024), device_param->pcfg_pool_parts, sizes);
+  }
+
+  return 0;
+}
+
 int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 {
   const bitmap_ctx_t         *bitmap_ctx          = hashcat_ctx->bitmap_ctx;
@@ -17013,6 +17207,22 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-D PCFG_DEV_MAXWORD=%u ", hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_maxword);
       build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-D PCFG_DEV_VARLEN=%u ",  hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_varlen);
 
+      // A device that cannot hold the pool is one device out of the run, the way a device that cannot
+      // hold its launch buffers is. Refusing the session here would take down with it the devices that
+      // can hold it, and the aggregate check at the end of this function is what decides whether
+      // nothing came up at all.
+
+      if (pcfg_pool_split (hashcat_ctx, device_param, hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool_size) == -1)
+      {
+        device_param->skipped_warning = true;
+
+        backend_memory_hit_warnings++;
+
+        continue;
+      }
+
+      build_options_len += snprintf (build_options_buf + build_options_len, build_options_sz - build_options_len, "-D PCFG_POOL_SPLIT=%u ",  (device_param->pcfg_pool_parts > 1) ? 1 : 0);
+
       // A mode that wants its candidate upper or lower cased has that done on the host for every other
       // attack, on the word a producer hands over. Here that word is only the base word and the rest is
       // built on the device, so the engine has to do it too. -m 130 and -m 131 share a kernel file and
@@ -17355,7 +17565,11 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       {
         extra_value += hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_maxword << 8;
         extra_value += hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_varlen  << 16;
-        extra_value += pcfg_pt_case (hashconfig)                               << 17;
+
+        // pcfg_pt_case answers 0, 1 or 2, so it spans bits 17 and 18 and the next flag starts at 19.
+
+        extra_value += pcfg_pt_case (hashconfig)                       << 17;
+        extra_value += ((device_param->pcfg_pool_parts > 1) ? 1u : 0u) << 19;
       }
 
       /**
@@ -18023,6 +18237,17 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
      */
 
     device_param->kernel_param.bitmap_mask         = bitmap_ctx->bitmap_mask;
+
+    // Where each part of the pcfg pool begins, in words. A part the run does not use is given a
+    // start no index can reach, so the search in the kernel stops at the last part there is: the
+    // start of a part beyond the last would not always fit the u32 it is carried in, and leaving
+    // it to be compared against anyway would be relying on the pool ending exactly where it does.
+
+    const u64 pool_at = device_param->size_pcfg_pool_part / 4;
+
+    device_param->kernel_param.pcfg_pool_at1       = (device_param->pcfg_pool_parts > 1) ? (u32) (pool_at * 1) : 0xffffffff;
+    device_param->kernel_param.pcfg_pool_at2       = (device_param->pcfg_pool_parts > 2) ? (u32) (pool_at * 2) : 0xffffffff;
+    device_param->kernel_param.pcfg_pool_at3       = (device_param->pcfg_pool_parts > 3) ? (u32) (pool_at * 3) : 0xffffffff;
     device_param->kernel_param.salt_pos_host       = 0;
     device_param->kernel_param.loop_pos            = 0;
     device_param->kernel_param.loop_cnt            = 0;
@@ -18064,8 +18289,9 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[23] = &device_param->cuda_d_extra3_buf;
       device_param->kernel_params[24] = &device_param->cuda_d_kernel_param;
       device_param->kernel_params[25] = &device_param->cuda_d_pcfg_cells;
-      device_param->kernel_params[26] = &device_param->cuda_d_pcfg_pool;
-      device_param->kernel_params[27] = &device_param->cuda_d_pcfg_wmap;
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) device_param->kernel_params[26 + i] = &device_param->cuda_d_pcfg_pool[i];
+
+      device_param->kernel_params[26 + PCFG_POOL_PARTS] = &device_param->cuda_d_pcfg_wmap;
     }
 
     if (device_param->is_hip == true)
@@ -18096,8 +18322,9 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[23] = &device_param->hip_d_extra3_buf;
       device_param->kernel_params[24] = &device_param->hip_d_kernel_param;
       device_param->kernel_params[25] = &device_param->hip_d_pcfg_cells;
-      device_param->kernel_params[26] = &device_param->hip_d_pcfg_pool;
-      device_param->kernel_params[27] = &device_param->hip_d_pcfg_wmap;
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) device_param->kernel_params[26 + i] = &device_param->hip_d_pcfg_pool[i];
+
+      device_param->kernel_params[26 + PCFG_POOL_PARTS] = &device_param->hip_d_pcfg_wmap;
     }
 
     #if defined (__APPLE__)
@@ -18129,8 +18356,9 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[23] = device_param->metal_d_extra3_buf.buf_ptr;
       device_param->kernel_params[24] = device_param->metal_d_kernel_param.buf_ptr;
       device_param->kernel_params[25] = device_param->metal_d_pcfg_cells.buf_ptr;
-      device_param->kernel_params[26] = device_param->metal_d_pcfg_pool.buf_ptr;
-      device_param->kernel_params[27] = device_param->metal_d_pcfg_wmap.buf_ptr;
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) device_param->kernel_params[26 + i] = device_param->metal_d_pcfg_pool[i].buf_ptr;
+
+      device_param->kernel_params[26 + PCFG_POOL_PARTS] = device_param->metal_d_pcfg_wmap.buf_ptr;
     }
     #endif // __APPLE__
 
@@ -18162,8 +18390,9 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[23] = &device_param->opencl_d_extra3_buf;
       device_param->kernel_params[24] = &device_param->opencl_d_kernel_param;
       device_param->kernel_params[25] = &device_param->opencl_d_pcfg_cells;
-      device_param->kernel_params[26] = &device_param->opencl_d_pcfg_pool;
-      device_param->kernel_params[27] = &device_param->opencl_d_pcfg_wmap;
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) device_param->kernel_params[26 + i] = &device_param->opencl_d_pcfg_pool[i];
+
+      device_param->kernel_params[26 + PCFG_POOL_PARTS] = &device_param->opencl_d_pcfg_wmap;
     }
 
     if (user_options->slow_candidates == true)
@@ -19166,6 +19395,17 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
     u64 size_brain_link_out = 4;
     #endif
 
+    // Every attack allocates the parts of the pcfg pool, because they are kernel arguments whichever
+    // attack runs, so an attack that has no pool still needs an answer here. The device engine
+    // settled its own above, where the kernel was built against it, and that answer is the one to
+    // keep.
+
+    if (user_options_extra->attack_kern != ATTACK_KERN_PCFG)
+    {
+      device_param->size_pcfg_pool_part = size_pcfg_pool;
+      device_param->pcfg_pool_parts     = 1;
+    }
+
     const u64 size_device_extra1234 = size_extra_buffer1 + size_extra_buffer2 + size_extra_buffer3 + size_extra_buffer4;
 
     // Still not 100% sure about the 64MiB here
@@ -19720,7 +19960,14 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_hooks,         device_param->size_hooks)    == -1) return -1;
 
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_pcfg_cells, size_pcfg_cells) == -1) return -1;
-      if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_pcfg_pool,  size_pcfg_pool)  == -1) return -1;
+
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++)
+      {
+        const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+        if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_pcfg_pool[i], sz) == -1) return -1;
+      }
+
       if (hc_cuMemAlloc (hashcat_ctx, &device_param->cuda_d_pcfg_wmap,  size_pcfg_wmap)  == -1) return -1;
 
       if (run_cuda_kernel_bzero (hashcat_ctx, device_param, device_param->cuda_d_pcfg_cells, size_pcfg_cells) == -1) return -1;
@@ -19728,7 +19975,15 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (user_options_extra->attack_kern == ATTACK_KERN_PCFG)
       {
-        if (hc_cuMemcpyHtoD (hashcat_ctx, device_param->cuda_d_pcfg_pool, hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool, size_pcfg_pool) == -1) return -1;
+        for (u32 i = 0; i < device_param->pcfg_pool_parts; i++)
+        {
+          const u64 at = (u64) i * device_param->size_pcfg_pool_part;
+          const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+          const u8 *src = ((const u8 *) hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool) + at;
+
+          if (hc_cuMemcpyHtoD (hashcat_ctx, device_param->cuda_d_pcfg_pool[i], src, sz) == -1) return -1;
+        }
       }
     }
 
@@ -19749,7 +20004,14 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_hooks,         device_param->size_hooks)    == -1) return -1;
 
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_pcfg_cells, size_pcfg_cells) == -1) return -1;
-      if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_pcfg_pool,  size_pcfg_pool)  == -1) return -1;
+
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++)
+      {
+        const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+        if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_pcfg_pool[i], sz) == -1) return -1;
+      }
+
       if (hc_hipMemAlloc (hashcat_ctx, &device_param->hip_d_pcfg_wmap,  size_pcfg_wmap)  == -1) return -1;
 
       if (run_hip_kernel_bzero (hashcat_ctx, device_param, device_param->hip_d_pcfg_cells, size_pcfg_cells) == -1) return -1;
@@ -19757,7 +20019,15 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (user_options_extra->attack_kern == ATTACK_KERN_PCFG)
       {
-        if (hc_hipMemcpyHtoD (hashcat_ctx, device_param->hip_d_pcfg_pool, hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool, size_pcfg_pool) == -1) return -1;
+        for (u32 i = 0; i < device_param->pcfg_pool_parts; i++)
+        {
+          const u64 at = (u64) i * device_param->size_pcfg_pool_part;
+          const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+          const u8 *src = ((const u8 *) hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool) + at;
+
+          if (hc_hipMemcpyHtoD (hashcat_ctx, device_param->hip_d_pcfg_pool[i], src, sz) == -1) return -1;
+        }
       }
     }
 
@@ -19779,7 +20049,16 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_hooks,         device_param->size_hooks)    == -1) return -1;
 
       HC_MTL_CREATEBUFFER(hashcat_ctx, size_pcfg_cells, NULL, pcfg_cells);
-      HC_MTL_CREATEBUFFER(hashcat_ctx, size_pcfg_pool,  NULL, pcfg_pool);
+
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++)
+      {
+        const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+        void *host = pcfg_pool_part_host (hashcat_ctx, device_param, i);
+
+        if (hc_mtlCreateBuffer (hashcat_ctx, device_param->metal_device, sz, host, &device_param->metal_d_pcfg_pool[i], metal_d_pcfg_pool_storageMode) == -1) return -1;
+      }
+
       HC_MTL_CREATEBUFFER(hashcat_ctx, size_pcfg_wmap,  NULL, pcfg_wmap);
 
       if (run_metal_kernel_bzero (hashcat_ctx, device_param, device_param->metal_d_pcfg_cells, size_pcfg_cells) == -1) return -1;
@@ -19787,7 +20066,20 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
 
       if (user_options_extra->attack_kern == ATTACK_KERN_PCFG)
       {
-        if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_device, device_param->metal_command_queue, device_param->metal_d_pcfg_pool, 0, hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool, size_pcfg_pool) == -1) return -1;
+        for (u32 i = 0; i < device_param->pcfg_pool_parts; i++)
+        {
+          // Where the buffer took the pointer there is nothing to send, and where it did not the
+          // bytes still have to get there. The buffer says which, so neither is assumed.
+
+          if (device_param->metal_d_pcfg_pool[i].buf_host == 1) continue;
+
+          const u64 at = (u64) i * device_param->size_pcfg_pool_part;
+          const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+          const u8 *src = ((const u8 *) hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool) + at;
+
+          if (hc_mtlMemcpyHtoD (hashcat_ctx, device_param->metal_device, device_param->metal_command_queue, device_param->metal_d_pcfg_pool[i], 0, src, sz) == -1) return -1;
+        }
       }
     }
     #endif
@@ -19799,7 +20091,16 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       HC_OCL_CREATEBUFFER(hashcat_ctx, size_pws_comp, NULL, pws_comp_buf);
       HC_OCL_CREATEBUFFER(hashcat_ctx, size_pws_idx,  NULL, pws_idx);
       HC_OCL_CREATEBUFFER(hashcat_ctx, size_pcfg_cells, NULL, pcfg_cells);
-      HC_OCL_CREATEBUFFER(hashcat_ctx, size_pcfg_pool,  NULL, pcfg_pool);
+
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++)
+      {
+        const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+        void *host = pcfg_pool_part_host (hashcat_ctx, device_param, i);
+
+        if (hc_clCreateBuffer_ext (hashcat_ctx, device_param->opencl_context, openclMemoryFlags[opencl_d_pcfg_pool_memoryFlags], sz, host, &device_param->opencl_d_pcfg_pool[i]) == -1) return -1;
+      }
+
       HC_OCL_CREATEBUFFER(hashcat_ctx, size_pcfg_wmap,  NULL, pcfg_wmap);
       HC_OCL_CREATEBUFFER(hashcat_ctx, size_tmps,     NULL, tmps);
       HC_OCL_CREATEBUFFER(hashcat_ctx, size_hooks,    NULL, hooks);
@@ -19811,9 +20112,17 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_pcfg_cells, size_pcfg_cells) == -1) return -1;
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_pcfg_wmap, size_pcfg_wmap) == -1) return -1;
 
-      if (user_options_extra->attack_kern == ATTACK_KERN_PCFG)
+      if ((user_options_extra->attack_kern == ATTACK_KERN_PCFG) && (pcfg_pool_shared (device_param) == false))
       {
-        if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_pcfg_pool, CL_TRUE, 0, size_pcfg_pool, hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool, 0, NULL, NULL) == -1) return -1;
+        for (u32 i = 0; i < device_param->pcfg_pool_parts; i++)
+        {
+          const u64 at = (u64) i * device_param->size_pcfg_pool_part;
+          const u64 sz = pcfg_pool_part_size (device_param, size_pcfg_pool, i);
+
+          const u8 *src = ((const u8 *) hashcat_ctx->generic_ctx[GENERIC_ROLE_BASE].dev_pool) + at;
+
+          if (hc_clEnqueueWriteBuffer (hashcat_ctx, device_param->opencl_command_queue, device_param->opencl_d_pcfg_pool[i], CL_TRUE, 0, sz, src, 0, NULL, NULL) == -1) return -1;
+        }
       }
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_tmps,          device_param->size_tmps)     == -1) return -1;
       if (run_opencl_kernel_bzero (hashcat_ctx, device_param, device_param->opencl_d_hooks,         device_param->size_hooks)    == -1) return -1;
@@ -19908,8 +20217,9 @@ int backend_session_begin (hashcat_ctx_t *hashcat_ctx)
       device_param->kernel_params[ 5] = device_param->metal_d_hooks.buf_ptr;
 
       device_param->kernel_params[25] = device_param->metal_d_pcfg_cells.buf_ptr;
-      device_param->kernel_params[26] = device_param->metal_d_pcfg_pool.buf_ptr;
-      device_param->kernel_params[27] = device_param->metal_d_pcfg_wmap.buf_ptr;
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) device_param->kernel_params[26 + i] = device_param->metal_d_pcfg_pool[i].buf_ptr;
+
+      device_param->kernel_params[26 + PCFG_POOL_PARTS] = device_param->metal_d_pcfg_wmap.buf_ptr;
     }
     #endif
 
@@ -20211,7 +20521,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       hc_cuMemFreePtr           (hashcat_ctx, &device_param->cuda_d_pws_buf);
       hc_cuMemFreePtr           (hashcat_ctx, &device_param->cuda_d_pws_amp_buf);
       hc_cuMemFreePtr           (hashcat_ctx, &device_param->cuda_d_pcfg_cells);
-      hc_cuMemFreePtr           (hashcat_ctx, &device_param->cuda_d_pcfg_pool);
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) hc_cuMemFreePtr (hashcat_ctx, &device_param->cuda_d_pcfg_pool[i]);
       hc_cuMemFreePtr           (hashcat_ctx, &device_param->cuda_d_pcfg_wmap);
       hc_cuMemFreePtr           (hashcat_ctx, &device_param->cuda_d_pws_comp_buf);
       hc_cuMemFreePtr           (hashcat_ctx, &device_param->cuda_d_pws_idx);
@@ -20305,7 +20615,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       hc_hipMemFreePtr          (hashcat_ctx, &device_param->hip_d_pws_buf);
       hc_hipMemFreePtr          (hashcat_ctx, &device_param->hip_d_pws_amp_buf);
       hc_hipMemFreePtr          (hashcat_ctx, &device_param->hip_d_pcfg_cells);
-      hc_hipMemFreePtr          (hashcat_ctx, &device_param->hip_d_pcfg_pool);
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) hc_hipMemFreePtr (hashcat_ctx, &device_param->hip_d_pcfg_pool[i]);
       hc_hipMemFreePtr          (hashcat_ctx, &device_param->hip_d_pcfg_wmap);
       hc_hipMemFreePtr          (hashcat_ctx, &device_param->hip_d_pws_comp_buf);
       hc_hipMemFreePtr          (hashcat_ctx, &device_param->hip_d_pws_idx);
@@ -20390,7 +20700,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pws_buf);
       hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pws_amp_buf);
       hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pcfg_cells);
-      hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pcfg_pool);
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pcfg_pool[i]);
       hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pcfg_wmap);
       hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pws_comp_buf);
       hc_mtlReleaseMemObject (hashcat_ctx, &device_param->metal_d_pws_idx);
@@ -20472,7 +20782,7 @@ void backend_session_destroy (hashcat_ctx_t *hashcat_ctx)
       hc_clReleaseMemObjectPtr  (hashcat_ctx, &device_param->opencl_d_pws_buf);
       hc_clReleaseMemObjectPtr  (hashcat_ctx, &device_param->opencl_d_pws_amp_buf);
       hc_clReleaseMemObjectPtr  (hashcat_ctx, &device_param->opencl_d_pcfg_cells);
-      hc_clReleaseMemObjectPtr  (hashcat_ctx, &device_param->opencl_d_pcfg_pool);
+      for (u32 i = 0; i < PCFG_POOL_PARTS; i++) hc_clReleaseMemObjectPtr (hashcat_ctx, &device_param->opencl_d_pcfg_pool[i]);
       hc_clReleaseMemObjectPtr  (hashcat_ctx, &device_param->opencl_d_pcfg_wmap);
       hc_clReleaseMemObjectPtr  (hashcat_ctx, &device_param->opencl_d_pws_comp_buf);
       hc_clReleaseMemObjectPtr  (hashcat_ctx, &device_param->opencl_d_pws_idx);

--- a/src/ext_metal.m
+++ b/src/ext_metal.m
@@ -949,18 +949,17 @@ int hc_mtlCreateBuffer (void *hashcat_ctx, mtl_device_id metal_device, size_t si
     // we are on Apple Silicon, nothing to do ;)
   }
 
-  if (ptr != NULL)
+  // newBufferWithBytesNoCopy () wants a Shared buffer, and the mode asked for above is not always the
+  // mode given. A device that takes Managed instead gets a buffer of its own and the caller puts the
+  // bytes there, rather than the call failing on it. buf_host says which of the two happened, so a
+  // caller handing a pointer over reads the answer instead of predicting it.
+
+  mem->buf_host = 0;
+
+  if ((ptr != NULL) && (bufferOptions == MTLResourceStorageModeShared))
   {
-    if (bufferOptions != MTLResourceStorageModeShared)
-    {
-      event_log_error (hashcat_ctx, "%s(): bufferOptions must be Shared when using unified memory", __func__);
-
-      return -1;
-    }
-
-    // using unified memory
-
-    mem->buf_ptr = [metal_device newBufferWithBytesNoCopy: ptr length: size options: bufferOptions deallocator: nil];
+    mem->buf_ptr  = [metal_device newBufferWithBytesNoCopy: ptr length: size options: bufferOptions deallocator: nil];
+    mem->buf_host = 1;
   }
   else
   {
@@ -969,7 +968,7 @@ int hc_mtlCreateBuffer (void *hashcat_ctx, mtl_device_id metal_device, size_t si
 
   if (mem->buf_ptr == nil)
   {
-    event_log_error (hashcat_ctx, "%s(): %s failed (size: %zu)", __func__, (ptr == NULL) ? "newBufferWithLength" : "newBufferWithBytesNoCopy", size);
+    event_log_error (hashcat_ctx, "%s(): %s failed (size: %zu)", __func__, (mem->buf_host == 1) ? "newBufferWithBytesNoCopy" : "newBufferWithLength", size);
 
     return -1;
   }

--- a/src/feeds/feed_pcfg.c
+++ b/src/feeds/feed_pcfg.c
@@ -8142,7 +8142,7 @@ void global_term (generic_global_ctx_t *global_ctx, MAYBE_UNUSED generic_thread_
   hcfree (pg->uls_cnt);
   hcfree (pg->ulvl_cost);
   hcfree (pg->ulvl_pref);
-  hcfree (pg->pool);
+  hc_free_aligned ((void **) &pg->pool);
   hcfree (pg->pool_base);
   hcfree (pg->pool_ubase);
   hcfree (pg->ent_base);
@@ -8305,8 +8305,20 @@ bool global_dev_init (generic_global_ctx_t *global_ctx, const u32 **pool, u64 *p
 
   hc_timer_set (&t_pack);
 
+  // Page aligned and a whole number of pages long, which is what Metal and OpenCL ask before they
+  // read these bytes instead of a copy. 64 KiB covers every page size hashcat runs on.
+
   pg->pool_size = need + 8;
-  pg->pool      = (u32 *) hccalloc (pg->pool_size / 4, sizeof (u32));
+  pg->pool_size = (pg->pool_size + (PCFG_POOL_ALIGN - 1)) & ~((u64) (PCFG_POOL_ALIGN - 1));
+
+  pg->pool = (u32 *) hc_alloc_aligned (PCFG_POOL_ALIGN, pg->pool_size);
+
+  if (pg->pool == NULL)
+  {
+    gerr (global_ctx, "the device pool wants %" PRIu64 " MiB and the host has none to give", pg->pool_size / (1024 * 1024));
+
+    return false;
+  }
 
   u8 *bytes = (u8 *) pg->pool;
 
@@ -8334,8 +8346,10 @@ bool global_dev_init (generic_global_ctx_t *global_ctx, const u32 **pool, u64 *p
 
     if (global_ctx->quiet == false)
     {
+      // From need and not from pool_size, which also carries the guard word and the page rounding.
+
       pmsg (pg, "pcfg: per entry offsets, %" PRIu64 " KiB of table behind %" PRIu64 " KiB of terminals",
-        (pg->pool_size - 8 - ent_at) / 1024, ent_at / 1024);
+        (need - ent_at) / 1024, ent_at / 1024);
     }
   }
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -123,6 +123,11 @@ void *hc_alloc_aligned (size_t alignment, size_t size)
 
   #endif
 
+  // Before the memset, so the pages are backed as they are first touched. hccalloc () does this for
+  // every other large allocation, and the pcfg pool is the largest one there is.
+
+  hc_hugepage_hint (ptr, size);
+
   memset (ptr, 0, size);
 
   return ptr;


### PR DESCRIPTION
Two things go wrong on the same path, the one the pcfg pool takes from the feed to the device, and they are in one change because the second settles the arithmetic of the first.

## The pool is refused whole

A device does not always allocate the pool in one block. The largest single allocation it offers is often a fraction of the memory it has, so a pool that fits the card is refused whole and the run falls back to the host engine on a card with memory to spare.

Two real cases, both OpenCL, both on cards with far more free memory than the pool needs:

```
NVIDIA GeForce RTX 4080, 15680 MiB free, 3993 MiB in one allocation
Apple M4 Pro,            36800 MiB free, 3456 MiB in one allocation
```

A grammar trained with hpcfg on hashmob's combined founds packs more terminals than either will take in one piece: 4325 MiB of them on the Linux box and 4269 MiB on the Mac, trained from the same corpus. Neither device would take it.

That one is also past what an offset into the pool reaches, which is a separate matter and a separate pull request, #4835. The runs further down use the same grammar at a `costmax` that keeps it inside.

## And where the device's memory is the host's, it is held twice

The pool is the largest buffer a run has, it is read only, and it lives for the whole run. `hc_clCreateBuffer_ext ()` and `hc_mtlCreateBuffer ()` already turn a host pointer into `CL_MEM_USE_HOST_PTR` and `newBufferWithBytesNoCopy`, and nothing in `backend.c` ever passed one, so the pool was copied even where the copy lands in the same memory it came from.

## Why the two are one change

They meet in the same handful of lines, and more than that, the second settles what the first is allowed to decide.

- **The budget.** `pcfg_pool_budget ()` decides how many parts a device needs, and on a unified memory device a copied pool costs twice, once in the feed and once on the device. So the budget has to know which of the two it is looking at. On the Apple M4 Pro under OpenCL it is 13824 MiB if the pool is handed over and 6912 MiB if it is copied, a factor of two, and between those two figures the question is not how the pool is cut but whether the device runs at all.
- **The alignment.** Both wrappers want a page aligned pointer. The feed aligns the pool for that, and the parts are cut on the same 64 KiB grain so that the pointer handed over for a part is aligned too. One grain answers both: splitting alone would not need it, and handing over alone would not survive a pool that had to be split.
- **The same devices.** Of the two cards that cannot take the pool whole, one is unified memory. It is the same device that would otherwise hold the pool twice in the memory it shares with the host.

Done as two changes, the second would have to reopen the same four lines of `backend.c` and rewrite the budget the first had just put there.

## What changes

The pool now travels to the kernel as up to `PCFG_POOL_PARTS` buffers instead of one, and a read finds the part its index falls in.

- `pcfg_pool_split()` decides how many parts a device needs and cuts them equal, as few as the ceiling on one allocation allows.
- A part is a whole number of pages rather than a power of two. Rounding a part down to a power of two threw away up to half of what the device offered.
- `pcfg_pool_budget()` answers two different bounds: what the parts come to together, and what one part may be. Reading the second as if it were also the first splits a pool the device would have taken whole.
- A device that cannot hold the pool drops out of the run with a warning, the way a device that cannot hold its launch buffers does, rather than taking the session down with it.

Where the pool went over in one piece the search is compiled out, because the number of parts is settled before the kernel is built.

## How the pool is handed over

- The feed allocates the pool page aligned and a whole number of pages long, which is what both wrappers ask of a host pointer. Parts are cut on the same grain, so the pointer handed over for a part is aligned too.
- A device that cannot be handed the bytes still takes a copy, and `pcfg_pool_budget ()` halves its budget, because on unified memory that copy comes out of the same pool of memory.
- An AMD device under Metal is one of those. `hc_mtlCreateBuffer ()` gives it a Managed buffer where Shared was asked for, and then refuses a host pointer on anything but Shared, and that refusal ends the session rather than the device.
- The pool moved from `hccalloc ()` to `hc_alloc_aligned ()`. `hccalloc ()` asks the kernel for huge pages on a large block and `hc_alloc_aligned ()` did not, so the hint moved with it rather than being lost on the largest allocation hashcat makes.

What that is worth, on an Apple M4 Pro running the same attack twice, the second time with `pcfg_pool_shared ()` forced to answer no so the pool is copied the way it was before:

```
              peak memory footprint     speed
handed over          3.49 GiB        3470.2 MH/s
copied               3.91 GiB        3472.2 MH/s
```

433 MiB apart on a pool of 462 MiB, and the same speed either way. Both runs covered the same `Progress 120757569592`.

## What it is groundwork for

The change that follows this one gives the device engine the OMEN escape, which today it cannot walk: on a grammar trained at the default coverage the escape holds about 40% of the model's mass, and a run either drops it or goes to the host engine to keep it.

The escape's tables go into this same pool. On the grammar used above that takes the pool from 3870 MiB of terminals to 6484 MiB with the escape beside them, against a largest single allocation of 3993 MiB on one of these cards and 3456 MiB on another. So the escape on the device cannot exist at all until the pool can travel in more than one buffer, which is what this change is.

The 4 GiB ceiling on a pool offset, #4835 against master, is the other half of the same groundwork. That one hands such a grammar to the host engine; the follow-up turns the bound into a cut instead, shortening the least probable terminal lists until they fit, which is what leaves the escape its tables in

```
pcfg: terminals cut at cost 28 instead of 64, 7 lists shorter, 3870 MiB instead of 4325 MiB, which leaves the escape its tables
```

## The parts travel as arguments, not behind a struct

This is not a style choice. A local struct whose address is taken goes to private memory, and every read of the descriptor then becomes a scratch access.

It was measured on an RX 6900 XT under HIP, with the ceiling on one buffer forced down so that the shipped ruleset's 17 MiB pool is cut into four and the search is compiled in. Same binary otherwise, same pinned launch, and both runs exhausted the same 229014641206 candidates:

| Arrangement | Private memory | `buffer_load` | Speed |
| --- | ---: | ---: | ---: |
| Four buffers behind a struct | 144 B | 86 | 8368.7 MH/s |
| Four buffers as arguments | 96 B | 38 | 9801.0 MH/s |

The 48 bytes between them are the struct itself, four pointers and three offsets.

The comparisons that find the part nest rather than chain, which is the other shape a reader might ask about. That one measures the same either way here, because a part is found once per slot and not once per byte:

| | nested | chained |
| --- | ---: | ---: |
| ISA lines | 13296 | 13112 |
| `s_and_saveexec` | 34 | 44 |
| `s_cbranch_execz` | 364 | 338 |
| Speed | 9801.0 MH/s | 9906.5 MH/s |

## What it costs when it does not split

This is the case that matters for everyone who is not hitting the limit, so it was measured rather than argued. Same ruleset, same parameters, kernels disassembled for gfx1030 and compared against the same commit without this change:

| Mode | ISA lines | vgpr | scratch | `buffer_load` |
| --- | --- | ---: | ---: | --- |
| 0 MD5 | 11853 -> 11849 | 53 | 96 | 38 |
| 23003 SecureZIP AES-256 | 12056 -> 12068 | 248 | 464 | 20 |
| 22951 PEM AES | 29736 -> 29748 | 256 | 272 | 88 |
| 17225 PKZIP | 23025 -> 22985 | 256 | 77456 | 627 -> 631 |
| 31400 SCRT v2 | 12840 -> 12836 | 120 | 352 | 20 |
| 26000 Mozilla 3DES | 36666 -> 36742 | 248 | 176 | 20 |
| 13100 Kerberos TGS | 13634 -> 13710 | 148 | 528 | 120 |

Registers and scratch are identical on every mode, and so are the memory instruction counts except on 17225, which is already at the register limit on its own (it spills 68 without this change and 69 with it) and takes four more `buffer_load`. The instruction count moves by 0.1 to 0.2 per cent, in both directions.

## Seeing it

The change is inert on the shipped ruleset, whose pool is 17 MiB. It shows up on a grammar trained on a large corpus, on a device whose single allocation ceiling is below the pool size. The grammar below is the one from the top of this page at `costmax=28`, which keeps its terminals inside what a `u32` reaches:

```
* Device #02: Apple M4 Pro, GPU, 36800/36864 MB (3456 MB allocatable), 20MCU
pcfg: device pool packed in 0s 218ms, 3839 MiB
* Device #2: pcfg pool of 3839 MiB in 2 buffers of 1919 MiB, 1919 MiB
Guess.Base.......: Feed (... (scale 1, device))
Candidate.Engine.: Device Generator
Speed.#02........: 813.8 MH/s @ Accel:711 Loops:1024 Thr:64 Vec:1
```

Without this change that device does not start the device engine at all.

## Reaching the split without that grammar

The change is inert on the shipped ruleset, whose 17 MiB pool every device here takes in one piece, and the grammar above is not something a reviewer has. A ceiling forced on one buffer makes the split reproducible on the shipped ruleset in a few seconds. In `pcfg_pool_budget ()`, immediately after

```c
u64 part = device_param->device_maxmem_alloc;

if (total < part) part = total;
```

add

```c
const char *env = getenv ("PCFG_POOL_ONE");

if (env != NULL) part = strtoull (env, NULL, 10);
```

The budget is clamped to `part_max` times `PCFG_POOL_PARTS` a few lines below, so bounding one part bounds the pool budget with it, and the 17 MiB pool comes out in two, three or four buffers.

Same binary, the same 9998 digests taken one in forty out of the first 400000 candidates, the same `--limit`, and the outfile sorted and hashed. On an RTX 4080 under CUDA:

```
                        recovered            progress              outfile
unchanged tree          9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab
this change, 1 buffer   9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab
forced to 2 buffers     9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab
forced to 3 buffers     9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab
forced to 4 buffers     9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab

* Device #1: pcfg pool of 17 MiB in 4 buffers of 4 MiB, 4 MiB, 4 MiB, 4 MiB
```

The same recipe reaches the split on the pocl CPU device. That one reports unified memory, so the pool goes through `CL_MEM_USE_HOST_PTR` rather than a copy, and the handover is exercised at the same time:

```
unchanged tree          9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab
this change, 1 buffer   9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab
forced to 4 buffers     9974/9998 (99.76%)   601105114/548000000   34ad50e9efb387ab
```

## The candidates do not change

On the shipped ruleset, whose 17 MiB pool no device has to split, the change should be invisible. Against the same commit without it, at the same `--limit`:


```
                     unchanged tree                        with this change
-d 1 (CUDA)  1774580599978/2285160000000  Rejected 0   1774580599978/2285160000000  Rejected 0
-d 2 (HIP)   1774580599978/2285160000000  Rejected 0   1774580599978/2285160000000  Rejected 0
```

All four runs exhausted, and identical to the digit.

On the device where the split fires the unchanged tree has nothing to compare against, because it produces no run at all. What can be compared is the split against no split, on one machine that does both: an Apple M4 Pro holds that 3839 MiB pool whole under Metal and takes it in two buffers of 1919 MiB under OpenCL. Same binary, same grammar, and both runs left to exhaust the whole of it rather than bounded:

```
-d 1 Metal    one buffer    Exhausted   Progress 2657077/2657077   Rejected 0
-d 2 OpenCL   two buffers   Exhausted   Progress 2657077/2657077   Rejected 0
```

Every candidate the grammar reaches, built once out of one buffer and once out of two, and the same count both ways.

## Checks

```
$ ./tools/test_edge.sh -m 0 -K 0                                        # Linux
[ test_edge_1788979196 ] # Processing Hash-Type 0, Attack-Type 12, Kernel-Type pure, Vector-Width 16, Target-Type multi
[ test_edge_1788979196 ] > All tests done in 0d:00h:02m:27s
[ test_edge_1788979196 ] > Errors detected: 0

$ ./tools/test_edge.sh -m 0 -K 0                                        # macOS
[ test_edge_1788978259 ] # Processing Hash-Type 0, Attack-Type 12, Kernel-Type pure, Vector-Width 16, Target-Type multi
[ test_edge_1788978259 ] > All tests done in 0d:00h:02m:48s
[ test_edge_1788978259 ] > Errors detected: 0

$ ./tools/test_package.sh --no-device                                   # both
ok    a .zst wordlist reads back the same 128416 words
## not run: the checks that need a backend device, --no-device was given
## ./hashcat: every check passed
```

The native, static and Windows builds compile without a warning.

`-K 0` is deliberate. Without it the suite also runs attack type 4 with `-O`, and the device engine has no optimized kernel, so hashcat refuses the combination and exits 255. That is unchanged from before this patch:

```
$ ./hashcat -m 0 -a 4 -O 8743b52063cd84097a65d1633f5c74f5 pcfg/default-passwords.tar.xz --runtime 1
The device engine has no optimized kernel. Run this without -O.
rc=255
```

The shipped ruleset still answers `12747516022634` and its first 20000 candidates still hash to `43b848a00665a0e0220e64760a247760`.

A CPU device is worth naming separately, because it has unified memory and so takes the pool through `CL_MEM_USE_HOST_PTR` rather than a copy. On pocl it covers the same candidates as the unchanged tree and rejects the same ones:

```
                 unchanged tree                  with this change
-d 3 (pocl CPU)  5621650743/5480000000  Rej 0    5621650743/5480000000  Rej 0
```