### PR TITLE
Give the host engine a pcfg grammar whose terminals pass 4 GiB

### DIFF
--- a/src/feeds/feed_pcfg.c
+++ b/src/feeds/feed_pcfg.c
@@ -8280,6 +8280,41 @@ bool global_dev_init (generic_global_ctx_t *global_ctx, const u32 **pool, u64 *p
     need = (need + 3) & ~((u64) 3);
   }
 
+  // Every offset into the terminals is a u32, in the cells the device reads and in the byte reads the
+  // kernel makes, while the pool is sized from a u64, so a grammar whose terminals sum past 4 GiB has
+  // the lists past that point packed on top of the ones at the start and read back from there, and
+  // the run then builds candidates out of the wrong bytes without saying anything. tlist_build ()
+  // guards the same quantity inside one list.
+  //
+  // Answered before the pool is packed, because none of that work can be used, and answered the way
+  // the empty index below answers it: the host engine reads the lists themselves and not the pool.
+
+  if (need > 0xffffffff)
+  {
+    if (global_ctx->quiet == false) pmsg (pg, "pcfg: the terminals reach %" PRIu64 " MiB and an offset into the pool stops at 4096 MiB, the host engine takes the run", need / (1024 * 1024));
+
+    global_ctx->dev_enable = false;
+
+    pcfg_pick_workers (pg);
+
+    snprintf (global_ctx->guess_base, sizeof (global_ctx->guess_base), "%s (scale %" PRIu64 ", %s)", pg->named, pg->scale, (pg->omen_lvl_cnt > 0) ? "host, OMEN" : "host");
+
+    if (pg->lookup != NULL) lookup_report (global_ctx, pg);
+
+    pool[0]      = NULL;
+    pool_size[0] = 0;
+    il_cnt[0]    = 0;
+    maxword[0]   = pg->maxword;
+    avg[0]       = 1;
+    front[0]     = 1;
+    step[0]      = 1;
+    varlen[0]    = (pg->varlen == true) ? 1 : 0;
+
+    memset (probe, 0, sizeof (pcfg_cell_t));
+
+    return true;
+  }
+
   // No terminal entries at all means there is nothing for this engine to amplify, and that is the
   // same grammar the empty index below describes: one whose mass sits on the escape. It is not
   // refused here, because the index comes out empty and answers it the same way, so the host engine


### PR DESCRIPTION
A pcfg run whose grammar holds more than 4 GiB of terminals builds candidates out of the wrong bytes. There is no error and no warning: the run looks normal, reports a normal speed, and cracks whatever it happens to reach.

## Where it is

`global_dev_init ()` in `src/feeds/feed_pcfg.c` lays every terminal list out in one pool and records where each one begins:

```c
u64 need = 4;

for (u32 i = 0; i < pg->lists_cnt; i++)
{
  const pcfg_tlist_t *t = &pg->lists[i];

  pg->pool_base[i] = (u32) need;

  need += t->off[t->cnt];
  ...
}
```

`need` is a `u64` and `pool_base` is a `u32`, and the cast is not checked. Every read of a terminal goes through one of these: `cell->slots[j].pool_off` on the device side is built from it, and the byte reads the kernel makes take a `u32` as well. Once the terminals sum past 4 GiB the running offset wraps, so the lists past that point are packed on top of the ones at the start of the pool and read back from there.

`tlist_build ()` guards the same quantity one level down, inside a single list, and its comment names this failure:

```c
// Every offset into a terminal list is a u32, here and in the reordered copy further down and in
// the bucket tables built from it, while the backing buffer is sized from a u64. A ruleset whose
// kept terminals sum past 4 GiB wrapped the running offset, so the reordered buffer was sized
// from the remainder and the copy into it walked far past the allocation.

if (vlen > (0xffffffff - t->off[t->cnt]))
```

The sum across lists is the same quantity one level up, and has no guard.

## Reproduction

The proof is the pool read back rather than the arithmetic. A ten line probe in `global_dev_init ()`, after the packing loop, compares every list against the bytes it was given:

```c
{
  u64 prev = 0;
  u32 back = 0;
  u32 bad  = 0;

  for (u32 i = 0; i < pg->lists_cnt; i++)
  {
    const pcfg_tlist_t *t = &pg->lists[i];

    if ((u64) pg->pool_base[i] < prev) back++;
    prev = pg->pool_base[i];

    const u32 len = t->off[t->cnt];
    const u32 cmp = (len < 4096) ? len : 4096;

    if (cmp == 0) continue;

    if (memcmp (bytes + pg->pool_base[i], t->buf, cmp) != 0) bad++;
  }

  fprintf (stderr, "need=%llu lists=%u going_backwards=%u read_back_wrong=%u\n",
           (unsigned long long) need, pg->lists_cnt, back, bad);
}
```

On a stock tree at 15a71f890:

```
shipped ruleset  need=17983640    lists=146  going_backwards=0  read_back_wrong=0
a large grammar  need=4535985876  lists=921  going_backwards=1  read_back_wrong=2
```

`4535985876` passes `0xffffffff` by 230 MiB. One list's base offset comes out lower than its predecessor's, and two lists no longer hold the bytes that were copied into them.

The grammar is one hpcfg trained on a public dump. Reaching this needs no unusual hardware, only a card that will allocate such a pool in one piece: the RX 6900 XT here offers 13912 MiB in a single block.

## No setting gets around it

`costmax` is the only one of the nine documented settings that touches the pool, and it does so as a side effect of dropping terminals whose own cost is above it. On that grammar:

| costmax | pool | lists read back wrong | candidates the run enumerates |
| ---: | ---: | ---: | ---: |
| 64, the default | 4325 MiB | 2 | 2.3e17 |
| 31 | 4325 MiB | 2 | 49,565,934 |
| 29 | 4317 MiB | 2 | 6,841,166 |
| 28 | 3870 MiB | 0 | |
| 27 | 3283 MiB | 0 | 1,053,199 |

The pool only becomes legal at a setting that has already thrown the attack away. `PCFG_MAX_STRUCTS` is not a way round it either: at 16M, 8M, 4M and 2M structures the pool is 4429673 KiB in every case, because the terminal lists are read from the ruleset's files and not from the structures that reference them.

## The host engine is not affected

It reads `pg->lists[i].buf` directly and never touches the pool. `pool_base` and `pool_ubase` are read only where the device cells are filled, so a run that does not reach the device engine enumerates the whole grammar correctly.

## What changes

The feed measures the terminals as it lays them out, and where they pass what an offset can reach it declines the device engine rather than packing them anyway. `tlist_build ()` already guards the same quantity inside one list, with a comment naming this failure; this is the same guard one level up, on the sum across lists.

It is not a failure. The run moves to the host engine, which reads the terminal lists themselves and never touches the pool, so it enumerates the whole grammar either way. That is the answer an empty index already gives a few lines below, and this takes the same exit.

The test is made before the pool is allocated and before the unit tables are built, because none of that work can be used: on the grammar above that is 4.3 GiB and 29 seconds spent on a pool that would then be discarded.

## What it does not change

Every grammar whose terminals fit, which is every ruleset small enough not to have the problem, the shipped one included. The keyspace, the caches and the cached unit tables are untouched there.

## The cure this is not

Trimming the least probable terminal lists until they fit would keep the device engine instead of giving it up, which is better for the user whose grammar is too large. That is a larger change and it belongs beside the one that already has to trim them to fit a device's single buffer. This one stops the wrong bytes.

## Checks

```
$ ./tools/test_edge.sh -m 0 -K 0                                        # Linux
[ test_edge_1788979343 ] > All tests done in 0d:00h:02m:42s
[ test_edge_1788979343 ] > Errors detected: 0

$ ./tools/test_package.sh --no-device
## not run: the checks that need a backend device, --no-device was given
## ./hashcat: every check passed
```

The shipped ruleset is untouched, which is the point of the section above. The same command on this change and on the merge base:

```
$ ./hashcat -m 0 -a 4 00000000000000000000000000000000 pcfg/default-passwords.tar.xz \
    --potfile-disable -d 1 --limit 200000 --status

this change:  Progress 601105114/548000000 (109.69%)   Candidate.Engine.: Device Generator
merge base:   Progress 601105114/548000000 (109.69%)   Candidate.Engine.: Device Generator
```

And on the grammar that goes over, where the run moves rather than reading the pool at wrapped offsets:

```
pcfg: the terminals reach 4325 MiB and an offset into the pool stops at 4096 MiB, the host engine takes the run
Candidate.Engine.: Host Generator + PCIe
```