### PR TITLE
Free the loopback filename rather than losing it every round

### DIFF
--- a/src/loopback.c
+++ b/src/loopback.c
@@ -78,7 +78,7 @@ int loopback_init (hashcat_ctx_t *hashcat_ctx)
 
   loopback_ctx->enabled  = true;
   loopback_ctx->fp.pfp   = NULL;
-  loopback_ctx->filename = (char *) hcmalloc (HCBUFSIZ_TINY);
+  loopback_ctx->filename = NULL;
 
   return 0;
 }
@@ -88,6 +88,8 @@ void loopback_destroy (hashcat_ctx_t *hashcat_ctx)
   loopback_ctx_t *loopback_ctx = hashcat_ctx->loopback_ctx;
 
   if (loopback_ctx->enabled == false) return;
+
+  hcfree (loopback_ctx->filename);
 
   memset (loopback_ctx, 0, sizeof (loopback_ctx_t));
 }
@@ -107,7 +109,17 @@ int loopback_write_open (hashcat_ctx_t *hashcat_ctx)
 
   const u32 random_num = get_random_num (0, 9999);
 
-  hc_asprintf (&loopback_ctx->filename, "%s/%s.%d_%u", induct_ctx->root_directory, LOOPBACK_FILE, (int) now, random_num);
+  // hc_asprintf () allocates and assigns, so the name it replaces is lost unless it is freed here.
+  // Every round of an induction run passes through, not only the first. The old name goes after the
+  // new one exists, so a failed allocation cannot leave a freed pointer behind.
+
+  char *filename = NULL;
+
+  hc_asprintf (&filename, "%s/%s.%d_%u", induct_ctx->root_directory, LOOPBACK_FILE, (int) now, random_num);
+
+  hcfree (loopback_ctx->filename);
+
+  loopback_ctx->filename = filename;
 
   if (hc_fopen (&loopback_ctx->fp, loopback_ctx->filename, "ab") == false)
   {


### PR DESCRIPTION
`loopback_ctx->filename` is allocated once and then replaced without being freed, so every cracking run leaks the buffer it starts with, and every induction round leaks the name of the file it just wrote.

## Reproduction

```
$ ./hashcat -m 0 -a 0 --potfile-disable -d 1 --loopback --induction-dir=induct -r rules/best66.rule example0.hash example.dict
```

Built with `make DEBUG=2`, which is `-fsanitize=address`, and run under `ASAN_OPTIONS=detect_leaks=1`. The allocations LeakSanitizer attributes to `loopback.c`:

```
before: Direct leak of 4096 byte(s) in 1 object(s)   loopback_init       loopback.c:81
        Direct leak of  128 byte(s) in 1 object(s)   loopback_write_open loopback.c:110
        Direct leak of  128 byte(s) in 1 object(s)   loopback_write_open loopback.c:110
after:  no allocation in loopback.c is reported at all

Status Exhausted, Recovered 53/6494 (0.82%), rc=1 on both sides.
```

The two smaller blocks are the two induction rounds the run went through, each the length of the name that round wrote, so their size follows the induction directory's path. A longer session leaks one per round.

The report as a whole shrinks by exactly those three allocations, from 84873 to 84870. The remaining ones are not this file's and are untouched here.

## What was wrong

`loopback_init ()` puts `HCBUFSIZ_TINY` into `loopback_ctx->filename`. Nothing ever writes to that buffer: the field is only ever filled by `loopback_write_open ()`, which calls `hc_asprintf ()` on it, and that is `vasprintf ()`:

```c
int hc_asprintf (char **strp, const char *fmt, ...)
{
  va_list args;
  va_start (args, fmt);
  int rc = vasprintf (strp, fmt, args);
  va_end (args);
  return rc;
}
```

`vasprintf ()` allocates and assigns, so whatever the pointer held is gone. `loopback_write_open ()` runs out of `inner2_loop ()`, once per induction round rather than once per run, so it happens again for every round the session goes through. `loopback_destroy ()` then memsets the context, which loses the last one as well.

The allocation nothing reads is dropped, the name a round replaces is freed once the name replacing it exists, and the last one is freed at destroy. The order matters: freeing first would leave a pointer to freed memory in the field whenever `hc_asprintf ()` failed, and `hc_fopen ()` and `loopback_write_unlink ()` both read it afterwards.

`hashcat_ctx->loopback_ctx` comes from `hcmalloc ()`, which is `hccalloc ()`, so the field is NULL until the first open. `loopback_write_unlink ()` already tests for that, and `hcfree ()` accepts NULL.

## tools/test_edge.sh

No hash mode is touched. `src/loopback.c` holds no kernel and no module, so there is no mode the suite would run against this change that it does not already run against master.