### PR TITLE
Add the sm3crypt pure kernel so mode 35100 takes a password over 15 bytes

### DIFF
--- a/OpenCL/m35100-pure.cl
+++ b/OpenCL/m35100-pure.cl
@@ -1,0 +1,370 @@
+/**
+ * Author......: See docs/credits.txt
+ * License.....: MIT
+ */
+
+#ifdef KERNEL_STATIC
+#include M2S(INCLUDE_PATH/inc_vendor.h)
+#include M2S(INCLUDE_PATH/inc_types.h)
+#include M2S(INCLUDE_PATH/inc_platform.cl)
+#include M2S(INCLUDE_PATH/inc_common.cl)
+#include M2S(INCLUDE_PATH/inc_hash_sm3.cl)
+#endif
+
+#define COMPARE_S M2S(INCLUDE_PATH/inc_comp_single.cl)
+#define COMPARE_M M2S(INCLUDE_PATH/inc_comp_multi.cl)
+
+typedef struct sm3crypt_tmp
+{
+  // pure version
+
+  u32 alt_result[8];
+  u32 p_bytes[64];
+  u32 s_bytes[64];
+
+} sm3crypt_tmp_t;
+
+KERNEL_FQ KERNEL_FA void m35100_init (KERN_ATTR_TMPS (sm3crypt_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  /**
+   * init
+   */
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  u32 w[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = pws[gid].i[idx];
+  }
+
+  for (u32 i = 0, idx = 0; i < pw_len; i += 4, idx += 1)
+  {
+    w[idx] = hc_swap32_S (w[idx]);
+  }
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 s[64] = { 0 };
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = salt_bufs[SALT_POS_HOST].salt_buf[idx];
+  }
+
+  for (u32 i = 0, idx = 0; i < salt_len; i += 4, idx += 1)
+  {
+    s[idx] = hc_swap32_S (s[idx]);
+  }
+
+  /**
+   * prepare
+   */
+
+  sm3_ctx_t ctx;
+
+  sm3_init (&ctx);
+
+  sm3_update (&ctx, w, pw_len);
+
+  sm3_update (&ctx, s, salt_len);
+
+  sm3_update (&ctx, w, pw_len);
+
+  sm3_final (&ctx);
+
+  u32 final[16] = { 0 };
+
+  final[0] = ctx.h[0];
+  final[1] = ctx.h[1];
+  final[2] = ctx.h[2];
+  final[3] = ctx.h[3];
+  final[4] = ctx.h[4];
+  final[5] = ctx.h[5];
+  final[6] = ctx.h[6];
+  final[7] = ctx.h[7];
+
+  // alt_result
+
+  sm3_init (&ctx);
+
+  sm3_update (&ctx, w, pw_len);
+
+  sm3_update (&ctx, s, salt_len);
+
+  int pl;
+
+  for (pl = pw_len; pl > 32; pl -= 32)
+  {
+    sm3_update (&ctx, final, 32);
+  }
+
+  u32 t_final[16] = { 0 };
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int i = 0; i < 8; i++) t_final[i] = final[i];
+
+  truncate_block_16x4_be_S (t_final + 0, t_final + 4, t_final + 8, t_final + 12, pl);
+
+  sm3_update (&ctx, t_final, pl);
+
+  for (int cnt = pw_len; cnt > 0; cnt >>= 1)
+  {
+    if ((cnt & 1) != 0)
+    {
+      sm3_update (&ctx, final, 32);
+    }
+    else
+    {
+      sm3_update (&ctx, w, pw_len);
+    }
+  }
+
+  sm3_final (&ctx);
+
+  tmps[gid].alt_result[0] = ctx.h[0];
+  tmps[gid].alt_result[1] = ctx.h[1];
+  tmps[gid].alt_result[2] = ctx.h[2];
+  tmps[gid].alt_result[3] = ctx.h[3];
+  tmps[gid].alt_result[4] = ctx.h[4];
+  tmps[gid].alt_result[5] = ctx.h[5];
+  tmps[gid].alt_result[6] = ctx.h[6];
+  tmps[gid].alt_result[7] = ctx.h[7];
+
+  // p_bytes
+
+  sm3_init (&ctx);
+
+  for (u32 j = 0; j < pw_len; j++)
+  {
+    sm3_update (&ctx, w, pw_len);
+  }
+
+  sm3_final (&ctx);
+
+  final[ 0] = ctx.h[0];
+  final[ 1] = ctx.h[1];
+  final[ 2] = ctx.h[2];
+  final[ 3] = ctx.h[3];
+  final[ 4] = ctx.h[4];
+  final[ 5] = ctx.h[5];
+  final[ 6] = ctx.h[6];
+  final[ 7] = ctx.h[7];
+  final[ 8] = 0;
+  final[ 9] = 0;
+  final[10] = 0;
+  final[11] = 0;
+  final[12] = 0;
+  final[13] = 0;
+  final[14] = 0;
+  final[15] = 0;
+
+  u32 p_final[64] = { 0 };
+
+  int idx;
+
+  for (pl = pw_len, idx = 0; pl > 32; pl -= 32, idx += 8)
+  {
+    p_final[idx + 0] = final[0];
+    p_final[idx + 1] = final[1];
+    p_final[idx + 2] = final[2];
+    p_final[idx + 3] = final[3];
+    p_final[idx + 4] = final[4];
+    p_final[idx + 5] = final[5];
+    p_final[idx + 6] = final[6];
+    p_final[idx + 7] = final[7];
+  }
+
+  truncate_block_16x4_be_S (final + 0, final + 4, final + 8, final + 12, pl);
+
+  p_final[idx + 0] = final[0];
+  p_final[idx + 1] = final[1];
+  p_final[idx + 2] = final[2];
+  p_final[idx + 3] = final[3];
+  p_final[idx + 4] = final[4];
+  p_final[idx + 5] = final[5];
+  p_final[idx + 6] = final[6];
+  p_final[idx + 7] = final[7];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int i = 0; i < 64; i++) tmps[gid].p_bytes[i] = p_final[i];
+
+  // s_bytes
+
+  sm3_init (&ctx);
+
+  for (u32 j = 0; j < 16 + (tmps[gid].alt_result[0] >> 24); j++)
+  {
+    sm3_update (&ctx, s, salt_len);
+  }
+
+  sm3_final (&ctx);
+
+  final[ 0] = ctx.h[0];
+  final[ 1] = ctx.h[1];
+  final[ 2] = ctx.h[2];
+  final[ 3] = ctx.h[3];
+  final[ 4] = ctx.h[4];
+  final[ 5] = ctx.h[5];
+  final[ 6] = ctx.h[6];
+  final[ 7] = ctx.h[7];
+  final[ 8] = 0;
+  final[ 9] = 0;
+  final[10] = 0;
+  final[11] = 0;
+  final[12] = 0;
+  final[13] = 0;
+  final[14] = 0;
+  final[15] = 0;
+
+  u32 s_final[64] = { 0 };
+
+  for (pl = salt_len, idx = 0; pl > 32; pl -= 32, idx += 8)
+  {
+    s_final[idx + 0] = final[0];
+    s_final[idx + 1] = final[1];
+    s_final[idx + 2] = final[2];
+    s_final[idx + 3] = final[3];
+    s_final[idx + 4] = final[4];
+    s_final[idx + 5] = final[5];
+    s_final[idx + 6] = final[6];
+    s_final[idx + 7] = final[7];
+  }
+
+  truncate_block_16x4_be_S (final + 0, final + 4, final + 8, final + 12, pl);
+
+  s_final[idx + 0] = final[0];
+  s_final[idx + 1] = final[1];
+  s_final[idx + 2] = final[2];
+  s_final[idx + 3] = final[3];
+  s_final[idx + 4] = final[4];
+  s_final[idx + 5] = final[5];
+  s_final[idx + 6] = final[6];
+  s_final[idx + 7] = final[7];
+
+  #ifdef _unroll
+  #pragma unroll
+  #endif
+  for (int i = 0; i < 64; i++) tmps[gid].s_bytes[i] = s_final[i];
+}
+
+KERNEL_FQ KERNEL_FA void m35100_loop (KERN_ATTR_TMPS (sm3crypt_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  const u32 pw_len = pws[gid].pw_len;
+
+  const u32 salt_len = salt_bufs[SALT_POS_HOST].salt_len;
+
+  u32 alt_result[16] = { 0 };
+
+  alt_result[0] = tmps[gid].alt_result[0];
+  alt_result[1] = tmps[gid].alt_result[1];
+  alt_result[2] = tmps[gid].alt_result[2];
+  alt_result[3] = tmps[gid].alt_result[3];
+  alt_result[4] = tmps[gid].alt_result[4];
+  alt_result[5] = tmps[gid].alt_result[5];
+  alt_result[6] = tmps[gid].alt_result[6];
+  alt_result[7] = tmps[gid].alt_result[7];
+
+  /* Repeatedly run the collected hash value through sm3 to burn
+     CPU cycles.  */
+
+  for (u32 i = 0, j = LOOP_POS; i < LOOP_CNT; i++, j++)
+  {
+    sm3_ctx_t ctx;
+
+    sm3_init (&ctx);
+
+    if (j & 1)
+    {
+      sm3_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+    }
+    else
+    {
+      sm3_update (&ctx, alt_result, 32);
+    }
+
+    if (j % 3)
+    {
+      sm3_update_global (&ctx, tmps[gid].s_bytes, salt_len);
+    }
+
+    if (j % 7)
+    {
+      sm3_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+    }
+
+    if (j & 1)
+    {
+      sm3_update (&ctx, alt_result, 32);
+    }
+    else
+    {
+      sm3_update_global (&ctx, tmps[gid].p_bytes, pw_len);
+    }
+
+    sm3_final (&ctx);
+
+    alt_result[0] = ctx.h[0];
+    alt_result[1] = ctx.h[1];
+    alt_result[2] = ctx.h[2];
+    alt_result[3] = ctx.h[3];
+    alt_result[4] = ctx.h[4];
+    alt_result[5] = ctx.h[5];
+    alt_result[6] = ctx.h[6];
+    alt_result[7] = ctx.h[7];
+  }
+
+  tmps[gid].alt_result[0] = alt_result[0];
+  tmps[gid].alt_result[1] = alt_result[1];
+  tmps[gid].alt_result[2] = alt_result[2];
+  tmps[gid].alt_result[3] = alt_result[3];
+  tmps[gid].alt_result[4] = alt_result[4];
+  tmps[gid].alt_result[5] = alt_result[5];
+  tmps[gid].alt_result[6] = alt_result[6];
+  tmps[gid].alt_result[7] = alt_result[7];
+}
+
+KERNEL_FQ KERNEL_FA void m35100_comp (KERN_ATTR_TMPS (sm3crypt_tmp_t))
+{
+  /**
+   * base
+   */
+
+  const u64 gid = get_global_id (0);
+
+  if (gid >= GID_CNT) return;
+
+  const u64 lid = get_local_id (0);
+
+  const u32 r0 = hc_swap32_S (tmps[gid].alt_result[0]);
+  const u32 r1 = hc_swap32_S (tmps[gid].alt_result[1]);
+  const u32 r2 = hc_swap32_S (tmps[gid].alt_result[2]);
+  const u32 r3 = hc_swap32_S (tmps[gid].alt_result[3]);
+
+  #define il_pos 0
+
+  #ifdef KERNEL_STATIC
+  #include COMPARE_M
+  #endif
+}


### PR DESCRIPTION
`-m 35100` cannot crack a password longer than 15 bytes. The module says it can.

## Reproduction

The hash is what `tools/test.pl passthrough 35100` produces for the password used as the mask, which is 20 characters.

```
$ ./hashcat -m 35100 -a 3 -d 1 --potfile-disable '$sm3$995050$B8DvnZ8bKWnPIRcIDIoNfUSAybQNmD.uwbPGxlU9rT2' AbcdefghijKlmnopqrst

before: Skipping mask 'AbcdefghijKlmnopqrst' because it is larger than the maximum password length.
        rc=255

after:  Kernel.Feature...: Pure Kernel (password length 0-256 bytes)
        Status...........: Cracked
        Guess.Mask.......: AbcdefghijKlmnopqrst [20]
        $sm3$995050$B8DvnZ8bKWnPIRcIDIoNfUSAybQNmD.uwbPGxlU9rT2:AbcdefghijKlmnopqrst
        rc=0
```

No `-O` is passed. That is the path where the module promises the full length, and the mask is 20 characters against the 15 the optimized kernel takes.

## What was wrong

`module_35100.c` chooses the limit the way the other crypt modes do:

```c
u32 module_pw_max (MAYBE_UNUSED const hashconfig_t *hashconfig, MAYBE_UNUSED const user_options_t *user_options, MAYBE_UNUSED const user_options_extra_t *user_options_extra)
{
  u32 pw_max = PW_MAX;

  const bool optimized_kernel = (hashconfig->opti_type & OPTI_TYPE_OPTIMIZED_KERNEL);

  if (optimized_kernel == true)
  {
    pw_max = 15;
  }

  return pw_max;
}
```

md5crypt and sha256crypt carry the same `OPTS_TYPE` and the same choice, sha512crypt the same choice with one flag fewer, and each of the three ships two kernels:

```
m00500-optimized.cl  m00500-pure.cl
m01800-optimized.cl  m01800-pure.cl
m07400-optimized.cl  m07400-pure.cl
m35100-optimized.cl
```

sm3crypt shipped one. With no `m35100-pure.cl` to load, every run takes the optimized kernel whatever the user asked for, so the `PW_MAX` arm is unreachable and a password over 15 bytes is rejected instead of tried.

## What this adds

`OpenCL/m35100-pure.cl`, and nothing else. No module changes.

The `sm3crypt_tmp_t` it uses is the struct `m35100-optimized.cl` already declares, under a comment that reads `// pure version`:

```c
typedef struct sm3crypt_tmp
{
  // pure version

  u32 alt_result[8];
  u32 p_bytes[64];
  u32 s_bytes[64];

} sm3crypt_tmp_t;
```

So `module_tmp_size` already returns the right size for it, and the two kernels agree on the layout the way `m00500`'s two do.

Benchmarks do not move, because a benchmark always takes the optimized kernel. Three runs each on an Apple M4 Pro, `-m 35100 -b -d 1`:

```
before: 173.2  172.7  173.7 kH/s      median 173.2, peak 173.7
after:  173.7  173.6  173.7 kH/s      median 173.7, peak 173.7
```

The command above cracks on both backends this machine has, each reporting `Cracked`, `Pure Kernel (password length 0-256 bytes)` and `Guess.Mask AbcdefghijKlmnopqrst [20]`: Metal as `-d 1` and OpenCL as `-d 2` on an Apple M4 Pro.

## tools/test_edge.sh

```
$ ./tools/test_edge.sh -m 35100 -d 1      # Metal, Apple M4 Pro

before: rc=0, 10m59s, Errors detected: 0
after:  rc=0, 20m19s, Errors detected: 0
```

The run takes about twice as long because the suite now has two kernel types to cover for this mode instead of one. Every `Kernel-Type pure` line in the log is a combination that did not exist before.