### PR TITLE
Release only the references the Python multiprocessing bridge owns

### DIFF
--- a/src/bridges/bridge_python_generic_hash_mp.c
+++ b/src/bridges/bridge_python_generic_hash_mp.c
@@ -854,11 +854,13 @@ void platform_term (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, void *platform_cont
 
   unit_buf->gstate = python->PyGILState_Ensure ();
 
+  // Only the two objects this file created are ours to release. pContext belongs to pArgs, because
+  // PyTuple_SetItem () steals the reference it is given, so dropping the tuple drops the dict with it.
+  // pFunc_Init, pFunc_Term and pFunc_kernel_loop are borrowed from pGlobals by PyDict_GetItemString ()
+  // and were never owned here. Releasing all four took their counts below what they really were, and
+  // the interpreter then freed live objects during its last collection.
+
   python->Py_DecRef (unit_buf->pArgs);
-  python->Py_DecRef (unit_buf->pContext);
-  python->Py_DecRef (unit_buf->pFunc_kernel_loop);
-  python->Py_DecRef (unit_buf->pFunc_Term);
-  python->Py_DecRef (unit_buf->pFunc_Init);
   python->Py_DecRef (unit_buf->pGlobals);
 
   //python->PyEval_RestoreThread (python_interpreter->tstate);


### PR DESCRIPTION
`-m 73000` reports its speed and then dies. On macOS it happens on every Python 3.14 and on no 3.13, because `platform_term ()` releases six objects and owns two of them.

## Reproduction

```
$ pyenv local 3.14.7
$ make clean && make
$ ./hashcat -b -m 73000

before: * Unit #01 -> #01: Python Interpreter (3.14.7 (main, Sep 10 2026, 02:07:59) [Clang 23.1.0 ])
        Speed.#*.........:      387 H/s (0.01ms) @ Accel:94 Loops:1
        rc=139
after:  * Unit #01 -> #01: Python Interpreter (3.14.7 (main, Sep 10 2026, 02:07:59) [Clang 23.1.0 ])
        Speed.#*.........:      387 H/s (0.01ms) @ Accel:94 Loops:1
        rc=0
```

Every version this machine has, before and after:

```
               before              after
python 3.13.9  rc=0    397 H/s     rc=0    399 H/s
python 3.14.0  rc=139  386 H/s     rc=0    368 H/s
python 3.14.3  rc=139  383 H/s     rc=0    382 H/s
python 3.14.7  rc=139  387 H/s     rc=0    387 H/s

$ ./hashcat -b -m 72000        # pyenv 3.14.7t, unaffected
rc=0   225 H/s before, 213 H/s after
```

A `make DEBUG=2` build names the place:

```
==49902==ERROR: AddressSanitizer: BUS on unknown address
    #0 _PyObject_ClearFreeLists    libpython3.14.dylib
    #1 gc_collect_main
    #2 PyGC_Collect
    #3 _Py_Finalize
    #4 platform_term               bridge_python_generic_hash_mp.c:866
    #5 bridges_destroy             bridges.c:328
    #6 outer_loop                  hashcat.c:1605
```

## What was wrong

`platform_init ()` builds the argument tuple like this:

```c
unit_buf->pArgs = python->PyTuple_New (4);

python->PyTuple_SetItem (unit_buf->pArgs, 0, unit_buf->pContext);
```

`PyTuple_SetItem ()` steals the reference it is handed, so `pContext` belongs to `pArgs` from that line on and dropping the tuple drops the dict with it. `pFunc_Init`, `pFunc_Term` and `pFunc_kernel_loop` come from `PyDict_GetItemString ()`, which returns a borrowed reference and never gave this file one to release. Releasing all six took four counts below what they really were, and the interpreter freed live objects while clearing its freelists on the way out. 3.13 tolerated it, 3.14 does not.

`pArgs` and `pGlobals` are the two this file creates. They are still released, so nothing leaks in exchange. `bridge_python_generic_hash_sp.c` does not have the bug, because its `platform_term ()` releases nothing at all.

## Where it does not happen

On Debian 13 aarch64 with clang 19.1.7 and PoCL 6.0, the same 3.14.7 does not fault either way:

```
$ ./hashcat -b -m 73000

before: rc=0  105 H/s
after:  rc=0  138 H/s
```

That is what an over-release does rather than an argument against fixing it. The ownership rules being broken are not platform specific.

## tools/test_edge.sh

No mode is touched by this change in a way the suite reaches: `-m 73000` needs the bridge and a Python, and the suite has no case for it. The mode is exercised by the run above instead, on four interpreters.