### PR TITLE
Say what is missing when the Python library for -m 73000 is not found

### DIFF
--- a/src/bridges/bridge_python_generic_hash_mp.c
+++ b/src/bridges/bridge_python_generic_hash_mp.c
@@ -535,7 +535,14 @@ static bool init_python (hashcat_ctx_t *hashcat_ctx, hc_python_lib_t *python, us
 
   if (python->lib == NULL)
   {
-    event_log_error (hashcat_ctx, "Awww, unable to find Python shared library.");
+    event_log_error (hashcat_ctx, "Unable to find suitable Python library for -m 73000.");
+    event_log_info (hashcat_ctx, "This mode wants an ordinary Python built as a shared library, not the free-threaded one.");
+    event_log_info (hashcat_ctx, "* On Windows, use the installer from https://www.python.org/downloads/windows/ and leave 'free-threaded' unchecked.");
+    event_log_info (hashcat_ctx, "* On Linux and MacOS, use `pyenv` and select a version with no `t` on the end (for instance `3.14.7`).");
+    event_log_info (hashcat_ctx, "  `pyenv versions` lists what is installed. A version selected but never installed looks exactly like this.");
+    event_log_info (hashcat_ctx, "  For -m 72000 instead, the version needs the `t`, and the two are separate installs.");
+    event_log_info (hashcat_ctx, NULL);
+    event_log_info (hashcat_ctx, NULL);
 
     return false;
   }
@@ -742,7 +749,7 @@ void *platform_init (hashcat_ctx_t *hashcat_ctx)
     if (user_options->machine_readable == false)
     {
       event_log_error (hashcat_ctx, "Attention!!! Falling back to single-threaded mode.");
-      event_log_info (hashcat_ctx, " Windows and MacOS ds not support multiprocessing module cleanly!");
+      event_log_info (hashcat_ctx, " Windows and MacOS do not support the multiprocessing module cleanly!");
       event_log_info (hashcat_ctx, " For multithreading on Windows and MacOS, please use -m 72000 instead.");
       event_log_info (hashcat_ctx, NULL);
     }


### PR DESCRIPTION
When `-m 73000` cannot find a Python library it says this, and stops. It does not name the library it wanted, where it looked, or anything to try.

## Reproduction

```
$ echo 3.13.99 > .python-version      # a version pyenv has not installed
$ ./hashcat -b -m 73000

before: Awww, unable to find Python shared library.
        Platform initialization failed
        Bridge initialization for hash-mode '73000' failed.
        rc=255

after:  Unable to find suitable Python library for -m 73000.
        This mode wants an ordinary Python built as a shared library, not the free-threaded one.
        * On Windows, use the installer from https://www.python.org/downloads/windows/ and leave 'free-threaded' unchecked.
        * On Linux and MacOS, use `pyenv` and select a version with no `t` on the end (for instance `3.14.7`).
          `pyenv versions` lists what is installed. A version selected but never installed looks exactly like this.
          For -m 72000 instead, the version needs the `t`, and the two are separate installs.
        Platform initialization failed
        Bridge initialization for hash-mode '73000' failed.
        rc=255
```

The version named is the newest `pyenv` offers. It works for this mode only together with the fix to `platform_term ()` in the same bridge, which is a separate pull request, because on macOS every 3.14 faults on the way out without it.

## One typo in the same file

The other message this mode prints on Windows and macOS has a word missing:

```
$ ./hashcat -b -m 73000

before: Attention!!! Falling back to single-threaded mode.
         Windows and MacOS ds not support multiprocessing module cleanly!
         For multithreading on Windows and MacOS, please use -m 72000 instead.

after:  Attention!!! Falling back to single-threaded mode.
         Windows and MacOS do not support the multiprocessing module cleanly!
         For multithreading on Windows and MacOS, please use -m 72000 instead.
```

It is two lines below the block above, in the same function, and prints on every run of this mode on those two platforms rather than only on a failure. It is here because it is the same file and the same kind of thing, not because it is related to the library search.

## Why it reads that way

`src/bridges/bridge_python_generic_hash_sp.c` is a near copy of this file, and the two `python->lib == NULL` blocks are six lines apart, at `sp:530` and `mp:536`. The `sp` one already prints five lines naming what is wanted and what to do on each platform. Only one of the two copies was ever given them, so this is not a decision about how much to say.

The two modes want opposite builds, which is the part a reader has to get right: `t` for 72000, no `t` for 73000. The line about a version selected but never installed is the case above. `pyenv local` writes a version into `.python-version` whether or not it is installed, so `python3` is absent and the symptom is identical to a Python built without `--enable-shared`. Both were candidates and the old text separated neither.

## tools/test_edge.sh

No mode is touched, and no behaviour. The change is the text of one error path.