### PR TITLE
Rebuild when a file the build reads is edited

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,24 +46,34 @@ on:
     paths:
       - 'OpenCL/**.h'
       - 'OpenCL/**.cl'
+      - 'deps/**'
       - 'include/**.h'
       - 'src/**.c'
+      - 'src/**.h'
+      - 'src/**.m'
       - 'src/**.mk'
-      - 'tools/**'
+      - 'tools/test_package.sh'
       - '**/Makefile'
       - '.github/workflows/build.yml'
+      - '.github/workflows/generate_docs.sh'
+      - '.github/workflows/hashcat-example-hashes_machine-readable2md.py'
   pull_request:
     branches:
       - master
     paths:
       - 'OpenCL/**.h'
       - 'OpenCL/**.cl'
+      - 'deps/**'
       - 'include/**.h'
       - 'src/**.c'
+      - 'src/**.h'
+      - 'src/**.m'
       - 'src/**.mk'
-      - 'tools/**'
+      - 'tools/test_package.sh'
       - '**/Makefile'
       - '.github/workflows/build.yml'
+      - '.github/workflows/generate_docs.sh'
+      - '.github/workflows/hashcat-example-hashes_machine-readable2md.py'
 
 jobs:
   build:


### PR DESCRIPTION
A change to `src/ext_metal.m` runs no build. The `paths` filter in `build.yml` lists `src/**.c` and nothing matching a `.m`, so the two Objective C sources in the tree, which together are the Metal backend, are the ones CI never compiles.

## Reproduction

````
$ git ls-tree -r --name-only HEAD src/ | grep '\.m$'
src/ext_iokit.m
src/ext_metal.m

$ grep -n 'src/%.m' src/Makefile
1342:obj/%.METAL.NATIVE.o: src/%.m obj/arrangement

$ sed -n '46,54p' .github/workflows/build.yml
    paths:
      - 'OpenCL/**.h'
      - 'OpenCL/**.cl'
      - 'include/**.h'
      - 'src/**.c'
      - 'src/**.mk'
      - 'tools/**'
      - '**/Makefile'
      - '.github/workflows/build.yml'
````

The rule that compiles a `.m` sits inside `ifeq ($(UNAME),Darwin)`, so the macOS job is the only one that can check those two files, and nothing brings it out for them.

## Four more, and one that should not be there

* **`src/**.h`**, ten headers. `src/Makefile` carries a comment about this exact class of miss on the make side: before `-MMD -MP`, a change to `src/feeds/feed_wordlist.h` left the artifact it belongs to untouched. CI has the same hole and no dependency file to catch it.
* **`deps/`**, whose headers are on the include path through `-I deps/OpenCL-Headers` and `-I deps/sse2neon`, and whose sources are compiled into `bridge_argon2id_reference.mk`, `bridge_scrypt_yescrypt.mk` and `bridge_scrypt_jane.mk`. Named as a whole directory: a vendored dependency arrives as files of several kinds at once.
* **`.github/workflows/generate_docs.sh`** and the **`.py`** it runs. `build.yml` runs the first at line 175 and that script runs the second at line 25 of itself. The filter names `build.yml` and stops.
* **`tools/**`** in the other direction. It matches 905 files and the workflow reads one, `tools/test_package.sh`, after each of the five builds. The rest is `test.pl`, `test.sh`, 517 test modules and the installers, none compiled and none packaged. Naming the file keeps the case that matters. Dropping the directory outright would take that script with it, and a workflow that stops rebuilding when the script it runs is edited is worse than one that rebuilds too often.

`Rust/` is left out although a default `make` builds those crates. `rust.yml` already runs `rustfmt --check`, `cargo check` and `cargo test` on three operating systems for a change there, and adding it here would put five hashcat builds on every `.rs` edit, which is the cost this removes from `tools/`.

## tools/test_edge.sh

No mode is touched, and no code. The change is one workflow file.