### PR TITLE
Refresh the versions the workflow pins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     name: Build ${{ matrix.os_name }} (${{ matrix.shared == 0 && 'Static' || 'Shared' }})
     runs-on: ${{ matrix.os == 'freebsd' && 'ubuntu-latest' || matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
@@ -204,7 +204,7 @@ jobs:
           fi
 
       - name: Generate artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hashcat-${{ matrix.os_name_lowercase }}-${{ matrix.shared == 0 && 'static' || 'shared' }}
           path: ${{ env.include_paths }}
@@ -217,7 +217,7 @@ jobs:
       matrix:
         shared: [0, 1]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
@@ -230,9 +230,9 @@ jobs:
 
           mkdir ~/src && cd ~/src
           mkdir /opt/win-python && cd /opt/win-python
-          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.12.11-1-any.pkg.tar.zst
-          unzstd mingw-w64-x86_64-python-3.12.11-1-any.pkg.tar.zst
-          tar -xf mingw-w64-x86_64-python-3.12.11-1-any.pkg.tar
+          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.14.7-1-any.pkg.tar.zst
+          unzstd mingw-w64-x86_64-python-3.14.7-1-any.pkg.tar.zst
+          tar -xf mingw-w64-x86_64-python-3.14.7-1-any.pkg.tar
 
           cd ~/src
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
@@ -253,7 +253,7 @@ jobs:
         run: bash tools/test_package.sh . --no-device
 
       - name: Generate artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hashcat-cross-${{ matrix.shared == 0 && 'static' || 'shared' }}
           path: ${{ env.include_paths }}


### PR DESCRIPTION
The Windows cross build unpacks a mingw Python from June 2025, and two actions are three major versions behind.

## What the workflow pulls in

`/opt/win-python` is `WIN_PYTHON` in `src/Makefile`, and `bridge_python_generic_hash_{sp,mp}.mk` take the `.dll` headers from `$(lastword $(sort $(wildcard $(WIN_PYTHON)/mingw64/include/python3.*)))`, so the package named here is what the Windows bridge is built against.

```
$ sed -n '232,235p' .github/workflows/build.yml

          mkdir /opt/win-python && cd /opt/win-python
          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.12.11-1-any.pkg.tar.zst
          unzstd mingw-w64-x86_64-python-3.12.11-1-any.pkg.tar.zst
          tar -xf mingw-w64-x86_64-python-3.12.11-1-any.pkg.tar
```

The newest the repository carries is `3.14.7-1`, from 9 August 2026. The same version from `pyenv` builds and runs the bridge before it is named here:

```
$ pyenv local 3.14.7t
$ make clean && make
$ ./hashcat -b -m 72000

macOS 15 arm64, Homebrew clang 23.1.0:
* Unit #01 -> #14: Python Interpreter (3.14.7 free-threading build)
Speed.#*.........:      205 H/s
rc=0
```

No plugin was skipped. That is the same version, not the same package, so the msys2 one is still first exercised by the cross build this workflow runs.

## The actions

`actions/checkout` and `actions/upload-artifact` go from v4 to v7. The two third party actions in the file are already on their current major, so they are left alone:

```
action                     latest release            pinned here
actions/checkout           v7.0.1  2026-07-20        v7
actions/upload-artifact    v7.0.1  2026-04-10        v7
msys2/setup-msys2          v2.32.0 2026-06-12        v2
vmactions/freebsd-vm       v1.5.6  2026-09-09        v1
```

## One thing found on the way

Moving to 3.14 turned up a crash in `-m 73000` on macOS that 3.13 was hiding, in `platform_term ()` of the multiprocessing bridge. It is a separate problem and it is in its own pull request, not on this branch. This one does not depend on it: the mingw package is for the Windows cross build, and the crash reproduces on macOS with a `pyenv` interpreter rather than from this package.

## tools/test_edge.sh

No mode is touched, and no code. The change is one workflow file.