### PR TITLE
Give the argument tuples of the Python bridge a reference of their own

### DIFF
--- a/src/bridges/bridge_python_generic_hash_mp.c
+++ b/src/bridges/bridge_python_generic_hash_mp.c
@@ -41,6 +41,7 @@
 typedef void                (PYTHON_API_CALL *PY_INITIALIZE)                    ();
 typedef void                (PYTHON_API_CALL *PY_FINALIZE)                      ();
 typedef void                (PYTHON_API_CALL *PY_DECREF)                        (PyObject *);
+typedef void                (PYTHON_API_CALL *PY_INCREF)                        (PyObject *);
 typedef PyObject           *(PYTHON_API_CALL *PYBOOL_FROMLONG)                  (long);
 typedef PyObject           *(PYTHON_API_CALL *PYBYTES_FROMSTRINGANDSIZE)        (const char *, Py_ssize_t);
 typedef int                 (PYTHON_API_CALL *PYDICT_DELITEMSTRING)             (PyObject *, const char *);
@@ -97,6 +98,7 @@ typedef struct hc_python_lib
   PY_INITIALIZE                     Py_Initialize;
   PY_FINALIZE                       Py_Finalize;
   PY_DECREF                         Py_DecRef;
+  PY_INCREF                         Py_IncRef;
   PYBOOL_FROMLONG                   PyBool_FromLong;
   PYBYTES_FROMSTRINGANDSIZE         PyBytes_FromStringAndSize;
   PYDICT_DELITEMSTRING              PyDict_DelItemString;
@@ -591,6 +593,7 @@ static bool init_python (hashcat_ctx_t *hashcat_ctx, hc_python_lib_t *python, us
   HC_LOAD_FUNC_PYTHON (python, Py_Initialize,                     Py_Initialize,                      PY_INITIALIZE,                    PYTHON, 1);
   HC_LOAD_FUNC_PYTHON (python, Py_Finalize,                       Py_Finalize,                        PY_FINALIZE,                      PYTHON, 1);
   HC_LOAD_FUNC_PYTHON (python, Py_DecRef,                         Py_DecRef,                          PY_DECREF,                        PYTHON, 1);
+  HC_LOAD_FUNC_PYTHON (python, Py_IncRef,                         Py_IncRef,                          PY_INCREF,                        PYTHON, 1);
   HC_LOAD_FUNC_PYTHON (python, PyBool_FromLong,                   PyBool_FromLong,                    PYBOOL_FROMLONG,                  PYTHON, 1);
   HC_LOAD_FUNC_PYTHON (python, PyBytes_FromStringAndSize,         PyBytes_FromStringAndSize,          PYBYTES_FROMSTRINGANDSIZE,        PYTHON, 1);
   HC_LOAD_FUNC_PYTHON (python, PyDict_DelItemString,              PyDict_DelItemString,               PYDICT_DELITEMSTRING,             PYTHON, 1);
@@ -917,6 +920,12 @@ bool thread_init (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED void *pl
     return false;
   }
 
+  // PyTuple_SetItem () steals the reference it is handed, and pContext is already owned by
+  // unit_buf->pArgs. Handing that one reference to a second tuple gives two owners one count, so this
+  // tuple takes a reference of its own and gives it back when it goes.
+
+  python->Py_IncRef (unit_buf->pContext);
+
   python->PyTuple_SetItem (pArgs, 0, unit_buf->pContext);
 
   PyObject *pReturn = python->PyObject_CallObject (unit_buf->pFunc_Init, pArgs);
@@ -925,10 +934,14 @@ bool thread_init (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED void *pl
   {
     python->PyErr_Print ();
 
+    python->Py_DecRef (pArgs);
+
     return false;
   }
 
   python->Py_DecRef (pReturn);
+
+  python->Py_DecRef (pArgs);
 
   python->PyGILState_Release (unit_buf->gstate);
 
@@ -956,9 +969,15 @@ void thread_term (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, MAYBE_UNUSED void *pl
     return;
   }
 
+  // As in units_init (): a reference of this tuple's own, given back below.
+
+  python->Py_IncRef (unit_buf->pContext);
+
   python->PyTuple_SetItem (pArgs, 0, unit_buf->pContext);
 
   python->PyObject_CallObject (unit_buf->pFunc_Term, pArgs);
+
+  python->Py_DecRef (pArgs);
 
   python->PyDict_DelItemString (unit_buf->pContext, "salts_cnt");
   python->PyDict_DelItemString (unit_buf->pContext, "salts_size");


### PR DESCRIPTION
`units_init ()` and `units_term ()` build a one element tuple, put `pContext` in it, and never release the tuple. `PyTuple_SetItem ()` steals the reference it is handed, so each tuple takes over the one reference `unit_buf->pArgs` already holds, and then outlives the run pointing at an object it does not keep alive.

## What the core says

```
#0  _PyObject_IS_GC (obj=0x7db02f33c480) at ./Include/internal/pycore_object.h:316
#1  visit_decref (op=0x7db02f33c480, parent=0x7db02f4a2f80) at Python/gc.c:437
#2  tuple_traverse (self=0x7db02f4a2f80, ...) at Objects/tupleobject.c:654
#3  subtract_refs / deduce_unreachable / gc_collect_main at Python/gc.c:1395
#6  PyGC_Collect () at Python/gc.c:1682
#7  _Py_Finalize () at Python/pylifecycle.c:2141
#8  platform_term () at src/bridges/bridge_python_generic_hash_mp.c:866

(gdb) p ((PyTupleObject *) self)->ob_base.ob_size
$2 = 1
(gdb) p ((PyTupleObject *) self)->ob_item[0]
$3 = (PyObject *) 0x7db02f33c480
(gdb) p op->ob_type
$8 = (PyTypeObject *) 0xffffffffffffffff
```

`ob_size` is 1. `unit_buf->pArgs` is built by `PyTuple_New (4)`, so the tuple being walked is not that one: it is one of the two temporaries, and `ob_type` of its only element is gone.

`platform_term ()` drops `unit_buf->pArgs`, which takes `pContext` to zero and frees it. The two leaked tuples are still tracked by the collector, so the collection inside `_Py_Finalize ()` reaches them and reads freed memory.

## Reproduction

This needs #4845 and #4840 first. Without them the mode does not reach its own teardown: #4845 fixes an illegal memory access from the autotune that every backend which traps it reports, and #4840 fixes a fault in `platform_term ()` that happens before the collector runs. With both applied, on an RTX 4080 under Debian 13, Python 3.14.7 from `pyenv`:

```
$ ./hashcat -b -m 73000 -R 1

before: 2 of 20 runs end rc=139, each after printing its speed
after:  0 of 20 runs fail, and 0 of a second 20
        2747 H/s, 2746 H/s, 2747 H/s
```

The run reports its speed and then dies, so the mode works and its shutdown does not. It is intermittent because it depends on whether the freed memory has been reused by the time the collector reaches it.

```
                             before      after
python 3.14.7, 20 runs       2 failed    0 failed
python 3.14.7, 20 more                   0 failed
python 3.13.8, 10 runs       0 failed    0 failed
```

3.13.8 never faults, and neither does macOS, where this bridge falls back to single threaded and does not run this path at all. Neither changes the fact that the count is wrong.

## What the fix is

Both sites take a reference of their own before handing `pContext` to the tuple, and release the tuple after the call, including on the error path where `pReturn == NULL` returned and left the tuple behind.

`Py_IncRef` joins the loaded symbols because the file had no use for it before.

`bridge_python_generic_hash_sp.c` has the same two sites, and there the release is present but commented out at line 920, which trades the fault for a leak. That file is not touched here, and neither is the one #4840 covers.

## tools/test_edge.sh

`-m 73000` needs the bridge and a Python, and the suite has no case for it. The mode is exercised by the 60 runs above instead.