### PR TITLE
Update the Python floor in BUILD.md to the one the build enforces

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,23 +1,23 @@
 
 # Hashcat Build Documentation
 
-**Revision**: 1.7  
+**Revision**: 1.8  
 **Author**: See `docs/credits.txt`
 
 ---
 
 ## Requirements
 
-- **Python 3.12** or higher
+- **Python 3.13** or higher
 
 Check your Python version:
 
 ```bash
 $ python3 --version
-# Expected output: Python 3.13.9
+# Expected output: Python 3.14.7
 ```
 
-If you can't install Python >= 3.12 globally, you can use **pyenv**.
+If you can't install Python >= 3.13 globally, you can use **pyenv**.
 
 > If you're using `pyenv`, follow **all steps** below. Otherwise, follow only **steps 3 and 5**.
 
@@ -55,10 +55,10 @@ $ brew install pyenv
 
 ### Step 2: Install Python using pyenv
 
-Install Python 3.12 (or newer):
+Install Python 3.13 (or newer):
 
 ```bash
-$ pyenv install 3.12
+$ pyenv install 3.14.7
 ```
 
 Check installed versions:
@@ -67,7 +67,7 @@ Check installed versions:
 $ pyenv versions
 # Example:
 # * system
-#   3.12.11
+#   3.14.7
 ```
 
 ---
@@ -84,7 +84,7 @@ $ cd hashcat
 ### Step 4: Set the local Python version
 
 ```bash
-$ pyenv local 3.12.11
+$ pyenv local 3.14.7
 ```
 
 ---


### PR DESCRIPTION
`BUILD.md` asks for Python 3.12 or higher. The build asks for 3.13, and a 3.12 no longer produces the `-m 72000` plugin at all.

## Reproduction

```
$ sed -n '11p' BUILD.md
- **Python 3.12** or higher

$ grep -n 'PYTHON_SP_MIN_VERSION :=' src/bridges/bridge_python_generic_hash_sp.mk
34:PYTHON_SP_MIN_VERSION := 3.13

$ make ENABLE_LTO=0 CC=clang CXX=clang++      # on a machine whose python3-config is 3.12.3

WARNING: Skipping freethreaded plugin 72000: Python 3.13+ headers not found.
         To use -m 72000, you must install the required Python headers.
```

## Why it said 3.12

It was right when it was written. `bridge_python_generic_hash_sp.mk` records what changed:

```
$ sed -n '25,28p' src/bridges/bridge_python_generic_hash_sp.mk

# The bridge refuses anything below 3.13 at run time, because that is where a free-threaded build of
# Python first exists and it is a free-threaded library this loads. The build used to ask for less: it
# looked for PyInterpreterConfig_OWN_GIL, which arrived in 3.12, so 3.12 headers produced a plugin
# that built cleanly and then failed on every run. The two ask for the same version now.
```

The floor moved from 3.12 to 3.13 in the makefile and `BUILD.md` was left behind. The same block already printed `Python 3.13.9` as the expected output two lines below the requirement, so it contradicted itself until now.

## What changes

The three places that named the floor say 3.13. The four that are examples say 3.14.7, which is the newest `pyenv` offers and the version these steps were run with: built with `make clean && make`, `-m 73000` at 2747 H/s on an RTX 4080 and 387 H/s on an Apple M4 Pro, and `-m 72000` with the matching `3.14.7t`.

Keeping the two apart is what the file already did, with a 3.12 floor and a 3.13.9 expected output. The floor is what the build enforces and the example is what a reader should install today.

```
$ git diff --stat
 BUILD.md | 14 +++++++-------
 1 file changed, 7 insertions(+), 7 deletions(-)

$ grep -c '3\.12' BUILD.md
0
```

## What is left alone

`docs/hashcat-requirements.md` gives the per mode minimums, 3.13 for `-m 72000` and 3.10 for `-m 73000`, and this file does not repeat them. Nothing here says which of the two modes a reader wants, and the structure of the section is untouched.

Documentation only: no source file changes, nothing to build and nothing to measure.

This one has no prior issue. It corrects one number in a file that #4780 last touched, so the discussion belongs against the diff rather than in a separate thread.