### PR TITLE
Count a python oracle as test coverage

### DIFF
--- a/tools/test_coverage.sh
+++ b/tools/test_coverage.sh
@@ -13,9 +13,12 @@
 # Nothing here needs a backend device or even a built hashcat; it only reads
 # the source tree, so it is cheap enough to run in CI.
 #
-# A mode counts as covered when it has a test.pl oracle in tools/test_modules/
-# or appears in one of test.sh's container mode lists. Those lists are read out
-# of test.sh rather than repeated here, so this stays correct when they change.
+# A mode counts as covered when it has an oracle in tools/test_modules/ or
+# appears in one of test.sh's container mode lists. An oracle is an m<mode>.pm,
+# read by test.pl, or an m<mode>.py, read by test_module_runner.py: a mode is
+# written in one language or the other, never both, so the set is the union of
+# the two, the same way test.sh builds it. Those lists are read out of test.sh
+# rather than repeated here, so this stays correct when they change.
 
 set -u
 
@@ -23,7 +26,7 @@ TDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEST_SH="${TDIR}/test.sh"
 MODULE_DIR="${TDIR}/../src/modules"
-PM_DIR="${TDIR}/test_modules"
+ORACLE_DIR="${TDIR}/test_modules"
 
 # Modes with no test.sh coverage on purpose. Each line is "<mode> <reason>".
 #
@@ -50,8 +53,10 @@ fi
 # every mode that ships a module
 all_modes=$(ls "${MODULE_DIR}"/module_*.c | sed -E 's/.*module_0*([0-9]+)\.c/\1/' | sort -un)
 
-# modes with a test.pl oracle
-pm_modes=$(ls "${PM_DIR}"/m*.pm 2>/dev/null | sed -E 's/.*m0*([0-9]+)\.pm/\1/' | sort -un)
+# modes with an oracle, in either language
+oracle_modes=$(ls "${ORACLE_DIR}"/m[0-9][0-9][0-9][0-9][0-9].pm "${ORACLE_DIR}"/m[0-9][0-9][0-9][0-9][0-9].py 2>/dev/null \
+  | sed -E 's/.*m0*([0-9]+)\.(pm|py)/\1/' \
+  | sort -un)
 
 # modes covered by a container or reference file, taken from test.sh's own lists
 container_modes=$(grep -hoE '^[A-Z0-9_]*MODES="[0-9 ]*"' "${TEST_SH}" \
@@ -76,7 +81,7 @@ if [ -n "${cl_modes}" ]; then
   container_modes=$(printf '%s\n14500\n' "${container_modes}" | sort -un)
 fi
 
-covered=$(printf '%s\n%s\n' "${pm_modes}" "${container_modes}" | sort -un)
+covered=$(printf '%s\n%s\n' "${oracle_modes}" "${container_modes}" | sort -un)
 
 excluded=$(printf '%s\n' "${UNTESTABLE}" | awk 'NF {print $1}' | sort -un)
 
@@ -121,7 +126,7 @@ for m in ${missing}; do
 done
 
 echo ""
-echo "Add tools/test_modules/m<mode>.pm, or add the mode to UNTESTABLE in this"
-echo "script with the reason it cannot have one."
+echo "Add tools/test_modules/m<mode>.pm or m<mode>.py, or add the mode to"
+echo "UNTESTABLE in this script with the reason it cannot have one."
 
 exit 1


### PR DESCRIPTION
`tools/test_coverage.sh` reports the hash-modes that `tools/test.sh` cannot test, and exits non-zero when one of them is not on its documented exclusion list. On the current master it fails on a tree where nothing is actually missing:

```
$ tools/test_coverage.sh
modules      : 595
with a test  : 584
excluded     : 9

No test and no documented reason:
  1000   NTLM
  5200   Password Safe v3

Add tools/test_modules/m<mode>.pm, or add the mode to UNTESTABLE in this
script with the reason it cannot have one.
$ echo $?
1
```

Both modes do have a test. They are the two written for the python oracle, added with `test_module_runner.py` in #4817:

```
tools/test_modules/m01000.py
tools/test_modules/m05200.py
```

The script collects the oracles with a glob for one extension:

```sh
pm_modes=$(ls "${PM_DIR}"/m*.pm 2>/dev/null | sed -E 's/.*m0*([0-9]+)\.pm/\1/' | sort -un)
```

That was the whole set when the script was added in #4792, on 2026-08-25. #4817 landed on 2026-09-10 and did not touch it, so the accounting has been one language behind ever since. `test.sh` itself already reads both extensions and says why:

```sh
# An oracle is a .pm or a .py: a mode is written in one
# language or the other, never both, so the set is the union of the two.
PM_MODES=$(ls "${TDIR}"/test_modules/m[0-9][0-9][0-9][0-9][0-9].pm "${TDIR}"/test_modules/m[0-9][0-9][0-9][0-9][0-9].py 2>/dev/null | ...)
```

This takes the same union in `test_coverage.sh`, renames the variable that changed meaning, and updates the two comments and the closing message that still named `.pm` as the only thing to add.

After the change:

```
$ tools/test_coverage.sh
modules      : 595
with a test  : 586
excluded     : 9

Every mode has a test or a documented reason not to.
$ echo $?
0
```

The glob is tightened from `m*.pm` to `m[0-9][0-9][0-9][0-9][0-9].pm`, matching `test.sh`. That does not change what is collected on this tree, and it keeps the non-oracle files in the directory out of the count:

```
$ ls tools/test_modules/m*.pm | wc -l
511
$ ls tools/test_modules/m[0-9][0-9][0-9][0-9][0-9].pm | wc -l
511
$ ls tools/test_modules/ | grep -vE '^m[0-9]{5}\.(pm|py)$'
README.md
__pycache__
luks1.sh
m34100.sh
test_helpers.py
```

The script still fails when it should. Hiding a perl oracle reports its mode, and hiding the python oracle for 1000 brings that mode back, so the fix is not simply making the check permissive:

```
$ mv tools/test_modules/m00000.pm /tmp && tools/test_coverage.sh; echo $?
modules      : 595
with a test  : 585
excluded     : 9

No test and no documented reason:
  0      MD5

Add tools/test_modules/m<mode>.pm or m<mode>.py, or add the mode to
UNTESTABLE in this script with the reason it cannot have one.
1

$ mv tools/test_modules/m01000.py /tmp && tools/test_coverage.sh; echo $?
modules      : 595
with a test  : 585
excluded     : 9

No test and no documented reason:
  1000   NTLM

Add tools/test_modules/m<mode>.pm or m<mode>.py, or add the mode to
UNTESTABLE in this script with the reason it cannot have one.
1
```

`bash -n` passes, and the script reads only the source tree, so it needs no backend device and no built binary.