### PR TITLE
Handle unavailable Intel GPU hwmon gracefully

### DIFF
--- a/src/ext_sysfs_intelgpu.c
+++ b/src/ext_sysfs_intelgpu.c
@@ -76,7 +76,21 @@ char *hm_SYSFS_INTELGPU_get_syspath_hwmon (void *hashcat_ctx, const int backend_
 
   if (hwmonN == NULL)
   {
-    event_log_error (hashcat_ctx, "First_file_in_directory() failed.");
+    hwmon_ctx_t *hwmon_ctx = ((hashcat_ctx_t *) hashcat_ctx)->hwmon_ctx;
+
+    hm_attrs_t *hm_device = &hwmon_ctx->hm_device[backend_device_idx];
+
+    if ((hm_device->fanspeed_get_supported == true) || (hm_device->temperature_get_supported == true))
+    {
+      backend_ctx_t *backend_ctx = ((hashcat_ctx_t *) hashcat_ctx)->backend_ctx;
+
+      const u32 device_id = backend_ctx->devices_param[backend_device_idx].device_id;
+
+      event_log_warning (hashcat_ctx, "* Device #%u: Intel GPU hwmon interface not available. Hardware monitoring disabled.", device_id + 1);
+    }
+
+    hm_device->fanspeed_get_supported = false;
+    hm_device->temperature_get_supported = false;
 
     hcfree (syspath);
 


### PR DESCRIPTION
Disable both sensor capabilities when the hwmon interface is unavailable and warn once per device instead of logging a generic First_file_in_directory() failed error for each sensor.

The current Linux i915 driver exposes hwmon only for discrete GPUs. Missing hwmon is therefore expected on integrated GPUs.

https://github.com/hashcat/hashcat/issues/4849