### PR TITLE
Say that two modes cannot take a password that is not ASCII

### DIFF
--- a/src/modules/module_08500.c
+++ b/src/modules/module_08500.c
@@ -24,6 +24,7 @@ static const u64   KERN_TYPE      = 8500;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
                                   | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_PT_ALWAYS_ASCII
                                   | OPTS_TYPE_ST_UPPER;
 static const u32   SALT_TYPE      = SALT_TYPE_EMBEDDED;
 static const char *ST_PASS        = "hashcat";

--- a/src/modules/module_16000.c
+++ b/src/modules/module_16000.c
@@ -23,7 +23,8 @@ static const char *HASH_NAME      = "Tripcode";
 static const u64   KERN_TYPE      = 16000;
 static const u32   OPTI_TYPE      = OPTI_TYPE_ZERO_BYTE;
 static const u64   OPTS_TYPE      = OPTS_TYPE_STOCK_MODULE
-                                  | OPTS_TYPE_PT_GENERATE_LE;
+                                  | OPTS_TYPE_PT_GENERATE_LE
+                                  | OPTS_TYPE_PT_ALWAYS_ASCII;
 static const u32   SALT_TYPE      = SALT_TYPE_NONE;
 static const char *ST_PASS        = "hashcat";
 static const char *ST_HASH        = "pfaRCwDe0U";


### PR DESCRIPTION
`tools/test.pl` gives a mode a password with a multi byte character in it unless the module says it cannot take one. It decides by reading the module source for a handful of bits, `OPTS_TYPE_PT_ALWAYS_ASCII` among them. Modes 8500 and 16000 cannot take one and did not say so, so both were tested with vectors neither of them can reproduce.

## 16000, Tripcode

The oracle re-encodes the password before hashing it:

```perl
$word = encode("shift_jis", $word);
```

hashcat hashes the bytes it is given. On ASCII the two encodings are the same byte string, so the test passes. Outside it they are not, and a character Shift_JIS has no room for becomes a question mark, which means the hash the oracle prints belongs to a password that no longer exists:

```
codepoint   UTF-8       Shift_JIS   same
U+9F8D      e9be8d      97b4        no
U+AC00      eab08039    3f39        no, and the character is lost
U+1F600     f09f9880    3f          no, and the character is lost
"hashcat"   68617368636174          yes
```

So the failure is by construction, not by chance: there is no password outside ASCII whose oracle hash hashcat can reproduce for this mode.

## 8500, RACF

Here the two sides cannot be compared by reading them. The oracle maps the password with `Convert::EBCDIC::ascii2ebcdic`; the kernel maps it through a table of its own:


```c
CONSTANT_VK u32a c_ascii_to_ebcdic_pc[256] = { ... };

key[0] = BOX1 (((w0 >>  0) & 0xff), c_ascii_to_ebcdic_pc) <<  0
```

The `_pc` is the DES PC-1 permutation: the table is EBCDIC composed with it, so its entries differ from `ascii2ebcdic` at every one of the 256 positions, including the ASCII ones. Comparing them proves nothing either way.

Measured instead, one candidate each, same salt, on the pure kernel:

```
password          bytes                 oracle hash                            hashcat
AB12CD34          4142313243443334      $racf$*HASHCAT*2F585361A0B69ACC        cracked
AB1<U+20AC>2CD    414231e282ac324344    $racf$*HASHCAT*7605C9E64AF917E7        not cracked
```

The oracle produces a hash in both cases; hashcat reproduces only the first.

## The change

```
 src/modules/module_08500.c | 1 +
 src/modules/module_16000.c | 3 ++-
 2 files changed, 3 insertions(+), 1 deletion(-)
```

No kernel, no host code and no test file is touched. The bit only tells the oracle to keep the passwords of these two modes ASCII, which is what both can take.

## Effect on the suite

Mode 16000 is the one where it can be shown end to end, but only together with the `-a 6` fix in #4651: without that fix the mode generates no `-a 6` case at all, so there is nothing to pass or fail. With it:

```
tools/test.sh alone       -m 16000 -a 6    > Error : 3/6 not found    4 non-ASCII masks in the report
tools/test.sh + this      -m 16000 -a 6    > OK    : 0/6 not found    0
```

The masks of the three failing cases name the bytes of the character the oracle had put in the password:

```
?d?d?dM-jM-0M-^@?d        ea b0 80, which is U+AC00
```

Merged before that pull request this change is a no-op that nothing exercises, which is a fine order to merge it in; merged after, it turns three failures back into passes. Either way nothing regresses.