### PR TITLE
Add -M to test_edge.sh, and fix three faults in the same file

### DIFF
--- a/tools/test_edge.sh
+++ b/tools/test_edge.sh
@@ -50,6 +50,8 @@ function usage()
   echo ""
   echo "     --skip-clean-cache             : Skip cleaning the kernel caches before starting the tests"
   echo ""
+  echo "-M / --minimal                      : test only 24 hash types covering all distinct code paths, vector-width 1"
+  echo ""
   echo "-f / --force                        : run hashcat using --force"
   echo ""
   echo "-v / --verbose                      : show debug messages (supported: -v or -vv)"
@@ -374,6 +376,7 @@ BACKEND_DEVICES_KEEPFREE=0
 ALL_ATTACKS=0
 SELF_TEST_DISABLE=1
 CLEAN_CACHE_DISABLE=0
+MINIMAL=0
 
 OPTS="--quiet --potfile-disable --machine-readable --logfile-disable"
 
@@ -425,6 +428,12 @@ while [[ $# -gt 0 ]]; do
         usage
       fi
       shift 2
+      ;;
+    --minimal)
+      MINIMAL=1
+      HASH_TYPE="all"
+      VECTOR_WIDTHS="1"
+      shift
       ;;
     --allow-all-attacks)
       ALL_ATTACKS=1
@@ -795,6 +804,11 @@ while [[ $# -gt 0 ]]; do
 
             break
             ;;
+          M)
+            MINIMAL=1
+            HASH_TYPE="all"
+            VECTOR_WIDTHS="1"
+            ;;
           *)
             echo "Unknown option: -$opt"
             usage
@@ -865,10 +879,33 @@ if [ ${VERBOSE} -ge 1 ]; then
   echo "Global hashcat options selected: ${OPTS}"
 fi
 
+# Attack type 4 asked for on one mode whose kernel runs inside, with the optimized kernel type and
+# nothing else, has nothing it can do: the round below would skip every cell. attack_exec is read
+# from the module rather than from --hash-info so that this costs no run of hashcat, the same way
+# tools/test.sh reads it. -K all is not this case, and neither is a mode whose kernel runs outside.
+
+if [ "${ATTACK_TYPES}" == "4" ] && [ "${KERNEL_TYPE}" == "1" ] && echo -n "${HASH_TYPE}" | grep -q '^[0-9]\+$'; then
+  edge_module=$(printf "%s/../src/modules/module_%05d.c" "${TDIR}" "${HASH_TYPE}")
+
+  if [ -r "${edge_module}" ] && ! grep -q ATTACK_EXEC_OUTSIDE_KERNEL "${edge_module}"; then
+    echo "! Attack type 4 has no optimized kernel for hash type ${HASH_TYPE}, and -K 1 asks for the"
+    echo "! optimized one only."
+    echo "!"
+    echo "! -a 4 amplifies on the device for a mode whose kernel runs inside, and that engine has a"
+    echo "! pure kernel only. Ask for the pure kernel type instead:"
+    echo "!"
+    echo "!     ${0} -m ${HASH_TYPE} -a 4 -K 0"
+
+    exit 1
+  fi
+fi
+
 errors=0
 startTime=$(date +%s)
 
 mkdir -p ${OUTD} &> /dev/null
+
+MINIMAL_MODES="0 100 110 400 500 2600 3000 3200 6211 11600 12500 13711 14200 14511 14600 14900 15400 15700 20510 22000 29511 33000 33500 34100"
 
 for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | awk '{print $1+=0}'); do
 
@@ -877,6 +914,10 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
   else
     if [ $hash_type -lt ${HASH_TYPE_MIN} ]; then continue; fi
     if [ $hash_type -gt ${HASH_TYPE_MAX} ]; then continue; fi
+  fi
+
+  if [ "${MINIMAL}" -eq 1 ]; then
+    if ! is_in_array "${hash_type}" ${MINIMAL_MODES}; then continue; fi
   fi
 
   if is_in_array "${hash_type}" ${SKIP_HASH_TYPES}; then
@@ -934,6 +975,21 @@ for hash_type in $(ls tools/test_modules/*.pm | cut -d'm' -f3 | cut -d'.' -f1 | 
       tmp_slow_hash=$(./hashcat -m ${hash_type} -HH | grep Slow\\.Hash | awk '{print $2}')
       if [ "${tmp_slow_hash}" == "Yes" ]; then
         slow_hash=1
+      fi
+
+      # -a 4 amplifies on the device for a mode whose kernel runs inside, and that engine has no
+      # optimized kernel: hashcat refuses the optimized flag for it rather than ignoring it. So an
+      # optimized round has nothing to run for attack type 4 on such a mode. A mode whose kernel runs
+      # outside is not this case: there the feed builds every candidate on the host and the round runs,
+      # so the test is on slow_hash and not on the kernel type alone.
+
+      if [ ${attack_type} -eq 4 ] && [ ${optimized} -eq 1 ] && [ ${slow_hash} -eq 0 ]; then
+        if [ ${VERBOSE} -ge 2 ]; then
+          echo "[ ${OUTD} ] > Skip processing Hash-Type ${hash_type} with Attack-Type ${attack_type} and Kernel-Type ${kernel_type} (attack type 4 has no optimized kernel)" | tee -a ${OUTD}/test_edge.details.log
+        else
+          echo "[ ${OUTD} ] > Skip processing Hash-Type ${hash_type} with Attack-Type ${attack_type} and Kernel-Type ${kernel_type} (attack type 4 has no optimized kernel)" >> ${OUTD}/test_edge.details.log
+        fi
+        continue
       fi
 
       binary_hashfile=0


### PR DESCRIPTION
Review on #4651 asked for the mode loop here to stop globbing `.pm` only, since 1000 and 5200 got a `.py` oracle in #4817 and have been outside this suite from that commit on. That is what this branch now carries beyond `-M` itself, and it turned out to need more than the glob.

## `-M`

Unchanged from the first commit here, and review settled that it stays that way: the benchmark array
in `src/benchmark.c` answers which modes a user wants measured, while `-M` answers the other end, one
mode per distinct code path. `tools/test.sh` now reads six of its 24 out of the family lists defined
in that same file, which cannot be done here because this script has no such lists.

## The glob

```
$ ls tools/test_modules/*.pm | wc -l
511
$ ls tools/test_modules/m[0-9][0-9][0-9][0-9][0-9].pm tools/test_modules/m[0-9][0-9][0-9][0-9][0-9].py | wc -l
513
```

#4817, merged as `731f2ed8c`, gave 1000 and 5200 a `.py` oracle. The loop globbed `*.pm`, so from that commit both modes have been outside this suite, and nothing said so:

```
$ ./tools/test_edge.sh -m 1000 -d 1 -D 2      # before
! cleaning cache ...
[ test_edge_1789300896 ] > All tests done in 0d:00h:00m:00s
[ test_edge_1789300896 ] > Errors detected: 0

$ ./tools/test_edge.sh -m 1000 -d 1 -D 2      # after
! cleaning cache ...
[ test_edge_1789300896 ] > Skip processing Hash-Type 1000 (edge is implemented in tools/test.pl only, and this mode's oracle is a .py)
[ test_edge_1789300896 ] > All tests done in 0d:00h:00m:01s
[ test_edge_1789300896 ] > Errors detected: 0

$ ./tools/test_edge.sh -m 5200 -d 1 -D 2      # before
! cleaning cache ...
[ test_edge_1789300897 ] > All tests done in 0d:00h:00m:00s
[ test_edge_1789300897 ] > Errors detected: 0

$ ./tools/test_edge.sh -m 5200 -d 1 -D 2      # after
! cleaning cache ...
[ test_edge_1789300897 ] > Skip processing Hash-Type 5200 (edge is implemented in tools/test.pl only, and this mode's oracle is a .py)
[ test_edge_1789300897 ] > All tests done in 0d:00h:00m:00s
[ test_edge_1789300897 ] > Errors detected: 0
```

`Errors detected: 0` on all four, and that is the point: before, the zero is over nothing at all, and
nothing in the run says the mode was asked for and not reached.

Anchoring the glob to `mNNNNN` keeps `test_helpers.py` out of it. The two modes cannot be run yet, because an edge case run needs the oracle's `edge` entry point and the Python runner does not implement it:

```
$ python3 tools/test_module_runner.py edge 1000
edge is not implemented in test_module_runner.py yet, use tools/test.pl
$ python3 tools/test_module_runner.py edge 5200
edge is not implemented in test_module_runner.py yet, use tools/test.pl
```

So they are named and skipped with the reason, the way the other skips in that loop read, rather than entering the loop and failing. `edge ()` and `edge_format ()` in `tools/test.pl` are 309 lines of per attack type length constraints, so porting them is a change of its own, and the skip goes away on its own once it exists.

## The skip for 73000

The `continue` sat outside the test for Darwin while the message sat inside it, so on every other platform the mode was skipped in silence. Measured on a Raspberry Pi 4, Linux aarch64, with `pyenv local` set to a free-threaded build so the branch is taken:

```
$ ./tools/test_edge.sh -m 73000 -f
```

before:

```
! cleaning cache ...
[ test_edge_1789260441 ] > All tests done in 0d:00h:00m:00s
[ test_edge_1789260441 ] > Errors detected: 0
```

after:

```
! cleaning cache ...
[ test_edge_1789260442 ] > Skip processing Hash-Type 73000 (needs a Python without the 'free-threaded' library support)
[ test_edge_1789260442 ] > All tests done in 0d:00h:00m:00s
[ test_edge_1789260442 ] > Errors detected: 0
```

The bridge refuses a free-threaded library wherever it runs, not only on Apple, which is what it says itself:

```
src/bridges/bridge_python_generic_hash_mp.c:541
  event_log_info (hashcat_ctx, "This mode wants an ordinary Python built as a shared library, not the free-threaded one.");
```

so the message names the Python rather than the platform.

## No other mode changes

The new skip fires for exactly the two modes whose oracle is a `.py`, and every other one of the 513 has a `.pm` beside it:

```
modes the glob lists                     513
of those, with no .pm                      2    1000 5200
```

A sample of five modes across the range, run in full on both sides, to show that nothing else moves:

```
mode    before                 after
0       Errors detected: 0     Errors detected: 0     160 combinations each side
100     Errors detected: 0     Errors detected: 0     160
400     Errors detected: 0     Errors detected: 0     180
1400    Errors detected: 0     Errors detected: 0     160
3000    Errors detected: 0     Errors detected: 0      85
```

Same count of attack, kernel, target and vector width combinations on both sides for every one of the
five, so the glob change adds the two modes and touches nothing else.