### PR TITLE
Stop two test modules deriving a password length from the wrong budget

### DIFF
--- a/tools/test_modules/m14400.pm
+++ b/tools/test_modules/m14400.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::SHA qw (sha1_hex);
 
-sub module_constraints { [[0, 235], [20, 20], [0, 24], [20, 20], [0, 55]] }
+sub module_constraints { [[0, 235], [20, 20], [0, 24], [20, 20], [-1, -1]] }
 
 sub module_generate_hash
 {

--- a/tools/test_modules/m15000.pm
+++ b/tools/test_modules/m15000.pm
@@ -10,7 +10,7 @@ use warnings;
 
 use Digest::SHA qw (sha512_hex);
 
-sub module_constraints { [[0, 256], [64, 64], [0, 47], [64, 64], [0, 55]] }
+sub module_constraints { [[0, 256], [64, 64], [0, 47], [64, 64], [-1, -1]] }
 
 sub module_generate_hash
 {


### PR DESCRIPTION
`module_constraints` returns five pairs, and `tools/test_modules/README.md` describes the fifth one as the combination of password and salt, adding that it "is important if the password and the salt is stored in the same buffer in the kernel".

When that pair is set and the salt has a fixed length, `init_db_word_rand ()` in `tools/test.pl` subtracts the salt length from the optimized password maximum:

```perl
if ($constraints->[4]->[0] != -1)
{
  my $salt_min = $constraints->[3]->[0];
  my $salt_max = $constraints->[3]->[1];

  if ($salt_min == $salt_max)
  {
    $len_max -= $salt_min;
  }
}
```

That is right for a mode whose optimized password maximum is the shared budget. `m14400` and `m15000` are not such modes: their maximum is the password's own limit, with the salt already taken off. `m15000` is the clearest case, because `47 + 64 = 111`, which is exactly what a single SHA-512 block holds, and its kernel packs through `switch_buffer_by_offset_8x4_le_VV`, not the 55 byte path the number 55 comes from.

So the subtraction takes the salt off a quantity it is not part of:

```
            declared             after the subtraction
m14400      salt 20, pw 0..24    pw 0..4
m15000      salt 64, pw 0..47    pw -17..-17
```

## What that does to the vectors

`IS_OPTIMIZED=1 perl tools/test.pl single <mode>`, on master, one line per generated password:

```
m14400                          m15000
len  0                          len 0
len  1   7                      len 0
len  2   57                     len 0
len  3   781                    len 0
len  4   가1                     len 0
len  4   가9                     len 0
len  4   가3                     len 0
len  4   가5                     len 0
```

Every optimized vector for `m15000` is the empty password, and `m14400` never exceeds four bytes. A mode tested only with the empty password is not tested, and `-a 6` and `-a 7`, which have to split the password between a wordlist and a mask, have nothing to split.

## With the fifth pair set to -1

```
m14400                                   m15000
len  0                                   len  0
len  5   48675                           len  3   767
len  8   6225가8                          len 19   793787码龍5中中
len 10   7Ａ8码65                          len 22   59龍883682😀41Ａ07
len 11   龍😀1769                          len 26   7Ａ1カ95😀龍3€29ह
len 16   龍か6ह164900                      len 27   😀5中00カ9524か0가가
len 18   34龍😀437844956                   len 30   6ह龍4カ中カ中4340600596
len 24   025中385€501576054ह               len 31   カ€9Ａ707か9187😀中5中
```

`m14400` now reaches its declared maximum of 24. `m15000` stops at 31 rather than 47, which is not this change: `init_db_word_rand ()` already caps a variable length mode at 31 because, as its comment says, "longer than 31 does not work for -a 0 in optimized mode".

## The other way to fix it

The subtraction could be kept by raising the optimized password maximum to the combined budget, 111 for `m15000`, and declaring the pair as `[64, 111]`. That needs the true combined budget of each scheme, and `m14400` inserts a separator of its own between the two fields, so its budget is not simply block size minus salt. The declared password maximum is already correct in both modules, so disabling the pair is the change that does not require re-deriving a number that is right.

## Scope

```
 tools/test_modules/m14400.pm | 2 +-
 tools/test_modules/m15000.pm | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

No hash mode, kernel or host code is touched: this is what the oracle generates.