### PR TITLE
Document -M and give test_edge.sh a section of its own

### DIFF
--- a/docs/hashcat-plugin-development-guide.md
+++ b/docs/hashcat-plugin-development-guide.md
@@ -201,11 +201,17 @@ The main options:
 * Select hash type (-m): Test only a special hash-mode
 * Select test mode (-t): Test either single-hash or multi-hash kernel
 * Select attack mode (-a): Test a special attack mode. With a slow hash, this is automatically switches to a straight attack, because there are no attack-mode specific kernel implementations
+* Minimal mode (-M): Test only 24 hash types that cover all distinct code paths and logic branches. This is useful for quick validation without running the full test suite across all hash modes
 
 If the options are not set, attack-mode 0 for hash-mode 0 is executed. To see additional options, see tools/test.sh --help
 
+### test_edge.sh ###
 
+The test_edge.sh is a complementary testing tool that generates edge cases for each hash-mode using the constraints defined in the test modules. Unlike test.sh which tests with random passwords, test_edge.sh specifically targets boundary conditions such as minimum and maximum password lengths, minimum and maximum salt lengths, and other constraint limits.
 
+It tests each hash-mode under every kernel type the mode has, and every attack mode that kernel type can run. The minimal mode (-M or --minimal) option is also available to restrict testing to the same 24 representative hash types used by test.sh -M.
+
+To see all available options, see tools/test_edge.sh --help
 
 ## Module ##
 

--- a/docs/hashcat-plugin-development-guide.md
+++ b/docs/hashcat-plugin-development-guide.md
@@ -201,7 +201,7 @@ The main options:
 * Select hash type (-m): Test only a special hash-mode
 * Select test mode (-t): Test either single-hash or multi-hash kernel
 * Select attack mode (-a): Test a special attack mode. With a slow hash, this is automatically switches to a straight attack, because there are no attack-mode specific kernel implementations
-* Minimal mode (-M): Test only 24 hash types that cover all distinct code paths and logic branches. This is useful for quick validation without running the full test suite across all hash modes
+* Minimal mode (-M): Test only the hash-modes hashcat benchmarks, which the suite reads from DEFAULT_BENCHMARK_ALGORITHMS_BUF in src/benchmark.c. Those cover the distinct code paths, and a mode that belongs in the set is added there rather than to a second list beside it
 
 If the options are not set, attack-mode 0 for hash-mode 0 is executed. To see additional options, see tools/test.sh --help
 
@@ -209,7 +209,7 @@ If the options are not set, attack-mode 0 for hash-mode 0 is executed. To see ad
 
 The test_edge.sh is a complementary testing tool that generates edge cases for each hash-mode using the constraints defined in the test modules. Unlike test.sh which tests with random passwords, test_edge.sh specifically targets boundary conditions such as minimum and maximum password lengths, minimum and maximum salt lengths, and other constraint limits.
 
-It tests each hash-mode under every kernel type the mode has, and every attack mode that kernel type can run. The minimal mode (-M or --minimal) option is also available to restrict testing to the same 24 representative hash types used by test.sh -M.
+It tests each hash-mode under every kernel type the mode has, and every attack mode that kernel type can run. The minimal mode (-M or --minimal) option is also available, and reads the same list out of src/benchmark.c that test.sh -M does.
 
 To see all available options, see tools/test_edge.sh --help
 


### PR DESCRIPTION
`docs/hashcat-plugin-development-guide.md` is where a contributor writing a module is sent to read about the test suite. Two gaps.

It lists the main options of `tools/test.sh` and does not mention `-M`, the minimal mode that #4651 adds to `tools/test.sh` and #4852 adds to `tools/test_edge.sh`.

It never describes `tools/test_edge.sh` at all, although that script is what tests a module's `module_constraints` at their limits, which is exactly what the contributor reading this page has just written.

## The change

```
 docs/hashcat-plugin-development-guide.md | 6 ++++++
 1 file changed, 6 insertions(+)
```

One bullet for `-M` under the options already listed, and a short section on `test_edge.sh` next to the `test.sh` one, saying what it does differently, that it takes `-M` as well, and where to read its options.

The `-M` bullet says what the mode is for: 24 hash types chosen one per distinct code path, for a quick check without a full sweep. Review on #4651 first asked for the list to be read out of `DEFAULT_BENCHMARK_ALGORITHMS_BUF` and then settled the other way, because that array answers which modes a user wants measured rather than which paths a change needs checked, so the wording here is the one it started with.

## A wording note

The new section says that `test_edge.sh` tests "each hash-mode under every kernel type the mode has, and every attack mode that kernel type can run", rather than the simpler "both Pure and Optimized kernel types and all attack modes". The longer form is deliberate: attack type 4 amplifies on the device for a mode whose kernel runs inside, that engine has no optimized kernel, and hashcat refuses the optimized flag for it, so that one round genuinely does not run. The companion `test_edge.sh` pull request makes the script skip it and say so. The sentence is true whichever order the three land in.