### PR TITLE
Unpack a MurmurHash candidate unsigned, the way the kernel reads it

### DIFF
--- a/tools/test_modules/m25700.pm
+++ b/tools/test_modules/m25700.pm
@@ -26,7 +26,7 @@ sub MurmurHash
 
   $hash += 0xdeadbeef;
 
-  my @chars = unpack ("c*", $word);
+  my @chars = unpack ("C*", $word);
 
   my $len = length $word;
 


### PR DESCRIPTION
`-m 25700` fails in `tools/test.sh` and `tools/test_edge.sh` whenever the generated password holds a byte over `0x7f`, which is most of them. The mode and its kernels are fine: the test module rebuilds the candidate with the wrong signedness, so it asks hashcat for a hash no kernel produces.

## Reproduction

The change is in the test module rather than in hashcat, so the before and after of one hashcat run is the same run. These two show what the module gets wrong: the first hash is what it generates for that password today, the second is the same password under the same salt hashed the way the kernel does it.

```
$ rm -rf cache/kernels/
$ ./hashcat -m 25700 -a 3 -D 2 --potfile-disable --logfile-disable '629ad913:92523450' '가7'
Status...........: Exhausted
Guess.Mask.......: 가7 [4]
Recovered........: 0/1 (0.00%) Digests (total), 0/1 (0.00%) Digests (new)
rc=1

$ ./hashcat -m 25700 -a 3 -D 2 --potfile-disable --logfile-disable '7972a837:92523450' '가7'
Status...........: Cracked
Guess.Mask.......: 가7 [4]
Recovered........: 1/1 (100.00%) Digests (total), 1/1 (100.00%) Digests (new)
rc=0
```

## What is wrong

`m25700.pm` builds each 32 bit word of the candidate out of single bytes:

```perl
my @chars = unpack ("c*", $word);
...
my $l = ($c0 << 0) | ($c1 << 8) | ($c2 << 16) | ($c3 << 24);
```

`c` is a signed char, so a byte over `0x7f` arrives negative and the shifts that rebuild the word sign extend. The kernel never composes that word from bytes:

```c
for (u32 i = 0; i < blocks; i++)
{
  const u32 tmp = (hash + w[i]) * M;

  hash = tmp ^ (tmp >> R);
}
```

It adds `w[i]` whole, so the candidate is unsigned by construction. The two agree while every byte is ASCII, which is why the mode passed for years: the generated passwords used to be digits from end to end, and `tools/test.pl` now seeds a multi byte character into most of them.

One of the 511 test modules unpacked a candidate signed. The fourteen others that unpack one already ask for `C`.

## tools/test_edge.sh

```
$ ./tools/test_edge.sh -m 25700 -d 1 -D 2

[ test_edge_1789255168 ] > All tests done in 0d:00h:02m:40s
[ test_edge_1789255168 ] > Errors detected: 85
[ test_edge_1789255168 ] !> Details on test_edge_1789255168/test_edge.details.log
```

With the change:

```
[ test_edge_1789255329 ] > All tests done in 0d:00h:02m:24s
[ test_edge_1789255329 ] > Errors detected: 0
```